### PR TITLE
[Core] validation: sync package from primary tree

### DIFF
--- a/pkg/validation/basemodel.go
+++ b/pkg/validation/basemodel.go
@@ -1,5 +1,3 @@
-// Package validation holds pure validation helpers (no Kubernetes client
-// dependencies) shared between CRD validators and admission webhooks.
 package validation
 
 import (
@@ -9,14 +7,12 @@ import (
 	"sigs.k8s.io/ome/pkg/utils/storage"
 )
 
-// ValidatePVCStorage enforces the pvc:// URI rules for a BaseModel /
-// ClusterBaseModel spec:
+// ValidatePVCStorage enforces the PVC URI shape rules:
 //
 //   - namespaced BaseModel: pvc:// URIs must NOT carry a namespace prefix
-//     (pvc://{pvc-name}/{sub-path}); the model's own namespace is used.
 //   - ClusterBaseModel: pvc:// URIs MUST carry a namespace prefix
-//     (pvc://{namespace}:{pvc-name}/{sub-path}).
-//   - the URI itself must parse (a sub-path is required).
+//   - the URI itself must parse
+//   - PVC + distribution=Sharded is rejected
 //
 // Non-PVC URIs are accepted unchanged.
 func ValidatePVCStorage(spec *v1beta1.BaseModelSpec, isClusterScoped bool) error {
@@ -27,6 +23,10 @@ func ValidatePVCStorage(spec *v1beta1.BaseModelSpec, isClusterScoped bool) error
 	storageType, err := storage.GetStorageType(uri)
 	if err != nil || storageType != storage.StorageTypePVC {
 		return nil
+	}
+
+	if spec.Distribution != nil && *spec.Distribution == v1beta1.DistributionSharded {
+		return fmt.Errorf("PVC storage URIs are not compatible with distribution=Sharded; use distribution=PerNode (or omit) for pvc:// models")
 	}
 
 	components, err := storage.ParsePVCStorageURI(uri)

--- a/pkg/validation/basemodel_test.go
+++ b/pkg/validation/basemodel_test.go
@@ -46,6 +46,21 @@ func TestValidatePVCStorage(t *testing.T) {
 			spec:    &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://")}},
 			wantErr: true,
 		},
+		{
+			name: "PVC + Sharded distribution is rejected",
+			spec: &v1beta1.BaseModelSpec{
+				Storage:      &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/models/llama")},
+				Distribution: ptr.To(v1beta1.DistributionSharded),
+			},
+			wantErr: true,
+		},
+		{
+			name: "PVC + PerNode distribution is allowed",
+			spec: &v1beta1.BaseModelSpec{
+				Storage:      &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/models/llama")},
+				Distribution: ptr.To(v1beta1.DistributionPerNode),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/validation/budget.go
+++ b/pkg/validation/budget.go
@@ -1,0 +1,81 @@
+// Shared semantic validation for rolling-update budget knobs
+// (maxSurge / maxUnavailable *intstr.IntOrString).
+//
+// The CRD schema's XIntOrString marker only gates the structural shape
+// (must parse as integer or string). These helpers add the semantic
+// checks the apiserver can't express — integers must be >= 0, strings
+// must be "<n>%" with 0 <= n <= 100 — parameterized by the full field
+// path so every caller (per-Component lifecycle, rollout groups) reports
+// the exact location of the invalid value. Anything outside those forms
+// resolves to zero in the runtime parser (ScaledCountFromIntOrString),
+// silently deleting the budget, so admission rejects it instead.
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// validateBudgetIntOrString enforces the semantic rules for a
+// rolling-update budget value:
+//   - integer values >= 0
+//   - string values match "<n>%" with 0 <= n <= 100
+//
+// path is the full field path (e.g.
+// "spec.rollout.groups[0].rollingUpdate.maxSurge") reported verbatim in
+// every error. Returns nil for nil inputs — nil means "use default",
+// and every defaulting layer fills a non-zero budget.
+func validateBudgetIntOrString(path string, v *intstr.IntOrString) error {
+	if v == nil {
+		return nil
+	}
+	if v.Type == intstr.Int {
+		if v.IntValue() < 0 {
+			return fmt.Errorf("%s=%d must be >= 0 (%s)",
+				path, v.IntValue(), ReasonInvalidRollingUpdateInteger)
+		}
+		return nil
+	}
+	// String form — must be "<n>%" with 0 <= n <= 100.
+	s := v.StrVal
+	if !strings.HasSuffix(s, "%") {
+		return fmt.Errorf("%s=%q must be an integer count or a percent string like \"25%%\" (%s)",
+			path, s, ReasonInvalidRollingUpdatePercent)
+	}
+	pctStr := strings.TrimSuffix(s, "%")
+	pct, err := strconv.Atoi(pctStr)
+	if err != nil {
+		return fmt.Errorf("%s=%q has a malformed percent value (%s)",
+			path, s, ReasonInvalidRollingUpdatePercent)
+	}
+	if pct < 0 || pct > 100 {
+		return fmt.Errorf("%s=%q percent must be between 0%% and 100%% (%s)",
+			path, s, ReasonInvalidRollingUpdatePercent)
+	}
+	return nil
+}
+
+// budgetResolvesToZero reports whether the runtime budget resolver
+// (ScaledCountFromIntOrString) turns v into a zero budget: explicit
+// zeros ("0%" or integer 0), negative integers (floored to 0), and
+// malformed strings (parse error yields 0) all qualify. A positive
+// percent is never zero here — its scaled value depends on the replica
+// count, which admission cannot know. nil is NOT zero: nil means "use
+// default", and every defaulting layer fills a non-zero budget.
+func budgetResolvesToZero(v *intstr.IntOrString) bool {
+	if v == nil {
+		return false
+	}
+	if v.Type == intstr.Int {
+		return v.IntValue() <= 0
+	}
+	s := v.StrVal
+	if !strings.HasSuffix(s, "%") {
+		return true
+	}
+	pct, err := strconv.Atoi(strings.TrimSuffix(s, "%"))
+	return err != nil || pct <= 0
+}

--- a/pkg/validation/canary.go
+++ b/pkg/validation/canary.go
@@ -47,6 +47,9 @@ const ReasonAnalysisInvalid = "AnalysisInvalid"
 //   - Every Component in the group is OMENative — other modes wedge at Pending.
 //   - Final step Traffic == 100 — otherwise the rollout never fully cuts over.
 //   - Final step Capacity == 100% — otherwise it completes on a partial fleet.
+//   - Every step Capacity parses strictly (integer >= 0, or "<N>%" with N in
+//     [0,100]) — the runtime resolver maps unparsable values to zero, so a
+//     malformed capacity would silently stage no new pods.
 //   - Traffic in [0,100], non-decreasing, and Traffic>0 requires Capacity>0.
 //   - Each analysis step's config is complete and well-formed (delegated to
 //     validateCanaryAnalysis).
@@ -122,24 +125,33 @@ func ValidateCanary(spec *v1beta1.InferenceServiceSpec) error {
 		if last.Traffic != 100 {
 			return fmt.Errorf("spec.rollout.groups[%d].canary final step traffic must be 100, got %d (%s)", gi, last.Traffic, ReasonCanaryInvalid)
 		}
-		// Only the percentage form is checkable at admission (absolute counts need
-		// the desired replica count); the done sentinel also forces partition 0.
-		if pct, ok := percentValue(last.Capacity); ok && pct != 100 {
-			return fmt.Errorf("spec.rollout.groups[%d].canary final step capacity must be 100%% (rollout completes at full capacity), got %q (%s)",
-				gi, last.Capacity.String(), ReasonCanaryInvalid)
-		}
 		var prevWeight int32
 		for i, s := range c.Steps {
+			// Strict capacity parsing: the runtime resolver maps anything it cannot
+			// parse to zero new capacity, so admission must reject every such form
+			// instead of letting a step silently stage nothing.
+			val, isPercent, perr := parseCanaryCapacity(s.Capacity)
+			if perr != nil {
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].capacity: %v (%s)", gi, i, perr, ReasonCanaryInvalid)
+			}
 			if s.Traffic < 0 || s.Traffic > 100 {
-				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d]: traffic %d must be in [0,100] (%s)", gi, i, s.Traffic, ReasonCanaryInvalid)
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].traffic: traffic %d must be in [0,100] (%s)", gi, i, s.Traffic, ReasonCanaryInvalid)
 			}
 			if s.Traffic < prevWeight {
-				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d]: traffic %d must be >= the previous step's %d (canary weights are non-decreasing) (%s)",
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].traffic: traffic %d must be >= the previous step's %d (canary weights are non-decreasing) (%s)",
 					gi, i, s.Traffic, prevWeight, ReasonCanaryInvalid)
 			}
 			prevWeight = s.Traffic
-			if s.Traffic > 0 && newCapacityIsZero(s.Capacity) {
-				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d]: traffic %d>0 requires capacity>0 (%s)", gi, i, s.Traffic, ReasonCanaryInvalid)
+			if s.Traffic > 0 && val == 0 {
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].capacity: capacity %q resolves to zero new capacity but traffic is %d — a step cannot send traffic to zero capacity (%s)",
+					gi, i, s.Capacity.String(), s.Traffic, ReasonCanaryInvalid)
+			}
+			// Only the percentage form of the final capacity is checkable at
+			// admission (absolute counts need the desired replica count); the done
+			// sentinel also forces partition 0.
+			if i == len(c.Steps)-1 && isPercent && val != 100 {
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].capacity: final step capacity must be 100%% (rollout completes at full capacity), got %q (%s)",
+					gi, i, s.Capacity.String(), ReasonCanaryInvalid)
 			}
 		}
 	}
@@ -206,25 +218,36 @@ func validateAnalysisMetrics(gi, si int, metrics []v1beta1.AnalysisMetric) error
 	return nil
 }
 
-// percentValue extracts the integer N from an IntOrString "<N>%" form.
-func percentValue(v intstr.IntOrString) (int, bool) {
-	if v.Type != intstr.String || !strings.HasSuffix(v.StrVal, "%") {
-		return 0, false
-	}
-	n, err := strconv.Atoi(strings.TrimSuffix(v.StrVal, "%"))
-	if err != nil {
-		return 0, false
-	}
-	return n, true
-}
-
-// newCapacityIsZero reports whether a step's Capacity resolves to zero pods
-// regardless of how it is expressed (integer 0, "0", or "0%").
-func newCapacityIsZero(c intstr.IntOrString) bool {
+// parseCanaryCapacity strictly resolves a step's Capacity to its numeric value.
+// A string must be "<N>%" with integer N in [0,100]; an integer must be >= 0.
+// Everything else is rejected: the runtime int/percent resolver maps a value it
+// cannot parse to zero, so an admission-time reject here is the only thing
+// standing between a typo and a step that silently stages no new capacity.
+// Absolute counts must use the integer form — a quoted count like "3" is not a
+// percentage and would resolve to zero at runtime.
+func parseCanaryCapacity(c intstr.IntOrString) (value int, isPercent bool, err error) {
 	if c.Type == intstr.Int {
-		return c.IntValue() == 0
+		n := c.IntValue()
+		if n < 0 {
+			return 0, false, fmt.Errorf("capacity %d must not be negative", n)
+		}
+		return n, false, nil
 	}
-	return c.StrVal == "0" || c.StrVal == "0%"
+	raw := c.StrVal
+	if !strings.HasSuffix(raw, "%") {
+		return 0, false, fmt.Errorf("capacity %q is not a percentage — use \"<N>%%\" for a fraction of desired replicas, or an unquoted integer for an absolute count", raw)
+	}
+	n, atoiErr := strconv.Atoi(strings.TrimSuffix(raw, "%"))
+	if atoiErr != nil {
+		return 0, true, fmt.Errorf("capacity %q is not a valid percentage — use \"<N>%%\" with integer N in [0,100]", raw)
+	}
+	if n < 0 {
+		return 0, true, fmt.Errorf("capacity %q must not be negative", raw)
+	}
+	if n > 100 {
+		return 0, true, fmt.Errorf("capacity %q must not exceed 100%% (capacity is a fraction of desired replicas)", raw)
+	}
+	return n, true, nil
 }
 
 // canaryEntrypoint returns the ISVC's external entrypoint Component, mirroring

--- a/pkg/validation/canary_test.go
+++ b/pkg/validation/canary_test.go
@@ -7,6 +7,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 )
@@ -78,6 +79,154 @@ func TestValidateCanary_TrafficToZeroPercentCapacity(t *testing.T) {
 	)
 	if err := ValidateCanary(spec); err == nil {
 		t.Fatal(`traffic>0 with "0%" Capacity must be rejected`)
+	}
+}
+
+// TestParseCanaryCapacity covers the strict parser: the runtime int/percent
+// resolver maps anything unparsable to zero, so the parser must reject every
+// form the resolver would drop and accept exactly the forms it resolves.
+func TestParseCanaryCapacity(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        intstr.IntOrString
+		value     int
+		isPercent bool
+		wantErr   bool
+	}{
+		{name: "int zero", in: intstr.FromInt(0), value: 0},
+		{name: "int positive", in: intstr.FromInt(3), value: 3},
+		{name: "int negative", in: intstr.FromInt(-1), wantErr: true},
+		{name: "percent zero", in: intstr.FromString("0%"), value: 0, isPercent: true},
+		{name: "percent mid", in: intstr.FromString("50%"), value: 50, isPercent: true},
+		{name: "percent full", in: intstr.FromString("100%"), value: 100, isPercent: true},
+		{name: "percent explicit plus sign", in: intstr.FromString("+10%"), value: 10, isPercent: true},
+		{name: "malformed word", in: intstr.FromString("abc"), wantErr: true},
+		{name: "empty string", in: intstr.FromString(""), wantErr: true},
+		{name: "bare percent sign", in: intstr.FromString("%"), wantErr: true},
+		{name: "non-numeric percent", in: intstr.FromString("abc%"), wantErr: true},
+		{name: "negative percent", in: intstr.FromString("-10%"), wantErr: true},
+		{name: "percent above 100", in: intstr.FromString("150%"), wantErr: true},
+		{name: "inner whitespace", in: intstr.FromString("10 %"), wantErr: true},
+		{name: "quoted absolute count", in: intstr.FromString("3"), wantErr: true},
+		{name: "fractional percent", in: intstr.FromString("10.5%"), wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, isPercent, err := parseCanaryCapacity(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseCanaryCapacity(%v) = (%d, %v, nil), want error", tc.in, value, isPercent)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCanaryCapacity(%v): unexpected error: %v", tc.in, err)
+			}
+			if value != tc.value || isPercent != tc.isPercent {
+				t.Fatalf("parseCanaryCapacity(%v) = (%d, %v), want (%d, %v)", tc.in, value, isPercent, tc.value, tc.isPercent)
+			}
+		})
+	}
+}
+
+// TestValidateCanary_CapacityStrictlyParsed: capacities the runtime resolver
+// would silently map to zero (or that are semantically out of range) are
+// rejected at admission, with the exact steps[i].capacity field path.
+func TestValidateCanary_CapacityStrictlyParsed(t *testing.T) {
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	cases := []struct {
+		name     string
+		capacity intstr.IntOrString
+	}{
+		{name: "malformed string", capacity: intstr.FromString("abc")},
+		{name: "negative integer", capacity: intstr.FromInt(-1)},
+		{name: "negative percent", capacity: intstr.FromString("-10%")},
+		{name: "percent above 100", capacity: intstr.FromString("150%")},
+		{name: "quoted absolute count", capacity: intstr.FromString("3")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := canarySpec(v1beta1.RolloutGroupStep{Capacity: tc.capacity, Traffic: 10}, final)
+			err := ValidateCanary(spec)
+			if err == nil || !strings.Contains(err.Error(), ReasonCanaryInvalid) {
+				t.Fatalf("capacity %v must be rejected with %s, got: %v", tc.capacity, ReasonCanaryInvalid, err)
+			}
+			if !strings.Contains(err.Error(), "spec.rollout.groups[0].canary.steps[0].capacity") {
+				t.Fatalf("error must carry the exact field path, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateCanary_MalformedFinalCapacityRejected: a malformed final-step
+// capacity slipping through would let the done sentinel run on a plan whose
+// last declared capacity is unparsable.
+func TestValidateCanary_MalformedFinalCapacityRejected(t *testing.T) {
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("10%"), Traffic: 10},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("abc"), Traffic: 100},
+	)
+	err := ValidateCanary(spec)
+	if err == nil || !strings.Contains(err.Error(), "spec.rollout.groups[0].canary.steps[1].capacity") {
+		t.Fatalf("malformed final capacity must be rejected with its field path, got: %v", err)
+	}
+}
+
+func TestValidateCanary_FinalPercentCapacityNot100(t *testing.T) {
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("10%"), Traffic: 10},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("50%"), Traffic: 100},
+	)
+	err := ValidateCanary(spec)
+	if err == nil || !strings.Contains(err.Error(), "spec.rollout.groups[0].canary.steps[1].capacity") {
+		t.Fatalf("final percent capacity below 100%% must be rejected with its field path, got: %v", err)
+	}
+}
+
+// TestValidateCanary_ValidPlansStayAccepted: every capacity form the runtime
+// resolver handles today keeps admitting — absolute integer steps, an absolute
+// final step (admission cannot compare it to desired replicas), and a zero
+// capacity paired with zero traffic.
+func TestValidateCanary_ValidPlansStayAccepted(t *testing.T) {
+	cases := []struct {
+		name  string
+		steps []v1beta1.RolloutGroupStep
+	}{
+		{
+			name: "percent steps",
+			steps: []v1beta1.RolloutGroupStep{
+				{Capacity: intstr.FromString("25%"), Traffic: 10},
+				{Capacity: intstr.FromString("100%"), Traffic: 100},
+			},
+		},
+		{
+			name: "absolute integer step",
+			steps: []v1beta1.RolloutGroupStep{
+				{Capacity: intstr.FromInt(1), Traffic: 10},
+				{Capacity: intstr.FromString("100%"), Traffic: 100},
+			},
+		},
+		{
+			name: "absolute final step",
+			steps: []v1beta1.RolloutGroupStep{
+				{Capacity: intstr.FromString("50%"), Traffic: 50},
+				{Capacity: intstr.FromInt(5), Traffic: 100},
+			},
+		},
+		{
+			name: "zero capacity with zero traffic",
+			steps: []v1beta1.RolloutGroupStep{
+				{Capacity: intstr.FromInt(0), Traffic: 0},
+				{Capacity: intstr.FromString("100%"), Traffic: 100},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateCanary(canarySpec(tc.steps...)); err != nil {
+				t.Fatalf("valid plan rejected: %v", err)
+			}
+		})
 	}
 }
 
