### PR TITLE
[CI/Tests] Add Alfred nested KWOK E2E harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -743,6 +743,45 @@ integration-test: fmt vet manifests envtest ## 🧪 Run integration tests
 	go test -v ./tests/... -ginkgo.v -ginkgo.trace
 	@echo "✅ Integration tests passed"
 
+# Alfred's E2E harness runs a nested KWOK control-plane in an isolated host
+# namespace and points a real Alfred pod at that simulated API server.
+ALFRED_E2E_IMG ?= $(ALFRED_IMG)
+ALFRED_E2E_HOST_KUBECONFIG ?= $(KUBECONFIG)
+ALFRED_E2E_HOST_CONTEXT ?=
+ALFRED_E2E_NAMESPACE ?= alfred-e2e
+ALFRED_E2E_PULL_SECRET_SOURCE ?= ome/alfred-build-registry
+
+.PHONY: alfred-e2e-cluster
+alfred-e2e-cluster: kustomize ## 🎩 Create an isolated nested KWOK Alfred E2E cluster
+	@ALFRED_E2E_HOST_KUBECONFIG="$(ALFRED_E2E_HOST_KUBECONFIG)" \
+		ALFRED_E2E_HOST_CONTEXT="$(ALFRED_E2E_HOST_CONTEXT)" \
+		ALFRED_E2E_NAMESPACE="$(ALFRED_E2E_NAMESPACE)" \
+		ALFRED_E2E_PULL_SECRET_SOURCE="$(ALFRED_E2E_PULL_SECRET_SOURCE)" \
+		ALFRED_E2E_IMG="$(ALFRED_E2E_IMG)" \
+		KUSTOMIZE_BIN="$(KUSTOMIZE)" \
+		hack/alfred-e2e/create.sh
+
+.PHONY: alfred-e2e-fragmentation
+alfred-e2e-fragmentation: ## 🎩 Load and verify the deterministic fragmentation scenario
+	@ALFRED_E2E_HOST_KUBECONFIG="$(ALFRED_E2E_HOST_KUBECONFIG)" \
+		ALFRED_E2E_HOST_CONTEXT="$(ALFRED_E2E_HOST_CONTEXT)" \
+		ALFRED_E2E_NAMESPACE="$(ALFRED_E2E_NAMESPACE)" \
+		hack/alfred-e2e/fragmentation.sh
+
+.PHONY: alfred-e2e-verify
+alfred-e2e-verify: ## 🎩 Re-check Alfred metrics and recommendations in the E2E cluster
+	@ALFRED_E2E_HOST_KUBECONFIG="$(ALFRED_E2E_HOST_KUBECONFIG)" \
+		ALFRED_E2E_HOST_CONTEXT="$(ALFRED_E2E_HOST_CONTEXT)" \
+		ALFRED_E2E_NAMESPACE="$(ALFRED_E2E_NAMESPACE)" \
+		hack/alfred-e2e/verify.sh
+
+.PHONY: alfred-e2e-clean
+alfred-e2e-clean: ## 🎩 Delete the isolated nested-KWOK E2E namespace
+	@ALFRED_E2E_HOST_KUBECONFIG="$(ALFRED_E2E_HOST_KUBECONFIG)" \
+		ALFRED_E2E_HOST_CONTEXT="$(ALFRED_E2E_HOST_CONTEXT)" \
+		ALFRED_E2E_NAMESPACE="$(ALFRED_E2E_NAMESPACE)" \
+		hack/alfred-e2e/delete.sh
+
 
 .PHONY: site-server
 site-server: hugo ## 🌐 Start Hugo development server

