### PR TITLE
[Core] add stage:// storage protocol for shared-storage models

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -63,6 +63,12 @@ spec:
         - '1'
         - --same-path-wait-timeout
         - 30m
+        {{- with .Values.modelAgent.stage.sourceRoots }}
+        - --stage-source-roots
+        - {{ join "," . | quote }}
+        - --stage-concurrency
+        - {{ $.Values.modelAgent.stage.concurrency | quote }}
+        {{- end }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -202,6 +202,32 @@ modelAgent:
   #     readOnly: true
   extraVolumeMounts: []
 
+  # stage:// support. A stage:// model is copied from an already-mounted source
+  # directory onto the node's local disk, so inference reads local disk instead
+  # of the share on every pod start.
+  #
+  # sourceRoots is a security boundary: a stage:// URI may only name a path
+  # under one of these roots, because whatever is staged gets mounted into
+  # inference pods. Empty (the default) disables staging entirely.
+  #
+  # Mount the source with extraVolumes/extraVolumeMounts and keep the mountPath
+  # IDENTICAL to the hostPath — storageUri is read inside the container while
+  # spec.storage.path is a node path, and only identical paths keep those two
+  # in the same coordinate system:
+  #
+  #   extraVolumes:
+  #     - name: nfs-src
+  #       hostPath: { path: /mnt/nfs-src }
+  #   extraVolumeMounts:
+  #     - name: nfs-src
+  #       mountPath: /mnt/nfs-src
+  #       readOnly: true
+  stage:
+    sourceRoots: []
+    # Staging is bounded by the share's egress, not by this node, so it gets a
+    # lower limit than the download workers.
+    concurrency: 2
+
   tolerations:
     - key: nvidia.com/gpu
       operator: Exists

--- a/cmd/model-agent/main.go
+++ b/cmd/model-agent/main.go
@@ -44,6 +44,8 @@ type config struct {
 	numDownloadWorker     int
 	numHighPriorityWorker int
 	samePathWaitTimeout   time.Duration
+	stageSourceRoots      []string
+	stageConcurrency      int
 	namespace             string
 	logLevel              string
 }
@@ -76,6 +78,8 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cfg.numDownloadWorker, "num-download-worker", 5, "Number of download workers")
 	rootCmd.PersistentFlags().IntVar(&cfg.numHighPriorityWorker, "num-high-priority-worker", 1, "Number of high-priority workers for delete and same-path reuse tasks")
 	rootCmd.PersistentFlags().DurationVar(&cfg.samePathWaitTimeout, "same-path-wait-timeout", 30*time.Minute, "Maximum time to wait for same-path model reuse before falling back to normal download")
+	rootCmd.PersistentFlags().StringSliceVar(&cfg.stageSourceRoots, "stage-source-roots", nil, "Directories under which stage:// sources are allowed; staging is disabled when empty")
+	rootCmd.PersistentFlags().IntVar(&cfg.stageConcurrency, "stage-concurrency", 2, "Number of concurrent stage:// copies; bounded by the shared storage rather than by this node")
 	rootCmd.PersistentFlags().StringVar(&cfg.namespace, "namespace", "ome", "Kubernetes namespace to use")
 	rootCmd.PersistentFlags().StringVar(&cfg.logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 
@@ -267,6 +271,10 @@ func initializeComponents(
 		cfg.multipartConcurrency,
 		cfg.downloadRetry,
 		cfg.modelsRootDir,
+		modelagent.StageConfig{
+			SourceRoots: cfg.stageSourceRoots,
+			Concurrency: cfg.stageConcurrency,
+		},
 		gopherTaskChan,
 		cfg.samePathWaitTimeout,
 		nodeLabelReconciler,

--- a/cmd/model-agent/main.go
+++ b/cmd/model-agent/main.go
@@ -178,7 +178,7 @@ func initializePrometheusMetrics(logger *Logger) *modelagent.Metrics {
 	}
 
 	// Initialize metrics
-	metrics := modelagent.NewMetrics(nil)
+	metrics := modelagent.NewMetrics(nil, cfg.modelsRootDir)
 	logger.Info("Initialized Prometheus metrics")
 	return metrics
 }

--- a/pkg/hfutil/hub/utils.go
+++ b/pkg/hfutil/hub/utils.go
@@ -410,6 +410,13 @@ func CacheCommitHashForRevision(storageFolder, revision, commitHash string) erro
 	return nil
 }
 