@@ -274,7 +423,7 @@ func TestValidateCanary_MaintainRatioRejected(t *testing.T) {
 		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
 			{
 				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
-				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptrInt32(5)},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptr.To(int32(5))},
 				Canary:        &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}},
 			},
 		}},

--- a/pkg/validation/compatibility.go
+++ b/pkg/validation/compatibility.go
@@ -1,0 +1,405 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	modelVer "sigs.k8s.io/ome/pkg/modelver"
+)
+
+// CompatibilityOptions configures model-to-format compatibility checks.
+type CompatibilityOptions struct {
+	ModelCacheProvider string
+}
+
+// CompatibilityOption is a functional option for CompareModelToFormat and
+// GetFormatMismatchReason.
+type CompatibilityOption func(*CompatibilityOptions)
+
+// WithModelCacheProvider sets the cluster's model cache provider name. When
+// set, sharded-distribution models are checked against the format's supported
+// providers. When omitted, the model-cache check is skipped (suitable for
+// offline validation where cluster config is unavailable).
+func WithModelCacheProvider(provider string) CompatibilityOption {
+	return func(o *CompatibilityOptions) { o.ModelCacheProvider = provider }
+}
+
+func buildOptions(opts []CompatibilityOption) CompatibilityOptions {
+	var o CompatibilityOptions
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}
+
+// CompareModelToFormat checks if a model matches a supported format entry. It
+// mirrors the logic of DefaultRuntimeMatcher.compareSupportedModelFormats but
+// is a pure function with no receiver or config dependency.
+func CompareModelToFormat(model *v1beta1.BaseModelSpec, format v1beta1.SupportedModelFormat, opts ...CompatibilityOption) bool {
+	o := buildOptions(opts)
+
+	if o.ModelCacheProvider != "" {
+		if modelRequiresCacheProvider(model) && !supportedFormatSupportsModelCacheProvider(format, o.ModelCacheProvider) {
+			return false
+		}
+	}
+
+	if ok, _ := compareDiffusionPipeline(model.DiffusionPipeline, format.DiffusionPipeline); !ok {
+		return false
+	}
+
+	// architecture
+	if model.ModelArchitecture != nil && format.ModelArchitecture != nil {
+		if *model.ModelArchitecture != *format.ModelArchitecture {
+			return false
+		}
+	} else if (model.ModelArchitecture == nil) != (format.ModelArchitecture == nil) {
+		return false
+	}
+
+	// quantization
+	if model.Quantization != nil && format.Quantization != nil {
+		if *model.Quantization != *format.Quantization {
+			return false
+		}
+	} else if (model.Quantization == nil) != (format.Quantization == nil) {
+		return false
+	}
+
+	// model format
+	if format.ModelFormat != nil {
+		if format.ModelFormat.Name != model.ModelFormat.Name {
+			return false
+		}
+		if format.ModelFormat.Version != nil && model.ModelFormat.Version != nil {
+			if !compareModelFormatVersions(format.ModelFormat, &model.ModelFormat) {
+				return false
+			}
+		} else if (format.ModelFormat.Version == nil) != (model.ModelFormat.Version == nil) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	// model framework
+	if format.ModelFramework != nil && model.ModelFramework != nil {
+		if format.ModelFramework.Name != model.ModelFramework.Name {
+			return false
+		}
+		if format.ModelFramework.Version != nil && model.ModelFramework.Version != nil {
+			if !compareModelFrameworkVersions(format.ModelFramework, model.ModelFramework) {
+				return false
+			}
+		} else if (format.ModelFramework.Version == nil) != (model.ModelFramework.Version == nil) {
+			return false
+		}
+	} else if (format.ModelFramework != nil) != (model.ModelFramework != nil) {
+		return false
+	}
+
+	return true
+}
+
+// GetFormatMismatchReason returns a human-readable reason why a model doesn't
+// match a supported format. Returns "unknown mismatch" if no specific reason
+// can be determined.
+func GetFormatMismatchReason(model *v1beta1.BaseModelSpec, format v1beta1.SupportedModelFormat, opts ...CompatibilityOption) string {
+	o := buildOptions(opts)
+	var reasons []string
+
+	if o.ModelCacheProvider != "" {
+		if modelRequiresCacheProvider(model) && !supportedFormatSupportsModelCacheProvider(format, o.ModelCacheProvider) {
+			reasons = append(reasons, modelCacheProviderMismatchReason(o.ModelCacheProvider, format))
+		}
+	}
+
+	if ok, reason := compareDiffusionPipeline(model.DiffusionPipeline, format.DiffusionPipeline); !ok {
+		if reason != "" {
+			reasons = append(reasons, reason)
+		} else {
+			reasons = append(reasons, "diffusion pipeline mismatch")
+		}
+	}
+
+	// architecture
+	if model.ModelArchitecture != nil && format.ModelArchitecture != nil {
+		if *model.ModelArchitecture != *format.ModelArchitecture {
+			reasons = append(reasons, fmt.Sprintf("architecture mismatch (model=%s, runtime=%s)",
+				*model.ModelArchitecture, *format.ModelArchitecture))
+		}
+	} else if (model.ModelArchitecture == nil) != (format.ModelArchitecture == nil) {
+		if model.ModelArchitecture == nil {
+			reasons = append(reasons, fmt.Sprintf("model has no architecture but runtime requires %s",
+				*format.ModelArchitecture))
+		} else {
+			reasons = append(reasons, fmt.Sprintf("model has architecture %s but runtime has no architecture requirement",
+				*model.ModelArchitecture))
+		}
+	}
+
+	// quantization
+	if model.Quantization != nil && format.Quantization != nil {
+		if *model.Quantization != *format.Quantization {
+			reasons = append(reasons, fmt.Sprintf("quantization mismatch (model=%s, runtime=%s)",
+				*model.Quantization, *format.Quantization))
+		}
+	} else if (model.Quantization == nil) != (format.Quantization == nil) {
+		if model.Quantization == nil {
+			reasons = append(reasons, fmt.Sprintf("model has no quantization but runtime requires %s",
+				*format.Quantization))
+		} else {
+			reasons = append(reasons, fmt.Sprintf("model has quantization %s but runtime has no quantization requirement",
+				*model.Quantization))
+		}
+	}
+
+	// model format
+	if format.ModelFormat != nil {
+		if format.ModelFormat.Name != model.ModelFormat.Name {
+			reasons = append(reasons, fmt.Sprintf("format name mismatch (model=%s, runtime=%s)",
+				model.ModelFormat.Name, format.ModelFormat.Name))
+		} else if format.ModelFormat.Version != nil && model.ModelFormat.Version != nil {
+			if !compareModelFormatVersions(format.ModelFormat, &model.ModelFormat) {
+				reasons = append(reasons, fmt.Sprintf("format version mismatch (model=%s, runtime=%s)",
+					*model.ModelFormat.Version, *format.ModelFormat.Version))
+			}
+		} else if (format.ModelFormat.Version == nil) != (model.ModelFormat.Version == nil) {
+			if model.ModelFormat.Version == nil {
+				reasons = append(reasons, fmt.Sprintf("model has no format version but runtime requires %s",
+					*format.ModelFormat.Version))
+			} else {
+				reasons = append(reasons, "model has format version but runtime has no version requirement")
+			}
+		}
+	}
+
+	// model framework
+	if format.ModelFramework != nil && model.ModelFramework != nil {
+		if format.ModelFramework.Name != model.ModelFramework.Name {
+			reasons = append(reasons, fmt.Sprintf("framework name mismatch (model=%s, runtime=%s)",
+				model.ModelFramework.Name, format.ModelFramework.Name))
+		} else if format.ModelFramework.Version != nil && model.ModelFramework.Version != nil {
+			if !compareModelFrameworkVersions(format.ModelFramework, model.ModelFramework) {
+				reasons = append(reasons, fmt.Sprintf("framework version mismatch (model=%s, runtime=%s)",
+					*model.ModelFramework.Version, *format.ModelFramework.Version))
+			}
+		} else if (format.ModelFramework.Version == nil) != (model.ModelFramework.Version == nil) {
+			if model.ModelFramework.Version == nil {
+				reasons = append(reasons, fmt.Sprintf("model has no framework version but runtime requires %s",
+					*format.ModelFramework.Version))
+			} else {
+				reasons = append(reasons, "model has framework version but runtime has no version requirement")
+			}
+		}
+	} else if (format.ModelFramework != nil) != (model.ModelFramework != nil) {
+		if model.ModelFramework == nil {
+			reasons = append(reasons, fmt.Sprintf("model has no framework but runtime requires %s",
+				format.ModelFramework.Name))
+		} else {
+			reasons = append(reasons, fmt.Sprintf("model has framework %s but runtime has no framework requirement",
+				model.ModelFramework.Name))
+		}
+	}
+
+	if len(reasons) == 0 {
+		return "unknown mismatch"
+	}
+	return strings.Join(reasons, ", ")
+}
+
+// --- version comparison helpers ---
+
+func compareModelFormatVersions(supportedFormat *v1beta1.ModelFormat, modelFormat *v1beta1.ModelFormat) bool {
+	baseVersion, err := modelVer.Parse(*modelFormat.Version)
+	if err != nil {
+		return false
+	}
+
+	supportedVersion, err := modelVer.Parse(*supportedFormat.Version)
+	if err != nil {
+		return false
+	}
+
+	hasUnofficial := modelVer.ContainsUnofficialVersion(baseVersion) ||
+		modelVer.ContainsUnofficialVersion(supportedVersion)
+
+	operator := getRuntimeSelectorOperator(supportedFormat.Operator)
+
+	if hasUnofficial || operator == "Equal" {
+		return modelVer.Equal(supportedVersion, baseVersion)
+	}
+
+	if baseVersion.Precision != supportedVersion.Precision ||
+		strings.Compare(baseVersion.MajorPrefix, supportedVersion.MajorPrefix) != 0 {
+		return false
+	}
+
+	switch operator {
+	case "GreaterThan":
+		return modelVer.GreaterThan(supportedVersion, baseVersion)
+	case "GreaterThanOrEqual":
+		return modelVer.GreaterThanOrEqual(supportedVersion, baseVersion)
+	default:
+		return modelVer.Equal(supportedVersion, baseVersion)
+	}
+}
+
+func compareModelFrameworkVersions(supportedFramework *v1beta1.ModelFrameworkSpec, modelFramework *v1beta1.ModelFrameworkSpec) bool {
+	baseVersion, err := modelVer.Parse(*modelFramework.Version)
+	if err != nil {
+		return false
+	}
+
+	supportedVersion, err := modelVer.Parse(*supportedFramework.Version)
+	if err != nil {
+		return false
+	}
+
+	hasUnofficial := modelVer.ContainsUnofficialVersion(baseVersion) ||
+		modelVer.ContainsUnofficialVersion(supportedVersion)
+
+	operator := getRuntimeSelectorOperator(supportedFramework.Operator)
+
+	if hasUnofficial || operator == "Equal" {
+		return modelVer.Equal(supportedVersion, baseVersion)
+	}
+
+	if baseVersion.Precision != supportedVersion.Precision ||
+		strings.Compare(baseVersion.MajorPrefix, supportedVersion.MajorPrefix) != 0 {
+		return false
+	}
+
+	switch operator {
+	case "GreaterThan":
+		return modelVer.GreaterThan(supportedVersion, baseVersion)
+	case "GreaterThanOrEqual":
+		return modelVer.GreaterThanOrEqual(supportedVersion, baseVersion)
+	default:
+		return modelVer.Equal(supportedVersion, baseVersion)
+	}
+}
+
+func getRuntimeSelectorOperator(operator *v1beta1.RuntimeSelectorOperator) string {
+	if operator == nil {
+		return string(v1beta1.RuntimeSelectorOpEqual)
+	}
+	return string(*operator)
+}
+
+// --- diffusion pipeline helpers ---
+
+func compareDiffusionPipeline(model *v1beta1.DiffusionPipelineSpec, format *v1beta1.DiffusionPipelineSpec) (bool, string) {
+	if format == nil {
+		return true, ""
+	}
+
+	if model == nil {
+		return false, "diffusion pipeline required by runtime but not specified in model"
+	}
+
+	if format.ClassName != nil {
+		if model.ClassName == nil || *format.ClassName != *model.ClassName {
+			modelClassName := "<nil>"
+			if model.ClassName != nil {
+				modelClassName = *model.ClassName
+			}
+			return false, fmt.Sprintf("pipeline class mismatch (model=%s, runtime=%s)",
+				modelClassName, *format.ClassName)
+		}
+	}
+
+	componentChecks := []struct {
+		name          string
+		model, format *v1beta1.DiffusionComponentSpec
+	}{
+		{name: "scheduler", model: model.Scheduler, format: format.Scheduler},
+		{name: "textEncoder", model: model.TextEncoder, format: format.TextEncoder},
+		{name: "tokenizer", model: model.Tokenizer, format: format.Tokenizer},
+		{name: "transformer", model: model.Transformer, format: format.Transformer},
+		{name: "vae", model: model.VAE, format: format.VAE},
+	}
+
+	for _, check := range componentChecks {
+		if ok, reason := compareDiffusionComponent(check.name, check.model, check.format); !ok {
+			return false, reason
+		}
+	}
+
+	if len(format.AdditionalComponents) > 0 {
+		if len(model.AdditionalComponents) == 0 {
+			return false, "diffusion pipeline missing required additional components"
+		}
+		for key, formatComponent := range format.AdditionalComponents {
+			modelComponent, exists := model.AdditionalComponents[key]
+			if !exists {
+				return false, fmt.Sprintf("diffusion component %s missing in model", key)
+			}
+			runtimeComponent := formatComponent
+			if ok, reason := compareDiffusionComponent(key, &modelComponent, &runtimeComponent); !ok {
+				return false, reason
+			}
+		}
+	}
+
+	return true, ""
+}
+
+func compareDiffusionComponent(name string, model *v1beta1.DiffusionComponentSpec, runtime *v1beta1.DiffusionComponentSpec) (bool, string) {
+	if runtime == nil {
+		return true, ""
+	}
+	if model == nil {
+		return false, fmt.Sprintf("component %s required by runtime but not specified in model", name)
+	}
+	if runtime.Library != "" && runtime.Library != model.Library {
+		return false, fmt.Sprintf("%s library mismatch (model=%s, runtime=%s)",
+			name, model.Library, runtime.Library)
+	}
+	if runtime.Type != "" && runtime.Type != model.Type {
+		return false, fmt.Sprintf("%s type mismatch (model=%s, runtime=%s)",
+			name, model.Type, runtime.Type)
+	}
+	return true, ""
+}
+
+// --- model cache provider helpers ---
+
+func modelRequiresCacheProvider(model *v1beta1.BaseModelSpec) bool {
+	return model != nil &&
+		model.Distribution != nil &&
+		*model.Distribution == v1beta1.DistributionSharded
+}
+
+func supportedFormatSupportsModelCacheProvider(format v1beta1.SupportedModelFormat, provider string) bool {
+	provider = strings.TrimSpace(provider)
+	if provider == "" || len(format.ModelCacheProviders) == 0 {
+		return false
+	}
+	for _, supported := range format.ModelCacheProviders {
+		if string(supported) == provider {
+			return true
+		}
+	}
+	return false
+}
+
+func modelCacheProviderMismatchReason(provider string, format v1beta1.SupportedModelFormat) string {
+	provider = strings.TrimSpace(provider)
+	if len(format.ModelCacheProviders) == 0 {
+		if provider == "" {
+			return "no model cache provider is configured for sharded model loading"
+		}
+		return fmt.Sprintf("runtime format does not support model cache provider %q", provider)
+	}
+	if provider == "" {
+		return "no model cache provider is configured for sharded model loading"
+	}
+
+	supported := make([]string, 0, len(format.ModelCacheProviders))
+	for _, cacheProvider := range format.ModelCacheProviders {
+		supported = append(supported, string(cacheProvider))
+	}
+	return fmt.Sprintf("runtime format supports model cache providers [%s], not %q", strings.Join(supported, ", "), provider)
+}

--- a/pkg/validation/compatibility_test.go
+++ b/pkg/validation/compatibility_test.go
@@ -1,0 +1,229 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestCompareModelToFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  *v1beta1.BaseModelSpec
+		format v1beta1.SupportedModelFormat
+		opts   []CompatibilityOption
+		want   bool
+	}{
+		{
+			name: "exact match",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:       v1beta1.ModelFormat{Name: "safetensors"},
+				ModelFramework:    &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+				ModelArchitecture: ptr.To("LlamaForCausalLM"),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat:       &v1beta1.ModelFormat{Name: "safetensors"},
+				ModelFramework:    &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+				ModelArchitecture: ptr.To("LlamaForCausalLM"),
+			},
+			want: true,
+		},
+		{
+			name: "format name mismatch",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "pytorch"},
+			},
+			want: false,
+		},
+		{
+			name: "nil format.ModelFormat",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			format: v1beta1.SupportedModelFormat{},
+			want:   false,
+		},
+		{
+			name: "architecture mismatch",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:       v1beta1.ModelFormat{Name: "safetensors"},
+				ModelArchitecture: ptr.To("LlamaForCausalLM"),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat:       &v1beta1.ModelFormat{Name: "safetensors"},
+				ModelArchitecture: ptr.To("MistralForCausalLM"),
+			},
+			want: false,
+		},
+		{
+			name: "model has architecture but runtime does not (asymmetric nil)",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:       v1beta1.ModelFormat{Name: "safetensors"},
+				ModelArchitecture: ptr.To("LlamaForCausalLM"),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			want: false,
+		},
+		{
+			name: "both nil architecture matches",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			want: true,
+		},
+		{
+			name: "quantization mismatch",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:  v1beta1.ModelFormat{Name: "safetensors"},
+				Quantization: ptr.To(v1beta1.ModelQuantizationFP8),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat:  &v1beta1.ModelFormat{Name: "safetensors"},
+				Quantization: ptr.To(v1beta1.ModelQuantizationINT4),
+			},
+			want: false,
+		},
+		{
+			name: "framework mismatch",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:    v1beta1.ModelFormat{Name: "safetensors"},
+				ModelFramework: &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat:    &v1beta1.ModelFormat{Name: "safetensors"},
+				ModelFramework: &v1beta1.ModelFrameworkSpec{Name: "tensorrtllm"},
+			},
+			want: false,
+		},
+		{
+			name: "model has framework but runtime does not (asymmetric nil)",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:    v1beta1.ModelFormat{Name: "safetensors"},
+				ModelFramework: &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			want: false,
+		},
+		{
+			name: "format version mismatch (symmetric nil)",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{Name: "safetensors", Version: ptr.To("1.0")},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			want: false,
+		},
+		{
+			name: "format version match",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{Name: "safetensors", Version: ptr.To("1.0")},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors", Version: ptr.To("1.0")},
+			},
+			want: true,
+		},
+		{
+			name: "sharded model without cache provider option skips cache check",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:  v1beta1.ModelFormat{Name: "safetensors"},
+				Distribution: ptr.To(v1beta1.DistributionSharded),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			want: true,
+		},
+		{
+			name: "sharded model with cache provider option and no support",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:  v1beta1.ModelFormat{Name: "safetensors"},
+				Distribution: ptr.To(v1beta1.DistributionSharded),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			opts: []CompatibilityOption{WithModelCacheProvider("alluxio")},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CompareModelToFormat(tc.model, tc.format, tc.opts...)
+			if got != tc.want {
+				t.Fatalf("CompareModelToFormat() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetFormatMismatchReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    *v1beta1.BaseModelSpec
+		format   v1beta1.SupportedModelFormat
+		contains string
+	}{
+		{
+			name: "architecture mismatch reason",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:       v1beta1.ModelFormat{Name: "safetensors"},
+				ModelArchitecture: ptr.To("LlamaForCausalLM"),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat:       &v1beta1.ModelFormat{Name: "safetensors"},
+				ModelArchitecture: ptr.To("MistralForCausalLM"),
+			},
+			contains: "architecture mismatch",
+		},
+		{
+			name: "format name mismatch reason",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{Name: "pytorch"},
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+			},
+			contains: "format name mismatch",
+		},
+		{
+			name: "quantization mismatch reason",
+			model: &v1beta1.BaseModelSpec{
+				ModelFormat:  v1beta1.ModelFormat{Name: "safetensors"},
+				Quantization: ptr.To(v1beta1.ModelQuantizationFP8),
+			},
+			format: v1beta1.SupportedModelFormat{
+				ModelFormat:  &v1beta1.ModelFormat{Name: "safetensors"},
+				Quantization: ptr.To(v1beta1.ModelQuantizationINT4),
+			},
+			contains: "quantization mismatch",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := GetFormatMismatchReason(tc.model, tc.format)
+			if reason == "" {
+				t.Fatal("expected non-empty reason")
+			}
+			if !strings.Contains(reason, tc.contains) {
+				t.Fatalf("reason %q does not contain %q", reason, tc.contains)
+			}
+		})
+	}
+}

