### PR TITLE
feat!: oci:// addresses CNCF ModelPack artifacts via llmman serve

### DIFF
--- a/internal/ome-agent/replica/factory.go
+++ b/internal/ome-agent/replica/factory.go
@@ -11,7 +11,7 @@ func NewReplicator(r *ReplicaAgent) (replicator.Replicator, error) {
 	sourceStorageType := r.ReplicationInput.SourceStorageType
 	targetStorageType := r.ReplicationInput.TargetStorageType
 	switch {
-	case sourceStorageType == storage.StorageTypeHuggingFace && targetStorageType == storage.StorageTypeOCI:
+	case sourceStorageType == storage.StorageTypeHuggingFace && targetStorageType == storage.StorageTypeOCIObjectStore:
 		return &replicator.HFToOCIReplicator{
 			Logger: r.Logger,
 			Config: replicator.HFToOCIReplicatorConfig{
@@ -25,7 +25,7 @@ func NewReplicator(r *ReplicaAgent) (replicator.Replicator, error) {
 			},
 			ReplicationInput: r.ReplicationInput,
 		}, nil
-	case sourceStorageType == storage.StorageTypeOCI && targetStorageType == storage.StorageTypeOCI:
+	case sourceStorageType == storage.StorageTypeOCIObjectStore && targetStorageType == storage.StorageTypeOCIObjectStore:
 		return &replicator.OCIToOCIReplicator{
 			Logger: r.Logger,
 			Config: replicator.OCIToOCIReplicatorConfig{
@@ -37,7 +37,7 @@ func NewReplicator(r *ReplicaAgent) (replicator.Replicator, error) {
 			},
 			ReplicationInput: r.ReplicationInput,
 		}, nil
-	case sourceStorageType == storage.StorageTypePVC && targetStorageType == storage.StorageTypeOCI:
+	case sourceStorageType == storage.StorageTypePVC && targetStorageType == storage.StorageTypeOCIObjectStore:
 		return &replicator.PVCToOCIReplicator{
 			Logger: r.Logger,
 			Config: replicator.PVCToOCIReplicatorConfig{
@@ -59,7 +59,7 @@ func NewReplicator(r *ReplicaAgent) (replicator.Replicator, error) {
 			},
 			ReplicationInput: r.ReplicationInput,
 		}, nil
-	case sourceStorageType == storage.StorageTypeOCI && targetStorageType == storage.StorageTypePVC:
+	case sourceStorageType == storage.StorageTypeOCIObjectStore && targetStorageType == storage.StorageTypePVC:
 		return &replicator.OCIToPVCReplicator{
 			Logger: r.Logger,
 			Config: replicator.OCIToPVCReplicatorConfig{

--- a/internal/ome-agent/replica/replica.go
+++ b/internal/ome-agent/replica/replica.go
@@ -100,13 +100,13 @@ func NewReplicaAgent(config *Config) (*ReplicaAgent, error) {
 		return nil, fmt.Errorf("failed to parse target storage URI %s - %w", config.Target.StorageURIStr, err)
 	}
 
-	if sourceStorageType == storage.StorageTypeOCI {
+	if sourceStorageType == storage.StorageTypeOCIObjectStore {
 		sourceObjectURI.Region = config.Source.OCIOSDataStore.Config.Region
 		if !strings.HasSuffix(sourceObjectURI.Prefix, "/") && sourceObjectURI.Prefix != "" {
 			sourceObjectURI.Prefix += "/"
 		}
 	}
-	if targetStorageType == storage.StorageTypeOCI {
+	if targetStorageType == storage.StorageTypeOCIObjectStore {
 		targetObjectURI.Region = config.Target.OCIOSDataStore.Config.Region
 		if !strings.HasSuffix(targetObjectURI.Prefix, "/") && targetObjectURI.Prefix != "" {
 			targetObjectURI.Prefix += "/"
@@ -205,7 +205,7 @@ func (r *ReplicaAgent) prepareTargetArtifactUpload() (*targetArtifactUploadLock,
 	if !r.Config.TargetArtifactReuseAllowed {
 		return nil, false, nil
 	}
-	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCI {
+	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCIObjectStore {
 		return nil, false, nil
 	}
 	if r.Config.Target.OCIOSDataStore == nil {
@@ -436,7 +436,7 @@ func (r *ReplicaAgent) prepareTargetArtifactAfterLockAcquired() (bool, error) {
 	if !r.Config.TargetArtifactReuseAllowed {
 		return false, nil
 	}
-	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCI {
+	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCIObjectStore {
 		return false, nil
 	}
 	if r.Config.Target.OCIOSDataStore == nil {
@@ -458,7 +458,7 @@ func (r *ReplicaAgent) prepareTargetArtifactAfterLockAcquired() (bool, error) {
 // removeTargetArtifactCompletionMarkerBeforeOverwrite ensures readers cannot
 // treat a target prefix as complete while replication overwrites its objects.
 func (r *ReplicaAgent) removeTargetArtifactCompletionMarkerBeforeOverwrite() error {
-	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCI {
+	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCIObjectStore {
 		return nil
 	}
 	if r.Config.Target.OCIOSDataStore == nil {
@@ -477,7 +477,7 @@ func (r *ReplicaAgent) writeCompletionMarker() error {
 	if !r.Config.TargetArtifactReuseAllowed {
 		return nil
 	}
-	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCI {
+	if r.ReplicationInput.TargetStorageType != storage.StorageTypeOCIObjectStore {
 		r.Logger.Infof("Skipping target artifact completion marker for non-OCI target storage type %s", r.ReplicationInput.TargetStorageType)
 		return nil
 	}
@@ -552,7 +552,7 @@ func (r *ReplicaAgent) writeTerminationLog(message string) {
 
 func (r *ReplicaAgent) listSourceObjects() ([]common.ReplicationObject, error) {
 	switch r.ReplicationInput.SourceStorageType {
-	case storage.StorageTypeOCI:
+	case storage.StorageTypeOCIObjectStore:
 		listOfObjectSummary, err := r.Config.Source.OCIOSDataStore.ListObjects(r.ReplicationInput.Source)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/v1beta1/benchmark/controller_test.go
+++ b/pkg/controller/v1beta1/benchmark/controller_test.go
@@ -331,7 +331,7 @@ func TestBenchmarkJobReconciler_createPodSpec(t *testing.T) {
 					TrafficScenarios:        []string{"scenario1", "scenario2"},
 					NumConcurrency:          []int{1, 2, 4},
 					OutputLocation: &v1beta1.StorageSpec{
-						StorageUri: StringPtr("oci://n/my-namespace/b/my-bucket/o/results"),
+						StorageUri: StringPtr("ocios://n/my-namespace/b/my-bucket/o/results"),
 					},
 				},
 			},
@@ -436,7 +436,7 @@ func TestBenchmarkJobReconciler_buildBenchmarkCommand(t *testing.T) {
 						GpuCount: 1,
 					},
 					OutputLocation: &v1beta1.StorageSpec{
-						StorageUri: StringPtr("oci://n/my-namespace/b/my-bucket/o/results"),
+						StorageUri: StringPtr("ocios://n/my-namespace/b/my-bucket/o/results"),
 					},
 				},
 			},
@@ -725,7 +725,7 @@ func TestBenchmarkJobReconciler_createPodSpec_NodeAffinity(t *testing.T) {
 			MaxTimePerIteration:     IntPtr(60),
 			MaxRequestsPerIteration: IntPtr(100),
 			OutputLocation: &v1beta1.StorageSpec{
-				StorageUri: StringPtr("oci://n/my-namespace/b/my-bucket/o/results"),
+				StorageUri: StringPtr("ocios://n/my-namespace/b/my-bucket/o/results"),
 			},
 		},
 	}
@@ -818,7 +818,7 @@ func TestBenchmarkJobReconciler_createPodSpec_NodeAffinity_WithPodOverride(t *te
 			MaxTimePerIteration:     IntPtr(60),
 			MaxRequestsPerIteration: IntPtr(100),
 			OutputLocation: &v1beta1.StorageSpec{
-				StorageUri: StringPtr("oci://n/my-namespace/b/my-bucket/o/results"),
+				StorageUri: StringPtr("ocios://n/my-namespace/b/my-bucket/o/results"),
 			},
 			// PodOverride triggers the applyPodOverrides path
 			PodOverride: &v1beta1.PodOverride{

--- a/pkg/controller/v1beta1/benchmark/utils/utils.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils.go
@@ -139,12 +139,12 @@ type storageArgsBuilder func(uri string, params map[string]string) ([]string, er
 
 // storageBuilders maps storage types to their argument builders
 var storageBuilders = map[storage.StorageType]storageArgsBuilder{
-	storage.StorageTypeOCI:    buildOCIArgs,
-	storage.StorageTypePVC:    buildPVCArgs,
-	storage.StorageTypeS3:     buildS3Args,
-	storage.StorageTypeAzure:  buildAzureArgs,
-	storage.StorageTypeGCS:    buildGCSArgs,
-	storage.StorageTypeGitHub: buildGitHubArgs,
+	storage.StorageTypeOCIObjectStore: buildOCIArgs,
+	storage.StorageTypePVC:            buildPVCArgs,
+	storage.StorageTypeS3:             buildS3Args,
+	storage.StorageTypeAzure:          buildAzureArgs,
+	storage.StorageTypeGCS:            buildGCSArgs,
+	storage.StorageTypeGitHub:         buildGitHubArgs,
 }
 
 // addParam appends a flag and value to args if the key exists in params
@@ -186,7 +186,7 @@ func BuildStorageArgs(storageSpec *v1beta1.StorageSpec) ([]string, error) {
 }
 
 func buildOCIArgs(uri string, params map[string]string) ([]string, error) {
-	components, err := storage.ParseOCIStorageURI(uri)
+	components, err := storage.ParseOCIObjectStoreURI(uri)
 	if err != nil {
 		return nil, fmt.Errorf("invalid OCI storage URI: %v", err)
 	}

--- a/pkg/controller/v1beta1/benchmark/utils/utils_test.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils_test.go
@@ -20,17 +20,17 @@ func strPtr(s string) *string {
 	return &s
 }
 
-func TestParseOCIStorageURI(t *testing.T) {
+func TestParseOCIObjectStoreURI(t *testing.T) {
 	tests := []struct {
 		name    string
 		uri     string
-		want    *storage.OCIStorageComponents
+		want    *storage.OCIObjectStoreComponents
 		wantErr bool
 	}{
 		{
 			name: "valid uri",
-			uri:  "oci://n/my-namespace/b/my-bucket/o/path/to/results",
-			want: &storage.OCIStorageComponents{
+			uri:  "ocios://n/my-namespace/b/my-bucket/o/path/to/results",
+			want: &storage.OCIObjectStoreComponents{
 				Namespace: "my-namespace",
 				Bucket:    "my-bucket",
 				Prefix:    "path/to/results",
@@ -39,7 +39,7 @@ func TestParseOCIStorageURI(t *testing.T) {
 		},
 		{
 			name:    "invalid uri - missing namespace",
-			uri:     "oci://n///b/my-bucket/o/results",
+			uri:     "ocios://n///b/my-bucket/o/results",
 			want:    nil,
 			wantErr: true,
 		},
@@ -57,8 +57,8 @@ func TestParseOCIStorageURI(t *testing.T) {
 		},
 		{
 			name: "valid uri - multiple path segments",
-			uri:  "oci://n/my-namespace/b/my-bucket/o/path/with/multiple/segments",
-			want: &storage.OCIStorageComponents{
+			uri:  "ocios://n/my-namespace/b/my-bucket/o/path/with/multiple/segments",
+			want: &storage.OCIObjectStoreComponents{
 				Namespace: "my-namespace",
 				Bucket:    "my-bucket",
 				Prefix:    "path/with/multiple/segments",
@@ -69,20 +69,20 @@ func TestParseOCIStorageURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := storage.ParseOCIStorageURI(tt.uri)
+			got, err := storage.ParseOCIObjectStoreURI(tt.uri)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseOCIStorageURI() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ParseOCIObjectStoreURI() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseOCIStorageURI() = %v, want %v", got, tt.want)
+				t.Errorf("ParseOCIObjectStoreURI() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
 func TestBuildStorageArgs(t *testing.T) {
-	ociStorageUri := "oci://n/my-namespace/b/my-bucket/o/results"
+	ociStorageUri := "ocios://n/my-namespace/b/my-bucket/o/results"
 	pvcStorageUri := "pvc://my-pvc/experiment-results"
 	tests := []struct {
 		name        string

--- a/pkg/llmman/client.go
+++ b/pkg/llmman/client.go
@@ -1,0 +1,263 @@
+// Package llmman is a client for a running `llmman serve` daemon
+// (https://github.com/llmmanorg/llmman), used to acquire models published as
+// CNCF ModelPack (https://github.com/modelpack/model-spec) OCI artifacts.
+//
+// The daemon owns the registry work -- ModelPack media types, registry auth,
+// resumable blob download and a content-addressed local store -- so it is not
+// reimplemented here. Two pieces are needed, because the daemon deliberately
+// exposes no local path: `POST /api/pull` streams the download, and
+// `llmman resolve --no-pull` reports where the bytes landed. That means a pull
+// needs both the daemon reachable and the binary on PATH; each missing piece
+// has its own error.
+//
+// Only the standard library is used, so this adds no dependency to OME.
+package llmman
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultHost and DefaultPort match `llmman serve`'s own defaults.
+	DefaultHost = "127.0.0.1"
+	DefaultPort = "17434"
+
+	// HostEnv is the same variable llmman's own clients read.
+	HostEnv = "LLMMAN_HOST"
+	// BinEnv overrides the llmman binary location.
+	BinEnv = "OME_LLMMAN_BIN"
+
+	defaultBinary = "llmman"
+)
+
+// ProgressFunc receives coarse pull progress. completed and total are zero
+// when the daemon does not report byte counts for a step.
+type ProgressFunc func(status string, completed, total int64)
+
+// Endpoint returns the http origin of the llmman daemon.
+//
+// LLMMAN_HOST is parsed as [scheme://]host[:port]; a wildcard bind host
+// (0.0.0.0 or ::) is rewritten to loopback, since a client cannot connect to
+// "every interface". This mirrors llmman's own client-side resolution.
+func Endpoint() string {
+	raw := strings.Trim(strings.TrimSpace(os.Getenv(HostEnv)), `"'`)
+	if raw == "" {
+		return "http://" + net.JoinHostPort(DefaultHost, DefaultPort)
+	}
+	if idx := strings.Index(raw, "://"); idx >= 0 {
+		raw = raw[idx+3:]
+	}
+	if idx := strings.Index(raw, "/"); idx >= 0 {
+		raw = raw[:idx]
+	}
+
+	host, port, err := net.SplitHostPort(raw)
+	if err != nil {
+		host, port = raw, DefaultPort
+	}
+	if host == "" {
+		host = DefaultHost
+	}
+	if port == "" {
+		port = DefaultPort
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		if ip.To4() != nil {
+			host = "127.0.0.1"
+		} else {
+			host = "::1"
+		}
+	}
+	return "http://" + net.JoinHostPort(host, port)
+}
+
+// Binary returns the llmman executable name, overridable via OME_LLMMAN_BIN.
+func Binary() string {
+	if v := strings.TrimSpace(os.Getenv(BinEnv)); v != "" {
+		return v
+	}
+	return defaultBinary
+}
+
+// CheckDaemon confirms an llmman daemon is listening and answering.
+//
+// /api/version is llmman's own identity endpoint; a response without a version
+// field means something else is bound to the port, which is worth
+// distinguishing from nothing listening at all.
+func CheckDaemon(ctx context.Context, client *http.Client, endpoint string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/version", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("no llmman daemon reachable at %s: %w. Start one with `llmman serve`, or point %s at an existing daemon", endpoint, err, HostEnv)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("llmman daemon at %s answered /api/version with HTTP %d", endpoint, resp.StatusCode)
+	}
+	var payload struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil || payload.Version == "" {
+		return fmt.Errorf("the server at %s is not an llmman daemon (no version in /api/version)", endpoint)
+	}
+	return nil
+}
+
+// pullLine is one newline-delimited JSON object from /api/pull, mirroring
+// Ollama's ProgressResponse.
+type pullLine struct {
+	Status    string `json:"status"`
+	Error     string `json:"error"`
+	Total     int64  `json:"total"`
+	Completed int64  `json:"completed"`
+}
+
+// Pull streams POST /api/pull until the daemon reports success.
+//
+// An error can arrive in-band at HTTP 200, and a stream that ends without
+// success is also a failure -- neither is treated as a completed pull.
+func Pull(ctx context.Context, client *http.Client, endpoint, reference string, progress ProgressFunc) error {
+	body, err := json.Marshal(map[string]string{"model": reference})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/api/pull", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("llmman pull of %q failed: %w", reference, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("llmman pull of %q failed: HTTP %d", reference, resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	succeeded := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var l pullLine
+		if err := json.Unmarshal([]byte(line), &l); err != nil {
+			// Tolerate a non-JSON diagnostic rather than aborting a pull that
+			// may still be progressing.
+			continue
+		}
+		if l.Error != "" {
+			return fmt.Errorf("llmman pull of %q failed: %s", reference, l.Error)
+		}
+		if l.Status == "success" {
+			succeeded = true
+			continue
+		}
+		if progress != nil && l.Status != "" {
+			progress(l.Status, l.Completed, l.Total)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading llmman pull stream for %q: %w", reference, err)
+	}
+	if !succeeded {
+		return fmt.Errorf("llmman pull of %q ended without reporting success", reference)
+	}
+	return nil
+}
+
+type resolveOutput struct {
+	Path string `json:"path"`
+}
+
+// Resolve reports where the daemon's pull left the model on disk.
+//
+// --no-pull guarantees this only reports on bytes /api/pull already fetched,
+// so the daemon stays the only thing that touches the network.
+func Resolve(ctx context.Context, reference string) (string, error) {
+	binary := Binary()
+	if _, err := exec.LookPath(binary); err != nil {
+		if _, statErr := os.Stat(binary); statErr != nil {
+			return "", fmt.Errorf("%q not found: install llmman (https://github.com/llmmanorg/llmman) and put it on PATH, or set %s to its location", binary, BinEnv)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "resolve", "--no-pull", reference)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("`%s resolve --no-pull %s` failed: %w: %s", binary, reference, err, strings.TrimSpace(stderr.String()))
+	}
+	return parseResolveOutput(stdout.String(), reference)
+}
+
+// parseResolveOutput takes the last non-empty stdout line, so a diagnostic
+// that leaks onto stdout does not break resolution, and ignores unknown JSON
+// keys so the contract can grow.
+func parseResolveOutput(stdout, reference string) (string, error) {
+	var last string
+	for _, line := range strings.Split(stdout, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			last = trimmed
+		}
+	}
+	if last == "" {
+		return "", fmt.Errorf("llmman resolve %q printed nothing on stdout", reference)
+	}
+
+	var out resolveOutput
+	if err := json.Unmarshal([]byte(last), &out); err != nil {
+		return "", fmt.Errorf("llmman resolve %q: could not parse output as JSON: %s", reference, last)
+	}
+	if strings.TrimSpace(out.Path) == "" {
+		return "", fmt.Errorf("llmman resolve %q returned an empty path", reference)
+	}
+	if _, err := os.Stat(out.Path); err != nil {
+		return "", fmt.Errorf("llmman resolve %q reported path %q which does not exist: %w", reference, out.Path, err)
+	}
+	return out.Path, nil
+}
+
+// PullAndResolve performs the full acquisition: probe, pull, report the path.
+func PullAndResolve(ctx context.Context, reference string, progress ProgressFunc) (string, error) {
+	endpoint := Endpoint()
+	if err := CheckDaemon(ctx, ProbeClient(), endpoint); err != nil {
+		return "", err
+	}
+	if err := Pull(ctx, DefaultClient(), endpoint, reference, progress); err != nil {
+		return "", err
+	}
+	return Resolve(ctx, reference)
+}
+
+// DefaultClient has no overall timeout: a multi-gigabyte pull is expected to
+// be long-running, and cancellation is the caller's context.
+func DefaultClient() *http.Client {
+	return &http.Client{Transport: http.DefaultTransport}
+}
+
+// ProbeClient is used only for the short /api/version reachability check.
+func ProbeClient() *http.Client {
+	return &http.Client{Timeout: 5 * time.Second}
+}

--- a/pkg/llmman/client_test.go
+++ b/pkg/llmman/client_test.go
@@ -1,0 +1,221 @@
+package llmman
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEndpointDefaultsToLlmmanServeDefault(t *testing.T) {
+	t.Setenv(HostEnv, "")
+	if got := Endpoint(); got != "http://127.0.0.1:17434" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestEndpointParsesHostForms(t *testing.T) {
+	cases := map[string]string{
+		"1.2.3.4:9999":                "http://1.2.3.4:9999",
+		"1.2.3.4":                     "http://1.2.3.4:17434",
+		"http://1.2.3.4:9999":         "http://1.2.3.4:9999",
+		"http://1.2.3.4:9999/ignored": "http://1.2.3.4:9999",
+		`"1.2.3.4:9999"`:              "http://1.2.3.4:9999",
+		// A wildcard bind is meaningful to the server but not to a client.
+		"0.0.0.0:9999": "http://127.0.0.1:9999",
+		"[::]:9999":    "http://[::1]:9999",
+	}
+	for in, want := range cases {
+		t.Setenv(HostEnv, in)
+		if got := Endpoint(); got != want {
+			t.Errorf("Endpoint(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCheckDaemonAcceptsALlmmanDaemon(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/version" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"version": "0.1.0"})
+	}))
+	defer srv.Close()
+
+	if err := CheckDaemon(context.Background(), srv.Client(), srv.URL); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckDaemonRejectsANonLlmmanServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"world"}`))
+	}))
+	defer srv.Close()
+
+	err := CheckDaemon(context.Background(), srv.Client(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "not an llmman daemon") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestCheckDaemonReportsNothingListening(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	err := CheckDaemon(context.Background(), ProbeClient(), url)
+	if err == nil || !strings.Contains(err.Error(), "llmman serve") {
+		t.Fatalf("expected an actionable error, got %v", err)
+	}
+}
+
+func ndjson(lines ...map[string]any) string {
+	var b strings.Builder
+	for _, l := range lines {
+		raw, _ := json.Marshal(l)
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func pullServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/pull" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var req map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req["model"] == "" {
+			t.Error("expected a model field in the pull request")
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestPullSucceedsAndForwardsProgress(t *testing.T) {
+	srv := pullServer(t, ndjson(
+		map[string]any{"status": "pulling manifest"},
+		map[string]any{"status": "pulling blobs", "completed": 50, "total": 100},
+		map[string]any{"status": "success"},
+	), http.StatusOK)
+	defer srv.Close()
+
+	var seen []string
+	var lastCompleted, lastTotal int64
+	err := Pull(context.Background(), srv.Client(), srv.URL, "ghcr.io/org/model:tag",
+		func(status string, completed, total int64) {
+			seen = append(seen, status)
+			lastCompleted, lastTotal = completed, total
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != 2 || seen[0] != "pulling manifest" {
+		t.Fatalf("progress = %v", seen)
+	}
+	if lastCompleted != 50 || lastTotal != 100 {
+		t.Fatalf("byte progress = %d/%d", lastCompleted, lastTotal)
+	}
+}
+
+func TestPullReportsInBandErrorAtHTTP200(t *testing.T) {
+	// The daemon streams errors in-band, so a 200 does not mean success.
+	srv := pullServer(t, ndjson(
+		map[string]any{"status": "pulling manifest"},
+		map[string]any{"error": "unauthorized"},
+	), http.StatusOK)
+	defer srv.Close()
+
+	err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil)
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestPullRejectsAStreamThatEndsWithoutSuccess(t *testing.T) {
+	srv := pullServer(t, ndjson(map[string]any{"status": "pulling blobs"}), http.StatusOK)
+	defer srv.Close()
+
+	err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil)
+	if err == nil || !strings.Contains(err.Error(), "without reporting success") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestPullReportsNonOKStatus(t *testing.T) {
+	srv := pullServer(t, `{"error":"bad request"}`, http.StatusBadRequest)
+	defer srv.Close()
+
+	if err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil); err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+func TestPullToleratesANonJSONDiagnosticLine(t *testing.T) {
+	body := "not json\n" + ndjson(map[string]any{"status": "success"})
+	srv := pullServer(t, body, http.StatusOK)
+	defer srv.Close()
+
+	if err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseResolveOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := parseResolveOutput(`{"reference":"r","path":"`+dir+`","format":"safetensors"}`, "r")
+	if err != nil || got != dir {
+		t.Fatalf("got %q, %v", got, err)
+	}
+
+	// A diagnostic leaking onto stdout must not break resolution.
+	got, err = parseResolveOutput("pulling...\n{\"path\":\""+dir+"\"}\n", "r")
+	if err != nil || got != dir {
+		t.Fatalf("got %q, %v", got, err)
+	}
+
+	// Unknown fields are ignored so the contract can grow.
+	if _, err := parseResolveOutput(`{"path":"`+dir+`","mmproj":"/x","future":1}`, "r"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, bad := range []string{
+		"", "   \n\n", "not json", `{"no_path":1}`, `{"path":""}`, `{"path":"/nonexistent/xyzzy"}`,
+	} {
+		if _, err := parseResolveOutput(bad, "r"); err == nil {
+			t.Errorf("expected an error for %q", bad)
+		}
+	}
+}
+
+func TestBinaryHonoursTheOverride(t *testing.T) {
+	t.Setenv(BinEnv, "")
+	if Binary() != "llmman" {
+		t.Fatalf("got %q", Binary())
+	}
+	t.Setenv(BinEnv, "/opt/bin/llmman")
+	if Binary() != "/opt/bin/llmman" {
+		t.Fatalf("got %q", Binary())
+	}
+	// An empty override is a mistake, not a request to run the empty string.
+	t.Setenv(BinEnv, "   ")
+	if Binary() != "llmman" {
+		t.Fatalf("got %q", Binary())
+	}
+}
+
+func TestResolveReportsAMissingBinary(t *testing.T) {
+	t.Setenv(BinEnv, filepath.Join(t.TempDir(), "definitely-not-here"))
+	_, err := Resolve(context.Background(), "ref")
+	if err == nil || !strings.Contains(err.Error(), "install llmman") {
+		t.Fatalf("expected an actionable error, got %v", err)
+	}
+}

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -439,6 +439,11 @@ func (s *Gopher) processTaskWithOptions(task *GopherTask, allowFallbackDownload 
 		downloadStartTime := time.Now()
 		switch storageType {
 		case storage.StorageTypeOCI:
+			s.logger.Infof("Starting CNCF ModelPack download for model %s", modelInfo)
+			if err := s.processModelPackModel(ctx, task, baseModelSpec, modelInfo, modelType, namespace, name); err != nil {
+				return err
+			}
+		case storage.StorageTypeOCIObjectStore:
 			osUri, err := getTargetDirPath(&baseModelSpec)
 			destPath := getDestPath(&baseModelSpec, s.modelRootDir)
 			if err != nil {
@@ -587,7 +592,7 @@ func (s *Gopher) processTaskWithOptions(task *GopherTask, allowFallbackDownload 
 
 		// Now proceed with deletion
 		switch storageType {
-		case storage.StorageTypeOCI:
+		case storage.StorageTypeOCI, storage.StorageTypeOCIObjectStore:
 			s.logger.Infof("Starting deletion for model %s", modelInfo)
 			destPath := getDestPath(&baseModelSpec, s.modelRootDir)
 			// check if it needs to skip artifact deletion
@@ -752,7 +757,7 @@ func (s *Gopher) isStartupRevalidation(task *GopherTask) bool {
 		return false
 	}
 	storageType, err := storage.GetStorageType(*baseModelSpec.Storage.StorageUri)
-	if err != nil || storageType != storage.StorageTypeOCI {
+	if err != nil || (storageType != storage.StorageTypeOCI && storageType != storage.StorageTypeOCIObjectStore) {
 		return false
 	}
 

--- a/pkg/modelagent/gopher_modelpack.go
+++ b/pkg/modelagent/gopher_modelpack.go
@@ -1,0 +1,117 @@
+package modelagent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/llmman"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// processModelPackModel acquires a CNCF ModelPack OCI artifact through a
+// running `llmman serve` daemon.
+//
+// The daemon owns the registry work -- ModelPack media types, registry auth,
+// resumable blob download and a content-addressed store -- so it is not
+// reimplemented here. It does the pull (POST /api/pull, streamed as NDJSON so
+// a multi-gigabyte fetch is not silent) but deliberately exposes no local
+// path, so `llmman resolve --no-pull` reports where the bytes landed.
+func (s *Gopher) processModelPackModel(ctx context.Context, task *GopherTask,
+	baseModelSpec v1beta1.BaseModelSpec, modelInfo, modelType, namespace, name string) error {
+
+	components, err := storage.ParseOCIStorageURI(*baseModelSpec.Storage.StorageUri)
+	if err != nil {
+		s.logger.Errorf("Failed to parse OCI URI for model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "invalid_oci_uri")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	destPath := getDestPath(&baseModelSpec, s.modelRootDir)
+
+	progress := func(status string, completed, total int64) {
+		if total > 0 {
+			s.logger.Infof("llmman: %s (%d/%d bytes) for model %s", status, completed, total, modelInfo)
+		} else {
+			s.logger.Infof("llmman: %s for model %s", status, modelInfo)
+		}
+	}
+
+	s.logger.Infof("Pulling ModelPack artifact %s for model %s", components.Reference, modelInfo)
+	resolved, err := llmman.PullAndResolve(ctx, components.Reference, progress)
+	if err != nil {
+		s.logger.Errorf("Failed to pull ModelPack artifact for model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "llmman_pull_failed")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	if err := materializeModelPack(resolved, destPath); err != nil {
+		s.logger.Errorf("Failed to place ModelPack artifact for model %s: %v", modelInfo, err)
+		s.metrics.RecordFailedDownload(modelType, namespace, name, "llmman_place_failed")
+		s.markModelOnNodeFailed(task)
+		return err
+	}
+
+	s.logger.Infof("Placed ModelPack artifact %s at %s", components.Reference, destPath)
+	return nil
+}
+
+// materializeModelPack places llmman's extracted artifact at dest.
+//
+// Files are hard-linked where possible so a model shared with llmman's store
+// costs its bytes once, falling back to a copy across filesystems.
+func materializeModelPack(src, dest string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("resolved path %q: %w", src, err)
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("creating %q: %w", dest, err)
+	}
+
+	if !info.IsDir() {
+		// A single-file payload, e.g. GGUF.
+		return linkOrCopyFile(src, filepath.Join(dest, filepath.Base(src)))
+	}
+
+	return filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if fi.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if !fi.Mode().IsRegular() {
+			// Symlinks and devices carry no model payload.
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return linkOrCopyFile(path, target)
+	})
+}
+
+func linkOrCopyFile(src, dest string) error {
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Link(src, dest); err == nil {
+		return nil
+	}
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, data, 0o644)
+}

--- a/pkg/modelagent/gopher_task_queue.go
+++ b/pkg/modelagent/gopher_task_queue.go
@@ -112,7 +112,7 @@ func isObjectStorageDownloadTask(task *GopherTask) bool {
 		return false
 	}
 	storageType, err := storage.GetStorageType(*storageSpec.StorageUri)
-	return err == nil && storageType == storage.StorageTypeOCI
+	return err == nil && (storageType == storage.StorageTypeOCI || storageType == storage.StorageTypeOCIObjectStore)
 }
 
 func removeSupersededTasks(tasks []*GopherTask, deleteTask *GopherTask) []*GopherTask {

--- a/pkg/utils/storage/storage.go
+++ b/pkg/utils/storage/storage.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	// OCIStoragePrefix is the prefix for OCI storage URIs
+	// OCIStoragePrefix is the prefix for CNCF ModelPack OCI artifact URIs,
+	// e.g. oci://ghcr.io/org/model:tag.
+	//
+	// BREAKING: this previously addressed Oracle Cloud Object Storage
+	// (oci://n/{namespace}/b/{bucket}/o/{path}). See docs for migration.
 	OCIStoragePrefix = "oci://"
 	// PVCStoragePrefix is the prefix for PVC storage URIs
 	PVCStoragePrefix = "pvc://"
@@ -26,6 +30,12 @@ const (
 	GitHubStoragePrefix = "github://"
 	// LocalStoragePrefix is the prefix for local filesystem storage URIs
 	LocalStoragePrefix = "local://"
+	// OCIObjectStorePrefix is the prefix for Oracle Cloud Object Storage URIs.
+	//
+	// This is where oci:// URIs moved to: oci:// now names a CNCF ModelPack
+	// artifact. Format is unchanged otherwise:
+	// ocios://n/{namespace}/b/{bucket}/o/{object_path}
+	OCIObjectStorePrefix = "ocios://"
 )
 
 // StorageType is a string enum for storage type
@@ -50,14 +60,14 @@ const (
 	StorageTypeGitHub StorageType = "GITHUB"
 	// StorageTypeLocal is the value for local filesystem storage
 	StorageTypeLocal StorageType = "LOCAL"
+	// StorageTypeOCIObjectStore is the value for Oracle Cloud Object Storage
+	StorageTypeOCIObjectStore StorageType = "OCIOS"
 )
 
-// OCIStorageComponents represents the components of an OCI storage URI
+// OCIStorageComponents represents a CNCF ModelPack OCI artifact reference.
 type OCIStorageComponents struct {
-	Namespace  string
-	Bucket     string
-	Prefix     string
-	ObjectName string
+	// Reference is the registry reference, e.g. "ghcr.io/org/model:tag".
+	Reference string
 }
 
 // PVCStorageComponents represents the components of a PVC storage URI
@@ -112,23 +122,65 @@ type LocalStorageComponents struct {
 	Path string // Absolute or relative path to the model files
 }
 
-// ParseOCIStorageURI parses an OCI storage URI and returns its components
-// Format: oci://n/{namespace}/b/{bucket}/o/{object_path}
+// OCIObjectStoreComponents represents the components of an Oracle Cloud
+// Object Storage URI.
+type OCIObjectStoreComponents struct {
+	Namespace  string
+	Bucket     string
+	Prefix     string
+	ObjectName string
+}
+
+// ParseOCIObjectStoreURI parses an Oracle Object Storage URI.
+// Format: ocios://n/{namespace}/b/{bucket}/o/{object_path}
+func ParseOCIObjectStoreURI(uri string) (*OCIObjectStoreComponents, error) {
+	if !strings.HasPrefix(uri, OCIObjectStorePrefix) {
+		return nil, fmt.Errorf("invalid Object Storage URI format: missing %s prefix", OCIObjectStorePrefix)
+	}
+
+	parts := strings.Split(strings.TrimPrefix(uri, OCIObjectStorePrefix), "/")
+	if len(parts) < 6 || parts[0] != "n" || parts[2] != "b" || parts[4] != "o" {
+		return nil, fmt.Errorf("invalid Object Storage URI format. Expected: ocios://n/{namespace}/b/{bucket}/o/{object_path}")
+	}
+
+	return &OCIObjectStoreComponents{
+		Namespace: parts[1],
+		Bucket:    parts[3],
+		Prefix:    strings.Join(parts[5:], "/"),
+	}, nil
+}
+
+// ValidateOCIObjectStoreURI validates an Oracle Object Storage URI.
+func ValidateOCIObjectStoreURI(uri string) error {
+	_, err := ParseOCIObjectStoreURI(uri)
+	return err
+}
+
+// ParseOCIStorageURI parses a CNCF ModelPack OCI artifact URI.
+// Format: oci://{registry}/{repository}[:{tag}|@{digest}]
+//
+// The whole remainder is the reference: a repository name may contain slashes,
+// so there is nothing further to split.
 func ParseOCIStorageURI(uri string) (*OCIStorageComponents, error) {
 	if !strings.HasPrefix(uri, OCIStoragePrefix) {
 		return nil, fmt.Errorf("invalid OCI storage URI format: missing %s prefix", OCIStoragePrefix)
 	}
 
-	parts := strings.Split(strings.TrimPrefix(uri, OCIStoragePrefix), "/")
-	if len(parts) < 6 || parts[0] != "n" || parts[2] != "b" || parts[4] != "o" {
-		return nil, fmt.Errorf("invalid OCI storage URI format. Expected: oci://n/{namespace}/b/{bucket}/o/{object_path}")
+	reference := strings.TrimSpace(strings.TrimPrefix(uri, OCIStoragePrefix))
+	if reference == "" {
+		return nil, fmt.Errorf("invalid OCI storage URI: empty reference in %q", uri)
+	}
+	if strings.HasPrefix(reference, "n/") {
+		return nil, fmt.Errorf(
+			"%q looks like an Oracle Object Storage URI, which oci:// no longer addresses; "+
+				"oci:// now names a CNCF ModelPack artifact (oci://{registry}/{repository}:{tag})", uri)
+	}
+	if !strings.Contains(reference, "/") {
+		return nil, fmt.Errorf(
+			"invalid OCI storage URI %q: expected oci://{registry}/{repository}[:{tag}]", uri)
 	}
 
-	return &OCIStorageComponents{
-		Namespace: parts[1],
-		Bucket:    parts[3],
-		Prefix:    strings.Join(parts[5:], "/"),
-	}, nil
+	return &OCIStorageComponents{Reference: reference}, nil
 }
 
 // ValidateOCIStorageURI validates if the given URI matches OCI storage format
@@ -534,6 +586,8 @@ func ValidateLocalStorageURI(uri string) error {
 // GetStorageType determines the type of storage URI
 func GetStorageType(uri string) (StorageType, error) {
 	switch {
+	case strings.HasPrefix(uri, OCIObjectStorePrefix):
+		return StorageTypeOCIObjectStore, nil
 	case strings.HasPrefix(uri, OCIStoragePrefix):
 		return StorageTypeOCI, nil
 	case strings.HasPrefix(uri, PVCStoragePrefix):
@@ -567,6 +621,8 @@ func ValidateStorageURI(uri string) error {
 	switch storageType {
 	case StorageTypeOCI:
 		return ValidateOCIStorageURI(uri)
+	case StorageTypeOCIObjectStore:
+		return ValidateOCIObjectStoreURI(uri)
 	case StorageTypePVC:
 		return ValidatePVCStorageURI(uri)
 	case StorageTypeVendor:
@@ -601,7 +657,7 @@ func NewObjectURI(uriStr string) (*ociobjectstore.ObjectURI, error) {
 	}
 
 	switch storageType {
-	case StorageTypeOCI:
+	case StorageTypeOCIObjectStore:
 		return parseOCIObjectURI(uriStr)
 	case StorageTypeHuggingFace:
 		return parseHuggingFaceObjectURI(uriStr)
@@ -668,12 +724,12 @@ func parseHuggingFaceObjectURI(uriStr string) (*ociobjectstore.ObjectURI, error)
 
 // parseOCIObjectURI parses an OCI URI string into an ObjectURI
 func parseOCIObjectURI(uriStr string) (*ociobjectstore.ObjectURI, error) {
-	if !strings.HasPrefix(uriStr, OCIStoragePrefix) {
-		return nil, fmt.Errorf("URI must start with '%s'", OCIStoragePrefix)
+	if !strings.HasPrefix(uriStr, OCIObjectStorePrefix) {
+		return nil, fmt.Errorf("URI must start with '%s'", OCIObjectStorePrefix)
 	}
 
 	// Remove the scheme
-	uriStr = strings.TrimPrefix(uriStr, "oci://")
+	uriStr = strings.TrimPrefix(uriStr, OCIObjectStorePrefix)
 
 	// Check for the OCI specific format: n/namespace/b/bucket/o/prefix
 	if strings.HasPrefix(uriStr, "n/") {

--- a/pkg/utils/storage/storage_local_test.go
+++ b/pkg/utils/storage/storage_local_test.go
@@ -188,8 +188,13 @@ func TestValidateStorageURIWithLocal(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "valid oci storage",
-			uri:     "oci://n/myns/b/mybucket/o/mypath",
+			name:    "valid oci object storage",
+			uri:     "ocios://n/myns/b/mybucket/o/mypath",
+			wantErr: false,
+		},
+		{
+			name:    "valid oci modelpack artifact",
+			uri:     "oci://ghcr.io/org/model:tag",
 			wantErr: false,
 		},
 		{

--- a/pkg/utils/storage/storage_modelpack_test.go
+++ b/pkg/utils/storage/storage_modelpack_test.go
@@ -1,0 +1,100 @@
+package storage
+
+import "testing"
+
+func TestParseOCIStorageURIParsesAModelPackReference(t *testing.T) {
+	got, err := ParseOCIStorageURI("oci://ghcr.io/org/model:tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The whole remainder is the reference: a repository name may contain
+	// slashes, so there is nothing further to split.
+	if got.Reference != "ghcr.io/org/model:tag" {
+		t.Fatalf("got %q", got.Reference)
+	}
+
+	got, err = ParseOCIStorageURI("oci://registry.example.com:5000/a/b/c@sha256:abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Reference != "registry.example.com:5000/a/b/c@sha256:abc" {
+		t.Fatalf("got %q", got.Reference)
+	}
+}
+
+func TestParseOCIStorageURIRejectsBadInput(t *testing.T) {
+	for _, uri := range []string{
+		"ghcr.io/org/model:tag", // no scheme
+		"oci://",                // empty reference
+		"oci://   ",
+		"oci://model", // no registry component
+	} {
+		if _, err := ParseOCIStorageURI(uri); err == nil {
+			t.Errorf("expected an error for %q", uri)
+		}
+	}
+}
+
+func TestParseOCIStorageURIGivesAMigrationHintForObjectStorage(t *testing.T) {
+	// The most likely mistake after this change: an old Oracle URI.
+	_, err := ParseOCIStorageURI("oci://n/mynamespace/b/mybucket/o/models/llama")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := err.Error(); !contains(got, "Oracle Object Storage") || !contains(got, "ModelPack") {
+		t.Fatalf("error should explain the migration, got: %s", got)
+	}
+}
+
+func TestObjectStorageMovedToItsOwnScheme(t *testing.T) {
+	got, err := ParseOCIObjectStoreURI("ocios://n/mynamespace/b/mybucket/o/models/llama")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Namespace != "mynamespace" || got.Bucket != "mybucket" || got.Prefix != "models/llama" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestGetStorageTypeDistinguishesTheTwoSchemes(t *testing.T) {
+	cases := map[string]StorageType{
+		"oci://ghcr.io/org/model:tag":  StorageTypeOCI,
+		"ocios://n/ns/b/bucket/o/path": StorageTypeOCIObjectStore,
+		"hf://org/model":               StorageTypeHuggingFace,
+		"s3://bucket/key":              StorageTypeS3,
+		"pvc://my-pvc/sub":             StorageTypePVC,
+	}
+	for uri, want := range cases {
+		got, err := GetStorageType(uri)
+		if err != nil {
+			t.Errorf("%s: %v", uri, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("GetStorageType(%q) = %q, want %q", uri, got, want)
+		}
+	}
+}
+
+func TestValidateStorageURICoversBothSchemes(t *testing.T) {
+	if err := ValidateStorageURI("oci://ghcr.io/org/model:tag"); err != nil {
+		t.Errorf("ModelPack URI should validate: %v", err)
+	}
+	if err := ValidateStorageURI("ocios://n/ns/b/bucket/o/path"); err != nil {
+		t.Errorf("Object Storage URI should validate: %v", err)
+	}
+	if err := ValidateStorageURI("oci://n/ns/b/bucket/o/path"); err == nil {
+		t.Error("an Oracle URI under oci:// should now fail")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/pkg/utils/storage/storage_test.go
+++ b/pkg/utils/storage/storage_test.go
@@ -9,18 +9,18 @@ import (
 	"sigs.k8s.io/ome/pkg/ociobjectstore"
 )
 
-func TestParseOCIStorageURI(t *testing.T) {
+func TestParseOCIObjectStoreURI(t *testing.T) {
 	tests := []struct {
 		name        string
 		uri         string
-		want        *OCIStorageComponents
+		want        *OCIObjectStoreComponents
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "valid uri with simple path",
-			uri:  "oci://n/myns/b/mybucket/o/mypath",
-			want: &OCIStorageComponents{
+			uri:  "ocios://n/myns/b/mybucket/o/mypath",
+			want: &OCIObjectStoreComponents{
 				Namespace: "myns",
 				Bucket:    "mybucket",
 				Prefix:    "mypath",
@@ -29,8 +29,8 @@ func TestParseOCIStorageURI(t *testing.T) {
 		},
 		{
 			name: "valid uri with nested path",
-			uri:  "oci://n/myns/b/mybucket/o/path/to/my/object",
-			want: &OCIStorageComponents{
+			uri:  "ocios://n/myns/b/mybucket/o/path/to/my/object",
+			want: &OCIObjectStoreComponents{
 				Namespace: "myns",
 				Bucket:    "mybucket",
 				Prefix:    "path/to/my/object",
@@ -39,8 +39,8 @@ func TestParseOCIStorageURI(t *testing.T) {
 		},
 		{
 			name: "valid uri with special characters",
-			uri:  "oci://n/my-ns.123/b/my_bucket-123/o/path.with.dots/and-dashes",
-			want: &OCIStorageComponents{
+			uri:  "ocios://n/my-ns.123/b/my_bucket-123/o/path.with.dots/and-dashes",
+			want: &OCIObjectStoreComponents{
 				Namespace: "my-ns.123",
 				Bucket:    "my_bucket-123",
 				Prefix:    "path.with.dots/and-dashes",
@@ -51,55 +51,55 @@ func TestParseOCIStorageURI(t *testing.T) {
 			name:        "missing oci prefix",
 			uri:         "n/myns/b/mybucket/o/mypath",
 			wantErr:     true,
-			errContains: "missing oci:// prefix",
+			errContains: "missing ocios:// prefix",
 		},
 		{
 			name:        "missing namespace marker",
-			uri:         "oci://myns/b/mybucket/o/mypath",
+			uri:         "ocios://myns/b/mybucket/o/mypath",
 			wantErr:     true,
-			errContains: "invalid OCI storage URI format",
+			errContains: "invalid Object Storage URI format",
 		},
 		{
 			name:        "missing bucket marker",
-			uri:         "oci://n/myns/mybucket/o/mypath",
+			uri:         "ocios://n/myns/mybucket/o/mypath",
 			wantErr:     true,
-			errContains: "invalid OCI storage URI format",
+			errContains: "invalid Object Storage URI format",
 		},
 		{
 			name:        "missing object marker",
-			uri:         "oci://n/myns/b/mybucket/mypath",
+			uri:         "ocios://n/myns/b/mybucket/mypath",
 			wantErr:     true,
-			errContains: "invalid OCI storage URI format",
+			errContains: "invalid Object Storage URI format",
 		},
 		{
 			name:        "empty uri",
 			uri:         "",
 			wantErr:     true,
-			errContains: "missing oci:// prefix",
+			errContains: "missing ocios:// prefix",
 		},
 		{
 			name:        "only prefix",
-			uri:         "oci://",
+			uri:         "ocios://",
 			wantErr:     true,
-			errContains: "invalid OCI storage URI format",
+			errContains: "invalid Object Storage URI format",
 		},
 		{
 			name:        "missing path after object marker",
-			uri:         "oci://n/myns/b/mybucket/o",
+			uri:         "ocios://n/myns/b/mybucket/o",
 			wantErr:     true,
-			errContains: "invalid OCI storage URI format",
+			errContains: "invalid Object Storage URI format",
 		},
 		{
 			name:        "invalid order of markers",
-			uri:         "oci://b/mybucket/n/myns/o/mypath",
+			uri:         "ocios://b/mybucket/n/myns/o/mypath",
 			wantErr:     true,
-			errContains: "invalid OCI storage URI format",
+			errContains: "invalid Object Storage URI format",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseOCIStorageURI(tt.uri)
+			got, err := ParseOCIObjectStoreURI(tt.uri)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {
@@ -113,7 +113,7 @@ func TestParseOCIStorageURI(t *testing.T) {
 	}
 }
 
-func TestValidateOCIStorageURI(t *testing.T) {
+func TestValidateOCIObjectStoreURI(t *testing.T) {
 	tests := []struct {
 		name        string
 		uri         string
@@ -122,26 +122,26 @@ func TestValidateOCIStorageURI(t *testing.T) {
 	}{
 		{
 			name:    "valid uri",
-			uri:     "oci://n/myns/b/mybucket/o/mypath",
+			uri:     "ocios://n/myns/b/mybucket/o/mypath",
 			wantErr: false,
 		},
 		{
 			name:        "invalid uri",
 			uri:         "invalid://uri",
 			wantErr:     true,
-			errContains: "missing oci:// prefix",
+			errContains: "missing ocios:// prefix",
 		},
 		{
 			name:        "empty uri",
 			uri:         "",
 			wantErr:     true,
-			errContains: "missing oci:// prefix",
+			errContains: "missing ocios:// prefix",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateOCIStorageURI(tt.uri)
+			err := ValidateOCIObjectStoreURI(tt.uri)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {
@@ -333,7 +333,7 @@ func TestParsePVCStorageURI(t *testing.T) {
 		},
 		{
 			name:    "invalid uri - wrong scheme",
-			uri:     "oci://my-pvc/results",
+			uri:     "ocios://my-pvc/results",
 			want:    nil,
 			wantErr: true,
 		},
@@ -454,8 +454,13 @@ func TestGetStorageType(t *testing.T) {
 		errContains string
 	}{
 		{
-			name: "oci storage",
-			uri:  "oci://n/myns/b/mybucket/o/mypath",
+			name: "oci object storage",
+			uri:  "ocios://n/myns/b/mybucket/o/mypath",
+			want: StorageTypeOCIObjectStore,
+		},
+		{
+			name: "oci modelpack artifact",
+			uri:  "oci://ghcr.io/org/model:tag",
 			want: StorageTypeOCI,
 		},
 		{
@@ -536,7 +541,7 @@ func TestValidateStorageURI(t *testing.T) {
 	}{
 		{
 			name:    "valid oci uri",
-			uri:     "oci://n/myns/b/mybucket/o/mypath",
+			uri:     "ocios://n/myns/b/mybucket/o/mypath",
 			wantErr: false,
 		},
 		{
@@ -566,7 +571,7 @@ func TestValidateStorageURI(t *testing.T) {
 		},
 		{
 			name:    "invalid oci uri",
-			uri:     "oci://invalid",
+			uri:     "ocios://invalid",
 			wantErr: true,
 		},
 		{
@@ -926,37 +931,37 @@ func TestNewObjectURI(t *testing.T) {
 		// OCI URIs
 		{
 			name:    "valid n/namespace/b/bucket/o/prefix",
-			uri:     "oci://n/myns/b/mybucket/o/myprefix",
+			uri:     "ocios://n/myns/b/mybucket/o/myprefix",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "myns", BucketName: "mybucket", Prefix: "myprefix"},
 			wantErr: false,
 		},
 		{
 			name:    "valid n/namespace/b/bucket/o/multi/level/prefix",
-			uri:     "oci://n/myns/b/mybucket/o/dir1/dir2/file.txt",
+			uri:     "ocios://n/myns/b/mybucket/o/dir1/dir2/file.txt",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "myns", BucketName: "mybucket", Prefix: "dir1/dir2/file.txt"},
 			wantErr: false,
 		},
 		{
 			name:    "valid namespace@region/bucket/prefix",
-			uri:     "oci://myns@us-phoenix-1/mybucket/myprefix",
+			uri:     "ocios://myns@us-phoenix-1/mybucket/myprefix",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "myns", Region: "us-phoenix-1", BucketName: "mybucket", Prefix: "myprefix"},
 			wantErr: false,
 		},
 		{
 			name:    "valid namespace@region/bucket with no prefix",
-			uri:     "oci://myns@us-phoenix-1/mybucket",
+			uri:     "ocios://myns@us-phoenix-1/mybucket",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "myns", Region: "us-phoenix-1", BucketName: "mybucket", Prefix: ""},
 			wantErr: false,
 		},
 		{
 			name:    "valid bucket/prefix (no namespace/region)",
-			uri:     "oci://mybucket/myprefix",
+			uri:     "ocios://mybucket/myprefix",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "", Region: "", BucketName: "mybucket", Prefix: "myprefix"},
 			wantErr: false,
 		},
 		{
 			name:    "valid bucket only (no namespace/region/prefix)",
-			uri:     "oci://mybucket",
+			uri:     "ocios://mybucket",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "", Region: "", BucketName: "mybucket", Prefix: ""},
 			wantErr: false,
 		},
@@ -968,19 +973,19 @@ func TestNewObjectURI(t *testing.T) {
 		},
 		{
 			name:        "malformed n/namespace/b/bucket/o (too short)",
-			uri:         "oci://n/myns/b/mybucket",
+			uri:         "ocios://n/myns/b/mybucket",
 			wantErr:     true,
 			errContains: "invalid OCI URI format",
 		},
 		{
 			name:        "malformed n/namespace/b/bucket/x/extra",
-			uri:         "oci://n/myns/b/mybucket/x/extra",
+			uri:         "ocios://n/myns/b/mybucket/x/extra",
 			wantErr:     true,
 			errContains: "invalid OCI URI format",
 		},
 		{
 			name:        "namespace@region missing bucket",
-			uri:         "oci://myns@us-phoenix-1",
+			uri:         "ocios://myns@us-phoenix-1",
 			wantErr:     true,
 			errContains: "missing bucket name",
 		},
@@ -992,13 +997,13 @@ func TestNewObjectURI(t *testing.T) {
 		},
 		{
 			name:        "oci:// only",
-			uri:         "oci://",
+			uri:         "ocios://",
 			wantErr:     true,
 			errContains: "missing bucket name",
 		},
 		{
-			name:    "oci://n/namespace/b/bucket/o/ (empty prefix)",
-			uri:     "oci://n/myns/b/mybucket/o/",
+			name:    "ocios://n/namespace/b/bucket/o/ (empty prefix)",
+			uri:     "ocios://n/myns/b/mybucket/o/",
 			expect:  &ociobjectstore.ObjectURI{Namespace: "myns", BucketName: "mybucket", Prefix: ""},
 			wantErr: false,
 		},

--- a/pkg/webhook/admission/benchmark/benchmark_webhook_test.go
+++ b/pkg/webhook/admission/benchmark/benchmark_webhook_test.go
@@ -257,7 +257,7 @@ func TestValidateStorage(t *testing.T) {
 	}{
 		"Valid storage URI": {
 			storage: &v1beta1.StorageSpec{
-				StorageUri: ptr("oci://n/mynamespace/b/mybucket/o/path/to/object"),
+				StorageUri: ptr("ocios://n/mynamespace/b/mybucket/o/path/to/object"),
 			},
 			expected: gomega.BeNil(),
 		},
@@ -273,19 +273,19 @@ func TestValidateStorage(t *testing.T) {
 		},
 		"Invalid storage URI format - missing n": {
 			storage: &v1beta1.StorageSpec{
-				StorageUri: ptr("oci://mynamespace/b/mybucket/o/object"),
+				StorageUri: ptr("ocios://mynamespace/b/mybucket/o/object"),
 			},
 			expected: gomega.HaveOccurred(),
 		},
 		"Invalid storage URI format - missing b": {
 			storage: &v1beta1.StorageSpec{
-				StorageUri: ptr("oci://n/mynamespace/mybucket/o/object"),
+				StorageUri: ptr("ocios://n/mynamespace/mybucket/o/object"),
 			},
 			expected: gomega.HaveOccurred(),
 		},
 		"Invalid storage URI format - missing o": {
 			storage: &v1beta1.StorageSpec{
-				StorageUri: ptr("oci://n/mynamespace/b/mybucket/object"),
+				StorageUri: ptr("ocios://n/mynamespace/b/mybucket/object"),
 			},
 			expected: gomega.HaveOccurred(),
 		},

--- a/pkg/webhook/admission/pod/fine_tuned_adapter_injector.go
+++ b/pkg/webhook/admission/pod/fine_tuned_adapter_injector.go
@@ -135,7 +135,7 @@ func (fa *FineTunedAdapterInjector) createInitContainer(envs []v1.EnvVar, mounts
 }
 
 // getFineTunedWeightUri retrieves the fine-tuned weight uri from the fine-tuned weight CR
-func (fa *FineTunedAdapterInjector) getFineTunedWeightUri(pod *v1.Pod) (*storage.OCIStorageComponents, error) {
+func (fa *FineTunedAdapterInjector) getFineTunedWeightUri(pod *v1.Pod) (*storage.OCIObjectStoreComponents, error) {
 	fineTunedWeight, err := isvcutils.GetFineTunedWeight(fa.client, fa.fineTunedWeightName)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func (fa *FineTunedAdapterInjector) getFineTunedWeightUri(pod *v1.Pod) (*storage
 		return nil, fmt.Errorf("fine-tuned weight %q storage.storageUri is required", fa.fineTunedWeightName)
 	}
 
-	osUri, err := storage.ParseOCIStorageURI(*fineTunedWeight.Spec.Storage.StorageUri)
+	osUri, err := storage.ParseOCIObjectStoreURI(*fineTunedWeight.Spec.Storage.StorageUri)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (fa *FineTunedAdapterInjector) getFineTunedWeightUri(pod *v1.Pod) (*storage
 }
 
 // getModelInitEnvs generates environment variables for the Model Init container.
-func (fa *FineTunedAdapterInjector) getModelInitEnvs(pod *v1.Pod, fineTunedWeightUri *storage.OCIStorageComponents) ([]v1.EnvVar, error) {
+func (fa *FineTunedAdapterInjector) getModelInitEnvs(pod *v1.Pod, fineTunedWeightUri *storage.OCIObjectStoreComponents) ([]v1.EnvVar, error) {
 	envVars := []v1.EnvVar{
 		{Name: constants.AgentAuthTypeEnvVarKey, Value: fa.AuthType},
 		{Name: constants.AgentCompartmentIDEnvVarKey, Value: fa.CompartmentId},

--- a/site/content/en/docs/concepts/base_model.md
+++ b/site/content/en/docs/concepts/base_model.md
@@ -6,6 +6,14 @@ description: >
   Base Model defines foundation models that can be automatically downloaded, parsed, and served across your cluster.
 ---
 
+
+> **Breaking change:** `oci://` now addresses a [CNCF ModelPack](https://github.com/modelpack/model-spec)
+> artifact in a container registry (`oci://{registry}/{repository}:{tag}`), pulled through a running
+> [`llmman serve`](https://github.com/llmmanorg/llmman) daemon. Oracle Cloud Object Storage moved to
+> `ocios://`, with an otherwise identical format. Parsing an old `oci://n/...` URI now fails with a
+> message naming the replacement.
+
+
 ## What is a Base Model?
 
 A Base Model in OME is a Kubernetes resource that represents a foundation AI model (like GPT, Llama, or Mistral) that you want to use for inference workloads. Think of it as a blueprint that tells OME where to find your model, how to download it, and where to store it on your cluster nodes.
@@ -48,7 +56,7 @@ spec:
     name: transformers
     version: "4.36.0"
   storage:
-    storageUri: oci://n/ai-models/b/llm-store/o/meta/llama-3.1-70b-instruct/
+    storageUri: ocios://n/ai-models/b/llm-store/o/meta/llama-3.1-70b-instruct/
     path: /raid/models/llama-3.1-70b-instruct
     storageKey: oci-credentials
     parameters:
@@ -103,13 +111,13 @@ OME supports multiple storage backends to work with your existing infrastructure
 
 Store your models in OCI Object Storage using this URI format:
 ```
-oci://n/{namespace}/b/{bucket}/o/{object_path}
+ocios://n/{namespace}/b/{bucket}/o/{object_path}
 ```
 
 Example:
 ```yaml
 storage:
-  storageUri: "oci://n/mycompany/b/ai-models/o/llama/llama-3-70b/"
+  storageUri: "ocios://n/mycompany/b/ai-models/o/llama/llama-3-70b/"
   path: "/raid/models/llama-3-70b-instruct"
   parameters:
     region: "us-phoenix-1"
@@ -175,7 +183,7 @@ Control which nodes download and store your models using node selectors and affi
 ### Simple Node Selection
 ```yaml
 storage:
-  storageUri: "oci://n/mycompany/b/models/o/llama-70b/"
+  storageUri: "ocios://n/mycompany/b/models/o/llama-70b/"
   nodeSelector:
     node.kubernetes.io/instance-type: "GPU.A100.4"
     models.ome.io/storage-tier: "fast-ssd"
@@ -508,7 +516,7 @@ spec:
 
   # Storage configuration
   storage:
-    storageUri: "oci://n/ai-models/b/llm-store/o/meta/llama-3.1-70b-instruct/"
+    storageUri: "ocios://n/ai-models/b/llm-store/o/meta/llama-3.1-70b-instruct/"
     path: "/raid/models/llama-3.1-70b-instruct"
     schemaPath: "config.json"
     storageKey: "oci-model-credentials"
@@ -578,7 +586,7 @@ spec:
 
   # Storage for fine-tuned weights
   storage:
-    storageUri: oci://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
+    storageUri: ocios://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
     path: /raid/fine-tuned/llama-70b-finance-lora
 
   # Training job reference

--- a/site/content/en/docs/concepts/benchmark.md
+++ b/site/content/en/docs/concepts/benchmark.md
@@ -65,7 +65,7 @@ spec:
    additionalRequestParams:
       temperature: "0.0"
    outputLocation:
-      storageUri: "oci://n/idqj093njucb/b/ome-benchmark-results/o/llama-3-1-70b-benchmark"
+      storageUri: "ocios://n/idqj093njucb/b/ome-benchmark-results/o/llama-3-1-70b-benchmark"
       parameters:
          auth: "instance_principal"
 ```
@@ -140,7 +140,7 @@ BenchmarkJob supports storing benchmark results in multiple cloud storage provid
 #### 1. OCI Object Storage
 ```yaml
 outputLocation:
-  storageUri: "oci://n/my-namespace/b/my-bucket/o/benchmark-results"
+  storageUri: "ocios://n/my-namespace/b/my-bucket/o/benchmark-results"
   parameters:
     auth: "instance_principal"  # Authentication type
     config_file: "/path/to/config"  # Optional: Config file for user_principal auth
@@ -201,7 +201,7 @@ outputLocation:
 
 | Provider | URI Format | Example |
 |----------|------------|---------|
-| OCI | `oci://n/{namespace}/b/{bucket}/o/{path}` | `oci://n/myns/b/mybucket/o/results` |
+| OCI | `ocios://n/{namespace}/b/{bucket}/o/{path}` | `ocios://n/myns/b/mybucket/o/results` |
 | S3 | `s3://{bucket}[@{region}]/{path}` | `s3://mybucket@us-west-2/results` |
 | Azure | `az://{account}/{container}/{path}` | `az://myaccount/mycontainer/results` |
 | GCS | `gs://{bucket}/{path}` | `gs://mybucket/results` |

--- a/site/content/en/docs/concepts/fine_tuned_weight.md
+++ b/site/content/en/docs/concepts/fine_tuned_weight.md
@@ -40,7 +40,7 @@ spec:
 
   # Storage for the fine-tuned weights (same StorageSpec as base models)
   storage:
-    storageUri: oci://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
+    storageUri: ocios://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
     path: /raid/fine-tuned/llama-70b-finance-lora
 ```
 
@@ -83,7 +83,7 @@ FineTunedWeight uses the same `StorageSpec` as [BaseModel](/ome/docs/concepts/ba
 ```yaml
 spec:
   storage:
-    storageUri: oci://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
+    storageUri: ocios://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
     path: /raid/fine-tuned/llama-70b-finance-lora
     storageKey: oci-model-credentials
     parameters:
@@ -137,7 +137,7 @@ spec:
 
   # Storage for fine-tuned weights
   storage:
-    storageUri: oci://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
+    storageUri: ocios://n/mycompany/b/fine-tuned/o/llama-70b-finance-lora/
     path: /raid/fine-tuned/llama-70b-finance-lora
     storageKey: oci-model-credentials
     parameters:

--- a/site/content/en/docs/reference/ome.v1beta1.md
+++ b/site/content/en/docs/reference/ome.v1beta1.md
@@ -3806,7 +3806,7 @@ This key will be used to fetch credentials during model download or access.</p>
    <p>StorageUri specifies the source URI of the model in a supported storage backend.
 Supported formats:</p>
 <ul>
-<li>OCI Object Storage:   oci://n/{namespace}/b/{bucket}/o/{object_path}</li>
+<li>OCI Object Storage:   ocios://n/{namespace}/b/{bucket}/o/{object_path}</li>
 <li>Persistent Volume:    pvc://{pvc-name}/{sub-path}</li>
 <li>Vendor-specific:      vendor://{vendor-name}/{resource-type}/{resource-path}
 This field is required.</li>

--- a/site/content/en/docs/tasks/run-workloads/run-benchmarks.md
+++ b/site/content/en/docs/tasks/run-workloads/run-benchmarks.md
@@ -115,7 +115,7 @@ spec:
     gpuType: "H100"
     gpuCount: 1
   outputLocation:
-    storageUri: "oci://n/idqj093njucb/b/ome-benchmark-results/o/e5-mistral-7b-instruct-benchmark"
+    storageUri: "ocios://n/idqj093njucb/b/ome-benchmark-results/o/e5-mistral-7b-instruct-benchmark"
     parameters:
       auth: "instance_principal"
       region: "eu-frankfurt-1"
@@ -165,7 +165,7 @@ spec:
     modelSize: "670B"
     deployment: "MultiNode-RDMA"
   outputLocation:
-    storageUri: "oci://n/idqj093njucb/b/ome-benchmark-results/o/deepseek-r1-benchmark"
+    storageUri: "ocios://n/idqj093njucb/b/ome-benchmark-results/o/deepseek-r1-benchmark"
     parameters:
       auth: "instance_principal"
       region: "us-phoenix-1"


### PR DESCRIPTION
## Summary

**Breaking.** `oci://` now names a [CNCF ModelPack](https://github.com/modelpack/model-spec) artifact in a container registry, acquired through a running [`llmman serve`](https://github.com/llmmanorg/llmman) daemon. Oracle Cloud Object Storage moves to `ocios://`.

```yaml
# CNCF ModelPack artifact (new meaning of oci://)
storageUri: oci://ghcr.io/org/model:tag

# Oracle Object Storage (moved, format otherwise identical)
storageUri: ocios://n/mynamespace/b/mybucket/o/models/llama
```

Model distribution is increasingly moving to OCI registries -- the same registries, credentials, mirroring and air-gap tooling a cluster already uses for container images. Taking `oci://` for that, rather than inventing a second scheme, keeps the URI meaning what it means everywhere else in the ecosystem.

## Migration

| Before | After |
|---|---|
| `oci://n/ns/b/bucket/o/path` | `ocios://n/ns/b/bucket/o/path` |

**Nothing is removed.** The entire Object Storage path keeps working unchanged under the new scheme, via a new `StorageTypeOCIObjectStore`:

- `pkg/ociobjectstore` — untouched
- `HFToOCIReplicator`, `OCIToOCIReplicator`, `PVCToOCIReplicator` — untouched, still upload to Object Storage
- benchmark storage args, the fine-tuned adapter injector, the gopher task queue and model deletion — all repointed at the new type

Parsing an old `oci://n/...` URI fails with a message that **names the replacement** rather than a generic format error, so the migration is self-describing:

```
"oci://n/ns/b/bucket/o/path" looks like an Oracle Object Storage URI, which oci:// no longer
addresses; oci:// now names a CNCF ModelPack artifact (oci://{registry}/{repository}:{tag})
```

## Implementation

- `pkg/utils/storage`: `oci://` → ModelPack reference; `ocios://` + `StorageTypeOCIObjectStore` carry the Oracle format and parser verbatim.
- `pkg/llmman` (new): the daemon client, **standard library only, no new dependency**. `GET /api/version` probes reachability *and* identity (a server without a `version` field is reported as "not an llmman daemon", distinct from nothing listening). `POST /api/pull` streams NDJSON; an error arriving **in-band at HTTP 200**, or a stream ending without `success`, are both failures rather than a completed pull. `llmman resolve --no-pull` then reports the on-disk path -- `--no-pull` keeps the daemon the only thing that touches the network. `LLMMAN_HOST` is parsed as llmman's own clients do, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.
- `pkg/modelagent`: `StorageTypeOCI` routes to `processModelPackModel`; deletion and local-artifact checks cover both schemes. Files are **hard-linked** out of llmman's store where possible, falling back to a copy across filesystems, so a shared model costs its bytes once.

A pull needs both the daemon reachable and the binary on `PATH` (or `OME_LLMMAN_BIN`); each missing piece has its own actionable error, and neither is required unless an `oci://` URI is used.

## Testing

```
$ go test ./pkg/... ./internal/...
93 ok, 12 FAIL
```

**Baseline on a clean tree, same environment: 92 ok, 12 FAIL.** The +1 is the new `pkg/llmman`, and the failure set is **byte-identical to baseline** (verified by diffing the two lists -- only elapsed times differ). All 12 are pre-existing: seven are `-lxet` link failures from the unbuilt Rust static lib (`basemodel`, `pernode`, `modelagent`, `xet`, `model-metadata`, `replica`, `replica/common`, `replica/replicator`), plus `inferenceservice` and `webhook/admission/pod` which already fail on `main`.

New `pkg/llmman/client_test.go` (13 tests) runs against a real `httptest` server, so the NDJSON contract is genuinely exercised: version probe accepted / non-llmman rejected / nothing-listening actionable; pull success with forwarded byte progress and the request body asserted; in-band error at HTTP 200; stream ending without `success`; non-OK status; non-JSON diagnostic tolerated; the resolve contract plus six malformed cases; binary default/override/empty-override; missing-binary error.

New `pkg/utils/storage/storage_modelpack_test.go` pins both schemes: a ModelPack reference parsed whole (including a registry port and a digest); bad input rejected; **the migration hint asserted explicitly**; Object Storage still parsing under `ocios://`; `GetStorageType` distinguishing the two; and `ValidateStorageURI` accepting both while rejecting an Oracle URI under `oci://`.

Existing fixtures across `storage`, `benchmark`, `benchmark/utils` and the benchmark webhook were migrated to `ocios://`, and docs under `site/content/en/docs/` updated with the breaking-change note.

- [x] `gofmt -l pkg/ internal/` clean; `go vet` reports only the three pre-existing `pkg/xet` unsafe.Pointer warnings

Not verified here, flagged rather than implied: no live cluster run, and no pull against a real registry through a live `llmman serve`. `pkg/modelagent` cannot be test-linked in this environment (`-lxet`), so `processModelPackModel` is covered by inspection rather than execution.

> Disclosure: written with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading and materializing CNCF ModelPack OCI artifacts through the `llmman` service.
  * Added progress reporting and improved handling for artifact download failures.
  * Added support for both OCI artifacts (`oci://`) and Oracle Cloud Object Storage (`ocios://`).

* **Breaking Changes**
  * Oracle Cloud Object Storage URIs must now use the `ocios://` scheme. Existing `oci://n/...` URIs are no longer accepted.

* **Documentation**
  * Updated configuration examples and reference documentation with the new URI formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->