+// AvailableDiskSpace returns the available disk space in bytes for the given
+// directory, so callers outside this package can report free space rather than
+// only assert against it.
+func AvailableDiskSpace(dir string) (int64, error) {
+	return getAvailableDiskSpace(dir)
+}
+
 // getAvailableDiskSpace returns the available disk space in bytes for the given directory
 // This is a cross-platform implementation
 func getAvailableDiskSpace(dir string) (int64, error) {

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -79,6 +79,9 @@ type Gopher struct {
 	samePathWaitDelay   time.Duration
 	samePathWaitTimeout time.Duration
 
+	stageConfig StageConfig
+	stageSlots  chan struct{}
+
 	startupReadyModelKeys map[string]struct{}
 }
 
@@ -99,6 +102,7 @@ func NewGopher(
 	multipartConcurrency int,
 	downloadRetry int,
 	modelRootDir string,
+	stageConfig StageConfig,
 	gopherChan chan *GopherTask,
 	samePathWaitTimeout time.Duration,
 	nodeLabelReconciler *NodeLabelReconciler,
@@ -112,6 +116,16 @@ func NewGopher(
 	}
 	if samePathWaitTimeout <= 0 {
 		samePathWaitTimeout = defaultSamePathWaitTimeout
+	}
+	if stageConfig.Concurrency <= 0 {
+		stageConfig.Concurrency = defaultStageConcurrency
+	}
+	// A source root that is not mounted yields nothing but per-model failures
+	// later, so say so once, loudly, at startup.
+	for _, root := range stageConfig.SourceRoots {
+		if _, statErr := os.Stat(root); statErr != nil {
+			logger.Errorf("Stage source root %s is not accessible: %v; stage:// models under it will fail", root, statErr)
+		}
 	}
 
 	return &Gopher{
@@ -133,6 +147,8 @@ func NewGopher(
 		taskQueue:              newGopherTaskQueue(),
 		samePathWaitDelay:      defaultSamePathWaitDelay,
 		samePathWaitTimeout:    samePathWaitTimeout,
+		stageConfig:            stageConfig,
+		stageSlots:             make(chan struct{}, stageConfig.Concurrency),
 	}, nil
 }
 
@@ -530,6 +546,12 @@ func (s *Gopher) processTaskWithOptions(task *GopherTask, allowFallbackDownload 
 			if err := s.processLocalStorageModel(ctx, task, baseModelSpec, modelInfo, modelType, namespace, name); err != nil {
 				return err
 			}
+		case storage.StorageTypeStage:
+			s.logger.Infof("Processing stage storage type for model %s", modelInfo)
+			// Stage storage copies the model from a mounted source onto local disk
+			if err := s.processStageStorageModel(ctx, task, baseModelSpec, modelInfo, modelType, namespace, name); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unknown storage type %s", storageType)
 		}
@@ -641,6 +663,18 @@ func (s *Gopher) processTaskWithOptions(task *GopherTask, allowFallbackDownload 
 				}
 			} else {
 				s.logger.Infof("no need to delete parent model artifact directory %s: %s", parentName, parentDir)
+			}
+		case storage.StorageTypeStage:
+			// Only the node-local copy goes; the shared source is never ours to delete.
+			destPath, pathErr := s.stageDestPath(baseModelSpec)
+			if pathErr != nil {
+				s.logger.Errorf("Cannot determine stage destination for model %s: %v", modelInfo, pathErr)
+				break
+			}
+			s.logger.Infof("Removing staged copy of model %s at %s", modelInfo, destPath)
+			if err = s.deleteModel(destPath, task); err != nil {
+				s.logger.Errorf("Failed to delete staged model %s: %v", modelInfo, err)
+				return err
 			}
 		case storage.StorageTypeLocal:
 			s.logger.Infof("Skipping deletion for local storage model %s (local files should not be deleted)", modelInfo)

--- a/pkg/modelagent/gopher_stage.go
+++ b/pkg/modelagent/gopher_stage.go
@@ -1,0 +1,165 @@
+package modelagent
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/hfutil/hub"
+	"sigs.k8s.io/ome/pkg/modelagent/stage"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// StageConfig configures how stage:// models are copied onto this node.
+type StageConfig struct {
+	// SourceRoots limits which paths a stage:// URI may name. Empty disables
+	// staging entirely — this is a security boundary, not a convenience,
+	// because whatever is staged ends up mounted into inference pods.
+	SourceRoots []string
+	// Concurrency caps simultaneous staging operations. Staging is bound by the
+	// shared storage's egress rather than by this node, so it gets its own
+	// limit instead of reusing the download concurrency.
+	Concurrency int
+}
+
+const defaultStageConcurrency = 2
+
+// stageDestPath returns the node-local directory a stage:// model is copied to.
+//
+// Unlike the object-storage protocols, stage:// cannot fall back to
+// getDestPath's modelRootDir + storageUri form: that would build a directory
+// literally named after the URI.
+func (s *Gopher) stageDestPath(baseModelSpec v1beta1.BaseModelSpec) (string, error) {
+	if baseModelSpec.Storage == nil || baseModelSpec.Storage.Path == nil || *baseModelSpec.Storage.Path == "" {
+		return "", fmt.Errorf("stage:// requires spec.storage.path to name the node-local destination")
+	}
+
+	destPath := *baseModelSpec.Storage.Path
+	if !strings.HasPrefix(destPath, "/") {
+		return "", fmt.Errorf("stage:// destination %q must be an absolute path", destPath)
+	}
+
+	return filepath.Clean(destPath), nil
+}
+
+// processStageStorageModel copies a model from an already-mounted source
+// directory onto this node's local disk.
+//
+// For stage storage:
+//   - Download: copies source -> spec.storage.path, atomically, then parses the
+//     model configuration from the copy
+//   - Delete: removes the node-local copy only; the source is left untouched
+func (s *Gopher) processStageStorageModel(ctx context.Context, task *GopherTask, baseModelSpec v1beta1.BaseModelSpec,
+	modelInfo, modelType, namespace, name string) error {
+
+	components, err := storage.ParseStageStorageURI(*baseModelSpec.Storage.StorageUri)
+	if err != nil {
+		s.logger.Errorf("Failed to parse stage storage URI for model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "invalid_stage_uri")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	destPath, err := s.stageDestPath(baseModelSpec)
+	if err != nil {
+		s.logger.Errorf("Invalid stage destination for model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "invalid_stage_destination")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	release, err := s.acquireStageSlot(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	alwaysCopy := baseModelSpec.Storage.DownloadPolicy != nil &&
+		*baseModelSpec.Storage.DownloadPolicy == v1beta1.AlwaysDownload
+
+	if err := s.checkStageDiskSpace(components.SourcePath, destPath, alwaysCopy); err != nil {
+		s.logger.Errorf("Cannot stage model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "insufficient_disk_space")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	s.logger.Infof("Staging model %s from %s to %s", modelInfo, components.SourcePath, destPath)
+	result, err := stage.Run(components.SourcePath, destPath, stage.Options{
+		SourceRoots: s.stageConfig.SourceRoots,
+		AlwaysCopy:  alwaysCopy,
+	})
+	if err != nil {
+		s.logger.Errorf("Failed to stage model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "stage_failed")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	if result.Copied {
+		s.metrics.RecordBytesTransferred(modelType, namespace, name, result.BytesCopied)
+		s.logger.Infof("Staged model %s to %s (%d bytes)", modelInfo, destPath, result.BytesCopied)
+	} else {
+		s.logger.Infof("Reusing existing stage of model %s at %s", modelInfo, destPath)
+	}
+
+	var baseModel *v1beta1.BaseModel
+	var clusterBaseModel *v1beta1.ClusterBaseModel
+	if task.BaseModel != nil {
+		baseModel = task.BaseModel
+	} else if task.ClusterBaseModel != nil {
+		clusterBaseModel = task.ClusterBaseModel
+	}
+
+	if err := s.safeParseAndUpdateModelConfig(destPath, baseModel, clusterBaseModel, nil); err != nil {
+		// Consistent with the other protocols: a model whose config we cannot
+		// parse may still be servable.
+		s.logger.Errorf("Failed to parse and update model config for staged model %s: %v", modelInfo, err)
+	}
+
+	return nil
+}
+
+// checkStageDiskSpace fails early when the node cannot hold the copy. Without
+// it a full disk surfaces as a partial copy far into the transfer.
+func (s *Gopher) checkStageDiskSpace(sourcePath, destPath string, alwaysCopy bool) error {
+	resolvedSource, err := stage.ResolveSource(sourcePath, s.stageConfig.SourceRoots)
+	if err != nil {
+		return err
+	}
+
+	if !alwaysCopy {
+		staged, err := stage.IsStaged(destPath, resolvedSource)
+		if err != nil {
+			return err
+		}
+		if staged {
+			// Nothing will be written, so sizing the source is wasted walking.
+			return nil
+		}
+	}
+
+	size, err := stage.DirSize(resolvedSource)
+	if err != nil {
+		return err
+	}
+
+	return hub.CheckDiskSpace(size, filepath.Dir(destPath))
+}
+
+// acquireStageSlot blocks until a staging slot is free, and returns the
+// function that gives it back.
+func (s *Gopher) acquireStageSlot(ctx context.Context) (func(), error) {
+	if s.stageSlots == nil {
+		return func() {}, nil
+	}
+
+	select {
+	case s.stageSlots <- struct{}{}:
+		return func() { <-s.stageSlots }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/pkg/modelagent/gopher_stage.go
+++ b/pkg/modelagent/gopher_stage.go
@@ -87,7 +87,7 @@ func (s *Gopher) processStageStorageModel(ctx context.Context, task *GopherTask,
 	}
 
 	s.logger.Infof("Staging model %s from %s to %s", modelInfo, components.SourcePath, destPath)
-	result, err := stage.Run(components.SourcePath, destPath, stage.Options{
+	result, err := stage.Run(ctx, components.SourcePath, destPath, stage.Options{
 		SourceRoots: s.stageConfig.SourceRoots,
 		AlwaysCopy:  alwaysCopy,
 	})

--- a/pkg/modelagent/gopher_stage_test.go
+++ b/pkg/modelagent/gopher_stage_test.go
@@ -1,0 +1,59 @@
+package modelagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func stageSpec(path *string) v1beta1.BaseModelSpec {
+	uri := "stage:///mnt/nfs-src/qwen/Qwen3-32B"
+	return v1beta1.BaseModelSpec{
+		Storage: &v1beta1.StorageSpec{
+			StorageUri: &uri,
+			Path:       path,
+		},
+	}
+}
+
+func TestStageDestPathUsesStoragePath(t *testing.T) {
+	g := &Gopher{logger: zap.NewNop().Sugar(), modelRootDir: "/mnt/data/models"}
+	path := "/mnt/data/models/qwen3-32b"
+
+	got, err := g.stageDestPath(stageSpec(&path))
+
+	require.NoError(t, err)
+	assert.Equal(t, "/mnt/data/models/qwen3-32b", got)
+}
+
+// getDestPath falls back to modelRootDir + storageUri when Path is unset, which
+// for stage:// would build a directory literally named after the URI.
+func TestStageDestPathRejectsMissingPath(t *testing.T) {
+	g := &Gopher{logger: zap.NewNop().Sugar(), modelRootDir: "/mnt/data/models"}
+
+	_, err := g.stageDestPath(stageSpec(nil))
+
+	assert.ErrorContains(t, err, "requires spec.storage.path")
+}
+
+func TestStageDestPathRejectsEmptyPath(t *testing.T) {
+	g := &Gopher{logger: zap.NewNop().Sugar(), modelRootDir: "/mnt/data/models"}
+	empty := ""
+
+	_, err := g.stageDestPath(stageSpec(&empty))
+
+	assert.ErrorContains(t, err, "requires spec.storage.path")
+}
+
+func TestStageDestPathRejectsRelativePath(t *testing.T) {
+	g := &Gopher{logger: zap.NewNop().Sugar(), modelRootDir: "/mnt/data/models"}
+	relative := "models/qwen3-32b"
+
+	_, err := g.stageDestPath(stageSpec(&relative))
+
+	assert.ErrorContains(t, err, "must be an absolute path")
+}

--- a/pkg/modelagent/metrics.go
+++ b/pkg/modelagent/metrics.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/hfutil/hub"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -40,10 +41,31 @@ type Metrics struct {
 }
 
 // NewMetrics creates a new Metrics struct with initialized Prometheus metrics
-func NewMetrics(registerer prometheus.Registerer) *Metrics {
+func NewMetrics(registerer prometheus.Registerer, modelsRootDir string) *Metrics {
 	if registerer == nil {
 		registerer = prometheus.DefaultRegisterer
 	}
+
+	// There is no eviction: a full models root turns into failed downloads that
+	// only a human can clear. Publishing free space is what makes that visible
+	// before it happens, and what the console reads to warn before staging.
+	modelsRootFreeBytes := promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+		Name: "model_agent_models_root_free_bytes",
+		Help: "Free bytes on the filesystem holding the models root directory",
+	})
+	updateModelsRootFreeBytes := func() {
+		available, err := hub.AvailableDiskSpace(modelsRootDir)
+		if err != nil {
+			// An unreadable models root must not take the agent down; 0 reads
+			// as "unknown or full", which is the safe direction for an alert.
+			modelsRootFreeBytes.Set(0)
+			return
+		}
+		modelsRootFreeBytes.Set(float64(available))
+	}
+	// Publish once synchronously so the gauge is meaningful immediately after
+	// startup rather than after the first tick.
+	updateModelsRootFreeBytes()
 
 	// Manual Go metrics for more detailed tracking
 	goGoroutines := promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
@@ -131,6 +153,8 @@ func NewMetrics(registerer prometheus.Registerer) *Metrics {
 					goGCDuration.Observe(float64(memStats.PauseNs[pauseIndex]) / 1e9)
 				}
 			}
+
+			updateModelsRootFreeBytes()
 
 			time.Sleep(15 * time.Second)
 		}

--- a/pkg/modelagent/metrics_disk_test.go
+++ b/pkg/modelagent/metrics_disk_test.go
@@ -1,6 +1,8 @@
 package modelagent
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,8 +23,12 @@ func TestNewMetricsPublishesModelsRootFreeBytes(t *testing.T) {
 
 func TestNewMetricsToleratesUnreadableModelsRoot(t *testing.T) {
 	reg := prometheus.NewRegistry()
+	// A regular file can never become a models root; an absent path would just
+	// be created by EnsureDir when the agent runs as root.
+	notADir := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
 
-	metrics := NewMetrics(reg, "/definitely/not/a/real/path")
+	metrics := NewMetrics(reg, notADir)
 
 	require.NotNil(t, metrics)
 	assert.Equal(t, float64(0), gaugeValue(t, reg, "model_agent_models_root_free_bytes"))

--- a/pkg/modelagent/metrics_disk_test.go
+++ b/pkg/modelagent/metrics_disk_test.go
@@ -1,0 +1,44 @@
+package modelagent
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The platform shows "staging needs X, node has Y free" before creating models,
+// and there is no eviction to fall back on, so the free-space gauge has to be
+// readable at any time — not only right after a staging run.
+func TestNewMetricsPublishesModelsRootFreeBytes(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	_ = NewMetrics(reg, t.TempDir())
+
+	assert.Greater(t, gaugeValue(t, reg, "model_agent_models_root_free_bytes"), float64(0))
+}
+
+func TestNewMetricsToleratesUnreadableModelsRoot(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	metrics := NewMetrics(reg, "/definitely/not/a/real/path")
+
+	require.NotNil(t, metrics)
+	assert.Equal(t, float64(0), gaugeValue(t, reg, "model_agent_models_root_free_bytes"))
+}
+
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		require.Len(t, family.GetMetric(), 1)
+		return family.GetMetric()[0].GetGauge().GetValue()
+	}
+	t.Fatalf("metric %s not registered", name)
+	return 0
+}

--- a/pkg/modelagent/metrics_test.go
+++ b/pkg/modelagent/metrics_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewMetrics_RegistersMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	metrics := NewMetrics(reg)
+	metrics := NewMetrics(reg, t.TempDir())
 
 	// Test that custom counters are registered and can be incremented
 	metrics.modelDownloadsSuccessTotal.WithLabelValues("testtype", "testns", "testmodel").Inc()
@@ -33,7 +33,7 @@ func TestNewMetrics_RegistersMetrics(t *testing.T) {
 
 func TestGoRuntimeMetrics_AreSet(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	_ = NewMetrics(reg)
+	_ = NewMetrics(reg, t.TempDir())
 
 	// Wait for the goroutine to update runtime metrics
 	time.Sleep(200 * time.Millisecond)

--- a/pkg/modelagent/stage/source.go
+++ b/pkg/modelagent/stage/source.go
@@ -1,0 +1,66 @@
+// Package stage implements staging a model from an already-mounted source
+// directory onto the node's local disk, which is what the stage:// storage
+// protocol does. It deliberately knows nothing about Kubernetes or about the
+// model agent: everything here is plain filesystem work.
+package stage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveSource checks that sourcePath is a directory contained in one of the
+// configured roots, and returns its symlink-resolved absolute path.
+//
+// The roots are a security boundary, not a convenience: stage:// lets the
+// author of a BaseModel name any path the agent can read, and whatever is
+// staged ends up mounted into inference pods. Resolution happens before the
+// containment check so a symlink under a root cannot be used to escape it.
+func ResolveSource(sourcePath string, roots []string) (string, error) {
+	if len(roots) == 0 {
+		return "", fmt.Errorf("no stage source roots configured: staging is disabled unless --stage-source-roots is set")
+	}
+
+	resolvedSource, err := filepath.EvalSymlinks(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("stage source %q does not exist", sourcePath)
+		}
+		return "", fmt.Errorf("failed to resolve stage source %q: %w", sourcePath, err)
+	}
+
+	info, err := os.Stat(resolvedSource)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat stage source %q: %w", sourcePath, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("stage source %q is not a directory", sourcePath)
+	}
+
+	for _, root := range roots {
+		resolvedRoot, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			// A misconfigured root must not silently widen or narrow the
+			// boundary; skip it and let the remaining roots decide.
+			continue
+		}
+		if contains(resolvedRoot, resolvedSource) {
+			return resolvedSource, nil
+		}
+	}
+
+	return "", fmt.Errorf("stage source %q resolves to %q, which is outside the configured stage source roots %v",
+		sourcePath, resolvedSource, roots)
+}
+
+// contains reports whether path is root itself or lives beneath it. Comparison
+// is per path segment: a string prefix check would let /mnt/nfs authorize
+// /mnt/nfs-evil.
+func contains(root, path string) bool {
+	if root == path {
+		return true
+	}
+	return strings.HasPrefix(path, strings.TrimSuffix(root, string(os.PathSeparator))+string(os.PathSeparator))
+}

--- a/pkg/modelagent/stage/source_test.go
+++ b/pkg/modelagent/stage/source_test.go
@@ -1,0 +1,106 @@
+package stage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSourceRejectsWhenNoRootsConfigured(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "qwen")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+
+	_, err := ResolveSource(src, nil)
+
+	assert.ErrorContains(t, err, "no stage source roots configured")
+}
+
+func TestResolveSourceAcceptsPathUnderRoot(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "qwen", "Qwen3-32B")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+
+	got, err := ResolveSource(src, []string{root})
+
+	require.NoError(t, err)
+	assert.Equal(t, mustEvalSymlinks(t, src), got)
+}
+
+func TestResolveSourceRejectsPathOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	src := filepath.Join(outside, "qwen")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+
+	_, err := ResolveSource(src, []string{root})
+
+	assert.ErrorContains(t, err, "outside the configured stage source roots")
+}
+
+// A root of /mnt/nfs must not authorize /mnt/nfs-evil: plain string prefixing
+// would let a sibling directory through.
+func TestResolveSourceRejectsSiblingWithRootAsStringPrefix(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "nfs")
+	sibling := filepath.Join(parent, "nfs-evil")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.MkdirAll(sibling, 0o755))
+
+	_, err := ResolveSource(sibling, []string{root})
+
+	assert.ErrorContains(t, err, "outside the configured stage source roots")
+}
+
+// A symlink living under the root but pointing outside it must be rejected:
+// the containment check has to run on the resolved path, not the declared one.
+func TestResolveSourceRejectsSymlinkEscapingRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	secrets := filepath.Join(outside, "secrets")
+	require.NoError(t, os.MkdirAll(secrets, 0o755))
+
+	link := filepath.Join(root, "escape")
+	require.NoError(t, os.Symlink(secrets, link))
+
+	_, err := ResolveSource(link, []string{root})
+
+	assert.ErrorContains(t, err, "outside the configured stage source roots")
+}
+
+func TestResolveSourceAcceptsRootItself(t *testing.T) {
+	root := t.TempDir()
+
+	got, err := ResolveSource(root, []string{root})
+
+	require.NoError(t, err)
+	assert.Equal(t, mustEvalSymlinks(t, root), got)
+}
+
+func TestResolveSourceRejectsMissingPath(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := ResolveSource(filepath.Join(root, "absent"), []string{root})
+
+	assert.ErrorContains(t, err, "does not exist")
+}
+
+func TestResolveSourceRejectsFile(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "config.json")
+	require.NoError(t, os.WriteFile(file, []byte("{}"), 0o644))
+
+	_, err := ResolveSource(file, []string{root})
+
+	assert.ErrorContains(t, err, "not a directory")
+}
+
+func mustEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return resolved
+}