--- a/pkg/validation/coordination.go
+++ b/pkg/validation/coordination.go
@@ -3,8 +3,9 @@
 // Webhook-level admission rules for the coordination-style progressions
 // (blueGreen / rollingUpdate) on spec.rollout.groups[]: per-group structural
 // checks (valid components, order subset), cross-group checks (a Component
-// appears in at most one group; a group references a declared Component; groups
-// are OMENative), pacing zero-budget, and the RollingUpdate lockstep on update.
+// appears in at most one group; every group member is a declared Component;
+// groups are OMENative), pacing zero-budget, and the RollingUpdate lockstep on
+// update.
 // The one-of progression shape and order⊆components are also enforced by the CRD
 // CEL rules; these are the value-level mirrors plus the cross-group rules CEL
 // can't express. Canary groups are validated by ValidateCanary.
@@ -12,8 +13,9 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
@@ -26,6 +28,7 @@ const (
 	ReasonInvalidComponentInCoordinationGroup    = "InvalidComponentInCoordinationGroup"
 	ReasonCoordinationRequiresOMENative          = "CoordinationRequiresOMENative"
 	ReasonRatioToleranceTooHigh                  = "RatioToleranceTooHigh"
+	ReasonRatioToleranceOutOfRange               = "RatioToleranceOutOfRange"
 	ReasonOrphanCoordinationGroup                = "OrphanCoordinationGroup"
 	ReasonInvalidCoordinationOrder               = "InvalidCoordinationOrder"
 	ReasonRollingUpdateLockstepViolation         = "RollingUpdateLockstepViolation"
@@ -39,6 +42,17 @@ const (
 	// multi-Component, or rollingUpdate group, nor on a rollout that does not
 	// collapse to Sequential.
 	ReasonSoakNotHonored = "SoakNotHonored"
+	// ReasonGroupOrderingNotHonored flags a multi-group rollout whose list
+	// order the engine would silently ignore. groups[] promises group N
+	// completes before group N+1 begins, but the engine enforces that only
+	// for a run of single-Component blueGreen groups; any other multi-group
+	// list runs concurrently on its disjoint Components.
+	ReasonGroupOrderingNotHonored = "GroupOrderingNotHonored"
+	// ReasonOrderNotHonored flags a non-empty groups[i].order. No current
+	// progression applies Order as a surge sequence — the Components in a
+	// group advance together — so accepting it would promise a sequence
+	// that never happens.
+	ReasonOrderNotHonored = "OrderNotHonored"
 )
 
 // ratioToleranceWarningThreshold is the upper bound the validator considers
@@ -72,6 +86,12 @@ func ValidateCoordination(spec *v1beta1.InferenceServiceSpec) error {
 		return err
 	}
 	if err := validateComponentsAreOMENative(spec, groups); err != nil {
+		return err
+	}
+	if err := validateGroupRollingUpdateBudgets(groups); err != nil {
+		return err
+	}
+	if err := validateRatioToleranceRange(groups); err != nil {
 		return err
 	}
 	if err := validatePacingNotZeroBudget(groups); err != nil {
@@ -182,26 +202,32 @@ func validateNoDuplicateMembership(groups []v1beta1.RolloutGroup) error {
 	return nil
 }
 
+// validateOrphanGroups requires EVERY Component named by a group to be declared
+// on the InferenceService. A group member without a declared Component can never
+// produce a live replica, so the group's rollout could never complete — the
+// error names the group index and each missing member so the operator can fix
+// the exact gap.
 func validateOrphanGroups(spec *v1beta1.InferenceServiceSpec, groups []v1beta1.RolloutGroup) error {
 	declared := declaredComponents(spec)
 	for i := range groups {
-		anyDeclared := false
+		var missing []string
 		for _, c := range groups[i].Components {
-			if _, ok := declared[c]; ok {
-				anyDeclared = true
-				break
+			if _, ok := declared[c]; !ok {
+				missing = append(missing, fmt.Sprintf("%q", c))
 			}
 		}
-		if !anyDeclared {
-			return fmt.Errorf("spec.rollout.groups[%d]: no component in this group is declared on the InferenceService (%s)",
-				i, ReasonOrphanCoordinationGroup)
+		if len(missing) > 0 {
+			return fmt.Errorf("spec.rollout.groups[%d]: component(s) %s not declared on the InferenceService (%s)",
+				i, strings.Join(missing, ", "), ReasonOrphanCoordinationGroup)
 		}
 	}
 	return nil
 }
 
 // validateComponentsAreOMENative requires every Component in a coordination-style
-// group to declare OMENative. Canary groups are checked in ValidateCanary.
+// group to declare OMENative. Canary groups are checked in ValidateCanary. An
+// undeclared member resolves to an empty mode and fails here too — the orphan
+// check runs first, so its more specific error normally wins.
 func validateComponentsAreOMENative(spec *v1beta1.InferenceServiceSpec, groups []v1beta1.RolloutGroup) error {
 	modeFor := omenativeDeploymentModeMap(spec)
 	for i := range groups {
@@ -210,11 +236,7 @@ func validateComponentsAreOMENative(spec *v1beta1.InferenceServiceSpec, groups [
 			continue
 		}
 		for _, c := range g.Components {
-			declared, ok := modeFor[c]
-			if !ok {
-				continue // not declared — handled by the orphan check
-			}
-			if declared != string(constants.OMENative) {
+			if declared := modeFor[c]; declared != string(constants.OMENative) {
 				return fmt.Errorf("spec.rollout.groups[%d]: component %q has deploymentMode=%q; coordination requires OMENative (%s)",
 					i, c, declared, ReasonCoordinationRequiresOMENative)
 			}
@@ -223,52 +245,86 @@ func validateComponentsAreOMENative(spec *v1beta1.InferenceServiceSpec, groups [
 	return nil
 }
 
-// validatePacingNotZeroBudget rejects a rollingUpdate group that explicitly sets
-// BOTH maxSurge=0 AND maxUnavailable=0: no surge headroom and no drain headroom
-// deadlocks the roll. nil (defaulted) values resolve to 25% and are not zero.
+// validateGroupRollingUpdateBudgets runs the semantic IntOrString checks
+// (integers >= 0, percent strings within 0%-100%) over every rollingUpdate
+// group's maxSurge/maxUnavailable, reporting the exact field path. The runtime
+// resolver turns malformed or negative values into a zero budget, which would
+// silently stall the roll — admission rejects them instead.
+func validateGroupRollingUpdateBudgets(groups []v1beta1.RolloutGroup) error {
+	for i := range groups {
+		ru := groups[i].RollingUpdate
+		if ru == nil {
+			continue
+		}
+		base := fmt.Sprintf("spec.rollout.groups[%d].rollingUpdate.", i)
+		if err := validateBudgetIntOrString(base+"maxSurge", ru.MaxSurge); err != nil {
+			return err
+		}
+		if err := validateBudgetIntOrString(base+"maxUnavailable", ru.MaxUnavailable); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateRatioToleranceRange is the value-level mirror of the CRD's
+// Minimum=0/Maximum=100 bounds on maintainRatio.tolerance, for callers that
+// bypass schema validation. Nil (omitted) is valid — the operator-configured
+// default applies at resolution.
+func validateRatioToleranceRange(groups []v1beta1.RolloutGroup) error {
+	for i := range groups {
+		mr := groups[i].MaintainRatio
+		if mr == nil || mr.Tolerance == nil {
+			continue
+		}
+		if *mr.Tolerance < 0 || *mr.Tolerance > 100 {
+			return fmt.Errorf("spec.rollout.groups[%d]: maintainRatio.tolerance=%d must be between 0 and 100 (%s)",
+				i, *mr.Tolerance, ReasonRatioToleranceOutOfRange)
+		}
+	}
+	return nil
+}
+
+// validatePacingNotZeroBudget rejects a rollingUpdate group whose maxSurge AND
+// maxUnavailable both RESOLVE to zero budget at runtime: no surge headroom and
+// no drain headroom deadlocks the roll. Resolved semantics (not just literal
+// zeros) keep the rule correct on its own; in the ValidateCoordination flow the
+// per-field semantic checks run first, so the operator sees the more precise
+// error for malformed or negative forms. nil (defaulted) values resolve to 25%
+// and are not zero.
 func validatePacingNotZeroBudget(groups []v1beta1.RolloutGroup) error {
 	for i := range groups {
 		ru := groups[i].RollingUpdate
 		if ru == nil {
 			continue
 		}
-		if explicitZeroIntOrString(ru.MaxSurge) && explicitZeroIntOrString(ru.MaxUnavailable) {
-			return fmt.Errorf("spec.rollout.groups[%d]: maxSurge=0 AND maxUnavailable=0 deadlocks rollouts — set at least one non-zero (%s)",
+		if budgetResolvesToZero(ru.MaxSurge) && budgetResolvesToZero(ru.MaxUnavailable) {
+			return fmt.Errorf("spec.rollout.groups[%d].rollingUpdate: maxSurge and maxUnavailable both resolve to zero, which deadlocks the rollout — set at least one non-zero (%s)",
 				i, ReasonZeroBudgetPacingUnstartable)
 		}
 	}
 	return nil
 }
 
-// explicitZeroIntOrString reports whether the user explicitly set the
-// IntOrString to a zero value (literal 0 or "0" or "0%"). Nil is not zero — nil
-// means "use default" and the resolver fills in 25%.
-func explicitZeroIntOrString(v *intstr.IntOrString) bool {
-	if v == nil {
-		return false
-	}
-	if v.Type == intstr.Int {
-		return v.IntValue() == 0
-	}
-	return v.StrVal == "0" || v.StrVal == "0%"
-}
-
+// validateRollingUpdateLockstep enforces the all-together contract of a
+// rollingUpdate group on update: if any grouped Component's revision-affecting
+// spec changed, every grouped Component's must have changed. The compare
+// covers the full revision-affecting view (componentRevisionSpecChanged), not
+// just container images — an env, command, resource, volume, label, or
+// annotation change re-renders the pod template and rolls the Component
+// exactly like an image bump, so it must obey the same group contract.
 func validateRollingUpdateLockstep(oldSpec, newSpec *v1beta1.InferenceServiceSpec, components []v1beta1.ComponentType) error {
-	oldImages := componentImages(oldSpec, components)
-	newImages := componentImages(newSpec, components)
-	anyChanged := false
-	allChanged := true
+	var changed, unchanged []v1beta1.ComponentType
 	for _, c := range components {
-		o, n := oldImages[c], newImages[c]
-		if o != n {
-			anyChanged = true
+		if componentRevisionSpecChanged(oldSpec, newSpec, c) {
+			changed = append(changed, c)
 		} else {
-			allChanged = false
+			unchanged = append(unchanged, c)
 		}
 	}
-	if anyChanged && !allChanged {
-		return fmt.Errorf("spec.rollout: rollingUpdate group requires all components to bump together (%s)",
-			ReasonRollingUpdateLockstepViolation)
+	if len(changed) > 0 && len(unchanged) > 0 {
+		return fmt.Errorf("spec.rollout: rollingUpdate group requires all components to bump together; changed %v but not %v (%s)",
+			changed, unchanged, ReasonRollingUpdateLockstepViolation)
 	}
 	return nil
 }
@@ -294,10 +350,9 @@ func declaredComponents(spec *v1beta1.InferenceServiceSpec) map[v1beta1.Componen
 // omenativeDeploymentModeMap returns Component → effective
 // deploymentMode value for each Component on the spec. Effective value
 // follows the resolution chain: per-Component annotation >
-// spec.deploymentMode > "" (empty when neither is set). Shape-derived
-// behavior (Leader/Worker → OMENative; PDDisaggregated) is intentionally
-// NOT considered — coordination only cares about the dispatch backend,
-// not the shape.
+// spec.deploymentMode > "" (empty when neither is set). The shape-derived
+// modes (MultiNode, PDDisaggregated) are intentionally NOT considered
+// — coordination only cares about the dispatch backend, not the shape.
 func omenativeDeploymentModeMap(spec *v1beta1.InferenceServiceSpec) map[v1beta1.ComponentType]string {
 	out := map[v1beta1.ComponentType]string{}
 	if spec == nil {
@@ -313,66 +368,6 @@ func omenativeDeploymentModeMap(spec *v1beta1.InferenceServiceSpec) map[v1beta1.
 		out[v1beta1.RouterComponent] = resolveComponentDeploymentMode(spec.Router.Annotations, spec.DeploymentMode)
 	}
 	return out
-}
-
-// componentImages returns the container image per Component in `components`.
-// Runner.Image takes precedence over the first PodSpec container image.
-func componentImages(spec *v1beta1.InferenceServiceSpec, components []v1beta1.ComponentType) map[v1beta1.ComponentType]string {
-	out := map[v1beta1.ComponentType]string{}
-	if spec == nil {
-		return out
-	}
-	for _, c := range components {
-		var img string
-		switch c {
-		case v1beta1.EngineComponent:
-			if spec.Engine != nil {
-				img = engineRunnerOrPodSpecImage(spec.Engine)
-			}
-		case v1beta1.DecoderComponent:
-			if spec.Decoder != nil {
-				img = decoderRunnerOrPodSpecImage(spec.Decoder)
-			}
-		case v1beta1.RouterComponent:
-			if spec.Router != nil {
-				img = routerRunnerOrPodSpecImage(spec.Router)
-			}
-		}
-		if img != "" {
-			out[c] = img
-		}
-	}
-	return out
-}
-
-func engineRunnerOrPodSpecImage(e *v1beta1.EngineSpec) string {
-	if e.Runner != nil && e.Runner.Image != "" {
-		return e.Runner.Image
-	}
-	if len(e.PodSpec.Containers) > 0 {
-		return e.PodSpec.Containers[0].Image
-	}
-	return ""
-}
-
-func decoderRunnerOrPodSpecImage(d *v1beta1.DecoderSpec) string {
-	if d.Runner != nil && d.Runner.Image != "" {
-		return d.Runner.Image
-	}
-	if len(d.PodSpec.Containers) > 0 {
-		return d.PodSpec.Containers[0].Image
-	}
-	return ""
-}
-
-func routerRunnerOrPodSpecImage(r *v1beta1.RouterSpec) string {
-	if r.Runner != nil && r.Runner.Image != "" {
-		return r.Runner.Image
-	}
-	if len(r.PodSpec.Containers) > 0 {
-		return r.PodSpec.Containers[0].Image
-	}
-	return ""
 }
 
 // rolloutCollapsesToSequential mirrors the engine's collapseSequential: the
@@ -419,4 +414,71 @@ func validateSoakOnlyWhenSequenced(groups []v1beta1.RolloutGroup) error {
 		}
 	}
 	return nil
+}
+
+// ValidateRolloutOrderingEnforced rejects rollout shapes that promise an
+// ordering the engine does not enforce, mirroring the Soak rule: an ordering
+// the engine would silently drop is rejected rather than accepted. Two rules:
+//
+//   - A non-empty groups[i].order is rejected on every group — no current
+//     progression applies Order as a surge sequence.
+//   - A multi-group list is accepted only when it is a pure run of
+//     single-Component blueGreen groups (the shape that collapses to the
+//     Sequential state machine, the one path that enforces cross-group
+//     order). Any other multi-group list — a rollingUpdate, canary, or
+//     multi-Component group in the mix — runs concurrently.
+//
+// Runs on create; updates apply it through the
+// ValidateRolloutOrderingEnforcedUpdate ratchet.
+func ValidateRolloutOrderingEnforced(spec *v1beta1.InferenceServiceSpec) error {
+	groups := spec.GetRolloutGroups()
+	if len(groups) == 0 {
+		return nil
+	}
+	for i := range groups {
+		if len(groups[i].Order) > 0 {
+			return fmt.Errorf("spec.rollout.groups[%d]: order is not applied by any progression — the Components in a group advance together; to roll Components one at a time, declare one single-Component blueGreen group per Component, in the desired sequence (%s)",
+				i, ReasonOrderNotHonored)
+		}
+	}
+	if len(groups) < 2 {
+		return nil // a single group makes no cross-group ordering promise
+	}
+	for i := range groups {
+		g := &groups[i]
+		var shape string
+		switch {
+		case g.Canary != nil:
+			shape = "a canary group"
+		case g.RollingUpdate != nil:
+			shape = "a rollingUpdate group"
+		case len(g.Components) != 1:
+			shape = "a multi-Component group"
+		default:
+			continue
+		}
+		return fmt.Errorf("spec.rollout.groups: groups[] is ordered (group N completes before group N+1 begins), but that is enforced only for a run of single-Component blueGreen groups; groups[%d] is %s, so the groups would run concurrently and the declared order would be dropped (%s)",
+			i, shape, ReasonGroupOrderingNotHonored)
+	}
+	return nil
+}
+
+// ValidateRolloutOrderingEnforcedUpdate is the update-time ratchet for
+// ValidateRolloutOrderingEnforced: the rules apply only when the update
+// changes spec.rollout. An update that leaves the rollout untouched is
+// admitted regardless of shape, so a stored object carrying an unenforced
+// shape keeps reconciling (and stays mutable) until its rollout is next
+// edited.
+func ValidateRolloutOrderingEnforcedUpdate(oldSpec, newSpec *v1beta1.InferenceServiceSpec) error {
+	var oldRollout, newRollout *v1beta1.RolloutSpec
+	if oldSpec != nil {
+		oldRollout = oldSpec.Rollout
+	}
+	if newSpec != nil {
+		newRollout = newSpec.Rollout
+	}
+	if apiequality.Semantic.DeepEqual(oldRollout, newRollout) {
+		return nil
+	}
+	return ValidateRolloutOrderingEnforced(newSpec)
 }

--- a/pkg/validation/coordination_lockstep.go
+++ b/pkg/validation/coordination_lockstep.go
@@ -1,0 +1,90 @@
+// RollingUpdate lockstep admission compare (spec.rollout.groups[]).
+//
+// A rollingUpdate group promises its Components bump together. The update-time
+// check therefore has to detect ANY change that mints a new workload revision
+// for a Component — not just an image bump. This file holds the
+// revision-affecting view of a Component's ISVC spec and the change predicate
+// validateRollingUpdateLockstep consumes.
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// componentRevisionSpec is the subset of one Component's ISVC spec that shapes
+// its rendered pod template — and therefore its workload revision hash. The
+// pod spec, runner/leader/worker overrides, gang topology key, router config,
+// and the pod-template labels/annotations all land on the rendered template;
+// changing any of them rolls the Component exactly like an image bump.
+//
+// Scaling, pacing, and autoscaling fields (replica bounds, timeout, PDB
+// budgets, deployment strategy, lifecycle, autoscaler, service port
+// protocols) are deliberately absent: they change behavior without
+// re-rendering pods, so a one-sided change to them must not trip lockstep.
+type componentRevisionSpec struct {
+	PodSpec     *v1beta1.PodSpec
+	Runner      *v1beta1.RunnerSpec
+	Leader      *v1beta1.LeaderSpec
+	Worker      *v1beta1.WorkerSpec
+	TopologyKey *string
+	Config      map[string]string
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+// componentRevisionSpecFor extracts the revision-affecting view for one
+// Component. nil when the Component is not declared on the spec, so
+// add/remove of a whole Component also reads as a change.
+func componentRevisionSpecFor(spec *v1beta1.InferenceServiceSpec, c v1beta1.ComponentType) *componentRevisionSpec {
+	if spec == nil {
+		return nil
+	}
+	switch c {
+	case v1beta1.EngineComponent:
+		if e := spec.Engine; e != nil {
+			return &componentRevisionSpec{
+				PodSpec:     &e.PodSpec,
+				Runner:      e.Runner,
+				Leader:      e.Leader,
+				Worker:      e.Worker,
+				TopologyKey: e.TopologyKey,
+				Labels:      e.Labels,
+				Annotations: e.Annotations,
+			}
+		}
+	case v1beta1.DecoderComponent:
+		if d := spec.Decoder; d != nil {
+			return &componentRevisionSpec{
+				PodSpec:     &d.PodSpec,
+				Runner:      d.Runner,
+				Leader:      d.Leader,
+				Worker:      d.Worker,
+				TopologyKey: d.TopologyKey,
+				Labels:      d.Labels,
+				Annotations: d.Annotations,
+			}
+		}
+	case v1beta1.RouterComponent:
+		if r := spec.Router; r != nil {
+			return &componentRevisionSpec{
+				PodSpec:     &r.PodSpec,
+				Runner:      r.Runner,
+				Config:      r.Config,
+				Labels:      r.Labels,
+				Annotations: r.Annotations,
+			}
+		}
+	}
+	return nil
+}
+
+// componentRevisionSpecChanged reports whether the Component's
+// revision-affecting spec differs between the old and new ISVC specs.
+// Semantic equality so resource quantities compare by value ("1" == "1000m").
+func componentRevisionSpecChanged(oldSpec, newSpec *v1beta1.InferenceServiceSpec, c v1beta1.ComponentType) bool {
+	return !equality.Semantic.DeepEqual(
+		componentRevisionSpecFor(oldSpec, c),
+		componentRevisionSpecFor(newSpec, c))
+}

--- a/pkg/validation/coordination_lockstep_test.go
+++ b/pkg/validation/coordination_lockstep_test.go
@@ -1,0 +1,136 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// lockstepGroupSpec attaches a 2-Component rollingUpdate group
+// (engine + decoder) to the spec so ValidateCoordinationUpdate runs
+// the lockstep check.
+func lockstepGroupSpec(spec *v1beta1.InferenceServiceSpec) *v1beta1.InferenceServiceSpec {
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+		},
+	}
+	return spec
+}
+
+func wantLockstepViolation(t *testing.T, err error, scenario string) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), ReasonRollingUpdateLockstepViolation) {
+		t.Errorf("%s: got %v want %s", scenario, err, ReasonRollingUpdateLockstepViolation)
+	}
+}
+
+// One-sided revision-affecting changes with UNCHANGED image strings must
+// trip lockstep — every one of these re-renders the engine pod template
+// and rolls the engine while the grouped decoder stays put.
+func TestValidateCoordinationUpdate_LockstepOneSidedNonImageChangesRejected(t *testing.T) {
+	cases := map[string]func(spec *v1beta1.InferenceServiceSpec){
+		"env": func(spec *v1beta1.InferenceServiceSpec) {
+			spec.Engine.Runner.Env = []corev1.EnvVar{{Name: "CONFIG_VERSION", Value: "2"}}
+		},
+		"command": func(spec *v1beta1.InferenceServiceSpec) {
+			spec.Engine.Runner.Command = []string{"serve", "--fast"}
+		},
+		"resources": func(spec *v1beta1.InferenceServiceSpec) {
+			spec.Engine.Runner.Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			}
+		},
+		"volume": func(spec *v1beta1.InferenceServiceSpec) {
+			spec.Engine.PodSpec.Volumes = []corev1.Volume{{Name: "scratch"}}
+		},
+		"pod-template label": func(spec *v1beta1.InferenceServiceSpec) {
+			spec.Engine.Labels = map[string]string{"tier": "canary"}
+		},
+		"pod-template annotation": func(spec *v1beta1.InferenceServiceSpec) {
+			ann := make(map[string]string, len(spec.Engine.Annotations)+1)
+			for k, v := range spec.Engine.Annotations {
+				ann[k] = v
+			}
+			ann["rollout-trigger"] = "1"
+			spec.Engine.Annotations = ann
+		},
+	}
+	for name, mutate := range cases {
+		oldSpec := omeNativePDSpecWithImages("v1", "v1")
+		newSpec := lockstepGroupSpec(omeNativePDSpecWithImages("v1", "v1"))
+		mutate(newSpec)
+		wantLockstepViolation(t, ValidateCoordinationUpdate(oldSpec, newSpec), name+"-only engine change")
+	}
+}
+
+// The same revision-affecting change applied to BOTH grouped Components
+// satisfies lockstep and is admitted.
+func TestValidateCoordinationUpdate_LockstepBothSidesChangedAccepted(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := lockstepGroupSpec(omeNativePDSpecWithImages("v1", "v1"))
+	newSpec.Engine.Runner.Env = []corev1.EnvVar{{Name: "CONFIG_VERSION", Value: "2"}}
+	newSpec.Decoder.Runner.Env = []corev1.EnvVar{{Name: "CONFIG_VERSION", Value: "2"}}
+	if err := ValidateCoordinationUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("env change on both grouped Components: unexpected error %v", err)
+	}
+}
+
+// Scaling knobs are not revision-affecting: a one-sided MinReplicas bump
+// must NOT trip lockstep (it scales the Component without re-rendering
+// its pod template).
+func TestValidateCoordinationUpdate_LockstepScaleOnlyChangeAccepted(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := lockstepGroupSpec(omeNativePDSpecWithImages("v1", "v1"))
+	three := 3
+	newSpec.Engine.MinReplicas = &three
+	if err := ValidateCoordinationUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("engine-only MinReplicas change: unexpected error %v", err)
+	}
+}
+
+// Lifecycle (pacing) is not revision-affecting either: a one-sided
+// partition change stages the rollout without minting a new revision.
+func TestValidateCoordinationUpdate_LockstepLifecycleOnlyChangeAccepted(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := lockstepGroupSpec(omeNativePDSpecWithImages("v1", "v1"))
+	partition := int32(1)
+	newSpec.Engine.Lifecycle = &v1beta1.LifecycleSpec{
+		UpdateStrategy: &v1beta1.UpdateStrategy{
+			RollingUpdate: &v1beta1.RollingUpdate{Partition: &partition},
+		},
+	}
+	if err := ValidateCoordinationUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("engine-only lifecycle change: unexpected error %v", err)
+	}
+}
+
+// A change to a Component OUTSIDE the group never trips the group's
+// lockstep — only grouped Components are compared.
+func TestValidateCoordinationUpdate_LockstepIgnoresUngroupedComponent(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	oldSpec.Router = &v1beta1.RouterSpec{}
+	newSpec := lockstepGroupSpec(omeNativePDSpecWithImages("v1", "v1"))
+	newSpec.Router = &v1beta1.RouterSpec{
+		Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Image: "router:v2"}},
+	}
+	if err := ValidateCoordinationUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("router change outside the group: unexpected error %v", err)
+	}
+}
+
+// The violation message names the changed and unchanged Components so an
+// operator can see which side of the group diverged.
+func TestValidateCoordinationUpdate_LockstepViolationNamesComponents(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := lockstepGroupSpec(omeNativePDSpecWithImages("v2", "v1"))
+	err := ValidateCoordinationUpdate(oldSpec, newSpec)
+	wantLockstepViolation(t, err, "one-sided image bump")
+	if err != nil && (!strings.Contains(err.Error(), "engine") || !strings.Contains(err.Error(), "decoder")) {
+		t.Errorf("violation should name changed and unchanged Components: %v", err)
+	}
+}

--- a/pkg/validation/coordination_test.go
+++ b/pkg/validation/coordination_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
@@ -73,6 +74,157 @@ func TestValidateCoordination_OrphanGroup(t *testing.T) {
 	err := ValidateCoordination(spec)
 	if err == nil || !strings.Contains(err.Error(), ReasonOrphanCoordinationGroup) {
 		t.Errorf("orphan group: got %v want %s", err, ReasonOrphanCoordinationGroup)
+	}
+}
+
+func TestValidateCoordination_GroupMembership(t *testing.T) {
+	// Every component named by a group must be declared on the ISVC. The
+	// error names the group index and each missing member (quoted), so a
+	// partially-declared group cannot slip through on the strength of the
+	// members that do exist.
+	cases := []struct {
+		name        string
+		spec        *v1beta1.InferenceServiceSpec
+		components  []v1beta1.ComponentType
+		wantErr     bool
+		wantSubstrs []string
+		notSubstrs  []string
+	}{
+		{
+			name:        "fully undeclared group",
+			spec:        omeNativeEngineOnlySpec(),
+			components:  []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.RouterComponent},
+			wantErr:     true,
+			wantSubstrs: []string{"groups[0]", `"decoder"`, `"router"`, ReasonOrphanCoordinationGroup},
+		},
+		{
+			name:        "partially undeclared group",
+			spec:        omeNativeEngineOnlySpec(),
+			components:  []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			wantErr:     true,
+			wantSubstrs: []string{"groups[0]", `"decoder"`, ReasonOrphanCoordinationGroup},
+			notSubstrs:  []string{`"engine"`},
+		},
+		{
+			name:       "fully declared group",
+			spec:       omeNativePDSpec(),
+			components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			wantErr:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.spec.Rollout = &v1beta1.RolloutSpec{
+				Groups: []v1beta1.RolloutGroup{
+					{Components: tc.components, BlueGreen: &v1beta1.GroupBlueGreen{}},
+				},
+			}
+			err := ValidateCoordination(tc.spec)
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected rejection, got nil")
+			}
+			for _, s := range tc.wantSubstrs {
+				if !strings.Contains(err.Error(), s) {
+					t.Errorf("error %q missing %q", err.Error(), s)
+				}
+			}
+			for _, s := range tc.notSubstrs {
+				if strings.Contains(err.Error(), s) {
+					t.Errorf("error %q should not name declared member %q", err.Error(), s)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCoordination_MembershipErrorNamesGroupIndex(t *testing.T) {
+	// With multiple groups the error must point at the offending group's
+	// index, not the first group.
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+			{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.RouterComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), "groups[1]") || !strings.Contains(err.Error(), `"router"`) {
+		t.Errorf("got %v want error naming groups[1] and \"router\"", err)
+	}
+}
+
+func TestValidateCoordination_UndeclaredMemberFailsModeCheckToo(t *testing.T) {
+	// The OMENative-mode check does not skip undeclared members: an
+	// undeclared component resolves to an empty mode and fails the check.
+	// (Through the public entry point the orphan check fires first; this
+	// pins the mode check's own behavior for defense in depth.)
+	spec := omeNativeEngineOnlySpec()
+	groups := []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+	}
+	err := validateComponentsAreOMENative(spec, groups)
+	if err == nil || !strings.Contains(err.Error(), ReasonCoordinationRequiresOMENative) {
+		t.Errorf("undeclared member: got %v want %s", err, ReasonCoordinationRequiresOMENative)
+	}
+}
+
+func TestValidateCoordination_ToleranceRange(t *testing.T) {
+	// Value-level mirror of the CRD Minimum=0/Maximum=100 bounds. Omitted
+	// (nil) is valid — the operator-configured default applies at
+	// resolution — and explicit 0 stays a valid, distinct request.
+	cases := []struct {
+		name      string
+		tolerance *int32
+		wantErr   bool
+	}{
+		{name: "omitted", tolerance: nil, wantErr: false},
+		{name: "explicit zero", tolerance: ptr.To(int32(0)), wantErr: false},
+		{name: "normal", tolerance: ptr.To(int32(25)), wantErr: false},
+		{name: "upper bound", tolerance: ptr.To(int32(100)), wantErr: false},
+		{name: "negative", tolerance: ptr.To(int32(-1)), wantErr: true},
+		{name: "over 100", tolerance: ptr.To(int32(101)), wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := omeNativePDSpec()
+			spec.Rollout = &v1beta1.RolloutSpec{
+				Groups: []v1beta1.RolloutGroup{{
+					Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+					BlueGreen:     &v1beta1.GroupBlueGreen{},
+					MaintainRatio: &v1beta1.MaintainRatio{Tolerance: tc.tolerance},
+				}},
+			}
+			err := ValidateCoordination(spec)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), ReasonRatioToleranceOutOfRange) {
+					t.Errorf("got %v want error with %s", err, ReasonRatioToleranceOutOfRange)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCoordinationRatioToleranceWarning_OmittedToleranceEmpty(t *testing.T) {
+	// maintainRatio with no tolerance defers to the operator-configured
+	// default; the webhook cannot know that value, so it must not warn.
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{{
+			Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			BlueGreen:     &v1beta1.GroupBlueGreen{},
+			MaintainRatio: &v1beta1.MaintainRatio{},
+		}},
+	}
+	if w := CoordinationRatioToleranceWarning(spec); w != "" {
+		t.Errorf("omitted tolerance: got %q want empty", w)
 	}
 }
 
@@ -148,7 +300,7 @@ func TestValidateCoordination_RatioBalancedWithBlueGreenAccepted(t *testing.T) {
 			{
 				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
 				BlueGreen:     &v1beta1.GroupBlueGreen{},
-				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptrInt32(5)},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptr.To(int32(5))},
 			},
 		},
 	}
@@ -239,6 +391,175 @@ func TestValidateCoordination_ZeroBudgetPacingRejectedStringForm(t *testing.T) {
 	err := ValidateCoordination(spec)
 	if err == nil || !strings.Contains(err.Error(), ReasonZeroBudgetPacingUnstartable) {
 		t.Errorf("zero-budget (str/int mix): got %v want error with %s", err, ReasonZeroBudgetPacingUnstartable)
+	}
+}
+
+// Semantic rejection matrix for group rollingUpdate budgets: negative
+// integers, non-percent strings, malformed percents, and percents outside
+// 0%-100% must all be rejected, and the error must carry the exact
+// spec.rollout.groups[i].rollingUpdate.* field path. Without this check the
+// runtime parser resolves every one of these to a zero budget.
+func TestValidateCoordination_GroupBudgetSemanticRejections(t *testing.T) {
+	cases := []struct {
+		name       string
+		surge      *intstr.IntOrString
+		unavail    *intstr.IntOrString
+		wantReason string
+		wantPath   string
+	}{
+		{"negative-int-surge", intstrPtr(intstr.FromInt(-1)), nil,
+			ReasonInvalidRollingUpdateInteger, "spec.rollout.groups[0].rollingUpdate.maxSurge"},
+		{"negative-int-unavailable", nil, intstrPtr(intstr.FromInt(-2)),
+			ReasonInvalidRollingUpdateInteger, "spec.rollout.groups[0].rollingUpdate.maxUnavailable"},
+		{"non-percent-string-surge", intstrPtr(intstr.FromString("abc")), nil,
+			ReasonInvalidRollingUpdatePercent, "spec.rollout.groups[0].rollingUpdate.maxSurge"},
+		{"plain-number-string-unavailable", nil, intstrPtr(intstr.FromString("25")),
+			ReasonInvalidRollingUpdatePercent, "spec.rollout.groups[0].rollingUpdate.maxUnavailable"},
+		{"malformed-percent-surge", intstrPtr(intstr.FromString("foo%")), nil,
+			ReasonInvalidRollingUpdatePercent, "spec.rollout.groups[0].rollingUpdate.maxSurge"},
+		{"negative-percent-unavailable", nil, intstrPtr(intstr.FromString("-25%")),
+			ReasonInvalidRollingUpdatePercent, "spec.rollout.groups[0].rollingUpdate.maxUnavailable"},
+		{"over-hundred-percent-surge", intstrPtr(intstr.FromString("150%")), nil,
+			ReasonInvalidRollingUpdatePercent, "spec.rollout.groups[0].rollingUpdate.maxSurge"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := omeNativePDSpec()
+			spec.Rollout = &v1beta1.RolloutSpec{
+				Groups: []v1beta1.RolloutGroup{
+					{
+						Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+						RollingUpdate: &v1beta1.GroupRollingUpdate{
+							MaxSurge:       tc.surge,
+							MaxUnavailable: tc.unavail,
+						},
+					},
+				},
+			}
+			err := ValidateCoordination(spec)
+			if err == nil {
+				t.Fatalf("expected rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantReason) {
+				t.Errorf("got %v want reason %s", err, tc.wantReason)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Errorf("got %v want exact path %s", err, tc.wantPath)
+			}
+		})
+	}
+}
+
+// A budget pair where BOTH values resolve to zero at runtime ("abc" parses to
+// zero, as does an explicit 0) must be rejected — otherwise the rollout has
+// neither surge nor drain headroom and stalls silently. The malformed half is
+// reported first with its exact path.
+func TestValidateCoordination_MalformedPairResolvingToZeroRejected(t *testing.T) {
+	abc := intstr.FromString("abc")
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{
+					MaxSurge:       &abc,
+					MaxUnavailable: &abc,
+				},
+			},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil {
+		t.Fatal("malformed budget pair resolving to zero must be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.rollout.groups[0].rollingUpdate.maxSurge") {
+		t.Errorf("got %v want exact maxSurge path", err)
+	}
+}
+
+// The zero-budget pair rule uses runtime-RESOLVED values, not just literal
+// zeros: a malformed string and a negative integer both resolve to zero, so
+// the pair deadlocks even though neither is written as 0. Exercised directly
+// to pin the rule independent of the per-field checks that run before it.
+func TestValidatePacingNotZeroBudget_ResolvedZeroPairRejected(t *testing.T) {
+	abc := intstr.FromString("abc")
+	neg := intstr.FromInt(-1)
+	groups := []v1beta1.RolloutGroup{
+		{
+			Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			RollingUpdate: &v1beta1.GroupRollingUpdate{
+				MaxSurge:       &abc,
+				MaxUnavailable: &neg,
+			},
+		},
+	}
+	err := validatePacingNotZeroBudget(groups)
+	if err == nil || !strings.Contains(err.Error(), ReasonZeroBudgetPacingUnstartable) {
+		t.Errorf("resolved-zero pair: got %v want error with %s", err, ReasonZeroBudgetPacingUnstartable)
+	}
+	if !strings.Contains(err.Error(), "spec.rollout.groups[0].rollingUpdate") {
+		t.Errorf("got %v want exact rollingUpdate path", err)
+	}
+}
+
+// The field path in a budget error carries the index of the offending group,
+// not always [0].
+func TestValidateCoordination_GroupBudgetPathCarriesGroupIndex(t *testing.T) {
+	bad := intstr.FromString("150%")
+	mode := constants.OMENative
+	spec := &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{},
+		Decoder:        &v1beta1.DecoderSpec{},
+		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{MaxSurge: &bad},
+			},
+		}},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), "spec.rollout.groups[1].rollingUpdate.maxSurge") {
+		t.Errorf("got %v want path spec.rollout.groups[1].rollingUpdate.maxSurge", err)
+	}
+}
+
+// Valid budget shapes: positive integers, in-range percents, boundary
+// percents, zero on one knob only, and nil (defaulted) knobs are all accepted.
+func TestValidateCoordination_GroupBudgetValidShapesAccepted(t *testing.T) {
+	cases := []struct {
+		name    string
+		surge   *intstr.IntOrString
+		unavail *intstr.IntOrString
+	}{
+		{"positive-ints", intstrPtr(intstr.FromInt(2)), intstrPtr(intstr.FromInt(1))},
+		{"mid-percents", intstrPtr(intstr.FromString("25%")), intstrPtr(intstr.FromString("50%"))},
+		{"boundary-percents", intstrPtr(intstr.FromString("100%")), intstrPtr(intstr.FromString("100%"))},
+		{"zero-surge-percent-unavailable", intstrPtr(intstr.FromInt(0)), intstrPtr(intstr.FromString("25%"))},
+		{"zero-percent-surge-int-unavailable", intstrPtr(intstr.FromString("0%")), intstrPtr(intstr.FromInt(1))},
+		{"nil-surge-zero-unavailable", nil, intstrPtr(intstr.FromInt(0))},
+		{"zero-surge-nil-unavailable", intstrPtr(intstr.FromInt(0)), nil},
+		{"both-nil", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := omeNativePDSpec()
+			spec.Rollout = &v1beta1.RolloutSpec{
+				Groups: []v1beta1.RolloutGroup{
+					{
+						Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+						RollingUpdate: &v1beta1.GroupRollingUpdate{
+							MaxSurge:       tc.surge,
+							MaxUnavailable: tc.unavail,
+						},
+					},
+				},
+			}
+			if err := ValidateCoordination(spec); err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+		})
 	}
 }
 
