### PR TITLE
[API] Add driver-aware accelerator selection

### DIFF
--- a/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
@@ -71,6 +71,13 @@ spec:
                       format: int64
                       minimum: 0
                       type: integer
+                    policy:
+                      enum:
+                        - BestFit
+                        - Cheapest
+                        - MostCapable
+                        - FirstAvailable
+                      type: string
                     preferredPrecisions:
                       items:
                         type: string

--- a/charts/ome-crd/templates/ome.io_servingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_servingruntimes.yaml
@@ -71,6 +71,13 @@ spec:
                       format: int64
                       minimum: 0
                       type: integer
+                    policy:
+                      enum:
+                        - BestFit
+                        - Cheapest
+                        - MostCapable
+                        - FirstAvailable
+                      type: string
                     preferredPrecisions:
                       items:
                         type: string

--- a/config/crd/full/ome.io_clusterservingruntimes.yaml
+++ b/config/crd/full/ome.io_clusterservingruntimes.yaml
@@ -71,6 +71,13 @@ spec:
                       format: int64
                       minimum: 0
                       type: integer
+                    policy:
+                      enum:
+                        - BestFit
+                        - Cheapest
+                        - MostCapable
+                        - FirstAvailable
+                      type: string
                     preferredPrecisions:
                       items:
                         type: string

--- a/config/crd/full/ome.io_servingruntimes.yaml
+++ b/config/crd/full/ome.io_servingruntimes.yaml
@@ -71,6 +71,13 @@ spec:
                       format: int64
                       minimum: 0
                       type: integer
+                    policy:
+                      enum:
+                        - BestFit
+                        - Cheapest
+                        - MostCapable
+                        - FirstAvailable
+                      type: string
                     preferredPrecisions:
                       items:
                         type: string