--- a/pkg/modelagent/stage/stage.go
+++ b/pkg/modelagent/stage/stage.go
@@ -1,0 +1,283 @@
+package stage
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// MarkerFileName is written at the root of a staged model once the copy has
+// finished. Its presence is what distinguishes a complete stage from a
+// directory left behind by an interrupted one — the agent only stats the model
+// path, so without this an aborted copy would be served as if it were whole.
+const MarkerFileName = ".ome-stage-complete"
+
+// Marker records what a completed stage contains.
+type Marker struct {
+	SourcePath  string    `json:"sourcePath"`
+	TotalBytes  int64     `json:"totalBytes"`
+	CompletedAt time.Time `json:"completedAt"`
+}
+
+// Options configures a staging run.
+type Options struct {
+	// SourceRoots limits which paths may be staged. Empty means staging is off.
+	SourceRoots []string
+	// AlwaysCopy re-copies even when a completed stage is already present.
+	// It carries DownloadPolicy=AlwaysDownload.
+	AlwaysCopy bool
+}
+
+// Result describes what a staging run did.
+type Result struct {
+	// Copied is false when an existing completed stage was reused.
+	Copied bool
+	// BytesCopied counts regular file bytes written; zero when reusing.
+	BytesCopied int64
+	// SourcePath is the symlink-resolved source that was staged.
+	SourcePath string
+}
+
+// Run copies the model at sourcePath onto the node's local disk at destPath.
+//
+// The copy lands in a sibling staging directory and is renamed into place only
+// once it is complete, so destPath either does not exist or is a whole model.
+func Run(sourcePath, destPath string, opts Options) (*Result, error) {
+	resolvedSource, err := ResolveSource(sourcePath, opts.SourceRoots)
+	if err != nil {
+		return nil, err
+	}
+
+	// Staging into the source would copy the tree into itself. The comparison
+	// needs both sides symlink-resolved, and the destination usually does not
+	// exist yet, hence resolveExistingAncestor.
+	resolvedDest, err := resolveExistingAncestor(destPath)
+	if err != nil {
+		return nil, err
+	}
+	if contains(resolvedSource, resolvedDest) {
+		return nil, fmt.Errorf("stage destination %q must not be inside the source %q", destPath, sourcePath)
+	}
+
+	if !opts.AlwaysCopy {
+		staged, err := IsStaged(destPath, resolvedSource)
+		if err != nil {
+			return nil, err
+		}
+		if staged {
+			return &Result{Copied: false, SourcePath: resolvedSource}, nil
+		}
+	}
+
+	destParent := filepath.Dir(destPath)
+	if err := os.MkdirAll(destParent, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create stage destination parent %q: %w", destParent, err)
+	}
+
+	// Same directory as the destination, so the final rename stays within one
+	// filesystem and is therefore atomic.
+	stagingDir, err := os.MkdirTemp(destParent, filepath.Base(destPath)+".staging-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create staging directory under %q: %w", destParent, err)
+	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+
+	bytesCopied, err := copyTree(resolvedSource, stagingDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stage %q: %w", sourcePath, err)
+	}
+
+	if err := writeMarker(stagingDir, Marker{
+		SourcePath:  resolvedSource,
+		TotalBytes:  bytesCopied,
+		CompletedAt: time.Now().UTC(),
+	}); err != nil {
+		return nil, err
+	}
+
+	// A previous stage (or an interrupted one) has to go before the rename;
+	// rename onto a non-empty directory fails.
+	if err := os.RemoveAll(destPath); err != nil {
+		return nil, fmt.Errorf("failed to clear stage destination %q: %w", destPath, err)
+	}
+	if err := os.Rename(stagingDir, destPath); err != nil {
+		return nil, fmt.Errorf("failed to publish stage destination %q: %w", destPath, err)
+	}
+	succeeded = true
+
+	return &Result{Copied: true, BytesCopied: bytesCopied, SourcePath: resolvedSource}, nil
+}
+
+// IsStaged reports whether destPath already holds a completed stage of
+// sourcePath.
+func IsStaged(destPath, sourcePath string) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(destPath, MarkerFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read stage marker in %q: %w", destPath, err)
+	}
+
+	var marker Marker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		// An unreadable marker is treated as no marker: re-staging is safe,
+		// serving a possibly-truncated model is not.
+		return false, nil
+	}
+
+	return marker.SourcePath == sourcePath, nil
+}
+
+// DirSize sums the size of every regular file under path.
+func DirSize(path string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(entry string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to size %q: %w", path, err)
+	}
+	return total, nil
+}
+
+// resolveExistingAncestor resolves symlinks in path, tolerating a path that
+// does not exist yet: it resolves the deepest existing ancestor and re-appends
+// the missing components.
+func resolveExistingAncestor(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve stage destination %q: %w", path, err)
+	}
+
+	remainder := ""
+	current := filepath.Clean(absolute)
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			return filepath.Join(resolved, remainder), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to resolve stage destination %q: %w", path, err)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached the filesystem root without finding anything that exists.
+			return filepath.Join(current, remainder), nil
+		}
+		remainder = filepath.Join(filepath.Base(current), remainder)
+		current = parent
+	}
+}
+
+func writeMarker(dir string, marker Marker) error {
+	data, err := json.Marshal(marker)
+	if err != nil {
+		return fmt.Errorf("failed to encode stage marker: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, MarkerFileName), data, 0o644); err != nil {
+		return fmt.Errorf("failed to write stage marker in %q: %w", dir, err)
+	}
+	return nil
+}
+
+// copyTree copies the contents of src into dst, which must already exist, and
+// returns the number of regular file bytes written.
+func copyTree(src, dst string) (int64, error) {
+	var total int64
+
+	err := filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+
+		switch {
+		case d.IsDir():
+			if rel == "." {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			return os.MkdirAll(target, info.Mode().Perm())
+		case d.Type()&os.ModeSymlink != 0:
+			// Copy the link itself; resolving it could pull in data from
+			// outside the source roots.
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(linkTarget, target)
+		case d.Type().IsRegular():
+			n, err := copyFile(path, target, d)
+			if err != nil {
+				return err
+			}
+			total += n
+			return nil
+		default:
+			// Sockets, devices and pipes have no place in a model directory.
+			return nil
+		}
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return total, nil
+}
+
+func copyFile(src, dst string, entry os.DirEntry) (int64, error) {
+	info, err := entry.Info()
+	if err != nil {
+		return 0, err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return 0, err
+	}
+
+	written, err := io.Copy(out, in)
+	if closeErr := out.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	return written, nil
+}

--- a/pkg/modelagent/stage/stage.go
+++ b/pkg/modelagent/stage/stage.go
@@ -1,6 +1,7 @@
 package stage
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -45,7 +46,10 @@ type Result struct {
 //
 // The copy lands in a sibling staging directory and is renamed into place only
 // once it is complete, so destPath either does not exist or is a whole model.
-func Run(sourcePath, destPath string, opts Options) (*Result, error) {
+// Cancelling ctx aborts the copy between entries and leaves nothing behind —
+// staging a large model runs for minutes, and a task nobody is waiting on
+// should stop pulling from the share.
+func Run(ctx context.Context, sourcePath, destPath string, opts Options) (*Result, error) {
 	resolvedSource, err := ResolveSource(sourcePath, opts.SourceRoots)
 	if err != nil {
 		return nil, err
@@ -83,6 +87,11 @@ func Run(sourcePath, destPath string, opts Options) (*Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create staging directory under %q: %w", destParent, err)
 	}
+	// MkdirTemp creates 0700; this directory becomes the published model, and a
+	// runtime that drops privileges has to be able to traverse it.
+	if err := os.Chmod(stagingDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to set permissions on staging directory %q: %w", stagingDir, err)
+	}
 	succeeded := false
 	defer func() {
 		if !succeeded {
@@ -90,7 +99,7 @@ func Run(sourcePath, destPath string, opts Options) (*Result, error) {
 		}
 	}()
 
-	bytesCopied, err := copyTree(resolvedSource, stagingDir)
+	bytesCopied, err := copyTree(ctx, resolvedSource, stagingDir, resolveRoots(opts.SourceRoots))
 	if err != nil {
 		return nil, fmt.Errorf("failed to stage %q: %w", sourcePath, err)
 	}
@@ -100,6 +109,12 @@ func Run(sourcePath, destPath string, opts Options) (*Result, error) {
 		TotalBytes:  bytesCopied,
 		CompletedAt: time.Now().UTC(),
 	}); err != nil {
+		return nil, err
+	}
+
+	// Publishing a copy the caller has already given up on would resurrect a
+	// model that may since have been deleted.
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
@@ -201,13 +216,40 @@ func writeMarker(dir string, marker Marker) error {
 	return nil
 }
 
+// resolveRoots returns the symlink-resolved form of each root, dropping the
+// ones that cannot be resolved: a root that is not mounted must neither widen
+// nor narrow the boundary.
+func resolveRoots(roots []string) []string {
+	resolved := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if r, err := filepath.EvalSymlinks(root); err == nil {
+			resolved = append(resolved, r)
+		}
+	}
+	return resolved
+}
+
+func containedInAny(path string, roots []string) bool {
+	for _, root := range roots {
+		if contains(root, path) {
+			return true
+		}
+	}
+	return false
+}
+
 // copyTree copies the contents of src into dst, which must already exist, and
-// returns the number of regular file bytes written.
-func copyTree(src, dst string) (int64, error) {
+// returns the number of regular file bytes written. Symlinks are staged
+// verbatim, so their targets are held to the same allowlist as the source
+// itself.
+func copyTree(ctx context.Context, src, dst string, roots []string) (int64, error) {
 	var total int64
 
 	err := filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
@@ -228,11 +270,20 @@ func copyTree(src, dst string) (int64, error) {
 			}
 			return os.MkdirAll(target, info.Mode().Perm())
 		case d.Type()&os.ModeSymlink != 0:
-			// Copy the link itself; resolving it could pull in data from
-			// outside the source roots.
+			// The link is copied rather than followed, so the staged tree can
+			// still reach whatever it points at. Resolve it lexically — a
+			// dangling link must be judged too — and hold it to the allowlist.
 			linkTarget, err := os.Readlink(path)
 			if err != nil {
 				return err
+			}
+			resolvedTarget := linkTarget
+			if !filepath.IsAbs(resolvedTarget) {
+				resolvedTarget = filepath.Join(filepath.Dir(path), resolvedTarget)
+			}
+			resolvedTarget = filepath.Clean(resolvedTarget)
+			if !containedInAny(resolvedTarget, roots) {
+				return fmt.Errorf("symlink %q points to %q, which is outside the configured stage source roots", path, resolvedTarget)
 			}
 			return os.Symlink(linkTarget, target)
 		case d.Type().IsRegular():

--- a/pkg/modelagent/stage/stage_test.go
+++ b/pkg/modelagent/stage/stage_test.go
@@ -1,6 +1,7 @@
 package stage
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +29,7 @@ func TestRunCopiesTreeToDestination(t *testing.T) {
 	root, src := newSource(t)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
 
-	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	result, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	assert.True(t, result.Copied)
@@ -40,7 +41,7 @@ func TestRunReportsBytesCopied(t *testing.T) {
 	root, src := newSource(t)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
 
-	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	result, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(`{"a":1}`)+len("weights")), result.BytesCopied)
@@ -50,7 +51,7 @@ func TestRunWritesCompletionMarker(t *testing.T) {
 	root, src := newSource(t)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
 
-	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	assert.FileExists(t, filepath.Join(dest, MarkerFileName))
@@ -61,7 +62,7 @@ func TestRunLeavesNoStagingDirectoryBehind(t *testing.T) {
 	destParent := t.TempDir()
 	dest := filepath.Join(destParent, "qwen3-32b")
 
-	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	entries, err := os.ReadDir(destParent)
@@ -73,12 +74,12 @@ func TestRunLeavesNoStagingDirectoryBehind(t *testing.T) {
 func TestRunReusesCompletedStage(t *testing.T) {
 	root, src := newSource(t)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
-	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 	require.NoError(t, err)
 	// A second copy would overwrite this marker file we planted in the destination.
 	require.NoError(t, os.WriteFile(filepath.Join(dest, "config.json"), []byte("untouched"), 0o644))
 
-	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	result, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	assert.False(t, result.Copied)
@@ -88,11 +89,11 @@ func TestRunReusesCompletedStage(t *testing.T) {
 func TestRunRecopiesWhenAlwaysCopyRequested(t *testing.T) {
 	root, src := newSource(t)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
-	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dest, "config.json"), []byte("stale"), 0o644))
 
-	result, err := Run(src, dest, Options{SourceRoots: []string{root}, AlwaysCopy: true})
+	result, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}, AlwaysCopy: true})
 
 	require.NoError(t, err)
 	assert.True(t, result.Copied)
@@ -107,7 +108,7 @@ func TestRunRestagesDestinationWithoutMarker(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dest, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dest, "config.json"), []byte("half"), 0o644))
 
-	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	result, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	assert.True(t, result.Copied)
@@ -119,10 +120,10 @@ func TestRunRestagesWhenMarkerNamesDifferentSource(t *testing.T) {
 	other := filepath.Join(root, "qwen", "Qwen3-8B")
 	writeModel(t, other)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
-	_, err := Run(other, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), other, dest, Options{SourceRoots: []string{root}})
 	require.NoError(t, err)
 
-	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	result, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.NoError(t, err)
 	assert.True(t, result.Copied)
@@ -132,7 +133,7 @@ func TestRunRejectsSourceOutsideRoots(t *testing.T) {
 	_, src := newSource(t)
 	dest := filepath.Join(t.TempDir(), "qwen3-32b")
 
-	_, err := Run(src, dest, Options{SourceRoots: []string{t.TempDir()}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{t.TempDir()}})
 
 	assert.ErrorContains(t, err, "outside the configured stage source roots")
 }
@@ -141,7 +142,7 @@ func TestRunRejectsDestinationInsideSource(t *testing.T) {
 	root, src := newSource(t)
 	dest := filepath.Join(src, "copy")
 
-	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	assert.ErrorContains(t, err, "must not be inside")
 }
@@ -149,7 +150,7 @@ func TestRunRejectsDestinationInsideSource(t *testing.T) {
 func TestRunRejectsDestinationEqualToSource(t *testing.T) {
 	root, src := newSource(t)
 
-	_, err := Run(src, src, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, src, Options{SourceRoots: []string{root}})
 
 	assert.ErrorContains(t, err, "must not be inside")
 }
@@ -157,6 +158,9 @@ func TestRunRejectsDestinationEqualToSource(t *testing.T) {
 // A failed copy must not leave a destination behind: the node label reconciler
 // would then advertise the model as present.
 func TestRunLeavesNoDestinationWhenCopyFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the mode bits this test relies on to fail the copy")
+	}
 	root, src := newSource(t)
 	unreadable := filepath.Join(src, "locked.bin")
 	require.NoError(t, os.WriteFile(unreadable, []byte("secret"), 0o000))
@@ -164,7 +168,7 @@ func TestRunLeavesNoDestinationWhenCopyFails(t *testing.T) {
 	destParent := t.TempDir()
 	dest := filepath.Join(destParent, "qwen3-32b")
 
-	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
 
 	require.Error(t, err)
 	assert.NoDirExists(t, dest)
@@ -187,4 +191,66 @@ func mustRead(t *testing.T, path string) []byte {
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return data
+}
+
+// MkdirTemp creates 0700, which after the rename would leave a model directory
+// only root can traverse — inference runtimes that drop privileges could not
+// read the weights.
+func TestRunPublishesTraversableDestination(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+// A symlink is staged verbatim, so one pointing outside the configured roots
+// would hand inference pods a path the allowlist exists to deny.
+func TestRunRejectsSymlinkEscapingRootsInsideSource(t *testing.T) {
+	root, src := newSource(t)
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(secret, filepath.Join(src, "leak")))
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
+
+	assert.ErrorContains(t, err, "outside the configured stage source roots")
+	assert.NoDirExists(t, dest)
+}
+
+func TestRunKeepsSymlinkResolvingInsideRoots(t *testing.T) {
+	root, src := newSource(t)
+	require.NoError(t, os.Symlink("config.json", filepath.Join(src, "config-link.json")))
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	_, err := Run(context.Background(), src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	target, err := os.Readlink(filepath.Join(dest, "config-link.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "config.json", target)
+}
+
+// Staging a large model takes minutes; a cancelled task must stop copying
+// rather than run to completion against a share nobody is waiting on.
+func TestRunStopsOnCancelledContext(t *testing.T) {
+	root, src := newSource(t)
+	destParent := t.TempDir()
+	dest := filepath.Join(destParent, "qwen3-32b")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Run(ctx, src, dest, Options{SourceRoots: []string{root}})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NoDirExists(t, dest)
+	entries, readErr := os.ReadDir(destParent)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "staging directory should be cleaned up")
 }

--- a/pkg/modelagent/stage/stage_test.go
+++ b/pkg/modelagent/stage/stage_test.go
@@ -1,0 +1,190 @@
+package stage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeModel(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"a":1}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nested", "model.safetensors"), []byte("weights"), 0o644))
+}
+
+func newSource(t *testing.T) (root, src string) {
+	t.Helper()
+	root = t.TempDir()
+	src = filepath.Join(root, "qwen", "Qwen3-32B")
+	writeModel(t, src)
+	return root, src
+}
+
+func TestRunCopiesTreeToDestination(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	assert.True(t, result.Copied)
+	assert.Equal(t, []byte(`{"a":1}`), mustRead(t, filepath.Join(dest, "config.json")))
+	assert.Equal(t, []byte("weights"), mustRead(t, filepath.Join(dest, "nested", "model.safetensors")))
+}
+
+func TestRunReportsBytesCopied(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(`{"a":1}`)+len("weights")), result.BytesCopied)
+}
+
+func TestRunWritesCompletionMarker(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dest, MarkerFileName))
+}
+
+func TestRunLeavesNoStagingDirectoryBehind(t *testing.T) {
+	root, src := newSource(t)
+	destParent := t.TempDir()
+	dest := filepath.Join(destParent, "qwen3-32b")
+
+	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	entries, err := os.ReadDir(destParent)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "qwen3-32b", entries[0].Name())
+}
+
+func TestRunReusesCompletedStage(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	require.NoError(t, err)
+	// A second copy would overwrite this marker file we planted in the destination.
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "config.json"), []byte("untouched"), 0o644))
+
+	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	assert.False(t, result.Copied)
+	assert.Equal(t, []byte("untouched"), mustRead(t, filepath.Join(dest, "config.json")))
+}
+
+func TestRunRecopiesWhenAlwaysCopyRequested(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "config.json"), []byte("stale"), 0o644))
+
+	result, err := Run(src, dest, Options{SourceRoots: []string{root}, AlwaysCopy: true})
+
+	require.NoError(t, err)
+	assert.True(t, result.Copied)
+	assert.Equal(t, []byte(`{"a":1}`), mustRead(t, filepath.Join(dest, "config.json")))
+}
+
+// An interrupted copy leaves a directory with no marker. Because the agent only
+// stats the path, treating it as complete would serve truncated weights.
+func TestRunRestagesDestinationWithoutMarker(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "config.json"), []byte("half"), 0o644))
+
+	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	assert.True(t, result.Copied)
+	assert.Equal(t, []byte(`{"a":1}`), mustRead(t, filepath.Join(dest, "config.json")))
+}
+
+func TestRunRestagesWhenMarkerNamesDifferentSource(t *testing.T) {
+	root, src := newSource(t)
+	other := filepath.Join(root, "qwen", "Qwen3-8B")
+	writeModel(t, other)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+	_, err := Run(other, dest, Options{SourceRoots: []string{root}})
+	require.NoError(t, err)
+
+	result, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.NoError(t, err)
+	assert.True(t, result.Copied)
+}
+
+func TestRunRejectsSourceOutsideRoots(t *testing.T) {
+	_, src := newSource(t)
+	dest := filepath.Join(t.TempDir(), "qwen3-32b")
+
+	_, err := Run(src, dest, Options{SourceRoots: []string{t.TempDir()}})
+
+	assert.ErrorContains(t, err, "outside the configured stage source roots")
+}
+
+func TestRunRejectsDestinationInsideSource(t *testing.T) {
+	root, src := newSource(t)
+	dest := filepath.Join(src, "copy")
+
+	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	assert.ErrorContains(t, err, "must not be inside")
+}
+
+func TestRunRejectsDestinationEqualToSource(t *testing.T) {
+	root, src := newSource(t)
+
+	_, err := Run(src, src, Options{SourceRoots: []string{root}})
+
+	assert.ErrorContains(t, err, "must not be inside")
+}
+
+// A failed copy must not leave a destination behind: the node label reconciler
+// would then advertise the model as present.
+func TestRunLeavesNoDestinationWhenCopyFails(t *testing.T) {
+	root, src := newSource(t)
+	unreadable := filepath.Join(src, "locked.bin")
+	require.NoError(t, os.WriteFile(unreadable, []byte("secret"), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+	destParent := t.TempDir()
+	dest := filepath.Join(destParent, "qwen3-32b")
+
+	_, err := Run(src, dest, Options{SourceRoots: []string{root}})
+
+	require.Error(t, err)
+	assert.NoDirExists(t, dest)
+	entries, readErr := os.ReadDir(destParent)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "staging directory should be cleaned up")
+}
+
+func TestDirSizeSumsRegularFiles(t *testing.T) {
+	_, src := newSource(t)
+
+	size, err := DirSize(src)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(`{"a":1}`)+len("weights")), size)
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}