@@ -334,7 +655,7 @@ func TestValidateCoordination_RatioBalancedWithZeroBudgetNotRejected(t *testing.
 			{
 				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
 				BlueGreen:     &v1beta1.GroupBlueGreen{},
-				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptrInt32(5)},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptr.To(int32(5))},
 			},
 		},
 	}
@@ -390,7 +711,7 @@ func TestCoordinationRatioToleranceWarning_AboveThreshold(t *testing.T) {
 			{
 				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
 				BlueGreen:     &v1beta1.GroupBlueGreen{},
-				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptrInt32(80)},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptr.To(int32(80))},
 			},
 		},
 	}
@@ -407,12 +728,232 @@ func TestCoordinationRatioToleranceWarning_BelowThresholdEmpty(t *testing.T) {
 			{
 				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
 				BlueGreen:     &v1beta1.GroupBlueGreen{},
-				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptrInt32(5)},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: ptr.To(int32(5))},
 			},
 		},
 	}
 	if w := CoordinationRatioToleranceWarning(spec); w != "" {
 		t.Errorf("safe tolerance: got %q want empty", w)
+	}
+}
+
+// --- Rollout-ordering enforceability ---
+
+func TestValidateRolloutOrderingEnforced_NilSpecAndNoGroupsOK(t *testing.T) {
+	if err := ValidateRolloutOrderingEnforced(nil); err != nil {
+		t.Errorf("nil spec: unexpected error %v", err)
+	}
+	if err := ValidateRolloutOrderingEnforced(&v1beta1.InferenceServiceSpec{}); err != nil {
+		t.Errorf("no rollout: unexpected error %v", err)
+	}
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{}}
+	if err := ValidateRolloutOrderingEnforced(spec); err != nil {
+		t.Errorf("empty groups: unexpected error %v", err)
+	}
+}
+
+// A pure run of single-Component blueGreen groups is the one multi-group shape
+// whose list order the engine enforces — it must stay accepted, in both the
+// explicit-blueGreen and the omitted-progression spelling.
+func TestValidateRolloutOrderingEnforced_SingleComponentBlueGreenRunAccepted(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}},
+	}}
+	if err := ValidateRolloutOrderingEnforced(spec); err != nil {
+		t.Errorf("two-group run: unexpected error %v", err)
+	}
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.RouterComponent}},
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}},
+	}}
+	if err := ValidateRolloutOrderingEnforced(spec); err != nil {
+		t.Errorf("three-group run: unexpected error %v", err)
+	}
+}
+
+// A single group makes no cross-group ordering promise, so every progression
+// shape stays accepted as long as it carries no Order.
+func TestValidateRolloutOrderingEnforced_SingleGroupShapesAccepted(t *testing.T) {
+	cases := map[string]v1beta1.RolloutGroup{
+		"multi-Component blueGreen": {
+			Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			BlueGreen:  &v1beta1.GroupBlueGreen{},
+		},
+		"multi-Component rollingUpdate": {
+			Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			RollingUpdate: &v1beta1.GroupRollingUpdate{},
+		},
+		"single-Component rollingUpdate": {
+			Components:    []v1beta1.ComponentType{v1beta1.EngineComponent},
+			RollingUpdate: &v1beta1.GroupRollingUpdate{},
+		},
+		"canary": {
+			Components: []v1beta1.ComponentType{v1beta1.EngineComponent},
+			Canary:     &v1beta1.GroupCanary{},
+		},
+	}
+	for name, g := range cases {
+		spec := omeNativePDSpec()
+		spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{g}}
+		if err := ValidateRolloutOrderingEnforced(spec); err != nil {
+			t.Errorf("%s (single group): unexpected error %v", name, err)
+		}
+	}
+}
+
+// Mixed-progression lists promise an order that runs concurrently: blueGreen
+// followed by rollingUpdate, and rollingUpdate followed by canary.
+func TestValidateRolloutOrderingEnforced_MixedProgressionListRejected(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+	}}
+	err := ValidateRolloutOrderingEnforced(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonGroupOrderingNotHonored) {
+		t.Errorf("blueGreen then rollingUpdate: got %v want %s", err, ReasonGroupOrderingNotHonored)
+	}
+
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, Canary: &v1beta1.GroupCanary{}},
+	}}
+	err = ValidateRolloutOrderingEnforced(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonGroupOrderingNotHonored) {
+		t.Errorf("rollingUpdate then canary: got %v want %s", err, ReasonGroupOrderingNotHonored)
+	}
+}
+
+func TestValidateRolloutOrderingEnforced_MultiComponentGroupInListRejected(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Router = &v1beta1.RouterSpec{}
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.RouterComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+	}}
+	err := ValidateRolloutOrderingEnforced(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonGroupOrderingNotHonored) {
+		t.Errorf("multi-Component group in ordered list: got %v want %s", err, ReasonGroupOrderingNotHonored)
+	}
+	if err != nil && !strings.Contains(err.Error(), "groups[0]") {
+		t.Errorf("error should name the offending group: got %q", err.Error())
+	}
+}
+
+// A canary group can never be part of the collapsed run (the canary engine
+// drives it independently), so mixing one into a multi-group list breaks the
+// promised order.
+func TestValidateRolloutOrderingEnforced_CanaryInListRejected(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, Canary: &v1beta1.GroupCanary{}},
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+	}}
+	err := ValidateRolloutOrderingEnforced(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonGroupOrderingNotHonored) {
+		t.Errorf("canary in ordered list: got %v want %s", err, ReasonGroupOrderingNotHonored)
+	}
+}
+
+// Order is rejected on every shape it could be written on — no progression
+// applies it.
+func TestValidateRolloutOrderingEnforced_OrderRejected(t *testing.T) {
+	cases := map[string]v1beta1.RolloutGroup{
+		"multi-Component blueGreen": {
+			Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			BlueGreen:  &v1beta1.GroupBlueGreen{},
+			Order:      []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.EngineComponent},
+		},
+		"multi-Component rollingUpdate": {
+			Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			RollingUpdate: &v1beta1.GroupRollingUpdate{},
+			Order:         []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.EngineComponent},
+		},
+		"canary": {
+			Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+			Canary:     &v1beta1.GroupCanary{},
+			Order:      []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.EngineComponent},
+		},
+		"single-Component (trivial order)": {
+			Components: []v1beta1.ComponentType{v1beta1.EngineComponent},
+			BlueGreen:  &v1beta1.GroupBlueGreen{},
+			Order:      []v1beta1.ComponentType{v1beta1.EngineComponent},
+		},
+	}
+	for name, g := range cases {
+		spec := omeNativePDSpec()
+		spec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{g}}
+		err := ValidateRolloutOrderingEnforced(spec)
+		if err == nil || !strings.Contains(err.Error(), ReasonOrderNotHonored) {
+			t.Errorf("%s with order: got %v want %s", name, err, ReasonOrderNotHonored)
+		}
+	}
+}
+
+// Ratchet: an update that does not touch spec.rollout is admitted even when
+// the stored rollout carries an unenforced shape, so existing objects keep
+// reconciling.
+func TestValidateRolloutOrderingEnforcedUpdate_UntouchedRolloutAdmitted(t *testing.T) {
+	unenforced := &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+	}}
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	oldSpec.Rollout = unenforced
+	newSpec := omeNativePDSpecWithImages("v2", "v2") // image bump, rollout untouched
+	newSpec.Rollout = unenforced.DeepCopy()
+	if err := ValidateRolloutOrderingEnforcedUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("untouched rollout: unexpected error %v", err)
+	}
+}
+
+// Ratchet: any update that changes spec.rollout must land on an enforced
+// shape — including an edit that swaps one unenforced shape for another.
+func TestValidateRolloutOrderingEnforcedUpdate_ChangedRolloutRejected(t *testing.T) {
+	oldSpec := omeNativePDSpec()
+	newSpec := omeNativePDSpec()
+	newSpec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+	}}
+	err := ValidateRolloutOrderingEnforcedUpdate(oldSpec, newSpec)
+	if err == nil || !strings.Contains(err.Error(), ReasonGroupOrderingNotHonored) {
+		t.Errorf("added unenforced rollout: got %v want %s", err, ReasonGroupOrderingNotHonored)
+	}
+
+	oldSpec = omeNativePDSpec()
+	oldSpec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}, Order: []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.EngineComponent}},
+	}}
+	newSpec = omeNativePDSpec()
+	newSpec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}, Order: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}},
+	}}
+	err = ValidateRolloutOrderingEnforcedUpdate(oldSpec, newSpec)
+	if err == nil || !strings.Contains(err.Error(), ReasonOrderNotHonored) {
+		t.Errorf("edited order: got %v want %s", err, ReasonOrderNotHonored)
+	}
+}
+
+// Ratchet: an update that changes the rollout INTO an enforced shape passes —
+// the ratchet only blocks writes that keep or introduce unenforced ordering.
+func TestValidateRolloutOrderingEnforcedUpdate_ChangedToEnforcedAccepted(t *testing.T) {
+	oldSpec := omeNativePDSpec()
+	oldSpec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+	}}
+	newSpec := omeNativePDSpec()
+	newSpec.Rollout = &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+		{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+	}}
+	if err := ValidateRolloutOrderingEnforcedUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("corrected rollout: unexpected error %v", err)
 	}
 }
 