--- a/hack/alfred-e2e/README.md
+++ b/hack/alfred-e2e/README.md
@@ -1,0 +1,58 @@
+# Alfred nested-KWOK E2E
+
+This harness runs a self-contained KWOK Kubernetes API server in an isolated
+namespace of an existing host cluster. A real Alfred pod connects to that
+nested API; only the nested Nodes and workload Pods are simulated. No local
+container runtime is required, and no fake Node is added to the host cluster.
+
+The fragmentation fixture creates ten fake 8-GPU nodes, places one movable
+1-GPU OME pod on each node, and leaves an 8-GPU demand pending. Its E2E-only
+configuration weights the 8-GPU bucket, making the scenario deterministic
+while retaining Alfred's normal `0.25` policy gate.
+
+## Run
+
+The host kubeconfig must point to a disposable/test Kubernetes cluster. The
+Alfred image must match the host node architecture. For a private image, name
+an existing `kubernetes.io/dockerconfigjson` pull secret to copy into the
+isolated namespace.
+
+```bash
+make alfred-e2e-cluster \
+  ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig \
+  ALFRED_E2E_IMG=fra.ocir.io/idqj093njucb/alfred-new:fra-test-6d936c56dea6 \
+  ALFRED_E2E_PULL_SECRET_SOURCE=ome/alfred-build-registry
+
+make alfred-e2e-fragmentation \
+  ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig
+```
+
+The second target succeeds only when:
+
+- the synthetic 8-GPU demand remains Pending;
+- `alfred_cluster_fragmentation_score` exceeds `0.25`;
+- `alfred-recommendations/last-cycle.json` contains recommendations; and
+- at least one recommendation is `withheld`, proving recommend-only admission.
+
+Re-run assertions without recreating the fixture:
+
+```bash
+make alfred-e2e-verify \
+  ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig
+```
+
+Delete the host namespace, including the nested cluster and its complete
+simulated state:
+
+```bash
+make alfred-e2e-clean \
+  ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig
+```
+
+Optional overrides:
+
+- `ALFRED_E2E_NAMESPACE` — host namespace, default `alfred-e2e`.
+- `ALFRED_E2E_HOST_CONTEXT` — explicit context inside the host kubeconfig.
+- `ALFRED_E2E_NESTED_PORT` — local tunnel port, default `18080`.
+- `KWOK_CLUSTER_IMAGE` — nested KWOK image, default
+  `registry.k8s.io/kwok/cluster:v0.8.0-k8s.v1.33.12`.

--- a/hack/alfred-e2e/README.md
+++ b/hack/alfred-e2e/README.md
@@ -6,9 +6,17 @@ nested API; only the nested Nodes and workload Pods are simulated. No local
 container runtime is required, and no fake Node is added to the host cluster.
 
 The fragmentation fixture creates ten fake 8-GPU nodes, places one movable
-1-GPU OME pod on each node, and leaves an 8-GPU demand pending. Its E2E-only
-configuration weights the 8-GPU bucket, making the scenario deterministic
-while retaining Alfred's normal `0.25` policy gate.
+1-GPU OME pod on each node, and leaves an 8-GPU demand pending. Seven GPUs
+free on every node seats no 8-GPU job at all, while a repack would free whole
+nodes — so reclaimable fragmentation lands near `0.64`, well clear of
+Alfred's normal `0.25` policy gate, which the fixture keeps unchanged.
+
+Two settings are E2E-only, both for determinism rather than to force the
+result. `demandBlendLambda: 1.0` takes the scoring weights entirely from the
+shipped size prior instead of from observed demand, so the score does not
+drift as pods come and go. The loop intervals and cooldowns are compressed to
+seconds and single minutes so a cycle is observable inside the verifier's
+120-second window.
 
 ## Run
 
@@ -29,7 +37,7 @@ make alfred-e2e-fragmentation \
 
 The second target succeeds only when:
 
-- the synthetic 8-GPU demand remains Pending;
+- the synthetic 8-GPU demand is rejected by the scheduler as `Unschedulable`;
 - `alfred_cluster_fragmentation_score` exceeds `0.25`;
 - `alfred-recommendations/last-cycle.json` contains recommendations; and
 - at least one recommendation is `withheld`, proving recommend-only admission.

--- a/hack/alfred-e2e/README.md
+++ b/hack/alfred-e2e/README.md
@@ -20,6 +20,10 @@ seconds and single minutes so a cycle is observable inside the verifier's
 
 ## Run
 
+Requires `kubectl` and `jq` on PATH. The make targets provision kustomize into
+`bin/` themselves; only a direct `hack/alfred-e2e/create.sh` invocation needs
+`KUSTOMIZE_BIN` pointed at one.
+
 The host kubeconfig must point to a disposable/test Kubernetes cluster. The
 Alfred image must match the host node architecture. For a private image, name
 an existing `kubernetes.io/dockerconfigjson` pull secret to copy into the
