### PR TITLE
[Bugfix] Keep one GPU pool per hardware shape

### DIFF
--- a/pkg/alfred/snapshot/builder.go
+++ b/pkg/alfred/snapshot/builder.go
@@ -98,6 +98,10 @@ func Build(ctx context.Context, r client.Reader, opts Options) (*ClusterSnapshot
 		node := &nodeList.Items[i]
 		s.Nodes[node.Name] = buildNode(node, &opts)
 	}
+	// Pool keys are derived per node but must partition consistently across
+	// the cluster; a partial GPU-feature-discovery rollout would otherwise
+	// split one physical pool in two. Runs before anything reads GPUPool.
+	reconcilePoolKeys(s.Nodes)
 
 	var podList corev1.PodList
 	if err := r.List(ctx, &podList); err != nil {

--- a/pkg/alfred/snapshot/builder_test.go
+++ b/pkg/alfred/snapshot/builder_test.go
@@ -461,3 +461,40 @@ func TestSnapshotHelpers(t *testing.T) {
 		t.Fatal("WithVirtualPending(nil) should return the receiver")
 	}
 }
+
+// TestBuildReconcilesPoolKeys pins the wiring rather than the algorithm:
+// reconcilePoolKeys must run inside Build, before anything reads GPUPool.
+// The unit tests in pools_test.go call it directly, so removing the call from
+// Build would leave them all green while every score silently halved. The
+// deprecated instance-type label carries the shape here, covering that rung
+// end to end at the same time.
+func TestBuildReconcilesPoolKeys(t *testing.T) {
+	labelled := gpuNode("labelled", "8", func(n *corev1.Node) {
+		n.Labels = map[string]string{
+			"nvidia.com/gpu.product":           testPool,
+			"beta.kubernetes.io/instance-type": "BM.GPU.H100.8",
+		}
+	})
+	bare := gpuNode("bare", "8", func(n *corev1.Node) {
+		n.Labels = map[string]string{"beta.kubernetes.io/instance-type": "BM.GPU.H100.8"}
+	})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(labelled, bare).
+		Build()
+
+	snap, err := Build(context.Background(), client.Reader(fakeClient), Options{
+		Now: func() time.Time { return buildNow },
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if got := snap.Nodes["bare"].GPUPool; got != testPool {
+		t.Fatalf("unlabelled node pool = %q, want %q — Build must reconcile pool keys", got, testPool)
+	}
+	if pools := snap.GPUPools(); len(pools) != 1 || pools[0] != testPool {
+		t.Fatalf("identical hardware must land in one pool, got %v", pools)
+	}
+}

--- a/pkg/alfred/snapshot/pools.go
+++ b/pkg/alfred/snapshot/pools.go
@@ -52,10 +52,11 @@ func shapePoolKey(labels map[string]string) string {
 	if shape == "" {
 		return ""
 	}
-	if short, err := utils.GetInstanceTypeShortName(shape); err == nil && short != "" {
-		return short
+	short, err := utils.GetInstanceTypeShortName(shape)
+	if err != nil {
+		return ""
 	}
-	return ""
+	return short
 }
 
 // reconcilePoolKeys makes the partition consistent across nodes of identical

--- a/pkg/alfred/snapshot/pools.go
+++ b/pkg/alfred/snapshot/pools.go
@@ -27,18 +27,88 @@ const gfdGPUProductLabel = "nvidia.com/gpu.product"
 //     hardware).
 //  3. The GPU resource name (nvidia.com/gpu, amd.com/gpu, a MIG profile) —
 //     coarse, but never mixes vendors or MIG geometries.
+//
+// The product label is the most precise rung but the least universally
+// present — GPU feature discovery is a DaemonSet, not something the hardware
+// announces — so per-node derivation alone can split one physical pool.
+// reconcilePoolKeys repairs that across the whole node set.
 func GPUPoolForNode(node *corev1.Node, gpuResource string) string {
 	if product := node.Labels[gfdGPUProductLabel]; product != "" {
 		return product
 	}
-	shape := node.Labels[constants.NodeInstanceShapeLabel]
-	if shape == "" {
-		shape = node.Labels[constants.DeprecatedNodeInstanceShapeLabel]
-	}
-	if shape != "" {
-		if short, err := utils.GetInstanceTypeShortName(shape); err == nil && short != "" {
-			return short
-		}
+	if shape := shapePoolKey(node.Labels); shape != "" {
+		return shape
 	}
 	return gpuResource
+}
+
+// shapePoolKey resolves the instance-shape rung on its own, returning "" when
+// the node carries no usable instance-type label.
+func shapePoolKey(labels map[string]string) string {
+	shape := labels[constants.NodeInstanceShapeLabel]
+	if shape == "" {
+		shape = labels[constants.DeprecatedNodeInstanceShapeLabel]
+	}
+	if shape == "" {
+		return ""
+	}
+	if short, err := utils.GetInstanceTypeShortName(shape); err == nil && short != "" {
+		return short
+	}
+	return ""
+}
+
+// reconcilePoolKeys makes the partition consistent across nodes of identical
+// hardware, which per-node derivation cannot guarantee. GPU feature discovery
+// runs as a DaemonSet, so a node it has not reached keys by instance shape
+// while its identical neighbours key by GPU product — one physical pool
+// silently becomes two. The damage is not cosmetic: each half scores against
+// only its own bins, and because pool is a hard boundary in candidate
+// selection, no workload can ever migrate across the split even between
+// adjacent nodes in the same rack.
+//
+// The rule is per shape group. A group whose labelled members agree on a
+// single product adopts that product for every member, unlabelled ones
+// included — precision preserved, split gone. A group carrying several
+// distinct products keeps its per-node keys, because that is a genuine
+// partition (MIG geometries, a mixed hardware refresh) and precisely what the
+// product label exists to express; an unlabelled node there stays on its own
+// shape key rather than being guessed into one of them, since splitting
+// identical hardware only costs opportunity while merging distinct hardware
+// would produce migrations onto the wrong accelerator.
+func reconcilePoolKeys(nodes map[string]*Node) {
+	// byShape collects the distinct products observed on each shape
+	// group's labelled nodes.
+	byShape := map[string]map[string]struct{}{}
+	for _, n := range nodes {
+		if n.TotalGPUs == 0 {
+			continue
+		}
+		product := n.Labels[gfdGPUProductLabel]
+		shape := shapePoolKey(n.Labels)
+		if product == "" || shape == "" {
+			continue
+		}
+		if byShape[shape] == nil {
+			byShape[shape] = map[string]struct{}{}
+		}
+		byShape[shape][product] = struct{}{}
+	}
+
+	for _, n := range nodes {
+		if n.TotalGPUs == 0 || n.Labels[gfdGPUProductLabel] != "" {
+			continue
+		}
+		shape := shapePoolKey(n.Labels)
+		if shape == "" {
+			continue
+		}
+		products := byShape[shape]
+		if len(products) != 1 {
+			continue
+		}
+		for product := range products {
+			n.GPUPool = product
+		}
+	}
 }

--- a/pkg/alfred/snapshot/pools_test.go
+++ b/pkg/alfred/snapshot/pools_test.go
@@ -65,3 +65,135 @@ func TestGPUPoolIgnoresClassOverlap(t *testing.T) {
 		t.Fatalf("identical hardware must share one pool: %q vs %q", a, b)
 	}
 }
+
+// poolNode is a snapshot Node carrying just what reconcilePoolKeys reads.
+func poolNode(name string, gpus int64, labels map[string]string) *Node {
+	return &Node{
+		Name:      name,
+		Labels:    labels,
+		TotalGPUs: gpus,
+		GPUPool:   GPUPoolForNode(nodeWithLabels(labels), "nvidia.com/gpu"),
+	}
+}
+
+func h100(product string) map[string]string {
+	labels := map[string]string{"node.kubernetes.io/instance-type": "BM.GPU.H100.8"}
+	if product != "" {
+		labels["nvidia.com/gpu.product"] = product
+	}
+	return labels
+}
+
+func poolsOf(nodes map[string]*Node) map[string]int {
+	out := map[string]int{}
+	for _, n := range nodes {
+		out[n.GPUPool]++
+	}
+	return out
+}
+
+// TestReconcilePoolKeysHealsPartialGFD reproduces a partial GPU-feature-
+// discovery rollout: fourteen identical BM.GPU.H100.8 nodes where two are
+// missing the product label. Per-node derivation splits them 12/2, which
+// halves every score and makes migration between the halves impossible.
+func TestReconcilePoolKeysHealsPartialGFD(t *testing.T) {
+	const product = "NVIDIA-H100-80GB-HBM3"
+	nodes := map[string]*Node{}
+	for i := 0; i < 12; i++ {
+		name := "labelled-" + string(rune('a'+i))
+		nodes[name] = poolNode(name, 8, h100(product))
+	}
+	nodes["bare-1"] = poolNode("bare-1", 6, h100(""))
+	nodes["bare-2"] = poolNode("bare-2", 8, h100(""))
+
+	if got := poolsOf(nodes); len(got) != 2 || got["H100"] != 2 {
+		t.Fatalf("precondition: want the 12/2 split, got %v", got)
+	}
+
+	reconcilePoolKeys(nodes)
+
+	got := poolsOf(nodes)
+	if len(got) != 1 || got[product] != 14 {
+		t.Fatalf("want all 14 nodes in %q, got %v", product, got)
+	}
+}
+
+// TestReconcilePoolKeysKeepsGenuinePartition: several distinct products under
+// one shape is real hardware variance (MIG geometries, a mixed refresh). An
+// unlabelled node must not be guessed into either — merging distinct hardware
+// would produce a migration onto the wrong accelerator, while leaving it
+// split only costs opportunity.
+func TestReconcilePoolKeysKeepsGenuinePartition(t *testing.T) {
+	nodes := map[string]*Node{
+		"mig-1":  poolNode("mig-1", 8, h100("NVIDIA-H100-80GB-HBM3")),
+		"mig-2":  poolNode("mig-2", 8, h100("NVIDIA-H100-80GB-HBM3-MIG-1g.10gb")),
+		"bare-1": poolNode("bare-1", 8, h100("")),
+	}
+
+	reconcilePoolKeys(nodes)
+
+	if nodes["bare-1"].GPUPool != "H100" {
+		t.Fatalf("ambiguous group must leave the unlabelled node on its shape key, got %q",
+			nodes["bare-1"].GPUPool)
+	}
+	if nodes["mig-1"].GPUPool == nodes["mig-2"].GPUPool {
+		t.Fatalf("distinct products must stay distinct pools")
+	}
+}
+
+// TestReconcilePoolKeysNoOps covers the two states that are already correct —
+// GFD everywhere, and GFD nowhere — plus nodes it must not touch.
+func TestReconcilePoolKeysNoOps(t *testing.T) {
+	const product = "NVIDIA-A10"
+	a10 := func(p string) map[string]string {
+		labels := map[string]string{"node.kubernetes.io/instance-type": "BM.GPU.A10.4"}
+		if p != "" {
+			labels["nvidia.com/gpu.product"] = p
+		}
+		return labels
+	}
+
+	t.Run("gfd everywhere", func(t *testing.T) {
+		nodes := map[string]*Node{
+			"a": poolNode("a", 4, a10(product)),
+			"b": poolNode("b", 4, a10(product)),
+		}
+		reconcilePoolKeys(nodes)
+		if got := poolsOf(nodes); len(got) != 1 || got[product] != 2 {
+			t.Fatalf("want one pool, got %v", got)
+		}
+	})
+
+	t.Run("gfd nowhere", func(t *testing.T) {
+		nodes := map[string]*Node{
+			"a": poolNode("a", 4, a10("")),
+			"b": poolNode("b", 4, a10("")),
+		}
+		reconcilePoolKeys(nodes)
+		if got := poolsOf(nodes); len(got) != 1 || got["A10"] != 2 {
+			t.Fatalf("want one shape-keyed pool, got %v", got)
+		}
+	})
+
+	t.Run("no shape label is left alone", func(t *testing.T) {
+		nodes := map[string]*Node{
+			"labelled": poolNode("labelled", 4, a10(product)),
+			"bare":     poolNode("bare", 4, nil),
+		}
+		reconcilePoolKeys(nodes)
+		if nodes["bare"].GPUPool != "nvidia.com/gpu" {
+			t.Fatalf("a node with no shape cannot join a shape group, got %q", nodes["bare"].GPUPool)
+		}
+	})
+
+	t.Run("gpu-less nodes are ignored", func(t *testing.T) {
+		nodes := map[string]*Node{
+			"labelled": poolNode("labelled", 4, a10(product)),
+			"cpu":      poolNode("cpu", 0, a10("")),
+		}
+		reconcilePoolKeys(nodes)
+		if nodes["cpu"].GPUPool == product {
+			t.Fatalf("a GPU-less node must not be promoted into a GPU pool")
+		}
+	})
+}

--- a/pkg/alfred/snapshot/types.go
+++ b/pkg/alfred/snapshot/types.go
@@ -57,7 +57,9 @@ type Node struct {
 	// via GPUPoolForNode — GPU product label, instance shape, or the GPU
 	// resource name — never from AcceleratorClass.Status.Nodes, which is
 	// a selection surface that shape-scoped classes (H100x1..x8) can all
-	// claim without partitioning hardware. Empty only on GPU-less nodes.
+	// claim without partitioning hardware. Reconciled across the node set
+	// after derivation so a partial GPU-feature-discovery rollout cannot
+	// split one physical pool in two. Empty only on GPU-less nodes.
 	GPUPool string
 
 	// GPUResource is the extended resource name this node exposes


### PR DESCRIPTION
## What this PR does

Makes the GPU pool partition consistent across nodes of identical hardware.
Pool keys are still derived per node, but are now reconciled across the whole
node set before anything reads them.

The rule is per shape group:

- a group whose labelled members agree on a single GPU product adopts that
  product for every member, unlabelled ones included
- a group carrying several distinct products keeps its per-node keys, and an
  unlabelled node there stays on its shape key rather than being guessed into
  one of them

## Why we need it

`GPUPoolForNode` prefers `nvidia.com/gpu.product`, falling back to the
instance shape. That label comes from GPU feature discovery, which runs as a
DaemonSet — so a node GFD has not reached keys by shape while its identical
neighbours key by product, and one physical pool silently becomes two.

Observed on a live cluster, from `alfred_fragmentation_reclaimable`:

```
alfred_fragmentation_reclaimable{pool="A10"} 0
alfred_fragmentation_reclaimable{pool="H100"} 0
alfred_fragmentation_reclaimable{pool="NVIDIA-A10"} 0
alfred_fragmentation_reclaimable{pool="NVIDIA-H100-80GB-HBM3"} 0.009
```

All fourteen H100 nodes are `BM.GPU.H100.8`; twelve carry the product label
and two do not, so they split 12/2. The three A10 nodes split 2/1.

The damage is not cosmetic. Each half scores against only its own bins, so
`TotalFree`, slot counts and the FFD repack all shrink to the subset. And
because pool is a hard boundary in candidate selection — `instanceInPool`,
`componentPrimaryPool`, `schedulableBins` — no workload can migrate across
the split, even between adjacent nodes in the same rack. On that cluster a
fully-capacity 8-GPU H100 node sat in a two-node pool, invisible as a target
to the other twelve; the single-node A10 pool could never produce a candidate
at all, since ranking excludes the instance's own node.

This is the same corruption the existing doc comment rejects
`AcceleratorClass` for — "any first-wins tie-break would split one physical
pool across classes and corrupt per-pool scoring" — arriving through the
label-precedence ladder instead.

The asymmetry behind keeping ambiguous groups split: merging distinct
hardware is a correctness failure, because nothing downstream checks GPU
*type* (placement filters on counts and model reachability), so a merged pool
could propose migrating an H100 workload onto an A10 node. Splitting
identical hardware only costs opportunity. Faced with the choice, split.

## How to test

`go test ./pkg/alfred/snapshot/... -run TestReconcilePoolKeys`

`TestReconcilePoolKeysHealsPartialGFD` reconstructs the cluster above —
fourteen `BM.GPU.H100.8` nodes, twelve labelled, two bare — and asserts the
12/2 split as a *precondition* before asserting one pool of fourteen after,
so the test documents the bug and fails if the fix is gutted.

Also covered: several distinct products under one shape must not merge (MIG
geometries), GFD everywhere, GFD nowhere, nodes with no shape label, and
GPU-less nodes.

Operators hitting this today can also fix it by completing the GFD rollout —
or by removing GFD entirely, since both uniform states already partition
correctly. Only partial coverage breaks.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU pool assignment across nodes to prevent identical hardware from being split into separate pools during partial feature-discovery rollouts.
  * Preserved distinct pools when nodes use genuinely different GPU products.
  * Maintained correct handling for nodes without GPU or shape information.
  * Ensured snapshots expose unified pools for matching hardware.

* **Documentation**
  * Clarified how GPU pool assignments are reconciled across nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->