@@ -445,5 +986,3 @@ func omeNativeEngineOnlySpec() *v1beta1.InferenceServiceSpec {
 		},
 	}
 }
-
-func ptrInt32(v int32) *int32 { return &v }

--- a/pkg/validation/doc.go
+++ b/pkg/validation/doc.go
@@ -1,0 +1,4 @@
+// Package validation provides pure validation functions for OME API types.
+// These functions have zero dependency on Kubernetes clients or cluster state
+// and can be used both by admission webhooks and by offline validation tooling.
+package validation

--- a/pkg/validation/isvc.go
+++ b/pkg/validation/isvc.go
@@ -297,11 +297,10 @@ func ValidateEngineDecoderDeploymentMode(spec *v1beta1.InferenceServiceSpec) err
 //  2. spec.deploymentMode (the typed top-level default).
 //  3. Empty string when neither is set.
 //
-// Shape-derived behavior (Leader/Worker → multi-node OMENative;
-// PDDisaggregated from Engine+Decoder pairing) is intentionally NOT
-// considered here: this helper is consumed by admission rules that only
-// care about the DISPATCH backend (OMENative vs RawDeployment), not the
-// shape.
+// Shape-derived modes (MultiNode from Leader/Worker; PDDisaggregated
+// from Engine+Decoder pairing) are intentionally NOT considered here:
+// this helper is consumed by admission rules that only care about the
+// DISPATCH backend (OMENative vs RawDeployment), not the shape.
 func resolveComponentDeploymentMode(annotations map[string]string, specMode *constants.DeploymentModeType) string {
 	if mode, ok := annotations[constants.DeploymentMode]; ok && mode != "" {
 		return mode

--- a/pkg/validation/isvc_test.go
+++ b/pkg/validation/isvc_test.go
@@ -147,24 +147,24 @@ func TestValidateEngineDecoderDeploymentMode(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "engine OMENative, decoder RawDeployment — mismatch",
+			name: "engine OMENative, decoder MultiNode — mismatch",
 			spec: &v1beta1.InferenceServiceSpec{
 				Engine:  engineWith(withMode(string(constants.OMENative))),
-				Decoder: decoderWith(withMode(string(constants.RawDeployment))),
+				Decoder: decoderWith(withMode(string(constants.MultiNode))),
 			},
 			wantErr: true,
 		},
 		{
-			name: "both RawDeployment (no OMENative) — rule does not apply",
+			name: "both MultiNode (no OMENative) — rule does not apply",
 			spec: &v1beta1.InferenceServiceSpec{
-				Engine:  engineWith(withMode(string(constants.RawDeployment))),
-				Decoder: decoderWith(withMode(string(constants.RawDeployment))),
+				Engine:  engineWith(withMode(string(constants.MultiNode))),
+				Decoder: decoderWith(withMode(string(constants.MultiNode))),
 			},
 		},
 		{
-			name: "engine RawDeployment, decoder RawDeployment (no OMENative) — rule does not apply",
+			name: "engine MultiNode, decoder RawDeployment (no OMENative) — rule does not apply",
 			spec: &v1beta1.InferenceServiceSpec{
-				Engine:  engineWith(withMode(string(constants.RawDeployment))),
+				Engine:  engineWith(withMode(string(constants.MultiNode))),
 				Decoder: decoderWith(withMode(string(constants.RawDeployment))),
 			},
 		},

--- a/pkg/validation/lifecycle.go
+++ b/pkg/validation/lifecycle.go
@@ -1,9 +1,9 @@
 // Per-Component LifecycleSpec.UpdateStrategy.RollingUpdate validation.
 //
-// The CRD schema's XIntOrString marker already gates the structural
-// shape (must parse as integer or string). These helpers add the
-// semantic checks the apiserver can't express: percent strings must
-// match "<n>%" with 0 <= n <= 100, integer values must be >= 0.
+// The semantic IntOrString rules (integers >= 0, percent strings
+// "<n>%" with 0 <= n <= 100) live in the shared
+// validateBudgetIntOrString helper in budget.go; this file composes
+// the per-Component field paths and adds the zero-budget pair rule.
 //
 // As of the per-Component MaxSurge/MaxUnavailable wire-up, the rollout
 // budget now reads the per-Component RollingUpdate fields directly
@@ -77,10 +77,11 @@ func validateComponentLifecycle(name string, lc *v1beta1.LifecycleSpec) error {
 		return nil
 	}
 	ru := lc.UpdateStrategy.RollingUpdate
-	if err := validateRollingUpdateIntOrString(name, "maxUnavailable", ru.MaxUnavailable); err != nil {
+	base := fmt.Sprintf("spec.%s.lifecycle.updateStrategy.rollingUpdate.", name)
+	if err := validateBudgetIntOrString(base+"maxUnavailable", ru.MaxUnavailable); err != nil {
 		return err
 	}
-	if err := validateRollingUpdateIntOrString(name, "maxSurge", ru.MaxSurge); err != nil {
+	if err := validateBudgetIntOrString(base+"maxSurge", ru.MaxSurge); err != nil {
 		return err
 	}
 	if err := validateRollingUpdateNotBothZero(name, ru.MaxSurge, ru.MaxUnavailable); err != nil {
@@ -142,41 +143,4 @@ func explicitZero(v *intstr.IntOrString) bool {
 		return false
 	}
 	return pct == 0
-}
-
-// validateRollingUpdateIntOrString enforces:
-//   - integer values >= 0
-//   - string values match "<n>%" with 0 <= n <= 100
-//
-// Returns nil for nil inputs (the workload reconciler defaults nil to
-// 25% — both the API documentation and pacingWithDefaults agree on
-// the same fallback).
-func validateRollingUpdateIntOrString(component, field string, v *intstr.IntOrString) error {
-	if v == nil {
-		return nil
-	}
-	if v.Type == intstr.Int {
-		if v.IntValue() < 0 {
-			return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%d must be >= 0 (%s)",
-				component, field, v.IntValue(), ReasonInvalidRollingUpdateInteger)
-		}
-		return nil
-	}
-	// String form — must be "<n>%" with 0 <= n <= 100.
-	s := v.StrVal
-	if !strings.HasSuffix(s, "%") {
-		return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%q must be an integer count or a percent string like \"25%%\" (%s)",
-			component, field, s, ReasonInvalidRollingUpdatePercent)
-	}
-	pctStr := strings.TrimSuffix(s, "%")
-	pct, err := strconv.Atoi(pctStr)
-	if err != nil {
-		return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%q has a malformed percent value (%s)",
-			component, field, s, ReasonInvalidRollingUpdatePercent)
-	}
-	if pct < 0 || pct > 100 {
-		return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%q percent must be between 0%% and 100%% (%s)",
-			component, field, s, ReasonInvalidRollingUpdatePercent)
-	}
-	return nil
 }