@@ -28,7 +32,7 @@ isolated namespace.
 ```bash
 make alfred-e2e-cluster \
   ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig \
-  ALFRED_E2E_IMG=fra.ocir.io/idqj093njucb/alfred-new:fra-test-6d936c56dea6 \
+  ALFRED_E2E_IMG=<registry>/<repo>/alfred:<tag> \
   ALFRED_E2E_PULL_SECRET_SOURCE=ome/alfred-build-registry
 
 make alfred-e2e-fragmentation \
@@ -64,3 +68,9 @@ Optional overrides:
 - `ALFRED_E2E_NESTED_PORT` — local tunnel port, default `18080`.
 - `KWOK_CLUSTER_IMAGE` — nested KWOK image, default
   `registry.k8s.io/kwok/cluster:v0.8.0-k8s.v1.33.12`.
+- `KUSTOMIZE_BIN` — kustomize binary, default `bin/kustomize`.
+
+The nested KWOK container runs as root: its all-in-one image declares no
+`USER` and writes control-plane state as root, so it meets the `baseline` Pod
+Security Standard but not `restricted`. Both containers drop all capabilities,
+disallow privilege escalation, and set `RuntimeDefault` seccomp.

--- a/hack/alfred-e2e/create.sh
+++ b/hack/alfred-e2e/create.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
+require_command kubectl jq
+
 alfred_image="${ALFRED_E2E_IMG:-}"
 pull_secret_source="${ALFRED_E2E_PULL_SECRET_SOURCE:-}"
 kustomize_bin="${KUSTOMIZE_BIN:-${project_dir}/bin/kustomize}"

--- a/hack/alfred-e2e/create.sh
+++ b/hack/alfred-e2e/create.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+alfred_image="${ALFRED_E2E_IMG:-}"
+pull_secret_source="${ALFRED_E2E_PULL_SECRET_SOURCE:-}"
+kustomize_bin="${KUSTOMIZE_BIN:-${project_dir}/bin/kustomize}"
+render_dir=""
+
+cleanup() {
+  stop_nested_tunnel
+  if [[ -n "${render_dir}" && -d "${render_dir}" ]]; then
+    rm -rf "${render_dir}"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${alfred_image}" ]]; then
+  echo "ALFRED_E2E_IMG must name the Alfred image to test" >&2
+  exit 1
+fi
+if [[ ! -x "${kustomize_bin}" ]]; then
+  echo "required executable not found: ${kustomize_bin}" >&2
+  exit 1
+fi
+if [[ -z "${pull_secret_source}" || "${pull_secret_source}" != */* ]]; then
+  echo "ALFRED_E2E_PULL_SECRET_SOURCE must be namespace/name" >&2
+  exit 1
+fi
+
+source_secret_namespace="${pull_secret_source%%/*}"
+source_secret_name="${pull_secret_source#*/}"
+
+echo "Creating isolated host namespace ${host_namespace}"
+"${host_kubectl[@]}" create namespace "${host_namespace}" \
+  --dry-run=client -o yaml | "${host_kubectl[@]}" apply -f -
+
+# Copy only the explicitly selected cluster secret into the isolated namespace.
+"${host_kubectl[@]}" -n "${source_secret_namespace}" get secret "${source_secret_name}" -o json |
+  jq --arg namespace "${host_namespace}" \
+    'del(.metadata.annotations, .metadata.creationTimestamp, .metadata.managedFields, .metadata.ownerReferences, .metadata.resourceVersion, .metadata.uid) |
+     .metadata.name = "alfred-e2e-registry" | .metadata.namespace = $namespace' |
+  "${host_kubectl[@]}" apply -f -
+
+render_dir="$(mktemp -d)"
+cp -R "${script_dir}/host/." "${render_dir}/"
+(
+  cd "${render_dir}"
+  "${kustomize_bin}" edit set namespace "${host_namespace}"
+  "${kustomize_bin}" edit set image "alfred-e2e-placeholder=${alfred_image}"
+  "${kustomize_bin}" edit set image \
+    "registry.k8s.io/kwok/cluster=${KWOK_CLUSTER_IMAGE:-registry.k8s.io/kwok/cluster:v0.8.0-k8s.v1.33.12}"
+)
+
+"${kustomize_bin}" build "${render_dir}" |
+  "${host_kubectl[@]}" apply --server-side --force-conflicts -f -
+"${host_kubectl[@]}" -n "${host_namespace}" rollout status \
+  deployment/kwok-cluster --timeout=240s
+
+start_nested_tunnel
+echo "Installing OME CRDs and Alfred configuration in nested KWOK"
+nested_kubectl apply --server-side --force-conflicts -k "${project_dir}/config/crd"
+crd_ready=false
+for _ in $(seq 1 60); do
+  established="$(nested_kubectl get crd inferenceservices.ome.io \
+    -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' \
+    2>/dev/null || true)"
+  if [[ "${established}" == "True" ]]; then
+    crd_ready=true
+    break
+  fi
+  sleep 2
+done
+if [[ "${crd_ready}" != "true" ]]; then
+  echo "InferenceService CRD did not become established" >&2
+  exit 1
+fi
+nested_kubectl apply -f "${script_dir}/nested/alfred-config.yaml"
+
+"${host_kubectl[@]}" -n "${host_namespace}" rollout restart \
+  deployment/alfred-under-test
+"${host_kubectl[@]}" -n "${host_namespace}" rollout status \
+  deployment/alfred-under-test --timeout=240s
+echo "Nested KWOK and Alfred are ready in host namespace ${host_namespace}"

--- a/hack/alfred-e2e/delete.sh
+++ b/hack/alfred-e2e/delete.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+"${host_kubectl[@]}" delete namespace "${host_namespace}" \
+  --ignore-not-found --wait=true

--- a/hack/alfred-e2e/fragmentation.sh
+++ b/hack/alfred-e2e/fragmentation.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 trap stop_nested_tunnel EXIT
 
+require_command kubectl
+
 scenario_namespace="alfred-e2e"
 scenario_label="alfred-e2e.ome.io/scenario=fragmentation"
 gpu_product="ALFRED-E2E-H100"

--- a/hack/alfred-e2e/fragmentation.sh
+++ b/hack/alfred-e2e/fragmentation.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+trap stop_nested_tunnel EXIT
+
+scenario_namespace="alfred-e2e"
+scenario_label="alfred-e2e.ome.io/scenario=fragmentation"
+gpu_product="ALFRED-E2E-H100"
+
+start_nested_tunnel
+
+echo "Resetting the nested fragmentation fixture"
+nested_kubectl delete namespace "${scenario_namespace}" \
+  --ignore-not-found --wait=true
+nested_kubectl delete nodes -l "${scenario_label}" \
+  --ignore-not-found --wait=true
+nested_kubectl create namespace "${scenario_namespace}"
+
+for index in $(seq 0 9); do
+  node_name="alfred-e2e-gpu-${index}"
+  nested_kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Node
+metadata:
+  name: ${node_name}
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    alfred-e2e.ome.io/scenario: fragmentation
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: ${node_name}
+    kubernetes.io/os: linux
+    nvidia.com/gpu.product: ${gpu_product}
+spec:
+  taints:
+    - key: kwok.x-k8s.io/node
+      value: fake
+      effect: NoSchedule
+status:
+  allocatable:
+    cpu: "32"
+    memory: 256Gi
+    pods: "110"
+    nvidia.com/gpu: "8"
+  capacity:
+    cpu: "32"
+    memory: 256Gi
+    pods: "110"
+    nvidia.com/gpu: "8"
+  phase: Running
+EOF
+done
+
+for index in $(seq 0 9); do
+  nested_kubectl wait --for=condition=Ready \
+    "node/alfred-e2e-gpu-${index}" --timeout=120s
+done
+
+nested_kubectl -n "${scenario_namespace}" apply -f - <<'EOF'
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: fragmented
+  annotations:
+    alfred.ome.io/movable: "true"
+spec:
+  engine:
+    minReplicas: 10
+    maxReplicas: 10
+EOF
+
+for index in $(seq 0 9); do
+  node_name="alfred-e2e-gpu-${index}"
+  nested_kubectl -n "${scenario_namespace}" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fragmented-${index}
+  labels:
+    alfred-e2e.ome.io/scenario: fragmentation
+    ome.io/inferenceservice: fragmented
+    component: engine
+spec:
+  nodeName: ${node_name}
+  tolerations:
+    - key: kwok.x-k8s.io/node
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: mock-engine
+      image: fake-image
+      resources:
+        requests:
+          nvidia.com/gpu: "1"
+        limits:
+          nvidia.com/gpu: "1"
+EOF
+done
+
+nested_kubectl -n "${scenario_namespace}" wait --for=condition=Ready pod \
+  -l "${scenario_label}" --timeout=120s
+
+for index in $(seq 0 9); do
+  nested_kubectl -n "${scenario_namespace}" patch "pod/fragmented-${index}" \
+    --subresource=status --type=merge \
+    -p '{"status":{"startTime":"2020-01-01T00:00:00Z"}}' >/dev/null
+done
+
+nested_kubectl -n "${scenario_namespace}" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pending-8gpu
+  labels:
+    alfred-e2e.ome.io/scenario: fragmentation
+spec:
+  nodeSelector:
+    nvidia.com/gpu.product: ${gpu_product}
+  tolerations:
+    - key: kwok.x-k8s.io/node
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: pending-demand
+      image: fake-image
+      resources:
+        requests:
+          nvidia.com/gpu: "8"
+        limits:
+          nvidia.com/gpu: "8"
+EOF
+
+# verify.sh owns its own port-forward. Release this script's tunnel first so
+# the verifier can bind the same deterministic local port.
+stop_nested_tunnel
+"${script_dir}/verify.sh"

--- a/hack/alfred-e2e/host/kustomization.yaml
+++ b/hack/alfred-e2e/host/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: alfred-e2e
+
+resources:
+  - resources.yaml
+
+images:
+  - name: alfred-e2e-placeholder
+    newName: alfred-e2e-placeholder
+    newTag: latest

--- a/hack/alfred-e2e/host/resources.yaml
+++ b/hack/alfred-e2e/host/resources.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kwok-cluster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kwok-cluster
+  template:
+    metadata:
+      labels:
+        app: kwok-cluster
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: cluster
+          image: registry.k8s.io/kwok/cluster:v0.8.0-k8s.v1.33.12
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: apiserver
+              containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: apiserver
+            periodSeconds: 2
+            failureThreshold: 60
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kwok-cluster
+spec:
+  selector:
+    app: kwok-cluster
+  ports:
+    - name: apiserver
+      port: 8080
+      targetPort: apiserver
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nested-kubeconfig
+data:
+  config: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: kwok
+        cluster:
+          server: http://kwok-cluster:8080
+    contexts:
+      - name: kwok
+        context:
+          cluster: kwok
+          user: anonymous
+    current-context: kwok
+    users:
+      - name: anonymous
+        user: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alfred-under-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alfred-under-test
+  template:
+    metadata:
+      labels:
+        app: alfred-under-test
+    spec:
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: alfred-e2e-registry
+      containers:
+        - name: alfred
+          image: alfred-e2e-placeholder:latest
+          imagePullPolicy: Always
+          args:
+            - --metrics-bind-address=:8080
+            - --health-probe-bind-address=:8081
+            - --leader-elect=true
+            - --config-name=alfred-config
+            - --config-key=config.yaml
+          env:
+            - name: KUBECONFIG
+              value: /etc/nested/config
+            - name: POD_NAMESPACE
+              value: ome
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: health
+              containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            periodSeconds: 2
+            failureThreshold: 60
+          volumeMounts:
+            - name: kubeconfig
+              mountPath: /etc/nested
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: nested-kubeconfig

--- a/hack/alfred-e2e/host/resources.yaml
+++ b/hack/alfred-e2e/host/resources.yaml
@@ -17,6 +17,15 @@ spec:
         - name: cluster
           image: registry.k8s.io/kwok/cluster:v0.8.0-k8s.v1.33.12
           imagePullPolicy: IfNotPresent
+          # No runAsNonRoot: the KWOK all-in-one image declares no USER and
+          # its entrypoint writes control-plane state as root.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: apiserver
               containerPort: 8080
@@ -88,6 +97,14 @@ spec:
         - name: alfred
           image: alfred-e2e-placeholder:latest
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           args:
             - --metrics-bind-address=:8080
             - --health-probe-bind-address=:8081

--- a/hack/alfred-e2e/lib.sh
+++ b/hack/alfred-e2e/lib.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_dir="$(cd "${script_dir}/../.." && pwd)"
+host_kubeconfig="${ALFRED_E2E_HOST_KUBECONFIG:-}"
+host_context="${ALFRED_E2E_HOST_CONTEXT:-}"
+host_namespace="${ALFRED_E2E_NAMESPACE:-alfred-e2e}"
+nested_port="${ALFRED_E2E_NESTED_PORT:-18080}"
+nested_server="http://127.0.0.1:${nested_port}"
+
+host_kubectl=(kubectl)
+if [[ -n "${host_kubeconfig}" ]]; then
+  host_kubectl+=(--kubeconfig "${host_kubeconfig}")
+fi
+if [[ -n "${host_context}" ]]; then
+  host_kubectl+=(--context "${host_context}")
+fi
+
+tunnel_pid=""
+tunnel_log=""
+
+stop_nested_tunnel() {
+  if [[ -n "${tunnel_pid}" ]]; then
+    kill "${tunnel_pid}" >/dev/null 2>&1 || true
+    wait "${tunnel_pid}" >/dev/null 2>&1 || true
+    tunnel_pid=""
+  fi
+  if [[ -n "${tunnel_log}" && -f "${tunnel_log}" ]]; then
+    rm -f "${tunnel_log}"
+    tunnel_log=""
+  fi
+}
+
+start_nested_tunnel() {
+  tunnel_log="$(mktemp)"
+  "${host_kubectl[@]}" -n "${host_namespace}" port-forward \
+    service/kwok-cluster "${nested_port}:8080" >"${tunnel_log}" 2>&1 &
+  tunnel_pid=$!
+
+  for _ in $(seq 1 30); do
+    if ! kill -0 "${tunnel_pid}" >/dev/null 2>&1; then
+      cat "${tunnel_log}" >&2
+      return 1
+    fi
+    if kubectl --server "${nested_server}" get --raw=/readyz >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  cat "${tunnel_log}" >&2
+  return 1
+}
+
+nested_kubectl() {
+  kubectl --server "${nested_server}" "$@"
+}

--- a/hack/alfred-e2e/lib.sh
+++ b/hack/alfred-e2e/lib.sh
@@ -18,6 +18,16 @@ if [[ -n "${host_context}" ]]; then
   host_kubectl+=(--context "${host_context}")
 fi
 
+require_command() {
+  local cmd
+  for cmd in "$@"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      echo "required command not found: ${cmd}" >&2
+      exit 1
+    fi
+  done
+}
+
 tunnel_pid=""
 tunnel_log=""
 
@@ -34,25 +44,42 @@ stop_nested_tunnel() {
 }
 
 start_nested_tunnel() {
-  tunnel_log="$(mktemp)"
-  "${host_kubectl[@]}" -n "${host_namespace}" port-forward \
-    service/kwok-cluster "${nested_port}:8080" >"${tunnel_log}" 2>&1 &
-  tunnel_pid=$!
+  local outcome
+  # A handoff between scripts can reach here before the previous forward has
+  # released the fixed local port, which kills the new one on bind. That is
+  # transient, so retry it; a forward that stays up but never answers is not.
+  for _ in 1 2 3; do
+    tunnel_log="$(mktemp)"
+    "${host_kubectl[@]}" -n "${host_namespace}" port-forward \
+      service/kwok-cluster "${nested_port}:8080" >"${tunnel_log}" 2>&1 &
+    tunnel_pid=$!
 
-  for _ in $(seq 1 30); do
-    if ! kill -0 "${tunnel_pid}" >/dev/null 2>&1; then
-      cat "${tunnel_log}" >&2
+    outcome="unready"
+    for _ in $(seq 1 30); do
+      if ! kill -0 "${tunnel_pid}" >/dev/null 2>&1; then
+        outcome="died"
+        break
+      fi
+      if nested_kubectl get --raw=/readyz >/dev/null 2>&1; then
+        return 0
+      fi
+      sleep 1
+    done
+
+    cat "${tunnel_log}" >&2
+    if [[ "${outcome}" != "died" ]]; then
       return 1
     fi
-    if kubectl --server "${nested_server}" get --raw=/readyz >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 1
+    stop_nested_tunnel
+    sleep 2
   done
-  cat "${tunnel_log}" >&2
   return 1
 }
 
+# The nested API is anonymous plain HTTP. --server overrides only the cluster
+# server, so without an explicit empty kubeconfig the ambient context's user
+# still applies — and every cloud kubeconfig runs an exec credential plugin,
+# which would make these calls fail for reasons unrelated to the nested cluster.
 nested_kubectl() {
-  kubectl --server "${nested_server}" "$@"
+  kubectl --kubeconfig /dev/null --server "${nested_server}" "$@"
 }

--- a/hack/alfred-e2e/nested/alfred-config.yaml
+++ b/hack/alfred-e2e/nested/alfred-config.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ome
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alfred-config
+  namespace: ome
+data:
+  config.yaml: |
+    schemaVersion: 1
+    mode: recommend-only
+    decisionLoopInterval: 2s
+    observationLoopInterval: 1s
+    earlyTickOn: [NodeConditionChange]
+    policies:
+      defragmentation:
+        enabled: true
+        fragmentationThreshold: 0.25
+        aggressiveness: balanced
+        scoring:
+          sizeLadder: [1, 2, 4, 8]
+          demandBlendLambda: 1.0
+          sizePrior:
+            "1": 0.0
+            "2": 0.0
+            "4": 0.0
+            "8": 1.0
+          pendingUrgencyTauMinutes: 1
+      nodeHealth:
+        enabled: true
+        aggressiveness: balanced
+        triggerConditions: [GpuUnhealthy]
+        signalOnly: false
+        healthCooldownFloorMinutes: 1
+        nodeSuspicionWindowMinutes: 1
+    defaultMovable: true
+    recentPlacementCooldownMinutes: 1
+    perWorkloadCooldownMinutes: 1
+    perNodeCooldownMinutes: 1
+    rawDeploymentMigrationEnabled: true
+    omenativeMigrationEnabled: true
+    lwsRecommendationsEnabled: true
+    recommendationsConfigMapEnabled: true
+    recommendationsConfigMapName: alfred-recommendations
+    maxInFlightMigrations: 3
+    maxMigrationsPerHour: 10
+    emergencyPendingAgeMinutes: 1
+    maintenanceWindows: []
+    spotPolicy:
+      avoidAsTarget: true
+      preferAsSource: true
+      preemptibleLabels:
+        - node.kubernetes.io/preemptible
+        - cloud.google.com/gke-preemptible
+    allowCrossTenantOptimization: true
+    logLevel: info
+    structuredLogging: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alfred-recommendations
+  namespace: ome

--- a/hack/alfred-e2e/nested/alfred-config.yaml
+++ b/hack/alfred-e2e/nested/alfred-config.yaml
@@ -24,10 +24,10 @@ data:
           sizeLadder: [1, 2, 4, 8]
           demandBlendLambda: 1.0
           sizePrior:
-            "1": 0.0
-            "2": 0.0
-            "4": 0.0
-            "8": 1.0
+            "1": 0.1
+            "2": 0.1
+            "4": 0.2
+            "8": 0.6
           pendingUrgencyTauMinutes: 1
       nodeHealth:
         enabled: true

--- a/hack/alfred-e2e/verify.sh
+++ b/hack/alfred-e2e/verify.sh
@@ -5,11 +5,14 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 trap stop_nested_tunnel EXIT
 
+require_command kubectl jq
+
 scenario_namespace="alfred-e2e"
 deadline=$((SECONDS + 120))
 last_score="unavailable"
 last_count="0"
 last_withheld="0"
+last_pending="unavailable"
 
 start_nested_tunnel
 
@@ -32,17 +35,23 @@ while (( SECONDS < deadline )); do
     last_withheld="$(jq -r '[.recommendations // [] | .[] | select(.outcome == "withheld")] | length' <<<"${record}")"
   fi
 
+  # An empty nodeName alone would also hold if nothing ever tried to schedule
+  # the pod, so require the scheduler's own verdict: it looked and found no
+  # node with 8 free GPUs, which is the condition the fixture exists to create.
   pending_node="$(nested_kubectl -n "${scenario_namespace}" get pod pending-8gpu \
     -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)"
+  pending_reason="$(nested_kubectl -n "${scenario_namespace}" get pod pending-8gpu \
+    -o jsonpath='{.status.conditions[?(@.type=="PodScheduled")].reason}' 2>/dev/null || true)"
+  last_pending="node=${pending_node:-none} reason=${pending_reason:-none}"
   if [[ -n "${last_score}" ]] &&
      awk -v score="${last_score}" 'BEGIN { exit !(score > 0.25) }' &&
      (( last_count > 0 )) && (( last_withheld > 0 )) &&
-     [[ -z "${pending_node}" ]]; then
+     [[ -z "${pending_node}" && "${pending_reason}" == "Unschedulable" ]]; then
     echo "Alfred fragmentation E2E passed"
     echo "  score: ${last_score}"
     echo "  recommendations: ${last_count}"
     echo "  recommend-only withheld: ${last_withheld}"
-    echo "  pending 8-GPU demand: unscheduled"
+    echo "  pending 8-GPU demand: Unschedulable"
     exit 0
   fi
   sleep 2
@@ -52,6 +61,7 @@ echo "Alfred fragmentation E2E timed out" >&2
 echo "  score: ${last_score}" >&2
 echo "  recommendations: ${last_count}" >&2
 echo "  recommend-only withheld: ${last_withheld}" >&2
+echo "  pending 8-GPU demand: ${last_pending}" >&2
 "${host_kubectl[@]}" -n "${host_namespace}" logs deployment/alfred-under-test \
   --tail=80 >&2 || true
 exit 1

--- a/hack/alfred-e2e/verify.sh
+++ b/hack/alfred-e2e/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+trap stop_nested_tunnel EXIT
+
+scenario_namespace="alfred-e2e"
+deadline=$((SECONDS + 120))
+last_score="unavailable"
+last_count="0"
+last_withheld="0"
+
+start_nested_tunnel
+
+while (( SECONDS < deadline )); do
+  alfred_pod="$("${host_kubectl[@]}" -n "${host_namespace}" get pods \
+    -l app=alfred-under-test -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [[ -z "${alfred_pod}" ]]; then
+    sleep 2
+    continue
+  fi
+
+  metrics="$("${host_kubectl[@]}" get --raw \
+    "/api/v1/namespaces/${host_namespace}/pods/${alfred_pod}:8080/proxy/metrics" \
+    2>/dev/null || true)"
+  last_score="$(awk '$1 == "alfred_cluster_fragmentation_score" {print $2}' <<<"${metrics}")"
+  record="$(nested_kubectl -n ome get configmap alfred-recommendations \
+    -o jsonpath='{.data.last-cycle\.json}' 2>/dev/null || true)"
+  if [[ -n "${record}" ]]; then
+    last_count="$(jq -r '.recommendations // [] | length' <<<"${record}")"
+    last_withheld="$(jq -r '[.recommendations // [] | .[] | select(.outcome == "withheld")] | length' <<<"${record}")"
+  fi
+
+  pending_node="$(nested_kubectl -n "${scenario_namespace}" get pod pending-8gpu \
+    -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)"
+  if [[ -n "${last_score}" ]] &&
+     awk -v score="${last_score}" 'BEGIN { exit !(score > 0.25) }' &&
+     (( last_count > 0 )) && (( last_withheld > 0 )) &&
+     [[ -z "${pending_node}" ]]; then
+    echo "Alfred fragmentation E2E passed"
+    echo "  score: ${last_score}"
+    echo "  recommendations: ${last_count}"
+    echo "  recommend-only withheld: ${last_withheld}"
+    echo "  pending 8-GPU demand: unscheduled"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Alfred fragmentation E2E timed out" >&2
+echo "  score: ${last_score}" >&2
+echo "  recommendations: ${last_count}" >&2
+echo "  recommend-only withheld: ${last_withheld}" >&2
+"${host_kubectl[@]}" -n "${host_namespace}" logs deployment/alfred-under-test \
+  --tail=80 >&2 || true
+exit 1


### PR DESCRIPTION
## What this PR does

Adds a self-contained E2E harness for Alfred under `hack/alfred-e2e`, plus
four `make` targets to drive it.

A KWOK API server runs in an isolated namespace of an existing host cluster.
A real Alfred pod connects to that nested API, so only the nested Nodes and
workload Pods are simulated — no local container runtime, and no fake Node is
ever added to the host cluster.

The fragmentation fixture creates ten fake 8-GPU nodes, places one movable
1-GPU OME pod on each, and leaves an 8-GPU demand pending. Seven free GPUs per
node seats no 8-GPU job, while a repack would free whole nodes, so reclaimable
fragmentation lands near `0.64` — well clear of the unchanged `0.25` gate.

`make alfred-e2e-fragmentation` passes only when all four hold:

- the synthetic 8-GPU demand is rejected by the scheduler as `Unschedulable`
- `alfred_cluster_fragmentation_score` exceeds `0.25`
- `alfred-recommendations/last-cycle.json` contains recommendations
- at least one is `withheld`, proving recommend-only admission

## Why we need it

Alfred's decision layer is unit-testable as a pure function of the snapshot,
but nothing exercised the wiring end to end: config load, the observation and
decision loops, leader election, metric emission, and the Reporter's
ConfigMap write. Those only fail together, against a live API server.

Nesting KWOK rather than adding fake nodes to the host keeps the blast radius
at one namespace — the entire simulated cluster is deleted with it — and
avoids requiring GPU hardware or a local runtime to test GPU behaviour.

Two settings are E2E-only, for determinism rather than to force the result:
`demandBlendLambda: 1.0` takes the weights from the shipped size prior instead
of observed demand, and the loop intervals and cooldowns are compressed so a
cycle is observable inside the verifier's window. The policy gate, the size
prior, and the scoring itself are the shipped defaults.

## How to test

```bash
make alfred-e2e-cluster \
  ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig \
  ALFRED_E2E_IMG=<alfred image> \
  ALFRED_E2E_PULL_SECRET_SOURCE=<ns>/<secret>

make alfred-e2e-fragmentation ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig
make alfred-e2e-clean         ALFRED_E2E_HOST_KUBECONFIG=/path/to/host-kubeconfig
```

The host kubeconfig must point at a disposable test cluster, and the Alfred
image must match the host node architecture. The targets are manual — nothing
here runs in CI.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [ ] `make test` passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an isolated end-to-end testing workflow for Alfred in a nested Kubernetes environment.
  * Added automated cluster setup, fragmentation scenario execution, verification, and cleanup.
  * Added configurable images, namespaces, kubeconfig, contexts, and pull secrets.
  * Added deterministic GPU fragmentation testing with recommendation and scheduling validation.
  * Added secure container defaults for the test environment.
* **Documentation**
  * Added prerequisites, setup instructions, configuration options, verification criteria, and cleanup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->