--- a/pkg/utils/storage/storage.go
+++ b/pkg/utils/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"sigs.k8s.io/ome/pkg/ociobjectstore"
@@ -26,6 +27,10 @@ const (
 	GitHubStoragePrefix = "github://"
 	// LocalStoragePrefix is the prefix for local filesystem storage URIs
 	LocalStoragePrefix = "local://"
+	// StageStoragePrefix is the prefix for staged filesystem storage URIs.
+	// A staged model is copied from an already-mounted source path onto the
+	// node's local disk, unlike local:// which is served in place.
+	StageStoragePrefix = "stage://"
 )
 
 // StorageType is a string enum for storage type
@@ -50,6 +55,8 @@ const (
 	StorageTypeGitHub StorageType = "GITHUB"
 	// StorageTypeLocal is the value for local filesystem storage
 	StorageTypeLocal StorageType = "LOCAL"
+	// StorageTypeStage is the value for staged filesystem storage
+	StorageTypeStage StorageType = "STAGE"
 )
 
 // OCIStorageComponents represents the components of an OCI storage URI
@@ -110,6 +117,11 @@ type GitHubStorageComponents struct {
 // LocalStorageComponents represents the components of a local filesystem storage URI
 type LocalStorageComponents struct {
 	Path string // Absolute or relative path to the model files
+}
+
+// StageStorageComponents represents the components of a staged storage URI
+type StageStorageComponents struct {
+	SourcePath string // Absolute path of the source directory, as seen by the model agent
 }
 
 // ParseOCIStorageURI parses an OCI storage URI and returns its components
@@ -531,6 +543,46 @@ func ValidateLocalStorageURI(uri string) error {
 	return err
 }
 
+// ParseStageStorageURI parses a staged storage URI and returns its components
+// Format: stage:///{absolute-source-path}
+//
+// The source path is a path already mounted into the model agent, not a network
+// address: mounting the underlying share (NFS, CephFS, ...) is the node's job.
+func ParseStageStorageURI(uri string) (*StageStorageComponents, error) {
+	if !strings.HasPrefix(uri, StageStoragePrefix) {
+		return nil, fmt.Errorf("invalid stage storage URI format: missing %s prefix", StageStoragePrefix)
+	}
+
+	sourcePath := strings.TrimPrefix(uri, StageStoragePrefix)
+	if sourcePath == "" {
+		return nil, fmt.Errorf("invalid stage storage URI format: missing source path")
+	}
+
+	// Absolute paths only: the same string has to be meaningful both inside the
+	// agent container and on the node, so relative and ~-based paths are out.
+	if !strings.HasPrefix(sourcePath, "/") {
+		return nil, fmt.Errorf("invalid stage storage URI format: source path %q must be an absolute path", sourcePath)
+	}
+
+	// Reject traversal before cleaning, otherwise Clean would silently resolve it
+	// and a URI could escape the configured source roots.
+	for _, segment := range strings.Split(sourcePath, "/") {
+		if segment == ".." {
+			return nil, fmt.Errorf("invalid stage storage URI format: source path %q must not contain \"..\" segments", sourcePath)
+		}
+	}
+
+	return &StageStorageComponents{
+		SourcePath: path.Clean(sourcePath),
+	}, nil
+}
+
+// ValidateStageStorageURI validates if the given URI matches staged storage format
+func ValidateStageStorageURI(uri string) error {
+	_, err := ParseStageStorageURI(uri)
+	return err
+}
+
 // GetStorageType determines the type of storage URI
 func GetStorageType(uri string) (StorageType, error) {
 	switch {
@@ -552,6 +604,8 @@ func GetStorageType(uri string) (StorageType, error) {
 		return StorageTypeGitHub, nil
 	case strings.HasPrefix(uri, LocalStoragePrefix):
 		return StorageTypeLocal, nil
+	case strings.HasPrefix(uri, StageStoragePrefix):
+		return StorageTypeStage, nil
 	default:
 		return "", fmt.Errorf("unknown storage type for URI: %s", uri)
 	}
@@ -583,6 +637,8 @@ func ValidateStorageURI(uri string) error {
 		return ValidateGitHubStorageURI(uri)
 	case StorageTypeLocal:
 		return ValidateLocalStorageURI(uri)
+	case StorageTypeStage:
+		return ValidateStageStorageURI(uri)
 	default:
 		return fmt.Errorf("unsupported storage type: %s", storageType)
 	}

--- a/pkg/utils/storage/storage_stage_test.go
+++ b/pkg/utils/storage/storage_stage_test.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseStageStorageURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		want        *StageStorageComponents
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid uri with absolute path",
+			uri:  "stage:///mnt/nfs-src/qwen/Qwen3-32B",
+			want: &StageStorageComponents{
+				SourcePath: "/mnt/nfs-src/qwen/Qwen3-32B",
+			},
+		},
+		{
+			name: "valid uri with trailing slash is normalized",
+			uri:  "stage:///mnt/nfs-src/qwen/Qwen3-32B/",
+			want: &StageStorageComponents{
+				SourcePath: "/mnt/nfs-src/qwen/Qwen3-32B",
+			},
+		},
+		{
+			name:        "missing stage prefix",
+			uri:         "/mnt/nfs-src/qwen",
+			wantErr:     true,
+			errContains: "missing stage:// prefix",
+		},
+		{
+			name:        "empty uri",
+			uri:         "",
+			wantErr:     true,
+			errContains: "missing stage:// prefix",
+		},
+		{
+			name:        "only prefix",
+			uri:         "stage://",
+			wantErr:     true,
+			errContains: "missing source path",
+		},
+		{
+			name:        "relative path is rejected",
+			uri:         "stage://models/qwen",
+			wantErr:     true,
+			errContains: "must be an absolute path",
+		},
+		{
+			name:        "parent directory traversal is rejected",
+			uri:         "stage:///mnt/nfs-src/../../etc",
+			wantErr:     true,
+			errContains: "must not contain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseStageStorageURI(tt.uri)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetStorageTypeStage(t *testing.T) {
+	got, err := GetStorageType("stage:///mnt/nfs-src/qwen/Qwen3-32B")
+	assert.NoError(t, err)
+	assert.Equal(t, StorageTypeStage, got)
+}
+
+func TestValidateStorageURIDispatchesStage(t *testing.T) {
+	assert.NoError(t, ValidateStorageURI("stage:///mnt/nfs-src/qwen/Qwen3-32B"))
+	assert.Error(t, ValidateStorageURI("stage://relative/path"))
+}

--- a/pkg/validation/basemodel.go
+++ b/pkg/validation/basemodel.go
@@ -4,6 +4,8 @@ package validation
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/utils/storage"
@@ -39,5 +41,50 @@ func ValidatePVCStorage(spec *v1beta1.BaseModelSpec, isClusterScoped bool) error
 	if !isClusterScoped && components.Namespace != "" {
 		return fmt.Errorf("namespaced BaseModel PVC URI must not specify a namespace; the BaseModel's own namespace is used, got %q", uri)
 	}
+	return nil
+}
+
+// ValidateStageStorage enforces the stage:// rules for a BaseModel /
+// ClusterBaseModel spec:
+//
+//   - the source URI must parse (absolute path, no ".." segments);
+//   - spec.storage.path is required and must be absolute — it names the
+//     node-local destination the model is copied to, and there is no sane
+//     default for it;
+//   - the destination must not sit inside the source, which would make the
+//     agent copy the tree into itself.
+//
+// Rejecting here keeps these mistakes from surfacing only on the node, where a
+// model just sits in In_Transit with the reason buried in agent logs.
+//
+// Non-stage URIs are accepted unchanged.
+func ValidateStageStorage(spec *v1beta1.BaseModelSpec) error {
+	if spec == nil || spec.Storage == nil || spec.Storage.StorageUri == nil {
+		return nil
+	}
+	uri := *spec.Storage.StorageUri
+	storageType, err := storage.GetStorageType(uri)
+	if err != nil || storageType != storage.StorageTypeStage {
+		return nil
+	}
+
+	components, err := storage.ParseStageStorageURI(uri)
+	if err != nil {
+		return fmt.Errorf("invalid stage storage URI %q: %w", uri, err)
+	}
+
+	if spec.Storage.Path == nil || *spec.Storage.Path == "" {
+		return fmt.Errorf("stage:// storage requires spec.storage.path to name the node-local destination")
+	}
+	destPath := path.Clean(*spec.Storage.Path)
+	if !strings.HasPrefix(destPath, "/") {
+		return fmt.Errorf("stage:// spec.storage.path must be an absolute path, got %q", *spec.Storage.Path)
+	}
+
+	if destPath == components.SourcePath ||
+		strings.HasPrefix(destPath, strings.TrimSuffix(components.SourcePath, "/")+"/") {
+		return fmt.Errorf("stage:// spec.storage.path %q must not be inside the source %q", destPath, components.SourcePath)
+	}
+
 	return nil
 }

--- a/pkg/validation/basemodel_stage_test.go
+++ b/pkg/validation/basemodel_stage_test.go
@@ -1,0 +1,73 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func specWithStorage(uri string, path *string) *v1beta1.BaseModelSpec {
+	return &v1beta1.BaseModelSpec{
+		Storage: &v1beta1.StorageSpec{
+			StorageUri: &uri,
+			Path:       path,
+		},
+	}
+}
+
+func TestValidateStageStorageAcceptsAbsoluteSourceAndPath(t *testing.T) {
+	dest := "/mnt/data/models/qwen3-32b"
+
+	err := ValidateStageStorage(specWithStorage("stage:///mnt/nfs-src/qwen/Qwen3-32B", &dest))
+
+	assert.NoError(t, err)
+}
+
+// Without spec.storage.path the agent has nowhere to copy to, and the failure
+// would only surface on the node.
+func TestValidateStageStorageRejectsMissingPath(t *testing.T) {
+	err := ValidateStageStorage(specWithStorage("stage:///mnt/nfs-src/qwen/Qwen3-32B", nil))
+
+	assert.ErrorContains(t, err, "spec.storage.path")
+}
+
+func TestValidateStageStorageRejectsEmptyPath(t *testing.T) {
+	empty := ""
+
+	err := ValidateStageStorage(specWithStorage("stage:///mnt/nfs-src/qwen/Qwen3-32B", &empty))
+
+	assert.ErrorContains(t, err, "spec.storage.path")
+}
+
+func TestValidateStageStorageRejectsRelativePath(t *testing.T) {
+	relative := "models/qwen3-32b"
+
+	err := ValidateStageStorage(specWithStorage("stage:///mnt/nfs-src/qwen/Qwen3-32B", &relative))
+
+	assert.ErrorContains(t, err, "absolute")
+}
+
+func TestValidateStageStorageRejectsInvalidSourceURI(t *testing.T) {
+	dest := "/mnt/data/models/qwen3-32b"
+
+	err := ValidateStageStorage(specWithStorage("stage://relative/source", &dest))
+
+	assert.ErrorContains(t, err, "must be an absolute path")
+}
+
+// Destination inside source would make the agent copy the tree into itself.
+func TestValidateStageStorageRejectsPathInsideSource(t *testing.T) {
+	dest := "/mnt/nfs-src/qwen/Qwen3-32B/copy"
+
+	err := ValidateStageStorage(specWithStorage("stage:///mnt/nfs-src/qwen/Qwen3-32B", &dest))
+
+	assert.ErrorContains(t, err, "must not be inside")
+}
+
+func TestValidateStageStorageIgnoresOtherProtocols(t *testing.T) {
+	assert.NoError(t, ValidateStageStorage(specWithStorage("local:///mnt/data/models/x", nil)))
+	assert.NoError(t, ValidateStageStorage(specWithStorage("pvc://claim/sub", nil)))
+	assert.NoError(t, ValidateStageStorage(nil))
+}

--- a/pkg/webhook/admission/basemodel/basemodel_webhook.go
+++ b/pkg/webhook/admission/basemodel/basemodel_webhook.go
@@ -32,6 +32,9 @@ func (v *BaseModelValidator) Handle(_ context.Context, req admission.Request) ad
 	if err := validation.ValidatePVCStorage(&bm.Spec, false); err != nil {
 		return admission.Denied(err.Error())
 	}
+	if err := validation.ValidateStageStorage(&bm.Spec); err != nil {
+		return admission.Denied(err.Error())
+	}
 	return admission.Allowed("")
 }
 