--- a/pkg/validation/pdb.go
+++ b/pkg/validation/pdb.go
@@ -1,0 +1,56 @@
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ValidatePodDisruptionBudget validates the mutually exclusive availability
+// budgets accepted by a Kubernetes PodDisruptionBudget.
+func ValidatePodDisruptionBudget(path string, minAvailable, maxUnavailable *intstr.IntOrString) error {
+	if minAvailable != nil && maxUnavailable != nil {
+		return fmt.Errorf("%s.minAvailable and %s.maxUnavailable cannot both be set", path, path)
+	}
+	if err := validatePodDisruptionBudgetValue(path+".minAvailable", minAvailable); err != nil {
+		return err
+	}
+	return validatePodDisruptionBudgetValue(path+".maxUnavailable", maxUnavailable)
+}
+
+func validatePodDisruptionBudgetValue(path string, value *intstr.IntOrString) error {
+	if value == nil {
+		return nil
+	}
+
+	switch value.Type {
+	case intstr.Int:
+		if value.IntVal < 0 {
+			return fmt.Errorf("%s must be a non-negative integer or a percentage from 0%% to 100%%", path)
+		}
+		return nil
+	case intstr.String:
+		percentage := value.StrVal
+		if !strings.HasSuffix(percentage, "%") {
+			return fmt.Errorf("%s must be a non-negative integer or a percentage from 0%% to 100%%", path)
+		}
+		number := strings.TrimSuffix(percentage, "%")
+		if number == "" {
+			return fmt.Errorf("%s must be a non-negative integer or a percentage from 0%% to 100%%", path)
+		}
+		for _, digit := range number {
+			if digit < '0' || digit > '9' {
+				return fmt.Errorf("%s must be a non-negative integer or a percentage from 0%% to 100%%", path)
+			}
+		}
+		parsed, err := strconv.Atoi(number)
+		if err != nil || parsed > 100 {
+			return fmt.Errorf("%s must be a non-negative integer or a percentage from 0%% to 100%%", path)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s must be a non-negative integer or a percentage from 0%% to 100%%", path)
+	}
+}

--- a/pkg/validation/pdb_test.go
+++ b/pkg/validation/pdb_test.go
@@ -1,0 +1,101 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestValidatePodDisruptionBudgetAcceptsValidBudgets(t *testing.T) {
+	tests := []struct {
+		name           string
+		minAvailable   *intstr.IntOrString
+		maxUnavailable *intstr.IntOrString
+	}{
+		{name: "unset"},
+		{name: "zero minimum", minAvailable: intOrStringPtr(intstr.FromInt(0))},
+		{name: "integer maximum", maxUnavailable: intOrStringPtr(intstr.FromInt(2))},
+		{name: "zero percent minimum", minAvailable: intOrStringPtr(intstr.FromString("0%"))},
+		{name: "full percent maximum", maxUnavailable: intOrStringPtr(intstr.FromString("100%"))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidatePodDisruptionBudget("config.podDisruptionBudget", tt.minAvailable, tt.maxUnavailable); err != nil {
+				t.Fatalf("ValidatePodDisruptionBudget() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidatePodDisruptionBudgetRejectsInvalidBudgets(t *testing.T) {
+	const path = "config.podDisruptionBudget.rawDeployment"
+
+	tests := []struct {
+		name           string
+		minAvailable   *intstr.IntOrString
+		maxUnavailable *intstr.IntOrString
+		wantFields     []string
+	}{
+		{
+			name:           "both fields",
+			minAvailable:   intOrStringPtr(intstr.FromInt(1)),
+			maxUnavailable: intOrStringPtr(intstr.FromString("25%")),
+			wantFields:     []string{path + ".minAvailable", path + ".maxUnavailable"},
+		},
+		{
+			name:         "negative minimum integer",
+			minAvailable: intOrStringPtr(intstr.FromInt(-1)),
+			wantFields:   []string{path + ".minAvailable"},
+		},
+		{
+			name:           "negative maximum integer",
+			maxUnavailable: intOrStringPtr(intstr.FromInt(-1)),
+			wantFields:     []string{path + ".maxUnavailable"},
+		},
+		{
+			name:         "malformed percentage",
+			minAvailable: intOrStringPtr(intstr.FromString("25.5%")),
+			wantFields:   []string{path + ".minAvailable"},
+		},
+		{
+			name:           "non-percentage string",
+			maxUnavailable: intOrStringPtr(intstr.FromString("1")),
+			wantFields:     []string{path + ".maxUnavailable"},
+		},
+		{
+			name:         "negative percentage",
+			minAvailable: intOrStringPtr(intstr.FromString("-1%")),
+			wantFields:   []string{path + ".minAvailable"},
+		},
+		{
+			name:           "percentage above one hundred",
+			maxUnavailable: intOrStringPtr(intstr.FromString("101%")),
+			wantFields:     []string{path + ".maxUnavailable"},
+		},
+		{
+			name:           "unknown value type",
+			maxUnavailable: intOrStringPtr(intstr.IntOrString{Type: 2}),
+			wantFields:     []string{path + ".maxUnavailable"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePodDisruptionBudget(path, tt.minAvailable, tt.maxUnavailable)
+			if err == nil {
+				t.Fatal("ValidatePodDisruptionBudget() error = nil")
+			}
+			for _, field := range tt.wantFields {
+				if !strings.Contains(err.Error(), field) {
+					t.Errorf("ValidatePodDisruptionBudget() error = %q, want field %q", err, field)
+				}
+			}
+		})
+	}
+}
+
+func intOrStringPtr(value intstr.IntOrString) *intstr.IntOrString {
+	return &value
+}

--- a/pkg/validation/scalingpolicy.go
+++ b/pkg/validation/scalingpolicy.go
@@ -1,0 +1,61 @@
+// ScalingPolicy admission validation.
+//
+// The ScalingPolicy schema (on InferenceService.spec and on the
+// ServingRuntime/ClusterServingRuntime default field) accepts three modes, but
+// no controller applies Proportional or Pinned: admitting either would store a
+// policy that silently behaves like Independent. Admission rejects them
+// instead, with ratchet semantics on update so stored objects that already
+// carry such a policy keep accepting unrelated writes.
+package validation
+
+import (
+	"fmt"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// ReasonScalingModeNotImplemented is the admission rejection reason for a
+// ScalingPolicy mode the API accepts but no controller applies. Operators and
+// tests reference it by name, so it's an exported constant.
+const ReasonScalingModeNotImplemented = "ScalingModeNotImplemented"
+
+// ValidateScalingPolicy rejects a ScalingPolicy whose mode no controller
+// applies (Proportional, Pinned) so the policy can never be a silent no-op.
+// nil, empty mode, and Independent are accepted — they all mean "every
+// Component autoscales independently", which is the implemented behavior.
+// fieldPath names the field in error messages (e.g. "spec.scalingPolicy").
+func ValidateScalingPolicy(policy *v1beta1.ScalingPolicy, fieldPath string) error {
+	if policy == nil {
+		return nil
+	}
+	switch policy.Mode {
+	case "", v1beta1.ScalingIndependent:
+		return nil
+	case v1beta1.ScalingProportional, v1beta1.ScalingPinned:
+		return fmt.Errorf(
+			"%s.mode %q is accepted by the API but not implemented: no controller applies it, so the policy would silently behave like %q; use %q or omit the policy (%s)",
+			fieldPath, policy.Mode, v1beta1.ScalingIndependent, v1beta1.ScalingIndependent,
+			ReasonScalingModeNotImplemented)
+	default:
+		// The CRD enum already rejects unknown modes; this covers callers
+		// that bypass the schema (e.g. direct Go API use).
+		return fmt.Errorf("%s.mode %q is not one of %s|%s|%s",
+			fieldPath, policy.Mode,
+			v1beta1.ScalingIndependent, v1beta1.ScalingProportional, v1beta1.ScalingPinned)
+	}
+}
+
+// ValidateScalingPolicyUpdate runs ValidateScalingPolicy only when this write
+// sets or changes the policy. An unchanged policy — however it was admitted —
+// never blocks the update, so objects stored with a now-rejected mode keep
+// reconciling and accepting unrelated spec changes. Equality is semantic, so
+// rewriting a ratio quantity in an equivalent form (e.g. "1" vs "1000m") does
+// not count as a change.
+func ValidateScalingPolicyUpdate(oldPolicy, newPolicy *v1beta1.ScalingPolicy, fieldPath string) error {
+	if apiequality.Semantic.DeepEqual(oldPolicy, newPolicy) {
+		return nil
+	}
+	return ValidateScalingPolicy(newPolicy, fieldPath)
+}

--- a/pkg/validation/scalingpolicy_test.go
+++ b/pkg/validation/scalingpolicy_test.go
@@ -1,0 +1,152 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func proportionalPolicy(decoderRatio string) *v1beta1.ScalingPolicy {
+	return &v1beta1.ScalingPolicy{
+		Mode: v1beta1.ScalingProportional,
+		Proportional: &v1beta1.ProportionalPolicy{
+			Anchor: v1beta1.EngineComponent,
+			Ratios: map[v1beta1.ComponentType]resource.Quantity{
+				v1beta1.DecoderComponent: resource.MustParse(decoderRatio),
+			},
+		},
+	}
+}
+
+func TestValidateScalingPolicy(t *testing.T) {
+	t.Run("nil policy is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicy(nil, "spec.scalingPolicy"))
+	})
+
+	t.Run("empty mode is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicy(&v1beta1.ScalingPolicy{}, "spec.scalingPolicy"))
+	})
+
+	t.Run("Independent is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicy(
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingIndependent}, "spec.scalingPolicy"))
+	})
+
+	t.Run("Proportional is rejected as not implemented", func(t *testing.T) {
+		err := ValidateScalingPolicy(proportionalPolicy("1"), "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.scalingPolicy.mode")
+		assert.Contains(t, err.Error(), "Proportional")
+		assert.Contains(t, err.Error(), "not implemented")
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("Proportional without proportional block is still rejected", func(t *testing.T) {
+		err := ValidateScalingPolicy(
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingProportional}, "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+
+	t.Run("Pinned is rejected as not implemented", func(t *testing.T) {
+		err := ValidateScalingPolicy(
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingPinned}, "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Pinned")
+		assert.Contains(t, err.Error(), "not implemented")
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("unknown mode is rejected", func(t *testing.T) {
+		err := ValidateScalingPolicy(
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingMode("Elastic")}, "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Elastic")
+		assert.Contains(t, err.Error(), "is not one of")
+	})
+
+	t.Run("fieldPath is reflected in the error", func(t *testing.T) {
+		err := ValidateScalingPolicy(
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingPinned}, "spec.other.path")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.other.path.mode")
+	})
+}
+
+func TestValidateScalingPolicyUpdate(t *testing.T) {
+	t.Run("nil to nil is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicyUpdate(nil, nil, "spec.scalingPolicy"))
+	})
+
+	t.Run("nil to Independent is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicyUpdate(
+			nil, &v1beta1.ScalingPolicy{Mode: v1beta1.ScalingIndependent}, "spec.scalingPolicy"))
+	})
+
+	t.Run("newly set Proportional is rejected", func(t *testing.T) {
+		err := ValidateScalingPolicyUpdate(nil, proportionalPolicy("1"), "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("newly set Pinned is rejected", func(t *testing.T) {
+		err := ValidateScalingPolicyUpdate(
+			nil, &v1beta1.ScalingPolicy{Mode: v1beta1.ScalingPinned}, "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("Independent changed to Proportional is rejected", func(t *testing.T) {
+		err := ValidateScalingPolicyUpdate(
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingIndependent},
+			proportionalPolicy("1"), "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("unchanged stored Proportional is ratcheted through", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicyUpdate(
+			proportionalPolicy("1"), proportionalPolicy("1"), "spec.scalingPolicy"))
+	})
+
+	t.Run("unchanged stored Pinned is ratcheted through", func(t *testing.T) {
+		pinned := &v1beta1.ScalingPolicy{Mode: v1beta1.ScalingPinned}
+		require.NoError(t, ValidateScalingPolicyUpdate(
+			pinned, pinned.DeepCopy(), "spec.scalingPolicy"))
+	})
+
+	t.Run("semantically equal ratio quantities count as unchanged", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicyUpdate(
+			proportionalPolicy("1"), proportionalPolicy("1000m"), "spec.scalingPolicy"))
+	})
+
+	t.Run("changed Proportional ratio is rejected", func(t *testing.T) {
+		err := ValidateScalingPolicyUpdate(
+			proportionalPolicy("1"), proportionalPolicy("2"), "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("Proportional changed to Pinned is rejected", func(t *testing.T) {
+		err := ValidateScalingPolicyUpdate(
+			proportionalPolicy("1"),
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingPinned}, "spec.scalingPolicy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ReasonScalingModeNotImplemented)
+	})
+
+	t.Run("Proportional downgraded to Independent is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicyUpdate(
+			proportionalPolicy("1"),
+			&v1beta1.ScalingPolicy{Mode: v1beta1.ScalingIndependent}, "spec.scalingPolicy"))
+	})
+
+	t.Run("Proportional removed entirely is ok", func(t *testing.T) {
+		require.NoError(t, ValidateScalingPolicyUpdate(
+			proportionalPolicy("1"), nil, "spec.scalingPolicy"))
+	})
+}