--- a/oeps/0003-accelerator-aware-runtime-selection/README.md
+++ b/oeps/0003-accelerator-aware-runtime-selection/README.md
@@ -23,12 +23,20 @@ compatibility with existing Kubernetes ecosystem tools like Kueue.
     - [AcceleratorClass](#acceleratorclass)
     - [InferenceService Extensions](#inferenceservice-extensions)
     - [ServingRuntime Extensions](#servingruntime-extensions)
+  - [Driver-Aware Runtime Configuration](#driver-aware-runtime-configuration)
+    - [Label Ownership](#label-ownership)
+    - [Compatibility Classes](#compatibility-classes)
+    - [Runtime Policy and Overrides](#runtime-policy-and-overrides)
+    - [Selection and Scheduling Safety](#selection-and-scheduling-safety)
+    - [Upgrade Lifecycle](#upgrade-lifecycle)
+    - [Vendor Portability](#vendor-portability)
   - [Kueue Integration](#kueue-integration)
   - [Override Hierarchy](#override-hierarchy)
   - [Implementation Architecture](#implementation-architecture)
   - [Test Plan](#test-plan)
     - [Unit Tests](#unit-tests)
     - [Integration Tests](#integration-tests)
+    - [Driver-Aware Validation](#driver-aware-validation)
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
@@ -1130,33 +1138,243 @@ type ServingRuntimeSpec struct {
 }
 
 type AcceleratorRequirements struct {
-    // SupportedClasses explicitly lists supported accelerator classes
+    // AcceleratorClasses lists supported classes in preference order
     // +optional
-    SupportedClasses []string `json:"supportedClasses,omitempty"`
+    AcceleratorClasses []string `json:"acceleratorClasses,omitempty"`
 
-    // RequiredCapabilities that any accelerator must meet
+    // Policy is the runtime default when a service or component does not
+    // provide its own policy
     // +optional
-    RequiredCapabilities *AcceleratorCapabilities `json:"requiredCapabilities,omitempty"`
+    Policy AcceleratorSelectionPolicy `json:"policy,omitempty"`
 
-    // PreferenceOrder for accelerator selection
+    // Capability constraints applied before policy selection
     // +optional
-    PreferenceOrder []AcceleratorPreference `json:"preferenceOrder,omitempty"`
-}
-
-type AcceleratorPreference struct {
-    // Class name or capability matcher
-    Class string `json:"class,omitempty"`
-
-    // Score for this preference (higher is better)
-    // +kubebuilder:validation:Minimum=0
-    // +kubebuilder:validation:Maximum=100
-    Score int32 `json:"score"`
-
-    // Conditions when this preference applies
-    // +optional
-    Conditions []PreferenceCondition `json:"conditions,omitempty"`
+    MinMemory *int64 `json:"minMemory,omitempty"`
+    MinComputePerformanceTFLOPS *int64 `json:"minComputePerformanceTFLOPS,omitempty"`
+    MinArchitectureVersion *string `json:"minArchitectureVersion,omitempty"`
+    RequiredFeatures []string `json:"requiredFeatures,omitempty"`
+    PreferredPrecisions []string `json:"preferredPrecisions,omitempty"`
 }
 ```
+
+### Driver-Aware Runtime Configuration
+
+Accelerator model alone is not sufficient to determine whether a runtime image
+can execute on a node. Runtime images ship a CUDA or ROCm user-space stack, while
+the kernel driver is supplied by the host. A geographically distributed fleet
+can therefore contain the same GPU model with several driver branches during a
+staged upgrade. Those nodes may require different runtime environment variables
+or arguments even though they expose the same extended GPU resource.
+
+This design models a driver compatibility band as an `AcceleratorClass`. The
+class owns the node constraints and resource requirements, while the
+`ServingRuntime` owns the ordered preference and the configuration associated
+with each selected class. This keeps hardware discovery out of runtime images
+and keeps runtime-specific compatibility behavior out of cluster-level
+`AcceleratorClass` objects.
+
+The design intentionally does not interpolate arbitrary node labels into pod
+environment variables. An InferenceService pod is constructed before the
+scheduler chooses a node, so such interpolation would be ambiguous in a
+multi-node cluster and could disagree with the scheduler. Selecting an
+`AcceleratorClass` first provides a stable configuration key and a scheduling
+constraint derived from the same object.
+
+#### Label Ownership
+
+OME consumes node labels; it does not install GPU discovery software or claim
+ownership of vendor label namespaces. A cluster operator is responsible for
+deploying and operating a trusted label provider. For NVIDIA clusters this is
+normally GPU Feature Discovery, which can publish labels such as:
+
+```text
+nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3
+nvidia.com/cuda.driver-version.major=580
+nvidia.com/cuda.driver-version.full=580.126.09
+```
+
+The label provider and its update cadence are part of the cluster's trust
+boundary. If labels are missing or stale, a driver-specific class has no
+matching nodes and cannot be selected by `FirstAvailable`. Admission policies
+may additionally restrict who can edit vendor-owned node labels and
+`AcceleratorClass` resources.
+
+#### Compatibility Classes
+
+Operators should define classes for meaningful compatibility bands rather than
+creating a class for every patch-level driver release. For example, a CUDA 13
+native class can select driver branch 580, while a compatibility class can
+select the older branches supported by the compatibility package shipped in the
+runtime image:
+
+```yaml
+apiVersion: ome.io/v1beta1
+kind: AcceleratorClass
+metadata:
+  name: nvidia-h100-cu13
+spec:
+  vendor: nvidia
+  family: hopper
+  model: h100
+  discovery:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: nvidia.com/gpu.product
+                  operator: In
+                  values: [NVIDIA-H100-80GB-HBM3]
+                - key: nvidia.com/cuda.driver-version.major
+                  operator: In
+                  values: ["580"]
+  resources:
+    - name: nvidia.com/gpu
+      quantity: "1"
+---
+apiVersion: ome.io/v1beta1
+kind: AcceleratorClass
+metadata:
+  name: nvidia-h100-cu12
+spec:
+  vendor: nvidia
+  family: hopper
+  model: h100
+  discovery:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: nvidia.com/gpu.product
+                  operator: In
+                  values: [NVIDIA-H100-80GB-HBM3]
+                - key: nvidia.com/cuda.driver-version.major
+                  operator: In
+                  values: ["535", "550", "570"]
+  resources:
+    - name: nvidia.com/gpu
+      quantity: "1"
+```
+
+Class names describe an operator-defined compatibility contract; OME does not
+infer CUDA compatibility from the name. The operator must choose ranges that
+are valid for the runtime image, vendor compatibility package, GPU family, and
+enabled features. Patch-specific classes remain possible when a known driver
+regression requires narrower targeting.
+
+A broader hardware-only class can be retained as the final fallback. Because a
+node may match both a driver-specific class and the broader class, overlap is
+expected and does not assign a node exclusively to one class.
+
+#### Runtime Policy and Overrides
+
+The runtime declares its selection policy and ordered compatibility bands:
+
+```yaml
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-h100
+spec:
+  acceleratorRequirements:
+    policy: FirstAvailable
+    acceleratorClasses:
+      - nvidia-h100-cu13
+      - nvidia-h100-cu12
+      - nvidia-h100
+  supportedModelFormats:
+    - modelFormat:
+        name: safetensors
+      acceleratorConfig:
+        nvidia-h100-cu13:
+          environmentOverride:
+            VLLM_ENABLE_CUDA_COMPATIBILITY: "0"
+        nvidia-h100-cu12:
+          environmentOverride:
+            VLLM_ENABLE_CUDA_COMPATIBILITY: "1"
+```
+
+`acceleratorConfig` remains keyed by the selected class and may also provide
+runtime argument and tensor-parallelism overrides. Environment override keys
+are applied in sorted order so semantically identical reconciliations produce a
+stable pod template and do not create spurious ReplicaSets.
+
+The effective policy precedence is:
+
+1. Component `acceleratorOverride.policy` for the engine or decoder.
+2. InferenceService `acceleratorSelector.policy`.
+3. ServingRuntime `acceleratorRequirements.policy`.
+4. No automatic class selection when no level specifies a policy.
+
+An explicitly named class at the component or InferenceService level continues
+to take precedence over policy-based selection. The runtime policy is therefore
+a default chosen by the runtime author, not a restriction on workload owners.
+
+#### Selection and Scheduling Safety
+
+For `FirstAvailable`, OME performs the following steps:
+
+1. Fetch classes named by `acceleratorRequirements.acceleratorClasses` without
+   changing their declaration order.
+2. Apply the existing accelerator constraints and exclusions.
+3. Select the first remaining class whose `status.availableNodes` is greater
+   than zero.
+4. Fail reconciliation when a policy was requested but no class has matching
+   nodes; do not silently create an unconstrained workload.
+5. Apply the selected class's resource requirements, required node affinity,
+   and model-format-specific runtime overrides to the engine or decoder pod.
+
+`status.availableNodes` means nodes matching the class definition; it is not a
+real-time count of unallocated GPUs. Normal Kubernetes scheduling still handles
+resource availability and contention.
+
+The AcceleratorClass controller calculates matching-node status from both
+`discovery.nodeSelector` and required node affinity. Kubernetes node selector
+semantics are preserved: selector terms are ORed, requirements within a term
+are ANDed, and `In`, `NotIn`, `Exists`, `DoesNotExist`, `Gt`, and `Lt` are
+supported. Preferred affinity influences scheduling but does not establish
+class membership.
+
+The same required affinity is copied into the generated pod. Status drives the
+selection decision, while pod affinity is the enforcement guard that prevents
+the selected runtime configuration from landing on a node outside its driver
+compatibility band. `requiredDuringSchedulingIgnoredDuringExecution` does not
+evict an already-running pod when a node label later changes; operators should
+use their normal rollout or node-drain procedure after driver replacement.
+
+#### Upgrade Lifecycle
+
+A rolling driver upgrade does not require editing every workload:
+
+1. Before the rollout, publish AcceleratorClasses covering both old and new
+   supported driver bands and update the runtime's ordered list and overrides.
+2. GPU discovery updates node labels after each node's driver changes.
+3. The AcceleratorClass controller watches Node updates and recomputes matching
+   nodes for every class.
+4. New InferenceServices, and existing services that reconcile into a new pod
+   template, select the first compatible class according to runtime order.
+5. After the fleet no longer needs the old band, remove it from runtimes first,
+   then remove the obsolete AcceleratorClass.
+
+This supports canary and region-by-region upgrades while keeping the runtime
+image and its compatibility behavior declarative. Updating a label does not
+mutate the environment of an existing pod; a rollout is required when an
+existing deployment must adopt a different accelerator configuration.
+
+#### Vendor Portability
+
+The mechanism is vendor-neutral because OME evaluates Kubernetes selectors and
+uses the resource name declared by the class. AMD clusters can use the same
+pattern with labels published by AMD GPU discovery or Node Feature Discovery,
+for example GPU family, ROCm version, or amdgpu driver labels, and request
+`amd.com/gpu`. Label keys and valid compatibility ranges differ by provider, so
+they remain operator configuration rather than hard-coded OME logic.
+
+Vendor portability depends on having a trustworthy, sufficiently precise label
+source. Where an AMD environment exposes only a GPU resource and product label,
+operators can use product-level classes but cannot safely make driver-specific
+runtime choices until a driver or ROCm compatibility label is published.
 
 ### Kueue Integration
 
@@ -1524,6 +1742,57 @@ graph TB
    - Conflicting requirements
    - Invalid accelerator class references
 
+#### Driver-Aware Validation
+
+The driver-aware extension adds unit coverage for:
+
+- Runtime policy precedence beneath component and InferenceService policies.
+- `FirstAvailable` preserving runtime declaration order, skipping classes with
+  zero matching nodes, and returning no selection when every class is
+  unavailable.
+- An explicit error when a requested policy cannot select any class.
+- Required node affinity matching, including selector term and operator
+  semantics used to calculate `AcceleratorClass.status.availableNodes`.
+- Deterministic environment override ordering to keep pod-template hashes
+  stable across reconciliations.
+
+The implementation was also validated on 2026-08-26 against a single-node k3s
+cluster with eight NVIDIA H100 80GB HBM3 GPUs. GPU Feature Discovery reported
+driver `580.126.09` and CUDA runtime `13.0`. The test runtime declared:
+
+```yaml
+acceleratorRequirements:
+  policy: FirstAvailable
+  acceleratorClasses:
+    - nvidia-h100-cu13
+    - nvidia-h100-cu12
+    - nvidia-h100
+```
+
+The test observed the following matching-node status:
+
+| AcceleratorClass | Matching nodes |
+|------------------|----------------|
+| `nvidia-h100-cu13` | 1 |
+| `nvidia-h100-cu12` | 0 |
+| `nvidia-h100` | 1 |
+
+OME selected `nvidia-h100-cu13`, proving that the ordered policy did not choose
+the broader `nvidia-h100` fallback even though it also matched the node. The
+generated pod requested and limited one `nvidia.com/gpu`, contained required
+node affinity for the H100 product and driver major 580, and exposed:
+
+```text
+OME_SELECTED_ACCELERATOR=nvidia-h100-cu13
+VLLM_ENABLE_CUDA_COMPATIBILITY=0
+```
+
+The pod reached Ready with no restarts. After deterministic environment
+ordering was added, repeated controller reconciliation left the Deployment at
+revision 1 with one Ready ReplicaSet, demonstrating that the override map did
+not cause pod-template churn. The isolated test namespace and sample resources
+were deleted after evidence was collected.
+
 ### Deployment Strategies
 
 Organizations can choose different approaches for managing AcceleratorClasses:
@@ -1588,6 +1857,8 @@ acceleratorClasses:
 - 2025-08-XX: Alpha implementation started
 - 2025-10-XX: Beta release with Kueue integration
 - 2025-12-XX: GA release
+- 2026-08-26: Driver-aware runtime defaults and ordered availability selection
+  designed and validated on NVIDIA H100
 
 ## Drawbacks
 

--- a/pkg/acceleratorclassselector/README.md
+++ b/pkg/acceleratorclassselector/README.md
@@ -74,12 +74,12 @@ The selector follows a prioritized selection logic:
    - Determine effective policy from:
      - Component-specific override policy
      - InferenceService-level policy
-     - Default policy (FirstAvailable)
+     - ServingRuntime-level default policy
    - Apply policy logic:
-     - **FirstAvailable**: Return the first accelerator from runtime requirements (currently implemented)
-     - **BestFit**: Select based on best resource match (TODO)
-     - **Cheapest**: Select based on cost optimization (TODO)
-     - **MostCapable**: Select based on maximum capabilities (TODO)
+     - **FirstAvailable**: Return the first class, in runtime order, that has matching nodes
+     - **BestFit**: Select based on best resource match
+     - **Cheapest**: Select based on cost optimization
+     - **MostCapable**: Select based on maximum capabilities
 
 4. **Fetch and Return**
    - Fetch the selected accelerator class spec from the cluster
@@ -97,7 +97,7 @@ InferenceService.AcceleratorSelector.AcceleratorClass
 Policy-based selection:
   - Component.AcceleratorOverride.Policy
   - InferenceService.AcceleratorSelector.Policy
-  - Default Policy (FirstAvailable)
+  - ServingRuntime.AcceleratorRequirements.Policy
     ↓
 Lowest Priority
 ```
@@ -229,11 +229,12 @@ type Config struct {
 
     // EnableDetailedLogging enables verbose logging for debugging
     EnableDetailedLogging bool
-
-    // DefaultPolicy is used when no policy is specified
-    DefaultPolicy v1beta1.AcceleratorSelectionPolicy
 }
 ```
+
+There is no package-wide default selection policy. A policy can be supplied by
+the component, the InferenceService, or the ServingRuntime. When none is
+specified, automatic AcceleratorClass selection is skipped.
 
 ### Creating a Selector with Custom Configuration
 
@@ -241,7 +242,6 @@ type Config struct {
 config := &acceleratorclassselector.Config{
     Client:                mgr.GetClient(),
     EnableDetailedLogging: true,
-    DefaultPolicy:         v1beta1.BestFitPolicy,
 }
 
 selector := acceleratorclassselector.NewWithConfig(config)
@@ -303,8 +303,8 @@ podSpec := buildPodSpec(runtime, engineAcc)
 
 ## Selection Policies
 
-### FirstAvailable (Default)
-- Returns the first accelerator class from runtime's `AcceleratorRequirements.AcceleratorClasses`
+### FirstAvailable
+- Returns the first accelerator class with matching nodes from the runtime's ordered `AcceleratorRequirements.AcceleratorClasses`
 - Fast and predictable
 - Best for simple deployments
 

--- a/pkg/acceleratorclassselector/selector.go
+++ b/pkg/acceleratorclassselector/selector.go
@@ -2,6 +2,7 @@ package acceleratorclassselector
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -63,13 +64,16 @@ func (s *defaultSelector) GetAcceleratorClass(ctx context.Context, isvc *v1beta1
 		// if policy is not specified, will skip getting acceleratorClass by policy
 		if acName == "" {
 			logger.Info("No acceleratorClass name found for component", "component", component, "inferenceService", isvc.Name)
-			acceleratorPolicy := s.getAcceleratorPolicy(isvc, component)
+			acceleratorPolicy := s.getAcceleratorPolicy(isvc, runtime, component)
 			if acceleratorPolicy == "" {
 				logger.Info("No acceleratorClass policy found for component", "component", component, "inferenceService", isvc.Name)
 				return nil, "", nil
 			}
 			if acceleratorClass := s.getAcceleratorClassByPolicy(ctx, isvc, runtime, acceleratorPolicy); acceleratorClass != nil {
 				acName = *acceleratorClass
+			}
+			if acName == "" {
+				return nil, "", fmt.Errorf("no accelerator class matched policy %q", acceleratorPolicy)
 			}
 		}
 	}
@@ -157,12 +161,18 @@ func (s *defaultSelector) getAcceleratorClassByPolicy(ctx context.Context, isvc 
 		return s.selectMostCapable(ctx, validCandidates, preferredPrecisions)
 
 	case v1beta1.FirstAvailablePolicy:
-		// Return the first valid candidate. `validCandidates` preserves the order from the runtime list.
-		if len(validCandidates) > 0 {
-			selected := validCandidates[0].Name
+		// Return the first candidate with matching nodes. `validCandidates`
+		// preserves the preference order declared by the runtime.
+		for _, candidate := range validCandidates {
+			if candidate.Status.AvailableNodes <= 0 {
+				logger.V(1).Info("Skipping unavailable accelerator class", "name", candidate.Name)
+				continue
+			}
+			selected := candidate.Name
 			logger.Info("FirstAvailable selected", "name", selected)
 			return &selected
 		}
+		logger.Info("No accelerator candidates have matching nodes")
 	}
 
 	return nil
@@ -234,11 +244,20 @@ func (s *defaultSelector) getComponentAcceleratorPolicy(isvc *v1beta1.InferenceS
 	return ""
 }
 
-// getAcceleratorPolicy determines the effective AcceleratorSelectionPolicy for the given component and InferenceService
-// If no policy is specified, an empty string is returned
-func (s *defaultSelector) getAcceleratorPolicy(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) v1beta1.AcceleratorSelectionPolicy {
-	// Check component-specific AcceleratorOverride
-	return s.getComponentAcceleratorPolicy(isvc, component)
+// getAcceleratorPolicy determines the effective AcceleratorSelectionPolicy for
+// the given component. InferenceService-level configuration takes precedence
+// over the runtime default. If no policy is specified, an empty string is
+// returned.
+func (s *defaultSelector) getAcceleratorPolicy(isvc *v1beta1.InferenceService, runtime *v1beta1.ServingRuntimeSpec, component v1beta1.ComponentType) v1beta1.AcceleratorSelectionPolicy {
+	if policy := s.getComponentAcceleratorPolicy(isvc, component); policy != "" {
+		return policy
+	}
+
+	if runtime != nil && runtime.AcceleratorRequirements != nil {
+		return runtime.AcceleratorRequirements.Policy
+	}
+
+	return ""
 }
 
 // getCandidateAccelerators fetches AcceleratorClass candidates from runtime.AcceleratorClasses

--- a/pkg/acceleratorclassselector/selector_test.go
+++ b/pkg/acceleratorclassselector/selector_test.go
@@ -25,6 +25,15 @@ func (m *mockAcceleratorFetcher) addAccelerator(name string, spec *v1beta1.Accel
 	m.accelerators[name] = &v1beta1.AcceleratorClass{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       *spec,
+		Status: v1beta1.AcceleratorClassStatus{
+			AvailableNodes: 1,
+		},
+	}
+}
+
+func (m *mockAcceleratorFetcher) setAvailableNodes(name string, availableNodes int32) {
+	if accelerator, found := m.accelerators[name]; found {
+		accelerator.Status.AvailableNodes = availableNodes
 	}
 }
 
@@ -644,6 +653,101 @@ func TestGetAcceleratorClassByPolicy_AllPolicies(t *testing.T) {
 					tt.description, *selected, tt.expectedName)
 			}
 		})
+	}
+}
+
+func TestGetAcceleratorPolicyPrecedence(t *testing.T) {
+	tests := []struct {
+		name      string
+		isvc      *v1beta1.InferenceService
+		runtime   *v1beta1.ServingRuntimeSpec
+		component v1beta1.ComponentType
+		expected  v1beta1.AcceleratorSelectionPolicy
+	}{
+		{
+			name: "component policy overrides service and runtime",
+			isvc: &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{
+				AcceleratorSelector: &v1beta1.AcceleratorSelector{Policy: v1beta1.CheapestPolicy},
+				Engine:              &v1beta1.EngineSpec{AcceleratorOverride: &v1beta1.AcceleratorSelector{Policy: v1beta1.MostCapablePolicy}},
+			}},
+			runtime: &v1beta1.ServingRuntimeSpec{AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
+				Policy: v1beta1.FirstAvailablePolicy,
+			}},
+			component: v1beta1.EngineComponent,
+			expected:  v1beta1.MostCapablePolicy,
+		},
+		{
+			name: "service policy overrides runtime",
+			isvc: &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{
+				AcceleratorSelector: &v1beta1.AcceleratorSelector{Policy: v1beta1.CheapestPolicy},
+			}},
+			runtime: &v1beta1.ServingRuntimeSpec{AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
+				Policy: v1beta1.FirstAvailablePolicy,
+			}},
+			component: v1beta1.EngineComponent,
+			expected:  v1beta1.CheapestPolicy,
+		},
+		{
+			name: "runtime policy is the default",
+			isvc: &v1beta1.InferenceService{},
+			runtime: &v1beta1.ServingRuntimeSpec{AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
+				Policy: v1beta1.FirstAvailablePolicy,
+			}},
+			component: v1beta1.EngineComponent,
+			expected:  v1beta1.FirstAvailablePolicy,
+		},
+		{
+			name:      "no policy configured",
+			isvc:      &v1beta1.InferenceService{},
+			runtime:   &v1beta1.ServingRuntimeSpec{},
+			component: v1beta1.EngineComponent,
+			expected:  "",
+		},
+	}
+
+	selector := &defaultSelector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := selector.getAcceleratorPolicy(tt.isvc, tt.runtime, tt.component)
+			if actual != tt.expected {
+				t.Fatalf("getAcceleratorPolicy() = %q, want %q", actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAcceleratorClass_RuntimeFirstAvailablePolicy(t *testing.T) {
+	mockFetcher := newMockFetcher()
+	accelerators := createRealisticAccelerators()
+	mockFetcher.addAccelerator("nvidia-h100-80gb", accelerators["nvidia-h100-80gb"])
+	mockFetcher.addAccelerator("nvidia-a100-40gb", accelerators["nvidia-a100-40gb"])
+	mockFetcher.setAvailableNodes("nvidia-h100-80gb", 0)
+
+	selector := &defaultSelector{
+		config:  &Config{},
+		fetcher: mockFetcher,
+	}
+	isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"}}
+	runtime := &v1beta1.ServingRuntimeSpec{AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
+		AcceleratorClasses: []string{"nvidia-h100-80gb", "nvidia-a100-40gb"},
+		Policy:             v1beta1.FirstAvailablePolicy,
+	}}
+
+	selected, selectedName, err := selector.GetAcceleratorClass(context.Background(), isvc, runtime, v1beta1.EngineComponent)
+	if err != nil {
+		t.Fatalf("GetAcceleratorClass() returned error: %v", err)
+	}
+	if selected == nil || selectedName != "nvidia-a100-40gb" {
+		t.Fatalf("GetAcceleratorClass() selected %q, want %q", selectedName, "nvidia-a100-40gb")
+	}
+
+	mockFetcher.setAvailableNodes("nvidia-a100-40gb", 0)
+	selected, selectedName, err = selector.GetAcceleratorClass(context.Background(), isvc, runtime, v1beta1.EngineComponent)
+	if err == nil {
+		t.Fatalf("GetAcceleratorClass() error = nil, want no matching accelerator error")
+	}
+	if selected != nil || selectedName != "" {
+		t.Fatalf("GetAcceleratorClass() selected unavailable accelerator %q", selectedName)
 	}
 }
 

--- a/pkg/apis/ome/v1beta1/servingruntime_types.go
+++ b/pkg/apis/ome/v1beta1/servingruntime_types.go
@@ -236,6 +236,12 @@ type AcceleratorRequirements struct {
 	// +listType=atomic
 	AcceleratorClasses []string `json:"acceleratorClasses,omitempty"`
 
+	// Policy defines the default selection policy when multiple accelerator classes are supported.
+	// An InferenceService-level or component-level policy takes precedence when specified.
+	// +kubebuilder:validation:Enum=BestFit;Cheapest;MostCapable;FirstAvailable
+	// +optional
+	Policy AcceleratorSelectionPolicy `json:"policy,omitempty"`
+
 	// MinMemory specifies minimum GPU memory required in GB
 	// +optional
 	// +kubebuilder:validation:Minimum=0

--- a/pkg/controller/v1beta1/acceleratorclass/controller.go
+++ b/pkg/controller/v1beta1/acceleratorclass/controller.go
@@ -3,6 +3,7 @@ package acceleratorclass
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -144,7 +145,93 @@ func nodePassesDiscovery(ac *v1beta1.AcceleratorClass, node *corev1.Node) bool {
 		}
 	}
 
+	// Required node affinity is part of AcceleratorClass discovery. Preferred
+	// affinity influences scheduling but does not determine class membership.
+	if ac.Spec.Discovery.Affinity != nil && ac.Spec.Discovery.Affinity.NodeAffinity != nil {
+		required := ac.Spec.Discovery.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		if required != nil {
+			for _, term := range required.NodeSelectorTerms {
+				if nodeMatchesSelectorTerm(node, term) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+
 	return true
+}
+
+func nodeMatchesSelectorTerm(node *corev1.Node, term corev1.NodeSelectorTerm) bool {
+	// Kubernetes defines an empty NodeSelectorTerm as matching no objects.
+	if len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+		return false
+	}
+
+	for _, requirement := range term.MatchExpressions {
+		value, exists := node.Labels[requirement.Key]
+		if !nodeSelectorRequirementMatches(value, exists, requirement) {
+			return false
+		}
+	}
+
+	for _, requirement := range term.MatchFields {
+		value, exists := nodeFieldValue(node, requirement.Key)
+		if !nodeSelectorRequirementMatches(value, exists, requirement) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func nodeFieldValue(node *corev1.Node, key string) (string, bool) {
+	switch key {
+	case "metadata.name":
+		return node.Name, true
+	default:
+		return "", false
+	}
+}
+
+func nodeSelectorRequirementMatches(value string, exists bool, requirement corev1.NodeSelectorRequirement) bool {
+	switch requirement.Operator {
+	case corev1.NodeSelectorOpIn:
+		return exists && containsString(requirement.Values, value)
+	case corev1.NodeSelectorOpNotIn:
+		return !exists || !containsString(requirement.Values, value)
+	case corev1.NodeSelectorOpExists:
+		return exists
+	case corev1.NodeSelectorOpDoesNotExist:
+		return !exists
+	case corev1.NodeSelectorOpGt, corev1.NodeSelectorOpLt:
+		if !exists || len(requirement.Values) != 1 {
+			return false
+		}
+		actual, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return false
+		}
+		target, err := strconv.ParseInt(requirement.Values[0], 10, 64)
+		if err != nil {
+			return false
+		}
+		if requirement.Operator == corev1.NodeSelectorOpGt {
+			return actual > target
+		}
+		return actual < target
+	default:
+		return false
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func nodeMatchCapabilities(ac *v1beta1.AcceleratorClass, node *corev1.Node) bool {

--- a/pkg/controller/v1beta1/acceleratorclass/controller_test.go
+++ b/pkg/controller/v1beta1/acceleratorclass/controller_test.go
@@ -120,6 +120,84 @@ func TestAcceleratorClass_Reconcile_MatchDiscovery(t *testing.T) {
 	g.Expect(curr.Status.Nodes).NotTo(ContainElement("node-b"))
 }
 
+func TestAcceleratorClass_Reconcile_MatchRequiredNodeAffinity(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	ac := &v1beta1.AcceleratorClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "nvidia-h100-cuda12-host"},
+		Spec: v1beta1.AcceleratorClassSpec{
+			Discovery: v1beta1.AcceleratorDiscovery{Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "nvidia.com/gpu.product",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"NVIDIA-H100-80GB-HBM3"},
+								},
+								{
+									Key:      "nvidia.com/cuda.driver.major",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"535", "550", "570"},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	node535 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "h100-r535",
+		Labels: map[string]string{
+			"nvidia.com/gpu.product":       "NVIDIA-H100-80GB-HBM3",
+			"nvidia.com/cuda.driver.major": "535",
+		},
+	}}
+	node580 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "h100-r580",
+		Labels: map[string]string{
+			"nvidia.com/gpu.product":       "NVIDIA-H100-80GB-HBM3",
+			"nvidia.com/cuda.driver.major": "580",
+		},
+	}}
+	a100Node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "a100-r535",
+		Labels: map[string]string{
+			"nvidia.com/gpu.product":       "NVIDIA-A100-SXM4-80GB",
+			"nvidia.com/cuda.driver.major": "535",
+		},
+	}}
+
+	c := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ac, node535, node580, a100Node).
+		WithStatusSubresource(&v1beta1.AcceleratorClass{}).
+		Build()
+
+	reconciler := &AcceleratorClassReconciler{
+		Client:   c,
+		Log:      ctrl.Log.WithName("AcceleratorClassTest"),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(5),
+	}
+
+	ctx := context.TODO()
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: ac.Name}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updated := &v1beta1.AcceleratorClass{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: ac.Name}, updated)).To(Succeed())
+	g.Expect(updated.Status.AvailableNodes).To(Equal(int32(1)))
+	g.Expect(updated.Status.Nodes).To(ConsistOf("h100-r535"))
+}
+
 func TestAcceleratorClass_Reconcile_MatchMemoryGB(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -3,6 +3,7 @@ package components
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -200,9 +201,14 @@ func UpdateEnvVariables(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 		acceleratorConfig := b.SupportedModelFormat.GetAcceleratorConfig(b.AcceleratorClassName)
 		if acceleratorConfig != nil {
 			envOverride := acceleratorConfig.EnvironmentOverride
-			for envName, envVar := range envOverride {
+			envNames := make([]string, 0, len(envOverride))
+			for envName := range envOverride {
+				envNames = append(envNames, envName)
+			}
+			sort.Strings(envNames)
+			for _, envName := range envNames {
 				isvcutils.UpdateEnvVars(container, &corev1.EnvVar{
-					Name: envName, Value: envVar})
+					Name: envName, Value: envOverride[envName]})
 			}
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/base_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -13,6 +14,44 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 )
+
+func TestUpdateEnvVariablesSortsAcceleratorEnvironmentOverride(t *testing.T) {
+	b := &BaseComponentFields{
+		SupportedModelFormat: &v1beta1.SupportedModelFormat{
+			AcceleratorConfig: map[string]*v1beta1.AcceleratorModelConfig{
+				"nvidia-h100-cu13": {
+					EnvironmentOverride: map[string]string{
+						"VLLM_ENABLE_CUDA_COMPATIBILITY": "0",
+						"OME_SELECTED_ACCELERATOR":       "nvidia-h100-cu13",
+					},
+				},
+			},
+		},
+		AcceleratorClassName: "nvidia-h100-cu13",
+		Log:                  logr.Discard(),
+	}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+	}
+	container := &v1.Container{
+		Env: []v1.EnvVar{{Name: "RUNTIME_BASELINE", Value: "present"}},
+	}
+
+	UpdateEnvVariables(b, isvc, container, &metav1.ObjectMeta{})
+
+	gotNames := make([]string, 0, len(container.Env))
+	for _, envVar := range container.Env {
+		gotNames = append(gotNames, envVar.Name)
+	}
+	wantNames := []string{
+		"RUNTIME_BASELINE",
+		"OME_SELECTED_ACCELERATOR",
+		"VLLM_ENABLE_CUDA_COMPATIBILITY",
+	}
+	if !slices.Equal(gotNames, wantNames) {
+		t.Fatalf("environment variables are not deterministic: got %v, want %v", gotNames, wantNames)
+	}
+}
 
 func TestUpdatePodSpecNodeSelector(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -901,6 +901,13 @@ func schema_pkg_apis_ome_v1beta1_AcceleratorRequirements(ref common.ReferenceCal
 							},
 						},
 					},
+					"policy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Policy defines the default selection policy when multiple accelerator classes are supported. An InferenceService-level or component-level policy takes precedence when specified.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"minMemory": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MinMemory specifies minimum GPU memory required in GB",

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -418,6 +418,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "policy": {
+          "description": "Policy defines the default selection policy when multiple accelerator classes are supported. An InferenceService-level or component-level policy takes precedence when specified.",
+          "type": "string"
+        },
         "preferredPrecisions": {
           "description": "PreferredPrecisions lists numeric precisions in order of preference Examples: [\"fp8\", \"fp16\", \"fp32\"]",
           "type": "array",

--- a/site/content/en/docs/concepts/inference_service.md
+++ b/site/content/en/docs/concepts/inference_service.md
@@ -296,7 +296,12 @@ OME can select the accelerator (GPU class) for an InferenceService declaratively
 | `BestFit`        | Selects the accelerator that best matches the model requirements. |
 | `Cheapest`       | Selects the lowest-cost accelerator that meets the requirements.  |
 | `MostCapable`    | Selects the most powerful accelerator available.                  |
-| `FirstAvailable` | Selects the first matching accelerator (fastest scheduling).      |
+| `FirstAvailable` | Selects the first class, in runtime declaration order, that has matching nodes. |
+
+When the InferenceService does not specify a policy, OME uses
+`ServingRuntime.spec.acceleratorRequirements.policy` if the runtime provides
+one. Component-level policies take precedence over the InferenceService-level
+policy, which takes precedence over the runtime default.
 
 #### Accelerator Constraints
 

--- a/site/content/en/docs/concepts/serving_runtime.md
+++ b/site/content/en/docs/concepts/serving_runtime.md
@@ -136,6 +136,7 @@ A runtime can declare the accelerators it supports and the minimum hardware it n
 | Field                                    | Type     | Description                                                                                          |
 |------------------------------------------|----------|------------------------------------------------------------------------------------------------------|
 | `acceleratorRequirements.acceleratorClasses`          | []string | Names of the `AcceleratorClass` resources this runtime supports                                     |
+| `acceleratorRequirements.policy`                      | AcceleratorSelectionPolicy | Default policy used to choose among the supported classes. An InferenceService or component policy overrides it. |
 | `acceleratorRequirements.minMemory`                   | int64    | Minimum accelerator memory required, in GB                                                          |
 | `acceleratorRequirements.minComputePerformanceTFLOPS` | int64    | Minimum compute capability required, in TFLOPS                                                      |
 | `acceleratorRequirements.minArchitectureVersion`      | string   | Minimum architecture version (NVIDIA compute capability or equivalent)                              |
@@ -155,6 +156,7 @@ spec:
       quantization: fp8
       autoSelect: true
   acceleratorRequirements:
+    policy: FirstAvailable
     acceleratorClasses:
       - nvidia-h100
       - nvidia-h200
@@ -169,6 +171,12 @@ spec:
     runner:
       image: lmsysorg/sglang:v0.4.6.post6
 ```
+
+`FirstAvailable` evaluates `acceleratorClasses` in declaration order and
+selects the first class that has matching nodes. This lets runtime authors
+declare a preferred accelerator with ordered fallbacks while still allowing an
+InferenceService to override the policy. Matching-node status honors both the
+class's `discovery.nodeSelector` and its required node affinity.
 
 ### Per-Accelerator Model Configuration
 

--- a/site/content/en/docs/reference/ome.v1beta1.md
+++ b/site/content/en/docs/reference/ome.v1beta1.md
@@ -757,6 +757,14 @@ Examples: [&quot;fp8&quot;, &quot;fp16&quot;, &quot;fp32&quot;]</p>
    <p>AcceleratorClasses lists the names of AcceleratorClasses this runtime supports</p>
 </td>
 </tr>
+<tr><td><code>policy</code><br/>
+<a href="#ome-io-v1beta1-AcceleratorSelectionPolicy"><code>AcceleratorSelectionPolicy</code></a>
+</td>
+<td>
+   <p>Policy defines the default selection policy when multiple accelerator classes are supported.
+An InferenceService-level or component-level policy takes precedence when specified.</p>
+</td>
+</tr>
 <tr><td><code>minMemory</code><br/>
 <code>int64</code>
 </td>


### PR DESCRIPTION
## What problem this PR solves

OME runtimes currently cannot provide a default accelerator selection policy.
This is limiting for fleets where the same GPU model runs several host-driver
branches during a staged upgrade: the runtime image may need different CUDA
compatibility environment variables or arguments for each driver band.

Selecting only by GPU model also leaves a safety gap. AcceleratorClass status
did not evaluate required node affinity, so a driver-specific affinity could be
enforced by the scheduler without being reflected in the class availability
used by selection.

## Design

This change models each meaningful driver compatibility band as an
AcceleratorClass and keeps runtime-specific behavior in the ServingRuntime:

```yaml
spec:
  acceleratorRequirements:
    policy: FirstAvailable
    acceleratorClasses:
      - nvidia-h100-cu13
      - nvidia-h100-cu12
      - nvidia-h100
  supportedModelFormats:
    - modelFormat:
        name: safetensors
      acceleratorConfig:
        nvidia-h100-cu13:
          environmentOverride:
            VLLM_ENABLE_CUDA_COMPATIBILITY: "0"
        nvidia-h100-cu12:
          environmentOverride:
            VLLM_ENABLE_CUDA_COMPATIBILITY: "1"
```

The effective policy precedence is:

1. Engine or decoder `acceleratorOverride.policy`.
2. InferenceService `acceleratorSelector.policy`.
3. ServingRuntime `acceleratorRequirements.policy`.
4. No policy-based selection when none is configured.

`FirstAvailable` preserves the runtime's class order and selects the first
candidate with `status.availableNodes > 0`. If no candidate has matching nodes,
reconciliation fails instead of producing an unconstrained workload.

AcceleratorClass availability now evaluates both `discovery.nodeSelector` and
required node affinity. The selected class's required affinity is also applied
to the pod, so selection and scheduler enforcement use the same driver
constraints. `availableNodes` describes matching nodes, not unallocated GPU
capacity; Kubernetes continues to resolve resource contention.

OME consumes node labels supplied by the cluster's trusted discovery stack,
such as NVIDIA GPU Feature Discovery. The mechanism remains vendor-neutral:
AMD deployments can use equivalent NFD/AMD labels and `amd.com/gpu` without
hard-coded vendor logic in OME.

OEP-0003 documents label ownership, compatibility bands, selection semantics,
policy precedence, scheduling guards, rolling driver upgrades, AMD portability,
operational caveats, and the completed H100 validation.

## Changes made

- Add the optional `ServingRuntime.spec.acceleratorRequirements.policy` API.
- Make `FirstAvailable` skip classes without matching nodes while preserving
  runtime declaration order.
- Return an explicit error when a requested policy cannot select a class.
- Include required node affinity in AcceleratorClass matching-node status.
- Sort accelerator environment overrides before applying them, preventing map
  iteration order from changing pod-template hashes.
- Regenerate CRDs, Helm CRDs, OpenAPI, Swagger, and API reference material.
- Update selector and user documentation.
- Extend OEP-0003 with the detailed driver-aware design and test evidence.

## Compatibility and behavior

The API field is optional and has no default. Existing runtimes that do not set
it retain their existing behavior, and explicit class selection remains higher
priority than policy selection.

`FirstAvailable` intentionally changes from "first valid object" to "first
valid object with matching nodes." Runtime authors can order specific classes
before broad fallback classes without assigning a node exclusively to one
class. Operators should define compatibility bands rather than one class per
patch release, except when isolating a known driver regression.

Required affinity uses Kubernetes selector semantics. Preferred affinity is not
used to establish class membership. Because the enforcement affinity is
`requiredDuringSchedulingIgnoredDuringExecution`, a driver-label change does
not evict existing pods; normal rollout or node-drain procedures are still
required after changing a host driver.

## Testing

Passed locally:

- `make fmt`
- `make generate manifests`
- `make vet`
- `go test -count=1` for:
  - `./pkg/apis/ome/v1beta1`
  - `./pkg/acceleratorclassselector`
  - `./pkg/controller/v1beta1/acceleratorclass`
  - `./pkg/controller/v1beta1/inferenceservice/components`
- Envtest-backed `go test -count=1
  ./pkg/controller/v1beta1/inferenceservice`
- `git diff --check`

`make test-no-xet` completed formatting, vet, manifest generation, and envtest
setup, but its command-package phase still links `manager` and `model-agent`
against `libxet`. The local machine has no configured Rust toolchain or built
`pkg/xet/target/release/libxet`, so those two binaries failed at link time. The
failure occurred before feature package tests and is unrelated to this change.

### Live H100 validation

The controller was built and deployed to a single-node k3s cluster containing
eight NVIDIA H100 80GB HBM3 GPUs. GPU Feature Discovery reported driver
`580.126.09` and CUDA runtime `13.0`.

The test created these matching states:

| AcceleratorClass | Matching nodes |
| --- | ---: |
| `nvidia-h100-cu13` | 1 |
| `nvidia-h100-cu12` | 0 |
| `nvidia-h100` | 1 |

With the ordered list shown above, OME selected `nvidia-h100-cu13`, not the
generic `nvidia-h100` class. The generated Deployment and live container
confirmed:

- `OME_SELECTED_ACCELERATOR=nvidia-h100-cu13`
- `VLLM_ENABLE_CUDA_COMPATIBILITY=0`
- Required affinity for `NVIDIA-H100-80GB-HBM3` and driver major `580`
- GPU request and limit `nvidia.com/gpu: 1`
- Ready pod with zero restarts
- Deployment revision 1 with one Ready ReplicaSet after repeated reconciliation

The isolated namespace and sample cluster resources were removed after the test.

## Impact and risk

- Incorrect or stale vendor labels can make a compatibility class unavailable.
  Selection fails closed, and pod affinity remains the scheduling guard.
- A newly created class may report zero matching nodes until its first status
  reconciliation; normal controller retries recover after status is populated.
- `availableNodes` is deliberately not a live free-capacity signal.
- Rollback consists of removing the runtime-level policy or reverting this
  change; the new API field is optional.

## Related design

- Extends OEP-0003: Accelerator-Aware Runtime Selection for Heterogeneous GPU
  Environments.