@@ -51,6 +54,9 @@ func (v *ClusterBaseModelValidator) Handle(_ context.Context, req admission.Requ
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	if err := validation.ValidatePVCStorage(&cbm.Spec, true); err != nil {
+		return admission.Denied(err.Error())
+	}
+	if err := validation.ValidateStageStorage(&cbm.Spec); err != nil {
 		return admission.Denied(err.Error())
 	}
 	return admission.Allowed("")

--- a/pkg/webhook/admission/basemodel/basemodel_webhook_stage_test.go
+++ b/pkg/webhook/admission/basemodel/basemodel_webhook_stage_test.go
@@ -1,0 +1,73 @@
+package basemodel
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func stageStorage(path *string) *v1beta1.StorageSpec {
+	return &v1beta1.StorageSpec{
+		StorageUri: ptr.To("stage:///mnt/nfs-src/qwen/Qwen3-32B"),
+		Path:       path,
+	}
+}
+
+func TestBaseModelValidator_HandleStage(t *testing.T) {
+	v := &BaseModelValidator{Decoder: newDecoder(t)}
+
+	tests := []struct {
+		name        string
+		path        *string
+		wantAllowed bool
+	}{
+		{name: "stage with absolute path allowed", path: ptr.To("/mnt/data/models/qwen3-32b"), wantAllowed: true},
+		{name: "stage without path denied", path: nil, wantAllowed: false},
+		{name: "stage with relative path denied", path: ptr.To("models/qwen3-32b"), wantAllowed: false},
+		{name: "stage with path inside source denied", path: ptr.To("/mnt/nfs-src/qwen/Qwen3-32B/copy"), wantAllowed: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bm := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "models"}}
+			bm.Spec.Storage = stageStorage(tc.path)
+			raw, err := json.Marshal(bm)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			resp := v.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}},
+			})
+			if resp.Allowed != tc.wantAllowed {
+				t.Fatalf("allowed=%v, want %v (result: %+v)", resp.Allowed, tc.wantAllowed, resp.Result)
+			}
+		})
+	}
+}
+
+func TestClusterBaseModelValidator_HandleStage(t *testing.T) {
+	v := &ClusterBaseModelValidator{Decoder: newDecoder(t)}
+
+	cbm := &v1beta1.ClusterBaseModel{ObjectMeta: metav1.ObjectMeta{Name: "m"}}
+	cbm.Spec.Storage = stageStorage(nil)
+	raw, err := json.Marshal(cbm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := v.Handle(context.TODO(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}},
+	})
+
+	if resp.Allowed {
+		t.Fatalf("expected stage:// without spec.storage.path to be denied, got %+v", resp.Result)
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds a `stage://` storage protocol. The model agent copies a model from an **already-mounted** source directory onto the node's local disk, and inference then loads the weights from local disk:

```yaml
spec:
  storage:
    storageUri: stage:///mnt/shared/qwen/Qwen3-32B   # source: a path already mounted into the agent
    path: /mnt/data/models/qwen3-32b                  # destination: node-local disk
```

The source is a filesystem path, not a network address — mounting the underlying share stays the node's job (fstab, autofs, an NFS PV). No network-protocol code is added, so NFS, CephFS, Lustre, GPFS and plain local disks are all handled identically.

Three things are worth a reviewer's attention:

**1. This is a model-agent-only change.** Serving reads only `spec.storage.path` — the volume, the mount path and `MODEL_PATH` all derive from it — and never looks at `storageUri`. The controller, pod construction and existing webhook behaviour are untouched.

**2. Atomic publication is required, not a nicety.** The agent decides a model is present by stat-ing its path, so a directory left behind by an interrupted copy would be indistinguishable from a complete one and would be served as truncated weights. The copy lands in a staging directory beside the destination, gets a `.ome-stage-complete` marker, and is renamed into place. The marker also backs `ReuseIfExists` and post-restart revalidation.

**3. Source roots are an allowlist, and staging is off by default.** `stage://` lets the author of a (cluster-scoped) model name any path the agent can read, and whatever is staged is then mounted into inference pods. `ResolveSource` resolves symlinks *before* checking containment, and compares per path segment — a string prefix would let a root of `/mnt/nfs` authorize `/mnt/nfs-evil`. With no `--stage-source-roots` configured, staging is refused outright, and the chart emits no stage arguments at all, so upgrading without opting in changes nothing.

Also included:

- `spec.storage.path` is required for `stage://`, and admission rejects a missing path, a relative path, and a destination inside the source. `getDestPath` falls back to `modelRootDir + storageUri` when `path` is empty, which for `stage://` would build a directory named after the URI; refusing is better than letting that succeed, and rejecting at admission keeps the model out of a silent `In_Transit`.
- Free space is checked before copying, reusing `hub.CheckDiskSpace`. An already-staged model that is not `AlwaysDownload` skips the check, which also skips a full walk of the source.
- Staging gets its own concurrency limit rather than reusing `--concurrency`: it is bounded by the share's egress, not by the node, and N nodes each running the download concurrency would converge on one server.
- A `model_agent_models_root_free_bytes` gauge. There is no eviction anywhere in the agent — a model is removed only when its CR goes away or a selector change makes the node ineligible — so a full models root becomes failed downloads that only an operator can clear. Publishing free space is what makes that visible before it happens. `AvailableDiskSpace` is exported from `hfutil/hub` rather than duplicating the platform-specific statfs code.

`DownloadPolicy` keeps its existing meaning: `AlwaysDownload` forces a fresh copy, `ReuseIfExists` (the default) trusts the completion marker.

## Why we need it

Today a model on shared storage has to be registered as `local://`, and `local://` is served **in place** — `processLocalStorageModel` validates the path and parses the config, but deliberately performs no copy. The pod mounts that path as a `hostPath`, so the weights are read over the network on every pod start, multiplied by every replica and paid again after a reboot or eviction.

`oci://` and `hf://` already have the shape that avoids this — source distinct from destination, agent lands the model on local disk — but they require the weights to live in object storage. Users whose models sit on an NFS export have no way to get that behaviour without standing up an object store and importing everything into it. `stage://` fills that gap by reusing the existing source-to-destination machinery with a local copy in place of a download.

Fixes #780

## How to test

**Unit tests** (39 added, all written before the implementation): URI parsing, allowlist containment including symlink-escape and sibling-prefix cases, atomic publication, reuse and re-stage semantics, destination-inside-source, disk sizing, admission validation, and the free-space gauge.

```
ok  sigs.k8s.io/ome/pkg/modelagent                   6.0s
ok  sigs.k8s.io/ome/pkg/modelagent/stage             3.6s
ok  sigs.k8s.io/ome/pkg/utils/storage                4.7s
ok  sigs.k8s.io/ome/pkg/validation                   6.6s
ok  sigs.k8s.io/ome/pkg/webhook/admission/basemodel  5.9s
ok  sigs.k8s.io/ome/cmd/model-agent                  7.1s
```

**On a cluster** (2-node, v1.29, V100, vLLM 0.8.5), source on a read-only NFS mount, destination on node-local ext4:

- 1.99 GB staged in 13.0 s; node labelled `Ready`; marker written; no staging directory left behind
- an `InferenceService` on the staged model started with `model='/mnt/local-models/...'` and served a real chat completion — weights loaded from local disk, not the share
- removing the marker and one weight file, then restarting the agent, re-staged the model completely
- `stage://` outside the configured roots → `Failed`
- `spec.storage.nodeSelector` honoured: the excluded node logged the CR event but did not stage or label
- deleting the CR removed the node-local copy only; the source on the share was untouched
- admission rejected a missing path, a relative path and a destination inside the source; `pvc://` and `local://` validation unchanged

**What was not verified, and matters:**

- **The performance benefit was not demonstrated.** On the same model, runtime and node, weights loaded in 1.08 s from the staged local copy versus 0.81 s from the NFS mount — the share was *faster*, almost certainly because the client page cache was warm from the staging read, and because 0.93 GiB over a local network is not where NFS hurts. A fair comparison needs cache dropping between runs, which I could not do on that cluster. The motivating case — large models, cold cache, many replicas, contended storage — remains untested. I would not present `stage://` as a default recommendation on this evidence; the copy cost is certain, the saving is not.
- Insufficient-disk-space handling was not exercised on a cluster (it would mean filling a shared node's disk); it is covered only by the code path, not by a test.

## Known limitations

- **The source is copied verbatim, including `.git`.** A model directory cloned from a hub carries a `.git` that can be a large fraction of the total. An exclusion list is probably worth adding, but I left it out of this PR to keep the change focused.
- Anyone testing this against a read-only share will find the agent pod stuck at `READY=false` — that is #787, a separate pre-existing bug where the readiness check requires write access to the models root. It does not affect staging itself, but it does stall DaemonSet rolling updates.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable) — not yet; happy to add a page under `site/` if you want this documented before merge
- [x] `make test` passes locally — full suite green (cmd, pkg, internal), `make manifests` leaves no drift