--- a/pkg/validation/servingruntime.go
+++ b/pkg/validation/servingruntime.go
@@ -1,0 +1,40 @@
+package validation
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+const (
+	priorityIsNotSameError = "different priorities assigned for the model format %s"
+)
+
+func ValidateSupportedModelFormats(formats []v1beta1.SupportedModelFormat) error {
+	for i, f := range formats {
+		if f.ModelFormat == nil || f.ModelFormat.Name == "" {
+			return fmt.Errorf("spec.supportedModelFormats[%d]: modelFormat.name is required", i)
+		}
+		if f.ModelFramework == nil || f.ModelFramework.Name == "" {
+			return fmt.Errorf("spec.supportedModelFormats[%d]: modelFramework.name is required", i)
+		}
+	}
+	return nil
+}
+
+func ValidateModelFormatPrioritySame(spec *v1beta1.ServingRuntimeSpec) error {
+	nameToPriority := make(map[string]*int32)
+
+	for _, f := range spec.SupportedModelFormats {
+		if f.IsAutoSelectEnabled() {
+			if existingPriority, ok := nameToPriority[f.Name]; ok {
+				if existingPriority != nil && f.Priority != nil && (*existingPriority != *f.Priority) {
+					return fmt.Errorf(priorityIsNotSameError, f.Name)
+				}
+			} else {
+				nameToPriority[f.Name] = f.Priority
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/validation/servingruntime_test.go
+++ b/pkg/validation/servingruntime_test.go
@@ -1,0 +1,120 @@
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestValidateSupportedModelFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		formats []v1beta1.SupportedModelFormat
+		wantErr bool
+	}{
+		{
+			name:    "nil formats",
+			formats: nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty formats",
+			formats: []v1beta1.SupportedModelFormat{},
+			wantErr: false,
+		},
+		{
+			name: "valid single format",
+			formats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat:    &v1beta1.ModelFormat{Name: "safetensors"},
+					ModelFramework: &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+				},
+			},
+		},
+		{
+			name: "missing modelFormat.name",
+			formats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFramework: &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing modelFramework.name",
+			formats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSupportedModelFormats(tc.formats)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateModelFormatPrioritySame(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *v1beta1.ServingRuntimeSpec
+		wantErr bool
+	}{
+		{
+			name: "no formats",
+			spec: &v1beta1.ServingRuntimeSpec{},
+		},
+		{
+			name: "consistent priority",
+			spec: &v1beta1.ServingRuntimeSpec{
+				SupportedModelFormats: []v1beta1.SupportedModelFormat{
+					{Name: "fmt1", Priority: ptr.To[int32](1), AutoSelect: ptr.To(true)},
+					{Name: "fmt1", Priority: ptr.To[int32](1), AutoSelect: ptr.To(true)},
+				},
+			},
+		},
+		{
+			name: "different priority for same format name",
+			spec: &v1beta1.ServingRuntimeSpec{
+				SupportedModelFormats: []v1beta1.SupportedModelFormat{
+					{Name: "fmt1", Priority: ptr.To[int32](1), AutoSelect: ptr.To(true)},
+					{Name: "fmt1", Priority: ptr.To[int32](2), AutoSelect: ptr.To(true)},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "different priority but autoselect disabled",
+			spec: &v1beta1.ServingRuntimeSpec{
+				SupportedModelFormats: []v1beta1.SupportedModelFormat{
+					{Name: "fmt1", Priority: ptr.To[int32](1), AutoSelect: ptr.To(true)},
+					{Name: "fmt1", Priority: ptr.To[int32](2), AutoSelect: ptr.To(false)},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateModelFormatPrioritySame(tc.spec)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/validation/traffic_annotations.go
+++ b/pkg/validation/traffic_annotations.go
@@ -23,10 +23,11 @@ type trafficAnnotationKind int
 const (
 	kindUnknown trafficAnnotationKind = iota
 	kindInt
+	kindPositiveInt // int >= 1
 	kindDuration
 	kindBool
 	kindRetryOnList
-	kindPromoteTarget // int >= 0 or "full"
+	kindPromoteTarget // canary revision hash
 )
 
 // trafficAnnotationKinds is the authoritative classifier for every
@@ -56,7 +57,7 @@ var trafficAnnotationKinds = map[string]trafficAnnotationKind{
 	// Operational.
 	constants.ManagedByConflictAckedAnnotation: kindBool,
 	constants.RolloutReadyTimeoutAnnotation:    kindDuration,
-	constants.RevisionHistoryLimitAnnotation:   kindInt,
+	constants.RevisionHistoryLimitAnnotation:   kindPositiveInt,
 	constants.RolloutPromoteAnnotation:         kindPromoteTarget,
 	constants.RolloutRollbackAnnotation:        kindBool,
 }
@@ -148,6 +149,14 @@ func validateAnnotationValue(key, value string, kind trafficAnnotationKind) erro
 		if _, err := strconv.Atoi(value); err != nil {
 			return fmt.Errorf("annotation %q value %q is not a valid integer (InvalidIntValue): %w", key, value, err)
 		}
+	case kindPositiveInt:
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("annotation %q value %q is not a valid integer (InvalidIntValue): %w", key, value, err)
+		}
+		if n < 1 {
+			return fmt.Errorf("annotation %q value %q must be a positive integer (>= 1) (InvalidPositiveIntValue)", key, value)
+		}
 	case kindDuration:
 		if _, err := time.ParseDuration(value); err != nil {
 			return fmt.Errorf("annotation %q value %q is not a valid duration (InvalidDuration): %w", key, value, err)
@@ -172,14 +181,11 @@ func validateAnnotationValue(key, value string, kind trafficAnnotationKind) erro
 			}
 		}
 	case kindPromoteTarget:
-		// The canary manual-promote verb expects the canary revision hash (the
-		// value copied from status.canary.canaryRevisionHash); "full" is also
-		// accepted. See promotion.shouldAdvanceManual.
-		if value == "full" {
-			return nil
-		}
+		// The canary manual-promote verb only ever matches the exact canary
+		// revision hash (promotion.shouldAdvanceManual), so admission accepts
+		// nothing else — any other value would sit on the object doing nothing.
 		if !isRevisionHashToken(value) {
-			return fmt.Errorf("annotation %q value %q must be a canary revision hash (lowercase alphanumeric, from status.canary.canaryRevisionHash) or \"full\" (InvalidRolloutPromoteTarget)", key, value)
+			return fmt.Errorf("annotation %q value %q must be the canary revision hash to promote, copied from status.canary.canaryRevisionHash (lowercase alphanumeric, at least 6 chars); \"full\" is not a supported promotion target (InvalidRolloutPromoteTarget)", key, value)
 		}
 	}
 	return nil

--- a/pkg/validation/traffic_annotations_test.go
+++ b/pkg/validation/traffic_annotations_test.go
@@ -44,13 +44,6 @@ func TestValidateTrafficAnnotations_TypedValues(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "valid promote target full",
-			annotations: map[string]string{
-				constants.RolloutPromoteAnnotation: "full",
-			},
-			wantOK: true,
-		},
-		{
 			name: "valid promote target revision hash",
 			annotations: map[string]string{
 				constants.RolloutPromoteAnnotation: "e5d6f79d",
@@ -61,6 +54,13 @@ func TestValidateTrafficAnnotations_TypedValues(t *testing.T) {
 			name: "valid rollback bool",
 			annotations: map[string]string{
 				constants.RolloutRollbackAnnotation: "true",
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid revision history limit",
+			annotations: map[string]string{
+				constants.RevisionHistoryLimitAnnotation: "1",
 			},
 			wantOK: true,
 		},
@@ -104,6 +104,27 @@ func TestValidateTrafficAnnotations_TypedValues(t *testing.T) {
 			wantContains: "InvalidRetryOn",
 		},
 		{
+			name: "revision history limit not an int",
+			annotations: map[string]string{
+				constants.RevisionHistoryLimitAnnotation: "many",
+			},
+			wantContains: "InvalidIntValue",
+		},
+		{
+			name: "revision history limit zero",
+			annotations: map[string]string{
+				constants.RevisionHistoryLimitAnnotation: "0",
+			},
+			wantContains: "InvalidPositiveIntValue",
+		},
+		{
+			name: "revision history limit negative",
+			annotations: map[string]string{
+				constants.RevisionHistoryLimitAnnotation: "-3",
+			},
+			wantContains: "InvalidPositiveIntValue",
+		},
+		{
 			name: "promote target negative",
 			annotations: map[string]string{
 				constants.RolloutPromoteAnnotation: "-1",
@@ -114,6 +135,16 @@ func TestValidateTrafficAnnotations_TypedValues(t *testing.T) {
 			name: "promote target garbage",
 			annotations: map[string]string{
 				constants.RolloutPromoteAnnotation: "next",
+			},
+			wantContains: "InvalidRolloutPromoteTarget",
+		},
+		{
+			// The executor only ever matches the exact canary revision hash, so a
+			// "full" promotion could never take effect — reject it at admission
+			// instead of accepting a command that silently does nothing.
+			name: "promote target full is rejected",
+			annotations: map[string]string{
+				constants.RolloutPromoteAnnotation: "full",
 			},
 			wantContains: "InvalidRolloutPromoteTarget",
 		},
@@ -408,7 +439,7 @@ func TestLevenshtein(t *testing.T) {
 		{"abc", "abc", 0},
 		{"abc", "", 3},
 		{"", "abc", 3},
-		{"abc", "abz", 1},  // substitution
+		{"abc", "abx", 1},  // substitution
 		{"abc", "ab", 1},   // deletion
 		{"abc", "abcd", 1}, // insertion
 		{"kitten", "sitting", 3},

--- a/pkg/validation/traffic_capabilities.go
+++ b/pkg/validation/traffic_capabilities.go
@@ -1,0 +1,107 @@
+// Traffic provider-capability validation.
+//
+// Maps the typed spec.traffic core onto the capability tokens the
+// active Gateway-implementation translator declares
+// (Translator.SupportedTrafficFields) and enforces the admission-time
+// half of the capability contract. The reconciler-side half —
+// surfacing dropped fields as a status condition — lives in the
+// traffic reconciler package and reuses RequiredTrafficCapabilities so
+// the two checks cannot drift.
+package validation
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// RequiredTrafficCapabilities returns the capability tokens
+// (pkg/constants TrafficCapability*) the given typed spec.traffic
+// block requires from a translator. Empty when t is nil or declares
+// nothing. Output order follows field order in TrafficSpec so it is
+// deterministic.
+func RequiredTrafficCapabilities(t *v1beta1.TrafficSpec) []string {
+	if t == nil {
+		return nil
+	}
+	var out []string
+	if t.Algorithm != nil {
+		out = append(out, constants.TrafficCapabilityAlgorithm)
+	}
+	if t.ConsistentHash != nil {
+		switch t.ConsistentHash.Type {
+		case v1beta1.HashTypeHeader:
+			out = append(out, constants.TrafficCapabilityHashHeader)
+			if len(t.ConsistentHash.Headers) > 1 {
+				out = append(out, constants.TrafficCapabilityHashMultipleHeaders)
+			}
+		case v1beta1.HashTypeCookie:
+			out = append(out, constants.TrafficCapabilityHashCookie)
+		case v1beta1.HashTypeSourceIP:
+			out = append(out, constants.TrafficCapabilityHashSourceIP)
+		}
+	}
+	if t.EndpointOverride != nil {
+		switch t.EndpointOverride.Type {
+		case v1beta1.EndpointOverrideTypeHeader:
+			out = append(out, constants.TrafficCapabilityEndpointOverrideHeader)
+		case v1beta1.EndpointOverrideTypeMetadata:
+			out = append(out, constants.TrafficCapabilityEndpointOverrideMetadata)
+		}
+	}
+	return out
+}
+
+// ValidateTrafficCapabilities enforces the admission-time capability
+// gate for typed spec.traffic fields. supportedCapabilities is the
+// active translator's declared capability set; an empty set means the
+// provider is unknown to the webhook (test wiring, or the noop
+// translator) and the provider-specific gate is disabled — the
+// controller surfaces dropped fields through the
+// BackendPolicyUnsupportedFields condition instead.
+//
+// Two rules:
+//
+//  1. endpointOverride.type=Metadata is rejected unless a translator
+//     declares the capability, regardless of provider knowledge: the
+//     value is reserved, no translator emits anything for it, so
+//     admitting it would report intent that can never take effect.
+//  2. Multi-header consistent hashing is rejected when the capability
+//     set is known and lacks the token: a translator without it hashes
+//     on a subset of the declared headers, silently changing session
+//     affinity — a partial application worse than an outright drop, so
+//     it fails fast at admission instead of degrading behind a
+//     condition.
+//
+// Fields a translator drops wholesale (e.g. endpointOverride on a
+// DestinationRule backend) stay admissible and surface through the
+// condition path, matching the API's documented contract.
+func ValidateTrafficCapabilities(t *v1beta1.TrafficSpec, supportedCapabilities []string) error {
+	if t == nil {
+		return nil
+	}
+	supported := make(map[string]struct{}, len(supportedCapabilities))
+	for _, c := range supportedCapabilities {
+		supported[c] = struct{}{}
+	}
+
+	if t.EndpointOverride != nil && t.EndpointOverride.Type == v1beta1.EndpointOverrideTypeMetadata {
+		if _, ok := supported[constants.TrafficCapabilityEndpointOverrideMetadata]; !ok {
+			return fmt.Errorf(
+				"spec.traffic.endpointOverride.type=Metadata is reserved and not implemented by the active translator (ReservedEndpointOverrideType)")
+		}
+	}
+
+	if len(supportedCapabilities) == 0 {
+		return nil
+	}
+	if t.ConsistentHash != nil && t.ConsistentHash.Type == v1beta1.HashTypeHeader && len(t.ConsistentHash.Headers) > 1 {
+		if _, ok := supported[constants.TrafficCapabilityHashMultipleHeaders]; !ok {
+			return fmt.Errorf(
+				"spec.traffic.consistentHash declares %d headers but the active translator hashes on a single header only; declare exactly one header (UnsupportedMultiHeaderHash)",
+				len(t.ConsistentHash.Headers))
+		}
+	}
+	return nil
+}

--- a/pkg/validation/traffic_capabilities_test.go
+++ b/pkg/validation/traffic_capabilities_test.go
@@ -1,0 +1,203 @@
+package validation
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestRequiredTrafficCapabilities(t *testing.T) {
+	tests := []struct {
+		name    string
+		traffic *v1beta1.TrafficSpec
+		want    []string
+	}{
+		{
+			name:    "nil traffic requires nothing",
+			traffic: nil,
+			want:    nil,
+		},
+		{
+			name:    "empty traffic requires nothing",
+			traffic: &v1beta1.TrafficSpec{},
+			want:    nil,
+		},
+		{
+			name:    "algorithm only",
+			traffic: &v1beta1.TrafficSpec{Algorithm: ptrLB(v1beta1.LoadBalancingTypeRoundRobin)},
+			want:    []string{constants.TrafficCapabilityAlgorithm},
+		},
+		{
+			name: "single-header hash",
+			traffic: &v1beta1.TrafficSpec{
+				Algorithm: ptrLB(v1beta1.LoadBalancingTypeConsistentHash),
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "x-tenant"}},
+				},
+			},
+			want: []string{
+				constants.TrafficCapabilityAlgorithm,
+				constants.TrafficCapabilityHashHeader,
+			},
+		},
+		{
+			name: "multi-header hash adds the multi-header token",
+			traffic: &v1beta1.TrafficSpec{
+				Algorithm: ptrLB(v1beta1.LoadBalancingTypeConsistentHash),
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "x-tenant"}, {Name: "x-session"}},
+				},
+			},
+			want: []string{
+				constants.TrafficCapabilityAlgorithm,
+				constants.TrafficCapabilityHashHeader,
+				constants.TrafficCapabilityHashMultipleHeaders,
+			},
+		},
+		{
+			name: "cookie hash",
+			traffic: &v1beta1.TrafficSpec{
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:   v1beta1.HashTypeCookie,
+					Cookie: &v1beta1.HashCookie{Name: "session"},
+				},
+			},
+			want: []string{constants.TrafficCapabilityHashCookie},
+		},
+		{
+			name: "source-ip hash",
+			traffic: &v1beta1.TrafficSpec{
+				ConsistentHash: &v1beta1.ConsistentHashSpec{Type: v1beta1.HashTypeSourceIP},
+			},
+			want: []string{constants.TrafficCapabilityHashSourceIP},
+		},
+		{
+			name: "endpoint override header",
+			traffic: &v1beta1.TrafficSpec{
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type:    v1beta1.EndpointOverrideTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "x-endpoint"}},
+				},
+			},
+			want: []string{constants.TrafficCapabilityEndpointOverrideHeader},
+		},
+		{
+			name: "endpoint override metadata",
+			traffic: &v1beta1.TrafficSpec{
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type: v1beta1.EndpointOverrideTypeMetadata,
+				},
+			},
+			want: []string{constants.TrafficCapabilityEndpointOverrideMetadata},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RequiredTrafficCapabilities(tc.traffic)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("RequiredTrafficCapabilities() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateTrafficCapabilities_MetadataOverride(t *testing.T) {
+	metadata := &v1beta1.TrafficSpec{
+		EndpointOverride: &v1beta1.EndpointOverrideSpec{
+			Type: v1beta1.EndpointOverrideTypeMetadata,
+		},
+	}
+
+	t.Run("rejected when the capability set is empty", func(t *testing.T) {
+		err := ValidateTrafficCapabilities(metadata, nil)
+		if err == nil {
+			t.Fatal("expected rejection, got nil")
+		}
+		if !strings.Contains(err.Error(), "ReservedEndpointOverrideType") {
+			t.Fatalf("error should carry the ReservedEndpointOverrideType rule name: %v", err)
+		}
+	})
+
+	t.Run("rejected when the active translator does not declare it", func(t *testing.T) {
+		supported := []string{
+			constants.TrafficCapabilityAlgorithm,
+			constants.TrafficCapabilityEndpointOverrideHeader,
+		}
+		if err := ValidateTrafficCapabilities(metadata, supported); err == nil {
+			t.Fatal("expected rejection, got nil")
+		}
+	})
+
+	t.Run("accepted once a translator declares the capability", func(t *testing.T) {
+		supported := []string{constants.TrafficCapabilityEndpointOverrideMetadata}
+		if err := ValidateTrafficCapabilities(metadata, supported); err != nil {
+			t.Fatalf("expected acceptance, got %v", err)
+		}
+	})
+}
+
+func TestValidateTrafficCapabilities_MultiHeaderHash(t *testing.T) {
+	multiHeader := &v1beta1.TrafficSpec{
+		Algorithm: ptrLB(v1beta1.LoadBalancingTypeConsistentHash),
+		ConsistentHash: &v1beta1.ConsistentHashSpec{
+			Type:    v1beta1.HashTypeHeader,
+			Headers: []v1beta1.HashHeader{{Name: "x-tenant"}, {Name: "x-session"}},
+		},
+	}
+
+	t.Run("permissive when the capability set is empty (provider unknown)", func(t *testing.T) {
+		if err := ValidateTrafficCapabilities(multiHeader, nil); err != nil {
+			t.Fatalf("empty set must not gate multi-header hashing, got %v", err)
+		}
+	})
+
+	t.Run("rejected when the active translator hashes a single header only", func(t *testing.T) {
+		supported := []string{
+			constants.TrafficCapabilityAlgorithm,
+			constants.TrafficCapabilityHashHeader,
+		}
+		err := ValidateTrafficCapabilities(multiHeader, supported)
+		if err == nil {
+			t.Fatal("expected rejection, got nil")
+		}
+		if !strings.Contains(err.Error(), "UnsupportedMultiHeaderHash") {
+			t.Fatalf("error should carry the UnsupportedMultiHeaderHash rule name: %v", err)
+		}
+	})
+
+	t.Run("accepted when the active translator declares multi-header hashing", func(t *testing.T) {
+		supported := []string{
+			constants.TrafficCapabilityAlgorithm,
+			constants.TrafficCapabilityHashHeader,
+			constants.TrafficCapabilityHashMultipleHeaders,
+		}
+		if err := ValidateTrafficCapabilities(multiHeader, supported); err != nil {
+			t.Fatalf("expected acceptance, got %v", err)
+		}
+	})
+
+	t.Run("single header passes without the multi-header capability", func(t *testing.T) {
+		single := &v1beta1.TrafficSpec{
+			Algorithm: ptrLB(v1beta1.LoadBalancingTypeConsistentHash),
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:    v1beta1.HashTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "x-tenant"}},
+			},
+		}
+		supported := []string{constants.TrafficCapabilityHashHeader}
+		if err := ValidateTrafficCapabilities(single, supported); err != nil {
+			t.Fatalf("expected acceptance, got %v", err)
+		}
+	})
+}
+
+func TestValidateTrafficCapabilities_NilTraffic(t *testing.T) {
+	if err := ValidateTrafficCapabilities(nil, nil); err != nil {
+		t.Fatalf("nil traffic must pass, got %v", err)
+	}
+}


### PR DESCRIPTION
Next batch of the tree sync (after #798, #799): `pkg/validation` brought to the current canonical state. Pure-function validators only — no Kubernetes client dependencies.

**New validators** (each with its test file):
- `budget.go` — rollout budget (`IntOrString`) semantics shared by lifecycle and coordination checks.
- `compatibility.go` — runtime compatibility checks.
- `coordination_lockstep.go` — rolling-update groups must bump all members together; a Component "changes" on any spec delta that rolls it, not just an image bump.
- `pdb.go` — PodDisruptionBudget shape validation.
- `scalingpolicy.go` — cross-Component scaling policy.
- `servingruntime.go` — serving-runtime spec checks.
- `traffic_capabilities.go` — traffic capability gating.

**Refreshed**: canary step semantics (zero-capacity forms rejected uniformly), coordination group rules, lifecycle budgets (IntOrString handling consolidated into the budget helpers), ISVC and placement checks, plus `doc.go`.

No files removed; the existing exported surface is preserved and extended.

Verified locally: `go build ./...`, `go vet` (including tests), and the consumer suites — full `pkg/validation`, `pkg/webhook`, and the entire `pkg/controller/v1beta1/inferenceservice` tree — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for model compatibility, serving-runtime formats, traffic capabilities, scaling policies, and pod disruption budgets.
  * Added clearer, field-specific diagnostics for invalid configurations and compatibility mismatches.
* **Bug Fixes**
  * Rejected unsupported sharded PVC storage and invalid canary capacities.
  * Strengthened rolling-update budgets, rollout ordering, coordination, and lockstep checks.
  * Tightened traffic annotation validation, including revision-history limits and promotion targets.
* **Documentation**
  * Clarified validation behavior and deployment-mode guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->