### PR TITLE
[Core] refresh base controllers, controllerconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/fx v1.24.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -155,7 +156,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/pkg/controller/v1beta1/acceleratorclass/controller.go
+++ b/pkg/controller/v1beta1/acceleratorclass/controller.go
@@ -3,7 +3,6 @@ package acceleratorclass
 import (
 	"context"
 	"sort"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -18,7 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -50,11 +51,19 @@ func (r *AcceleratorClassReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// Handle deletion
+	// Handle deletion. Finalizer writes race with the Node-watch fan-out and
+	// this controller's own status patches, so optimistic-lock conflicts are a
+	// normal outcome — requeue instead of surfacing an error.
 	if !ac.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(ac, constants.AcceleratorClassFinalizer) {
 			controllerutil.RemoveFinalizer(ac, constants.AcceleratorClassFinalizer)
 			if err := r.Update(ctx, ac); err != nil {
+				if errors.IsNotFound(err) {
+					return ctrl.Result{}, nil
+				}
+				if errors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
 				return ctrl.Result{}, err
 			}
 		}
@@ -65,6 +74,12 @@ func (r *AcceleratorClassReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if !controllerutil.ContainsFinalizer(ac, constants.AcceleratorClassFinalizer) {
 		controllerutil.AddFinalizer(ac, constants.AcceleratorClassFinalizer)
 		if err := r.Update(ctx, ac); err != nil {
+			if errors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if errors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	}
@@ -88,7 +103,9 @@ func (r *AcceleratorClassReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	sort.Strings(matchedNodes)
 
-	// In Reconcile, after computing desired fields (without setting LastUpdated yet):
+	// Re-fetch the latest object and patch status against it so the patch
+	// base carries a fresh resourceVersion; LastUpdated is stamped only when
+	// the rest of the status actually changed.
 	latest := &v1beta1.AcceleratorClass{}
 	if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -129,7 +146,20 @@ func (r *AcceleratorClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return requests
 			}),
-			builder.WithPredicates(),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldNode, okOld := e.ObjectOld.(*corev1.Node)
+					newNode, okNew := e.ObjectNew.(*corev1.Node)
+					if !okOld || !okNew {
+						return true
+					}
+					// Discovery matches on labels; capability matching on
+					// capacity. Everything else (conditions, images,
+					// heartbeats) cannot change class membership.
+					return !equality.Semantic.DeepEqual(oldNode.Labels, newNode.Labels) ||
+						!equality.Semantic.DeepEqual(oldNode.Status.Capacity, newNode.Status.Capacity)
+				},
+			}),
 		).
 		Complete(r)
 }
@@ -147,63 +177,20 @@ func nodePassesDiscovery(ac *v1beta1.AcceleratorClass, node *corev1.Node) bool {
 	return true
 }
 
+// nodeMatchCapabilities checks the node actually exposes the accelerator
+// hardware this class declares. capabilities.memoryGB describes per-device
+// GPU memory, which no standard node resource reports — the reliable signal
+// is the class's declared extended resources (e.g. nvidia.com/gpu) being
+// present in the node's capacity.
 func nodeMatchCapabilities(ac *v1beta1.AcceleratorClass, node *corev1.Node) bool {
-	// memoryGB: compare with node memory capacity
-	if ac.Spec.Capabilities.MemoryGB != nil {
-		memQty := node.Status.Capacity[corev1.ResourceMemory]
-		if memQty.Cmp(*ac.Spec.Capabilities.MemoryGB) < 0 {
+	for _, res := range ac.Spec.Resources {
+		qty, ok := node.Status.Capacity[corev1.ResourceName(res.Name)]
+		if !ok || qty.IsZero() {
 			return false
 		}
 	}
 
 	return true
-}
-
-func getGPUCapacity(node *corev1.Node) (total int64, byResource map[string]int64) {
-	byResource = make(map[string]int64)
-
-	// Prefer Capacity if you want physical capacity; use Allocatable if you care about schedulable.
-	res := node.Status.Capacity
-	if len(res) == 0 {
-		res = node.Status.Allocatable
-	}
-
-	for name, q := range res {
-		n := string(name)
-
-		// NVIDIA classic
-		if n == "nvidia.com/gpu" {
-			v := q.Value()
-			byResource[n] = v
-			total += v
-			continue
-		}
-
-		// NVIDIA MIG profiles (treat as accelerators; not equivalent to card count)
-		if strings.HasPrefix(n, "nvidia.com/mig-") {
-			v := q.Value()
-			byResource[n] += v
-			total += v
-			continue
-		}
-
-		// AMD (common)
-		if n == "amd.com/gpu" {
-			v := q.Value()
-			byResource[n] = v
-			total += v
-			continue
-		}
-
-		// Intel (common plugin exposes under gpu.intel.com/*; skip memory-only resources)
-		if strings.HasPrefix(n, "gpu.intel.com/") && !strings.Contains(n, "memory") {
-			v := q.Value()
-			byResource[n] += v
-			total += v
-			continue
-		}
-	}
-	return total, byResource
 }
 
 // returns true if equal when ignoring LastUpdated

--- a/pkg/controller/v1beta1/acceleratorclass/controller_test.go
+++ b/pkg/controller/v1beta1/acceleratorclass/controller_test.go
@@ -120,7 +120,7 @@ func TestAcceleratorClass_Reconcile_MatchDiscovery(t *testing.T) {
 	g.Expect(curr.Status.Nodes).NotTo(ContainElement("node-b"))
 }
 
-func TestAcceleratorClass_Reconcile_MatchMemoryGB(t *testing.T) {
+func TestAcceleratorClass_Reconcile_MatchDeclaredResources(t *testing.T) {
 	g := NewWithT(t)
 
 	scheme := runtime.NewScheme()
@@ -128,15 +128,17 @@ func TestAcceleratorClass_Reconcile_MatchMemoryGB(t *testing.T) {
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 	ac := &v1beta1.AcceleratorClass{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-ac-memory"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ac-resources"},
 		Spec: v1beta1.AcceleratorClassSpec{
 			Discovery: v1beta1.AcceleratorDiscovery{NodeSelector: map[string]string{"accel": "nvidia"}},
-			Capabilities: v1beta1.AcceleratorCapabilities{
-				MemoryGB: resource.NewQuantity(16*1024*1024*1024, resource.BinarySI), // 16Gi
+			Resources: []v1beta1.AcceleratorResource{
+				{Name: constants.NvidiaGPUResourceType, Quantity: resource.MustParse("1")},
 			},
 		},
 	}
 
+	// node-a exposes the declared GPU resource; node-b matches the discovery
+	// labels but exposes no GPU capacity (mislabeled or drained hardware).
 	nodeA := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-a", Labels: map[string]string{"accel": "nvidia"}},
 		Status: corev1.NodeStatus{
@@ -150,8 +152,7 @@ func TestAcceleratorClass_Reconcile_MatchMemoryGB(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node-b", Labels: map[string]string{"accel": "nvidia"}},
 		Status: corev1.NodeStatus{
 			Capacity: corev1.ResourceList{
-				corev1.ResourceName(constants.NvidiaGPUResourceType): resource.MustParse("1"),
-				corev1.ResourceMemory:                                resource.MustParse("8Gi"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
 			},
 		},
 	}
@@ -220,27 +221,4 @@ func TestAcceleratorClass_Reconcile_DoesNotUpdateTimestampOnNoChange(t *testing.
 	post := &v1beta1.AcceleratorClass{}
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: ac.Name}, post)).To(Succeed())
 	g.Expect(post.Status.LastUpdated.Time.Equal(firstUpdate.Time)).To(BeTrue())
-}
-
-func Test_getGPUCapacity_Helper(t *testing.T) {
-	g := NewWithT(t)
-
-	n := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "gpu-node"},
-		Status: corev1.NodeStatus{
-			Capacity: corev1.ResourceList{
-				corev1.ResourceName("nvidia.com/gpu"):         resource.MustParse("2"),
-				corev1.ResourceName("nvidia.com/mig-1g.10gb"): resource.MustParse("4"),
-				corev1.ResourceName("amd.com/gpu"):            resource.MustParse("1"),
-				corev1.ResourceName("gpu.intel.com/cards"):    resource.MustParse("3"),
-			},
-		},
-	}
-
-	total, byRes := getGPUCapacity(n)
-	g.Expect(total).To(Equal(int64(10))) // 2 + 4 + 1 + 3
-	g.Expect(byRes).To(HaveKeyWithValue("nvidia.com/gpu", int64(2)))
-	g.Expect(byRes).To(HaveKeyWithValue("nvidia.com/mig-1g.10gb", int64(4)))
-	g.Expect(byRes).To(HaveKeyWithValue("amd.com/gpu", int64(1)))
-	g.Expect(byRes).To(HaveKeyWithValue("gpu.intel.com/cards", int64(3)))
 }

--- a/pkg/controller/v1beta1/basemodel/backend.go
+++ b/pkg/controller/v1beta1/basemodel/backend.go
@@ -24,19 +24,16 @@ func pickBackend(backends []shared.Backend, spec *v1beta1.BaseModelSpec) shared.
 	panic("basemodel: no default backend registered (expected per-node fallback last)")
 }
 
-// perNodeBackend is the observational default: it reflects the per-node
-// model-status ConfigMaps written by the model-agent DaemonSet into the
-// model's status. It always matches and is the registry fallback.
+// perNodeBackend wraps pernode.Reconcile with a pre-step that scrubs
+// PVC artifacts left over when a model's URI flips away from pvc://.
+// Lives here (not in pernode/) so that cross-backend cleanup doesn't
+// drag a pernode→pvc import.
 type perNodeBackend struct{}
 
 func (perNodeBackend) Name() string                          { return "pernode" }
 func (perNodeBackend) Matches(_ *v1beta1.BaseModelSpec) bool { return true }
 
 func (perNodeBackend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
-	// A model whose storage URI flipped away from pvc:// lands on the
-	// per-node backend; scrub any leftover PVC Job / ConfigMap / conditions
-	// before running the per-node flow. Idempotent no-op when there are no
-	// PVC artifacts (the common case).
 	if err := pvc.CleanupStaleArtifacts(ctx, a.Client, a.Log, a.Obj, a.IsClusterScoped); err != nil {
 		a.Log.Error(err, "Failed to clean up stale PVC artifacts after URI swap")
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
@@ -47,7 +44,6 @@ func (perNodeBackend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
-	// Requeue while downloading to ensure status is updated regularly
 	if a.Status.State == v1beta1.LifeCycleStateImporting || a.Status.State == v1beta1.LifeCycleStateInTransit {
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/deletion.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/deletion.go
@@ -13,22 +13,25 @@ import (
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
-	"sigs.k8s.io/ome/pkg/modelagent"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
 )
 
-// HandleModelDeletion is the per-node deletion handler. It waits for every
+// HandleModelDeletion is the per-node deletion handler. Waits for every
 // node's model-agent to clear or mark-deleted the model in its per-node
-// ConfigMap before dropping the finalizer. This prevents orphaned models
-// when nodes are down or agents aren't running.
+// ConfigMap before dropping the finalizer.
 func HandleModelDeletion(ctx context.Context, kubeClient client.Client, obj client.Object, finalizer string) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if controllerutil.ContainsFinalizer(obj, finalizer) {
+		// Before removing the finalizer, make sure all entries are cleared from ConfigMaps
+		// This prevents orphaned models when nodes are down or agents aren't running
+
 		// Determine model name, namespace and if it's cluster-scoped
 		modelName := obj.GetName()
 		var modelNamespace string
 		var isClusterScope bool
 
+		// Set namespace and scope based on object type
 		switch typedObj := obj.(type) {
 		case *v1beta1.BaseModel:
 			modelNamespace = typedObj.Namespace
@@ -62,6 +65,7 @@ func HandleModelDeletion(ctx context.Context, kubeClient client.Client, obj clie
 
 		for i := range configMaps.Items {
 			configMap := &configMaps.Items[i]
+			// Check if the model exists in this ConfigMap
 			data, exists := configMap.Data[modelKey]
 			if !exists {
 				continue
@@ -69,10 +73,10 @@ func HandleModelDeletion(ctx context.Context, kubeClient client.Client, obj clie
 			nodesWithModel++
 
 			// Check if it's already marked for deletion
-			var modelEntry modelagent.ModelEntry
+			var modelEntry shared.ModelEntry
 			if err := json.Unmarshal([]byte(data), &modelEntry); err == nil {
 				// If model entry is present but not marked as deleted, add it to the list
-				if modelEntry.Status != modelagent.ModelStatusDeleted {
+				if modelEntry.Status != shared.ModelStatusDeleted {
 					modelsNotDeleted = append(modelsNotDeleted, configMap.Name)
 				}
 			} else {

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/reconcile.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/reconcile.go
@@ -7,21 +7,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
-	"sigs.k8s.io/ome/pkg/modelagent"
 )
 
-// ReconcileStatusFromConfigMaps drives the per-node ConfigMap handshake:
-// list per-node model-status ConfigMaps, parse this model's entries, and
-// reflect them into Status.NodesReady/NodesFailed plus LifeCycleState.
-// This is the observational "normal flow" — the model-agent DaemonSet
-// downloads to nodes and writes status; the controller only reads it back.
+// ReconcileStatusFromConfigMaps drives the per-node ConfigMap
+// handshake: list per-node model-status ConfigMaps, parse this model's
+// entries, and reflect into Status.NodesReady/NodesFailed plus
+// LifeCycleState. Sharded + PVC backends bypass this path entirely.
 func ReconcileStatusFromConfigMaps(ctx context.Context, c client.Client, log logr.Logger, obj client.Object, isClusterScoped bool, kind string) error {
 	var namespace string
 	if !isClusterScoped {
 		namespace = obj.GetNamespace()
 	}
-	specUpdate := func(ctx context.Context, config *modelagent.ModelConfig) error {
-		return retrySpecUpdate(ctx, c, log, obj, config, func(ctx context.Context, kubeClient client.Client, latest client.Object, config *modelagent.ModelConfig) error {
+	specUpdate := func(ctx context.Context, config *shared.ModelConfig) error {
+		return retrySpecUpdate(ctx, c, log, obj, config, func(ctx context.Context, kubeClient client.Client, latest client.Object, config *shared.ModelConfig) error {
 			latestSpec, _, err := shared.ModelSpecAndStatus(latest)
 			if err != nil {
 				return err

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/status.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/status.go
@@ -15,15 +15,15 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
-	"sigs.k8s.io/ome/pkg/modelagent"
 )
 
-// processModelStatus walks the per-node model-status ConfigMaps for this
-// model and folds them into nodesReady/nodesFailed via the caller-supplied
-// statusUpdateFunc. Per-node spec updates from the agent flow through
-// specUpdateFunc (filtered to entries that carry a non-nil Config).
+// processModelStatus walks the per-node model-status ConfigMaps for
+// this model and folds them into nodesReady/nodesFailed via the
+// caller-supplied statusUpdateFunc. Per-node spec updates from the
+// agent flow through specUpdateFunc (filtered to entries that carry a
+// non-nil Config).
 func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, namespace, name string, isClusterScope bool,
-	specUpdateFunc func(context.Context, *modelagent.ModelConfig) error,
+	specUpdateFunc func(context.Context, *shared.ModelConfig) error,
 	statusUpdateFunc func(context.Context, []string, []string) error) error {
 
 	modelInfo := name
@@ -32,7 +32,6 @@ func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.
 	}
 	log = log.WithValues("model", modelInfo)
 
-	// List all ConfigMaps with model status label in the ome namespace
 	configMaps := &corev1.ConfigMapList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(constants.OMENamespace),
@@ -45,21 +44,17 @@ func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.
 
 	log.Info("Processing model status from ConfigMaps", "configMapsTotal", len(configMaps.Items))
 
-	// Track counters for logging
 	var processedNodes, validNodes, readyNodes, failedNodes int
 	var nodesReady []string
 	var nodesFailed []string
 	var specUpdateErrors []string
 
-	// Process each ConfigMap to find this model's status
 	for _, configMap := range configMaps.Items {
 		processedNodes++
 
-		// Verify the node still exists
 		node := &corev1.Node{}
 		if err := kubeClient.Get(ctx, types.NamespacedName{Name: configMap.Name}, node); err != nil {
 			if errors.IsNotFound(err) {
-				// Node was deleted, skip silently
 				continue
 			}
 			log.Error(err, "Failed to get node", "node", configMap.Name)
@@ -67,16 +62,13 @@ func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.
 		}
 		validNodes++
 
-		// Look for this model in the ConfigMap
 		modelKey := constants.GetModelConfigMapKey(namespace, name, isClusterScope)
 		data, exists := configMap.Data[modelKey]
 		if !exists {
-			// Model not found in this ConfigMap, continue silently
 			continue
 		}
 
-		// Parse the model entry
-		var modelEntry modelagent.ModelEntry
+		var modelEntry shared.ModelEntry
 		if err := json.Unmarshal([]byte(data), &modelEntry); err != nil {
 			log.Error(err, "Failed to parse model entry", "node", configMap.Name, "key", modelKey)
 			continue
@@ -84,54 +76,43 @@ func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.
 
 		log.V(1).Info("Processing model entry", "node", configMap.Name, "status", modelEntry.Status, "hasConfig", modelEntry.Config != nil, "hasProgress", modelEntry.Progress != nil)
 
-		// Update model spec with config if available
 		if modelEntry.Config != nil {
 			if err := specUpdateFunc(ctx, modelEntry.Config); err != nil {
 				log.Error(err, "Failed to update model spec", "node", configMap.Name)
 				specUpdateErrors = append(specUpdateErrors, configMap.Name)
-				// Continue processing other nodes even if spec update fails
 			}
 		}
 
-		// Update status arrays based on model status
 		switch modelEntry.Status {
-		case modelagent.ModelStatusReady:
+		case shared.ModelStatusReady:
 			nodesReady = addToSlice(nodesReady, configMap.Name)
 			readyNodes++
-		case modelagent.ModelStatusFailed:
+		case shared.ModelStatusFailed:
 			nodesFailed = addToSlice(nodesFailed, configMap.Name)
 			failedNodes++
-		case modelagent.ModelStatusUpdating, modelagent.ModelStatusDeleted:
-			// Updating: transient, don't add to either array.
-			// Deleted: shouldn't be in ConfigMap, leave out of both.
+		case shared.ModelStatusUpdating, shared.ModelStatusDeleted:
 		default:
 			log.V(1).Info("Unknown model status", "node", configMap.Name, "status", modelEntry.Status)
 		}
 	}
 
-	// Sort the arrays for consistency
 	slices.Sort(nodesReady)
 	slices.Sort(nodesFailed)
 
-	// Log summary - important for observability
 	log.Info("Model status summary",
 		"readyNodes", readyNodes,
 		"failedNodes", failedNodes,
 		"totalProcessed", processedNodes,
 		"validNodes", validNodes)
 
-	// Log spec update errors if any occurred
 	if len(specUpdateErrors) > 0 {
 		log.Info("Some nodes failed spec updates", "failedNodes", specUpdateErrors)
 	}
 
-	// Update the model status with retry logic
 	return statusUpdateFunc(ctx, nodesReady, nodesFailed)
 }
 
-// updateModelSpecWithConfig fills blank spec fields from a per-node
-// ConfigMap entry and persists the object if anything changed.
-func updateModelSpecWithConfig(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, spec *v1beta1.BaseModelSpec, config *modelagent.ModelConfig, modelType string) error {
+func updateModelSpecWithConfig(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, spec *v1beta1.BaseModelSpec, config *shared.ModelConfig, modelType string) error {
 	if updated := shared.UpdateSpecWithConfig(spec, config); updated {
 		if err := kubeClient.Update(ctx, obj); err != nil {
 			return fmt.Errorf("failed to update %s spec: %w", modelType, err)
@@ -142,7 +123,6 @@ func updateModelSpecWithConfig(ctx context.Context, kubeClient client.Client, lo
 	return nil
 }
 
-// addToSlice adds an item to a slice if it doesn't already exist
 func addToSlice(s []string, item string) []string {
 	for _, existing := range s {
 		if existing == item {
@@ -152,7 +132,6 @@ func addToSlice(s []string, item string) []string {
 	return append(s, item)
 }
 
-// CalculateLifecycleState determines the lifecycle state based on node status
 func CalculateLifecycleState(nodesReady, nodesFailed []string) v1beta1.LifeCycleState {
 	if len(nodesReady) > 0 {
 		return v1beta1.LifeCycleStateReady
@@ -162,8 +141,6 @@ func CalculateLifecycleState(nodesReady, nodesFailed []string) v1beta1.LifeCycle
 	return v1beta1.LifeCycleStateInTransit
 }
 
-// updateModelStatusWithRetry updates model status (NodesReady/NodesFailed/
-// State) with conflict-retry, skipping the write when nothing changed.
 func updateModelStatusWithRetry(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, nodesReady, nodesFailed []string, modelType string) error {
 	updateFunc := func(ctx context.Context, client client.Client, obj client.Object) error {
 		_, status, err := shared.ModelSpecAndStatus(obj)
@@ -181,6 +158,7 @@ func updateModelStatusWithRetry(ctx context.Context, kubeClient client.Client, l
 		status.NodesReady = nodesReady
 		status.NodesFailed = nodesFailed
 		status.State = newState
+		shared.StampObservedReconcile(obj, status)
 
 		if err := client.Status().Update(ctx, obj); err != nil {
 			return err
@@ -195,8 +173,7 @@ func updateModelStatusWithRetry(ctx context.Context, kubeClient client.Client, l
 	return shared.RetryUpdate(ctx, kubeClient, log, obj, "status", updateFunc)
 }
 
-// retrySpecUpdate wraps a spec updateFunc in the shared conflict-retry loop.
-func retrySpecUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, config *modelagent.ModelConfig, updateFunc func(context.Context, client.Client, client.Object, *modelagent.ModelConfig) error) error {
+func retrySpecUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, config *shared.ModelConfig, updateFunc func(context.Context, client.Client, client.Object, *shared.ModelConfig) error) error {
 	wrappedUpdateFunc := func(ctx context.Context, client client.Client, obj client.Object) error {
 		return updateFunc(ctx, client, obj, config)
 	}

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/watches.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/watches.go
@@ -14,28 +14,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/ome/pkg/constants"
-	"sigs.k8s.io/ome/pkg/modelagent"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
 )
 
-// CreateNodeDeletionPredicate creates a predicate that only triggers on Node deletions.
 func CreateNodeDeletionPredicate() predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return false // Don't trigger on node creation
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return false // Don't trigger on node updates
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return true // Only trigger on node deletion
-		},
+		CreateFunc: func(e event.CreateEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool { return false },
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
 	}
 }
 
-// HandleNodeDeletion handles Node deletion events by cleaning up the
-// corresponding ConfigMap. If no ConfigMap exists for this node, it simply
-// skips without error (normal for nodes that never ran model-agent). Used
-// by both BaseModel and ClusterBaseModel controllers.
+// HandleNodeDeletion deletes the per-node model-status ConfigMap when
+// the Node it was tracking goes away. No-op if no ConfigMap exists
+// (nodes that never ran model-agent).
 func HandleNodeDeletion(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object) []reconcile.Request {
 	node, ok := obj.(*corev1.Node)
 	if !ok {
@@ -45,7 +37,6 @@ func HandleNodeDeletion(ctx context.Context, kubeClient client.Client, log logr.
 	nodeName := node.GetName()
 	log = log.WithValues("node", nodeName)
 
-	// Check if a ConfigMap exists for this node
 	configMap := &corev1.ConfigMap{}
 	configMapKey := types.NamespacedName{
 		Namespace: constants.OMENamespace,
@@ -54,19 +45,16 @@ func HandleNodeDeletion(ctx context.Context, kubeClient client.Client, log logr.
 
 	if err := kubeClient.Get(ctx, configMapKey, configMap); err != nil {
 		if errors.IsNotFound(err) {
-			// No ConfigMap for this node, nothing to clean up
 			return nil
 		}
 		log.Error(err, "Failed to check ConfigMap for deleted node")
 		return nil
 	}
 
-	// Verify this is a model status ConfigMap before deleting
 	if !IsModelStatusConfigMap(configMap) {
 		return nil
 	}
 
-	// Delete the stale ConfigMap
 	log.Info("Node deleted, cleaning up associated model status ConfigMap")
 	if err := kubeClient.Delete(ctx, configMap); err != nil {
 		if !errors.IsNotFound(err) {
@@ -79,8 +67,6 @@ func HandleNodeDeletion(ctx context.Context, kubeClient client.Client, log logr.
 	return nil
 }
 
-// CreateModelStatusConfigMapPredicate creates the shared predicate for
-// per-node model-status ConfigMap events.
 func CreateModelStatusConfigMapPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -95,7 +81,6 @@ func CreateModelStatusConfigMapPredicate() predicate.Predicate {
 	}
 }
 
-// IsModelStatusConfigMap checks if a ConfigMap is a per-node model status ConfigMap.
 func IsModelStatusConfigMap(obj client.Object) bool {
 	if obj.GetNamespace() != constants.OMENamespace {
 		return false
@@ -118,20 +103,16 @@ func MapConfigMapToModelRequests(obj client.Object, log logr.Logger, isNamespace
 		return requests
 	}
 
-	// Parse the ConfigMap data to find model references
 	for key, data := range configMap.Data {
-		// Parse using the centralized parsing function
 		namespace, modelName, isClusterBaseModel, success := constants.ParseModelInfoFromConfigMapKey(key)
 		if !success {
 			continue
 		}
-		// Skip keys that don't match the expected model type
 		if (isNamespaced && isClusterBaseModel) || (!isNamespaced && !isClusterBaseModel) {
 			continue
 		}
 
-		// Parse the model entry to validate it's a valid entry
-		var modelEntry modelagent.ModelEntry
+		var modelEntry shared.ModelEntry
 		if err := json.Unmarshal([]byte(data), &modelEntry); err != nil {
 			log.V(1).Info("Failed to parse model entry in ConfigMap", "configMap", configMap.Name, "key", key, "error", err)
 			continue

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/watches_test.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/watches_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,6 +110,7 @@ func TestMapConfigMapToModelRequests(t *testing.T) {
 				g.Expect(requests[0].NamespacedName).To(gomega.Equal(*tt.expectedFirst))
 			} else if tt.expectedCount > 0 {
 				// Instead of checking order, verify that all expected requests are present
+				// For BaseModel mapping case
 				if tt.name == "BaseModel mapping" {
 					foundDefault := false
 					foundTestNs := false
@@ -133,7 +135,7 @@ func TestMapConfigMapToModelRequests(t *testing.T) {
 func TestCreateModelStatusConfigMapPredicate(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	pred := CreateModelStatusConfigMapPredicate()
+	predicate := CreateModelStatusConfigMapPredicate()
 
 	tests := []struct {
 		name     string
@@ -194,15 +196,15 @@ func TestCreateModelStatusConfigMapPredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test CreateFunc
-			result := pred.Create(event.TypedCreateEvent[client.Object]{Object: tt.obj})
+			result := predicate.Create(event.TypedCreateEvent[client.Object]{Object: tt.obj})
 			g.Expect(result).To(gomega.Equal(tt.expected))
 
 			// Test UpdateFunc
-			result = pred.Update(event.TypedUpdateEvent[client.Object]{ObjectNew: tt.obj})
+			result = predicate.Update(event.TypedUpdateEvent[client.Object]{ObjectNew: tt.obj})
 			g.Expect(result).To(gomega.Equal(tt.expected))
 
 			// Test DeleteFunc
-			result = pred.Delete(event.TypedDeleteEvent[client.Object]{Object: tt.obj})
+			result = predicate.Delete(event.TypedDeleteEvent[client.Object]{Object: tt.obj})
 			g.Expect(result).To(gomega.Equal(tt.expected))
 		})
 	}
@@ -235,10 +237,10 @@ func TestCreateNodeDeletionPredicate(t *testing.T) {
 func TestHandleNodeDeletion(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	// Create scheme
 	scheme := runtime.NewScheme()
 	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(batchv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 
 	tests := []struct {
 		name       string
@@ -250,7 +252,6 @@ func TestHandleNodeDeletion(t *testing.T) {
 			name:     "Node deletion cleans up associated ConfigMap",
 			nodeName: "node-with-configmap",
 			setupMocks: func(c client.Client) {
-				// Create ome namespace
 				omeNamespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: constants.OMENamespace,
@@ -259,7 +260,6 @@ func TestHandleNodeDeletion(t *testing.T) {
 				err := c.Create(context.TODO(), omeNamespace)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Create a model status ConfigMap for this node
 				configMap := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "node-with-configmap",
@@ -276,7 +276,6 @@ func TestHandleNodeDeletion(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 			},
 			validate: func(t *testing.T, c client.Client, nodeName string) {
-				// ConfigMap should be deleted
 				configMap := &corev1.ConfigMap{}
 				err := c.Get(context.TODO(), types.NamespacedName{
 					Namespace: constants.OMENamespace,
@@ -289,7 +288,6 @@ func TestHandleNodeDeletion(t *testing.T) {
 			name:     "Node deletion with no ConfigMap does nothing",
 			nodeName: "node-without-configmap",
 			setupMocks: func(c client.Client) {
-				// Create ome namespace but no ConfigMap
 				omeNamespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: constants.OMENamespace,
@@ -300,14 +298,12 @@ func TestHandleNodeDeletion(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client, nodeName string) {
 				// No ConfigMap to check - just ensure no error occurred
-				// The function should silently skip
 			},
 		},
 		{
 			name:     "Node deletion skips non-model-status ConfigMap",
 			nodeName: "node-with-other-configmap",
 			setupMocks: func(c client.Client) {
-				// Create ome namespace
 				omeNamespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: constants.OMENamespace,
@@ -316,12 +312,10 @@ func TestHandleNodeDeletion(t *testing.T) {
 				err := c.Create(context.TODO(), omeNamespace)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Create a ConfigMap without model status label
 				configMap := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "node-with-other-configmap",
 						Namespace: constants.OMENamespace,
-						// No model status label
 					},
 					Data: map[string]string{
 						"some-key": "some-value",
@@ -331,7 +325,6 @@ func TestHandleNodeDeletion(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 			},
 			validate: func(t *testing.T, c client.Client, nodeName string) {
-				// ConfigMap should NOT be deleted (it's not a model status ConfigMap)
 				configMap := &corev1.ConfigMap{}
 				err := c.Get(context.TODO(), types.NamespacedName{
 					Namespace: constants.OMENamespace,
@@ -352,20 +345,16 @@ func TestHandleNodeDeletion(t *testing.T) {
 
 			log := ctrl.Log.WithName("test")
 
-			// Create the node object that was "deleted"
 			deletedNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tt.nodeName,
 				},
 			}
 
-			// Call HandleNodeDeletion (shared function)
 			requests := HandleNodeDeletion(context.TODO(), c, log, deletedNode)
 
-			// Should return nil (no reconcile requests needed)
 			g.Expect(requests).To(gomega.BeNil())
 
-			// Validate the result
 			tt.validate(t, c, tt.nodeName)
 		})
 	}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_job.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_job.go
@@ -40,8 +40,8 @@ const (
 
 	// metadataJobAgentConfigPath is the path to the bundled ome-agent
 	// config file inside the standard ome-agent image
-	// (dockerfiles/ome-agent.Dockerfile:85). The agent's configProvider
-	// (cmd/ome-agent/config.go:28) errors with "no config file provided"
+	// (dockerfiles/ome-agent.Dockerfile). The agent's configProvider
+	// (cmd/ome-agent/config.go) errors with "no config file provided"
 	// if --config is empty, even though `model-metadata` reads all its
 	// runtime params from --model-path / --basemodel-name / etc. flags.
 	// Passing the bundled path satisfies the gratuitous existence check

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_job_test.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_job_test.go
@@ -1,0 +1,468 @@
+package pvc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+func TestMetadataJobName(t *testing.T) {
+	tests := []struct {
+		name        string
+		modelName   string
+		uri         string
+		wantPrefix  string
+		wantSuffLen int
+	}{
+		{
+			name:        "short model name",
+			modelName:   "llama-7b",
+			uri:         "pvc://my-pvc/models/llama",
+			wantPrefix:  "llama-7b-metadata-",
+			wantSuffLen: 8,
+		},
+		{
+			name:        "different uri yields different name",
+			modelName:   "llama-7b",
+			uri:         "pvc://my-pvc/models/other",
+			wantPrefix:  "llama-7b-metadata-",
+			wantSuffLen: 8,
+		},
+	}
+
+	seen := map[string]string{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := metadataJobName(tc.modelName, tc.uri)
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Fatalf("name %q missing prefix %q", got, tc.wantPrefix)
+			}
+			if len(got)-len(tc.wantPrefix) != tc.wantSuffLen {
+				t.Fatalf("hash suffix length: got %d, want %d", len(got)-len(tc.wantPrefix), tc.wantSuffLen)
+			}
+			if len(got) > 63 {
+				t.Fatalf("name %q exceeds 63 chars", got)
+			}
+			if prev, ok := seen[got]; ok {
+				t.Fatalf("name collision %q for inputs %q and %q", got, prev, tc.uri)
+			}
+			seen[got] = tc.uri
+		})
+	}
+}
+
+func TestMetadataJobName_TooLongModelTrimmed(t *testing.T) {
+	long := strings.Repeat("a", 80)
+	got := metadataJobName(long, "pvc://my-pvc/p")
+	if len(got) > 63 {
+		t.Fatalf("name %q exceeds 63 chars", got)
+	}
+}
+
+func TestMetadataJobName_EmptyAfterTrimGuard(t *testing.T) {
+	// Pathological input: a model name long enough that the trim leaves
+	// nothing must NOT yield a name starting with '-'. Use an extreme
+	// length to force the trimmed-to-empty branch even with the 8-char hash.
+	got := metadataJobName(strings.Repeat("a", 200), "pvc://my-pvc/p")
+	if got == "" || got[0] == '-' {
+		t.Fatalf("name %q must start with an alphanumeric (DNS-1123)", got)
+	}
+	if len(got) > 63 {
+		t.Fatalf("name %q exceeds 63 chars", got)
+	}
+}
+
+func TestBuildMetadataJob_BaseModel(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	bm := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models", UID: "uid-1"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://my-pvc/models/llama"),
+		}},
+	}
+	components := &storage.PVCStorageComponents{PVCName: "my-pvc", SubPath: "models/llama"}
+	cfg := MetadataJobConfig{
+		Image:          "ome-agent:latest",
+		ServiceAccount: "ome-model-metadata",
+		CPURequest:     "100m",
+		MemoryRequest:  "128Mi",
+	}
+
+	job, err := buildMetadataJob(bm, false, components, "models", cfg, scheme)
+	if err != nil {
+		t.Fatalf("buildMetadataJob: %v", err)
+	}
+
+	if job.Namespace != "models" {
+		t.Errorf("job namespace = %q, want models", job.Namespace)
+	}
+	if got := job.Labels[constants.PVCMetadataScopeLabel]; got != metadataJobScopeNamespaced {
+		t.Errorf("scope label = %q, want %q", got, metadataJobScopeNamespaced)
+	}
+	if got := job.Labels[constants.PVCMetadataModelNameLabel]; got != "llama-7b" {
+		t.Errorf("model-name label = %q, want llama-7b", got)
+	}
+
+	if got := len(job.OwnerReferences); got != 1 {
+		t.Fatalf("expected 1 owner ref, got %d", got)
+	}
+	or := job.OwnerReferences[0]
+	if or.Kind != "BaseModel" {
+		t.Errorf("owner kind = %q, want BaseModel", or.Kind)
+	}
+
+	if *job.Spec.BackoffLimit != 2 {
+		t.Errorf("backoff limit = %d, want 2", *job.Spec.BackoffLimit)
+	}
+	if *job.Spec.TTLSecondsAfterFinished != 3600 {
+		t.Errorf("ttl = %d, want 3600", *job.Spec.TTLSecondsAfterFinished)
+	}
+
+	pod := job.Spec.Template.Spec
+	if pod.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("restartPolicy = %q, want Never", pod.RestartPolicy)
+	}
+	if pod.ServiceAccountName != cfg.ServiceAccount {
+		t.Errorf("SA = %q, want %q", pod.ServiceAccountName, cfg.ServiceAccount)
+	}
+	if got := len(pod.Volumes); got != 1 {
+		t.Fatalf("expected 1 volume, got %d", got)
+	}
+	if pvc := pod.Volumes[0].PersistentVolumeClaim; pvc == nil {
+		t.Fatalf("expected PVC volume source")
+	} else {
+		if pvc.ClaimName != "my-pvc" {
+			t.Errorf("claim name = %q, want my-pvc", pvc.ClaimName)
+		}
+		if !pvc.ReadOnly {
+			t.Errorf("expected PVC mount to be read-only")
+		}
+	}
+
+	if got := len(pod.Containers); got != 1 {
+		t.Fatalf("expected 1 container, got %d", got)
+	}
+	c := pod.Containers[0]
+	if c.Image != cfg.Image {
+		t.Errorf("image = %q, want %q", c.Image, cfg.Image)
+	}
+	args := strings.Join(c.Args, " ")
+	for _, want := range []string{
+		"model-metadata",
+		// --config satisfies the agent's gratuitous configFilePath != ""
+		// check (cmd/ome-agent/config.go:28). Without it the Job pod
+		// crash-loops with "no config file provided" before reaching
+		// model-metadata logic.
+		"--config " + metadataJobAgentConfigPath,
+		"--model-path " + metadataJobModelMountPath,
+		"--basemodel-name llama-7b",
+		"--basemodel-namespace models",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args %q missing %q", args, want)
+		}
+	}
+	if strings.Contains(args, "--cluster-scoped") {
+		t.Errorf("namespaced BaseModel must not pass --cluster-scoped")
+	}
+
+	if got := len(c.VolumeMounts); got != 1 {
+		t.Fatalf("expected 1 volume mount, got %d", got)
+	}
+	vm := c.VolumeMounts[0]
+	if vm.MountPath != metadataJobModelMountPath {
+		t.Errorf("mount path = %q, want %q", vm.MountPath, metadataJobModelMountPath)
+	}
+	if vm.SubPath != "models/llama" {
+		t.Errorf("sub path = %q, want models/llama", vm.SubPath)
+	}
+	if !vm.ReadOnly {
+		t.Errorf("volume mount must be read-only")
+	}
+
+	if c.Resources.Requests.Cpu().String() != "100m" {
+		t.Errorf("cpu request = %q, want 100m", c.Resources.Requests.Cpu().String())
+	}
+	if c.Resources.Requests.Memory().String() != "128Mi" {
+		t.Errorf("memory request = %q, want 128Mi", c.Resources.Requests.Memory().String())
+	}
+
+	// POD_NAMESPACE must propagate the controller's resolved OME ns
+	// to the Job pod so the agent's writeStatus targets the SAME
+	// namespace the controller reads ConfigMaps from. Otherwise an
+	// install in any namespace except the literal "ome" produces a
+	// permanent ConfigMap-not-found loop.
+	var foundPodNamespace bool
+	for _, env := range c.Env {
+		if env.Name == "POD_NAMESPACE" {
+			foundPodNamespace = true
+			if env.Value != constants.OMENamespace {
+				t.Errorf("POD_NAMESPACE = %q, want %q (controller's resolved OME ns)", env.Value, constants.OMENamespace)
+			}
+		}
+	}
+	if !foundPodNamespace {
+		t.Error("Job container must set POD_NAMESPACE env so the agent writes status ConfigMaps in the controller's OME namespace")
+	}
+}
+
+func TestBuildMetadataJob_ClusterBaseModel(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	cbm := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-llama", UID: "uid-2"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://shared:my-pvc/models/llama"),
+		}},
+	}
+	components := &storage.PVCStorageComponents{Namespace: "shared", PVCName: "my-pvc", SubPath: "models/llama"}
+
+	job, err := buildMetadataJob(cbm, true, components, "shared", MetadataJobConfig{
+		Image:          "ome-agent:latest",
+		ServiceAccount: "ome-model-metadata",
+	}, scheme)
+	if err != nil {
+		t.Fatalf("buildMetadataJob: %v", err)
+	}
+
+	if job.Namespace != "shared" {
+		t.Errorf("job namespace = %q, want shared", job.Namespace)
+	}
+	if got := job.Labels[constants.PVCMetadataScopeLabel]; got != metadataJobScopeCluster {
+		t.Errorf("scope label = %q, want %q", got, metadataJobScopeCluster)
+	}
+
+	if got := len(job.OwnerReferences); got != 1 {
+		t.Fatalf("expected 1 owner ref, got %d", got)
+	}
+	or := job.OwnerReferences[0]
+	if or.Kind != "ClusterBaseModel" {
+		t.Errorf("owner kind = %q, want ClusterBaseModel", or.Kind)
+	}
+
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, " ")
+	if !strings.Contains(args, "--cluster-scoped") {
+		t.Errorf("cluster-scoped BaseModel must pass --cluster-scoped, got %q", args)
+	}
+	if strings.Contains(args, "--basemodel-namespace") {
+		t.Errorf("cluster-scoped BaseModel must not pass --basemodel-namespace, got %q", args)
+	}
+}
+
+func TestBuildMetadataJob_SchedulingHints_PassedThrough(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	bm := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://my-pvc/models/llama"),
+		}},
+	}
+	cfg := MetadataJobConfig{
+		Image:             "ome-agent:test",
+		ServiceAccount:    "ome-model-metadata",
+		NodeSelector:      map[string]string{"disktype": "ssd"},
+		PriorityClassName: "system-cluster-critical",
+		Tolerations: []corev1.Toleration{{
+			Key:      "nvidia.com/gpu",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		}},
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"us-east-1a"},
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	job, err := buildMetadataJob(bm, false, &storage.PVCStorageComponents{PVCName: "my-pvc", SubPath: "models/llama"}, "models", cfg, scheme)
+	if err != nil {
+		t.Fatalf("buildMetadataJob: %v", err)
+	}
+	pod := job.Spec.Template.Spec
+	if pod.NodeSelector["disktype"] != "ssd" {
+		t.Errorf("NodeSelector not passed through: %v", pod.NodeSelector)
+	}
+	if pod.PriorityClassName != "system-cluster-critical" {
+		t.Errorf("PriorityClassName = %q, want system-cluster-critical", pod.PriorityClassName)
+	}
+	if len(pod.Tolerations) != 1 || pod.Tolerations[0].Key != "nvidia.com/gpu" {
+		t.Errorf("Tolerations not passed through: %+v", pod.Tolerations)
+	}
+	if pod.Affinity == nil || pod.Affinity.NodeAffinity == nil {
+		t.Errorf("Affinity not passed through: %+v", pod.Affinity)
+	}
+}
+
+// TestOmeAgentConfig_RoundTrip_ChartJSONIntoPodSpec asserts that the
+// JSON shape the Helm chart's `omeAgent: |-` block emits survives the
+// full chain: ConfigMap data → controllerconfig.OmeAgentConfig (json
+// Unmarshal) → omeAgentConfigToMetadataJobConfig → buildMetadataJob →
+// pod spec. If a contributor renames a JSON tag on OmeAgentConfig, drops
+// a field from the converter, or removes a key from the chart template,
+// the assertions below fire — without this test those mismatches would
+// silently render the corresponding override unusable.
+func TestOmeAgentConfig_RoundTrip_ChartJSONIntoPodSpec(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+
+	// Mirror the keys+shapes the Helm template renders. Keep this in
+	// sync with charts/ome-resources/templates/ome-controller/configmap.yaml
+	// (the omeAgent block) and config/configmap/inferenceservice.yaml.
+	chartJSON := `{
+        "image": "ome-agent:from-chart",
+        "serviceAccount": "ome-model-metadata",
+        "memoryRequest": "256Mi",
+        "memoryLimit": "512Mi",
+        "cpuRequest": "100m",
+        "cpuLimit": "500m",
+        "backoffLimit": 7,
+        "ttlSecondsAfterFinished": 1234,
+        "nodeSelector": {"disktype": "ssd"},
+        "tolerations": [{"key": "models-only", "operator": "Exists", "effect": "NoSchedule"}],
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [{
+                "matchExpressions": [{
+                  "key": "topology.kubernetes.io/zone",
+                  "operator": "In",
+                  "values": ["us-east-1a"]
+                }]
+              }]
+            }
+          }
+        },
+        "priorityClassName": "system-cluster-critical"
+    }`
+
+	cfg := &controllerconfig.OmeAgentConfig{}
+	if err := json.Unmarshal([]byte(chartJSON), cfg); err != nil {
+		t.Fatalf("unmarshal chart-shaped JSON: %v", err)
+	}
+
+	jobCfg := omeAgentConfigToMetadataJobConfig(cfg)
+	if jobCfg.Image != "ome-agent:from-chart" {
+		t.Errorf("Image lost in conversion: %q", jobCfg.Image)
+	}
+	if jobCfg.BackoffLimit != 7 {
+		t.Errorf("BackoffLimit lost in conversion: %d", jobCfg.BackoffLimit)
+	}
+	if jobCfg.TTLSecondsAfterFinished != 1234 {
+		t.Errorf("TTLSecondsAfterFinished lost in conversion: %d", jobCfg.TTLSecondsAfterFinished)
+	}
+
+	bm := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://my-pvc/models/llama"),
+		}},
+	}
+	job, err := buildMetadataJob(bm, false, &storage.PVCStorageComponents{PVCName: "my-pvc", SubPath: "models/llama"}, "models", jobCfg, scheme)
+	if err != nil {
+		t.Fatalf("buildMetadataJob: %v", err)
+	}
+
+	pod := job.Spec.Template.Spec
+	if pod.NodeSelector["disktype"] != "ssd" {
+		t.Errorf("nodeSelector did not round-trip from chart JSON to pod spec: %+v", pod.NodeSelector)
+	}
+	if pod.PriorityClassName != "system-cluster-critical" {
+		t.Errorf("priorityClassName did not round-trip: %q", pod.PriorityClassName)
+	}
+	if len(pod.Tolerations) != 1 || pod.Tolerations[0].Key != "models-only" {
+		t.Errorf("tolerations did not round-trip: %+v", pod.Tolerations)
+	}
+	if pod.Affinity == nil || pod.Affinity.NodeAffinity == nil {
+		t.Fatalf("affinity did not round-trip: %+v", pod.Affinity)
+	}
+	terms := pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if terms == nil || len(terms.NodeSelectorTerms) != 1 {
+		t.Fatalf("affinity NodeSelectorTerms missing: %+v", terms)
+	}
+	exprs := terms.NodeSelectorTerms[0].MatchExpressions
+	if len(exprs) != 1 || exprs[0].Key != "topology.kubernetes.io/zone" {
+		t.Errorf("affinity MatchExpressions lost: %+v", exprs)
+	}
+
+	if *job.Spec.BackoffLimit != 7 {
+		t.Errorf("BackoffLimit not propagated to Job: %d", *job.Spec.BackoffLimit)
+	}
+	if *job.Spec.TTLSecondsAfterFinished != 1234 {
+		t.Errorf("TTLSecondsAfterFinished not propagated to Job: %d", *job.Spec.TTLSecondsAfterFinished)
+	}
+}
+
+func TestBuildMetadataJob_PodSecurityContext_Restricted(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	bm := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://my-pvc/models/llama"),
+		}},
+	}
+	components := &storage.PVCStorageComponents{PVCName: "my-pvc", SubPath: "models/llama"}
+
+	job, err := buildMetadataJob(bm, false, components, "models",
+		MetadataJobConfig{Image: "ome-agent:test"}, scheme)
+	if err != nil {
+		t.Fatalf("buildMetadataJob: %v", err)
+	}
+
+	pod := job.Spec.Template.Spec
+	psc := pod.SecurityContext
+	if psc == nil {
+		t.Fatalf("expected pod SecurityContext to be set")
+	}
+	if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
+		t.Errorf("RunAsNonRoot must be true")
+	}
+	if psc.RunAsUser == nil || *psc.RunAsUser != metadataJobNonRootUID {
+		t.Errorf("RunAsUser = %v, want %d", psc.RunAsUser, metadataJobNonRootUID)
+	}
+	if psc.SeccompProfile == nil || psc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("seccompProfile must be RuntimeDefault, got %+v", psc.SeccompProfile)
+	}
+
+	c := pod.Containers[0]
+	csc := c.SecurityContext
+	if csc == nil {
+		t.Fatalf("expected container SecurityContext to be set")
+	}
+	if csc.AllowPrivilegeEscalation == nil || *csc.AllowPrivilegeEscalation {
+		t.Errorf("AllowPrivilegeEscalation must be false")
+	}
+	if csc.ReadOnlyRootFilesystem == nil || !*csc.ReadOnlyRootFilesystem {
+		t.Errorf("ReadOnlyRootFilesystem must be true")
+	}
+	if csc.Capabilities == nil || len(csc.Capabilities.Drop) == 0 || csc.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("Capabilities.Drop must be [ALL], got %+v", csc.Capabilities)
+	}
+}
+
+func TestBuildMetadataJob_RejectsMissingImage(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	bm := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://my-pvc/p"),
+		}},
+	}
+	if _, err := buildMetadataJob(bm, false, &storage.PVCStorageComponents{PVCName: "my-pvc", SubPath: "p"}, "models", MetadataJobConfig{}, scheme); err == nil {
+		t.Fatalf("expected error when image is empty")
+	}
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_rbac.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_rbac.go
@@ -43,9 +43,8 @@ const metadataJobSourceNamespaceLabel = "models.ome/metadata-source-namespace"
 //  2. A RoleBinding in the OME namespace binding the existing cluster-
 //     scoped ClusterRole to the SA in `jobNamespace`. The agent only
 //     writes the per-model status ConfigMap in the OME namespace
-//     (the model-metadata agent's writeStatus/newPVCMetadataConfigMap
-//     hardcode constants.OMENamespace), so an in-namespace RoleBinding
-//     wouldn't help — the agent needs
+//     (model-metadata/metadata.go hardcodes constants.OMENamespace),
+//     so an in-namespace RoleBinding wouldn't help — the agent needs
 //     cross-namespace write to ome/configmaps.
 //
 // Both objects are looked up by Get-or-Create so re-reconciles are

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_rbac_test.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_rbac_test.go
@@ -1,0 +1,176 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func newRBACTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 AddToScheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("rbacv1 AddToScheme: %v", err)
+	}
+	return scheme
+}
+
+func TestEnsureMetadataJobRBAC_CreatesSAAndOMENamespaceRoleBinding(t *testing.T) {
+	scheme := newRBACTestScheme(t)
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx := context.Background()
+	const ns = "playground"
+	const sa = "ome-model-metadata"
+
+	if err := ensureMetadataJobRBAC(ctx, c, logf.Log, ns, sa, sa); err != nil {
+		t.Fatalf("ensureMetadataJobRBAC: %v", err)
+	}
+
+	gotSA := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, types.NamespacedName{Name: sa, Namespace: ns}, gotSA); err != nil {
+		t.Fatalf("expected SA %s/%s to be created, got: %v", ns, sa, err)
+	}
+	if gotSA.Labels["app.kubernetes.io/component"] != metadataJobRBACComponent {
+		t.Errorf("SA missing component label, got labels %v", gotSA.Labels)
+	}
+
+	rbName := metadataJobOMENamespaceRoleBindingName(sa, ns)
+	gotRB := &rbacv1.RoleBinding{}
+	if err := c.Get(ctx, types.NamespacedName{Name: rbName, Namespace: constants.OMENamespace}, gotRB); err != nil {
+		t.Fatalf("expected RoleBinding %s/%s to be created, got: %v", constants.OMENamespace, rbName, err)
+	}
+	if gotRB.RoleRef.Kind != "ClusterRole" || gotRB.RoleRef.Name != sa {
+		t.Errorf("RoleRef = %+v, want ClusterRole/%s", gotRB.RoleRef, sa)
+	}
+	if len(gotRB.Subjects) != 1 || gotRB.Subjects[0].Namespace != ns || gotRB.Subjects[0].Name != sa {
+		t.Errorf("Subjects = %+v, want one ServiceAccount %s/%s", gotRB.Subjects, ns, sa)
+	}
+	if gotRB.Labels[metadataJobSourceNamespaceLabel] != ns {
+		t.Errorf("RB missing source-ns label, got %v", gotRB.Labels)
+	}
+}
+
+func TestEnsureMetadataJobRBAC_NoOpInOMENamespace(t *testing.T) {
+	// Chart already provisions the SA, ClusterRole, and ClusterRoleBinding
+	// in the OME namespace. The controller must NOT create a duplicate
+	// RoleBinding there — it'd collide with the chart-managed objects on
+	// upgrade and confuse operators about ownership.
+	scheme := newRBACTestScheme(t)
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx := context.Background()
+	if err := ensureMetadataJobRBAC(ctx, c, logf.Log, constants.OMENamespace, "ome-model-metadata", "ome-model-metadata"); err != nil {
+		t.Fatalf("ensureMetadataJobRBAC: %v", err)
+	}
+
+	// Nothing should have been created.
+	sa := &corev1.ServiceAccount{}
+	err := c.Get(ctx, types.NamespacedName{Name: "ome-model-metadata", Namespace: constants.OMENamespace}, sa)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected no SA created in OME namespace, got %v", err)
+	}
+	rb := &rbacv1.RoleBinding{}
+	rbName := metadataJobOMENamespaceRoleBindingName("ome-model-metadata", constants.OMENamespace)
+	err = c.Get(ctx, types.NamespacedName{Name: rbName, Namespace: constants.OMENamespace}, rb)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected no RoleBinding created in OME namespace, got %v", err)
+	}
+}
+
+func TestEnsureMetadataJobRBAC_IdempotentWhenObjectsAlreadyExist(t *testing.T) {
+	// Re-reconciles must be safe — second call observes the existing
+	// objects via Get and short-circuits without an Update or duplicate
+	// Create. Pin this so a future "always patch labels" change doesn't
+	// accidentally start writing on every reconcile (causes etcd churn
+	// and resourceVersion bumps that fan out to every watch consumer).
+	scheme := newRBACTestScheme(t)
+	const ns = "playground"
+	const sa = "ome-model-metadata"
+
+	preExistingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: sa, Namespace: ns, Labels: map[string]string{"chart-managed": "true"}},
+	}
+	rbName := metadataJobOMENamespaceRoleBindingName(sa, ns)
+	preExistingRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: constants.OMENamespace, Labels: map[string]string{"chart-managed": "true"}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: sa},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: sa, Namespace: ns}},
+	}
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(preExistingSA, preExistingRB).Build()
+
+	ctx := context.Background()
+	if err := ensureMetadataJobRBAC(ctx, c, logf.Log, ns, sa, sa); err != nil {
+		t.Fatalf("ensureMetadataJobRBAC: %v", err)
+	}
+
+	// SA labels must be unchanged — proves we did NOT overwrite.
+	gotSA := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, types.NamespacedName{Name: sa, Namespace: ns}, gotSA); err != nil {
+		t.Fatalf("get SA: %v", err)
+	}
+	if gotSA.Labels["chart-managed"] != "true" {
+		t.Errorf("ensureMetadataJobRBAC overwrote pre-existing SA labels, got %v", gotSA.Labels)
+	}
+	gotRB := &rbacv1.RoleBinding{}
+	if err := c.Get(ctx, types.NamespacedName{Name: rbName, Namespace: constants.OMENamespace}, gotRB); err != nil {
+		t.Fatalf("get RB: %v", err)
+	}
+	if gotRB.Labels["chart-managed"] != "true" {
+		t.Errorf("ensureMetadataJobRBAC overwrote pre-existing RB labels, got %v", gotRB.Labels)
+	}
+}
+
+func TestEnsureMetadataJobRBAC_NoOpWhenSANameEmpty(t *testing.T) {
+	// The Image-must-be-configured guard in buildMetadataJob fires later
+	// and surfaces a clear PVCConfigMissing status. This function should
+	// not preempt that with a confusing nameless SA create error.
+	scheme := newRBACTestScheme(t)
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx := context.Background()
+	if err := ensureMetadataJobRBAC(ctx, c, logf.Log, "playground", "", ""); err != nil {
+		t.Errorf("ensureMetadataJobRBAC with empty saName must be a no-op, got %v", err)
+	}
+}
+
+func TestEnsureMetadataJobRBAC_PerSourceNSRoleBindingNamesAreDistinct(t *testing.T) {
+	// Two BaseModels in two different user namespaces must both
+	// successfully ensure their RBAC — the OME-ns RoleBindings must be
+	// distinct so they don't overwrite each other's subjects.
+	scheme := newRBACTestScheme(t)
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx := context.Background()
+	if err := ensureMetadataJobRBAC(ctx, c, logf.Log, "playground", "ome-model-metadata", "ome-model-metadata"); err != nil {
+		t.Fatalf("playground RBAC: %v", err)
+	}
+	if err := ensureMetadataJobRBAC(ctx, c, logf.Log, "research", "ome-model-metadata", "ome-model-metadata"); err != nil {
+		t.Fatalf("research RBAC: %v", err)
+	}
+
+	for _, ns := range []string{"playground", "research"} {
+		rbName := metadataJobOMENamespaceRoleBindingName("ome-model-metadata", ns)
+		rb := &rbacv1.RoleBinding{}
+		if err := c.Get(ctx, types.NamespacedName{Name: rbName, Namespace: constants.OMENamespace}, rb); err != nil {
+			t.Errorf("expected RB %s/%s for source ns %s, got %v", constants.OMENamespace, rbName, ns, err)
+			continue
+		}
+		if len(rb.Subjects) != 1 || rb.Subjects[0].Namespace != ns {
+			t.Errorf("RB %q has subjects %+v, want single subject in ns %q", rbName, rb.Subjects, ns)
+		}
+	}
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/pvc.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/pvc.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
-	"sigs.k8s.io/ome/pkg/modelagent"
 	"sigs.k8s.io/ome/pkg/utils/storage"
 )
 
@@ -39,7 +38,7 @@ import (
 // per-PVC ConfigMap, both cache-backed.
 const pvcRequeueAfter = 5 * time.Second
 
-// IsPVCStorage reports whether the given BaseModel/ClusterBaseModel spec
+// isPVCStorage reports whether the given BaseModel/ClusterBaseModel spec
 // references a PVC-backed storage URI.
 func IsPVCStorage(spec *v1beta1.BaseModelSpec) bool {
 	if spec == nil || spec.Storage == nil || spec.Storage.StorageUri == nil {
@@ -78,8 +77,8 @@ func resolvePVCNamespace(modelNamespace string, isClusterScoped bool, components
 	return modelNamespace, nil
 }
 
-// Reconcile handles the PVC-specific reconcile flow for a BaseModel or
-// ClusterBaseModel:
+// reconcilePVCStorage handles the PVC-specific reconcile flow for a BaseModel
+// or ClusterBaseModel:
 //
 //  1. Parse the URI, resolve the PVC namespace, validate the PVC exists
 //     and is Bound (pre-Job).
@@ -301,7 +300,7 @@ func applyPVCStatusFromConfigMap(ctx context.Context, kubeClient client.Client, 
 			v1beta1.ModelConditionReasonPVCMetadataExtracting,
 			fmt.Sprintf("PVC metadata ConfigMap %s lacks entry %q yet", cmName, modelKey))
 	}
-	var entry modelagent.ModelEntry
+	var entry shared.ModelEntry
 	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
 		log.Error(err, "Failed to parse PVC ConfigMap model entry", "configMap", cmName, "key", modelKey)
 		return setPVCInTransitStatus(ctx, kubeClient, log, obj,
@@ -310,7 +309,7 @@ func applyPVCStatusFromConfigMap(ctx context.Context, kubeClient client.Client, 
 	}
 
 	switch entry.Status {
-	case modelagent.ModelStatusReady:
+	case shared.ModelStatusReady:
 		// Apply spec from the agent's parsed metadata. Re-read the latest
 		// CR to avoid clobbering concurrent edits.
 		if entry.Config != nil {
@@ -320,7 +319,7 @@ func applyPVCStatusFromConfigMap(ctx context.Context, kubeClient client.Client, 
 		}
 		return setPVCReadyStatus(ctx, kubeClient, log, obj,
 			fmt.Sprintf("PVC metadata extraction succeeded; ConfigMap %s applied", cmName))
-	case modelagent.ModelStatusFailed:
+	case shared.ModelStatusFailed:
 		msg := cm.Annotations[constants.PVCMetadataLastErrorAnnotation]
 		if msg == "" {
 			msg = "agent reported Failed without an error message"
@@ -335,7 +334,7 @@ func applyPVCStatusFromConfigMap(ctx context.Context, kubeClient client.Client, 
 
 // applyPVCSpecUpdate applies the agent's ModelConfig to the model spec,
 // reading the latest CR via retry-on-conflict to avoid clobbering writes.
-func applyPVCSpecUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, cfg *modelagent.ModelConfig) error {
+func applyPVCSpecUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, cfg *shared.ModelConfig) error {
 	return shared.RetryUpdate(ctx, kubeClient, log, obj, "pvc-spec", func(ctx context.Context, c client.Client, latest client.Object) error {
 		var spec *v1beta1.BaseModelSpec
 		switch m := latest.(type) {
@@ -353,10 +352,10 @@ func applyPVCSpecUpdate(ctx context.Context, kubeClient client.Client, log logr.
 	})
 }
 
-// HandleModelDeletion is the deletion path for PVC-backed BaseModel and
-// ClusterBaseModel. Unlike per-node models, PVC models have no agent to
-// mark Status=Deleted across N nodes — there is exactly one ConfigMap to
-// clean up. Order: delete the Job first so the agent stops re-creating
+// handlePVCModelDeletion is the deletion path for PVC-backed BaseModel
+// and ClusterBaseModel. Unlike per-node models, PVC models have no agent
+// to mark Status=Deleted across N nodes — there is exactly one ConfigMap
+// to clean up. Order: delete the Job first so the agent stops re-creating
 // the ConfigMap, then delete the ConfigMap, then drop the finalizer.
 func HandleModelDeletion(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, isClusterScoped bool, finalizer string) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(obj, finalizer) {
@@ -404,9 +403,9 @@ func HandleModelDeletion(ctx context.Context, kubeClient client.Client, log logr
 	return ctrl.Result{}, nil
 }
 
-// CleanupStaleArtifacts deletes any per-PVC ConfigMap, any metadata
-// extraction Jobs, and strips PVC-specific stale conditions from a
-// BaseModel/ClusterBaseModel that is no longer PVC-backed.
+// cleanupStalePVCArtifacts deletes any per-PVC ConfigMap, any
+// metadata extraction Jobs, and strips PVC-specific stale conditions
+// from a BaseModel/ClusterBaseModel that is no longer PVC-backed.
 //
 // Called when a model whose previous spec was pvc:// has its
 // storage URI changed to a non-PVC backend (oci://, hf://, etc.).
@@ -448,7 +447,7 @@ func CleanupStaleArtifacts(ctx context.Context, kubeClient client.Client, log lo
 	}
 
 	// 3. Strip PVC-specific conditions from the CR's status. We re-fetch
-	// inside RetryUpdate to avoid clobbering concurrent edits. No-op if
+	// inside retryUpdate to avoid clobbering concurrent edits. No-op if
 	// no PVC conditions are present.
 	return shared.RetryUpdate(ctx, kubeClient, log, obj, "pvc-condition-cleanup", func(ctx context.Context, c client.Client, latest client.Object) error {
 		var conditions *[]metav1.Condition
@@ -458,7 +457,7 @@ func CleanupStaleArtifacts(ctx context.Context, kubeClient client.Client, log lo
 		case *v1beta1.ClusterBaseModel:
 			conditions = &m.Status.Conditions
 		default:
-			return fmt.Errorf("CleanupStaleArtifacts: unsupported type %T", latest)
+			return fmt.Errorf("cleanupStalePVCArtifacts: unsupported type %T", latest)
 		}
 		filtered := make([]metav1.Condition, 0, len(*conditions))
 		removed := false
@@ -479,7 +478,7 @@ func CleanupStaleArtifacts(ctx context.Context, kubeClient client.Client, log lo
 
 // isPVCConditionReason reports whether the supplied condition Reason
 // is part of the PVC reconcile branch's reason set. Used by
-// CleanupStaleArtifacts to identify stale conditions left behind
+// cleanupStalePVCArtifacts to identify stale conditions left behind
 // after a URI swap from pvc:// to non-PVC.
 func isPVCConditionReason(reason string) bool {
 	switch reason {

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/pvc_test.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/pvc_test.go
@@ -1,0 +1,634 @@
+package pvc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+func testMetadataJobConfig() MetadataJobConfig {
+	return MetadataJobConfig{
+		Image:          "ome-agent:test",
+		ServiceAccount: "ome-model-metadata",
+	}
+}
+
+func TestIsPVCStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *v1beta1.BaseModelSpec
+		want bool
+	}{
+		{name: "nil spec", spec: nil, want: false},
+		{name: "nil storage", spec: &v1beta1.BaseModelSpec{}, want: false},
+		{name: "nil storage uri", spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{}}, want: false},
+		{
+			name: "pvc namespaced uri",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/models/llama2-7b")}},
+			want: true,
+		},
+		{
+			name: "pvc cluster-scoped uri",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://shared:my-pvc/models/llama2-7b")}},
+			want: true,
+		},
+		{
+			name: "huggingface uri",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("hf://meta-llama/Llama-2-7b")}},
+			want: false,
+		},
+		{
+			name: "oci uri",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("oci://n/ns/b/bucket/o/path")}},
+			want: false,
+		},
+		{
+			name: "garbage uri",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("not-a-uri")}},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPVCStorage(tc.spec); got != tc.want {
+				t.Fatalf("isPVCStorage = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolvePVCNamespace(t *testing.T) {
+	tests := []struct {
+		name            string
+		modelNamespace  string
+		isClusterScoped bool
+		components      *storage.PVCStorageComponents
+		want            string
+		wantErr         bool
+	}{
+		{
+			name:       "nil components",
+			components: nil,
+			wantErr:    true,
+		},
+		{
+			name:           "namespaced, no ns prefix in uri",
+			modelNamespace: "models",
+			components:     &storage.PVCStorageComponents{PVCName: "pvc1", SubPath: "x"},
+			want:           "models",
+		},
+		{
+			name:           "namespaced, ns prefix in uri is rejected",
+			modelNamespace: "models",
+			components:     &storage.PVCStorageComponents{Namespace: "other", PVCName: "pvc1", SubPath: "x"},
+			wantErr:        true,
+		},
+		{
+			name:            "cluster-scoped, ns prefix in uri",
+			isClusterScoped: true,
+			components:      &storage.PVCStorageComponents{Namespace: "shared", PVCName: "pvc1", SubPath: "x"},
+			want:            "shared",
+		},
+		{
+			name:            "cluster-scoped, missing ns prefix is rejected",
+			isClusterScoped: true,
+			components:      &storage.PVCStorageComponents{PVCName: "pvc1", SubPath: "x"},
+			wantErr:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolvePVCNamespace(tc.modelNamespace, tc.isClusterScoped, tc.components)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got namespace=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("namespace = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func newPVCTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 AddToScheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("batchv1 AddToScheme: %v", err)
+	}
+	// rbacv1: ensureMetadataJobRBAC creates a RoleBinding in the OME
+	// namespace before the Job is submitted (covers PVC-backed BMs in
+	// non-OME namespaces). The reconcile path's fake client needs the
+	// kind registered or the create errors out.
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("rbacv1 AddToScheme: %v", err)
+	}
+	return scheme
+}
+
+func newBoundPVC(ns, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+}
+
+func newPendingPVC(ns, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+}
+
+// jobWithCondition returns a Job whose name matches buildMetadataJob's
+// deterministic naming, carrying the given condition. Used to simulate
+// Job-watcher-driven re-reconciles in tests.
+func jobWithCondition(t *testing.T, obj client.Object, isClusterScoped bool, components *storage.PVCStorageComponents, pvcNamespace string, condType batchv1.JobConditionType, message string) *batchv1.Job {
+	t.Helper()
+	scheme := newPVCTestScheme(t)
+	job, err := buildMetadataJob(obj, isClusterScoped, components, pvcNamespace, testMetadataJobConfig(), scheme)
+	if err != nil {
+		t.Fatalf("buildMetadataJob: %v", err)
+	}
+	job.Status = batchv1.JobStatus{
+		Conditions: []batchv1.JobCondition{
+			{Type: condType, Status: corev1.ConditionTrue, Message: message},
+		},
+	}
+	return job
+}
+
+func TestReconcilePVCStorage_BaseModel(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	ctx := context.Background()
+	log := logf.Log.WithName("test")
+
+	bm := func() *v1beta1.BaseModel {
+		return &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "models", UID: "uid"},
+			Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+				StorageUri: ptr.To("pvc://my-pvc/models/llama"),
+			}},
+		}
+	}
+	components := &storage.PVCStorageComponents{PVCName: "my-pvc", SubPath: "models/llama"}
+
+	tests := []struct {
+		name         string
+		bm           *v1beta1.BaseModel
+		seed         []client.Object
+		cfg          MetadataJobConfig
+		wantState    v1beta1.LifeCycleState
+		wantReason   string
+		wantCondType string
+		wantCondVal  metav1.ConditionStatus
+		wantJobCount int
+	}{
+		{
+			name: "valid bound PVC creates Job and asserts InTransit",
+			bm:   bm(),
+			seed: []client.Object{newBoundPVC("models", "my-pvc")},
+			cfg:  testMetadataJobConfig(),
+			// First reconcile creates the Job and asserts InTransit while
+			// the agent runs; ConfigMap takes over once it completes.
+			wantState:    v1beta1.LifeCycleStateInTransit,
+			wantReason:   v1beta1.ModelConditionReasonPVCMetadataExtracting,
+			wantCondType: v1beta1.ModelConditionSourceReachable,
+			wantCondVal:  metav1.ConditionTrue,
+			wantJobCount: 1,
+		},
+		{
+			name: "Job exists, no ConfigMap yet → state untouched (still InTransit from prior step)",
+			bm:   bm(),
+			seed: []client.Object{
+				newBoundPVC("models", "my-pvc"),
+				jobWithCondition(t, bm(), false, components, "models", batchv1.JobComplete, ""),
+			},
+			cfg: testMetadataJobConfig(),
+			// reconciler doesn't translate Job status; it reads the ConfigMap.
+			// No ConfigMap seeded → no state/condition write at all.
+			wantState:    "",
+			wantCondType: "", // no condition
+		},
+		{
+			name: "PVC missing",
+			bm: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "models"},
+				Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+					StorageUri: ptr.To("pvc://no-such/models/llama"),
+				}},
+			},
+			cfg:          testMetadataJobConfig(),
+			wantState:    v1beta1.LifeCycleStateFailed,
+			wantReason:   v1beta1.ModelConditionReasonPVCNotFound,
+			wantCondType: v1beta1.ModelConditionSourceReachable,
+			wantCondVal:  metav1.ConditionFalse,
+		},
+		{
+			name:         "PVC pending",
+			bm:           bm(),
+			seed:         []client.Object{newPendingPVC("models", "my-pvc")},
+			cfg:          testMetadataJobConfig(),
+			wantState:    v1beta1.LifeCycleStateInTransit,
+			wantReason:   v1beta1.ModelConditionReasonPVCNotBound,
+			wantCondType: v1beta1.ModelConditionSourceReachable,
+			wantCondVal:  metav1.ConditionTrue,
+		},
+		{
+			name: "namespaced uri rejected for namespaced BaseModel",
+			bm: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "models"},
+				Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+					StorageUri: ptr.To("pvc://other:my-pvc/models/llama"),
+				}},
+			},
+			cfg:          testMetadataJobConfig(),
+			wantState:    v1beta1.LifeCycleStateFailed,
+			wantReason:   v1beta1.ModelConditionReasonPVCInvalid,
+			wantCondType: v1beta1.ModelConditionSourceReachable,
+			wantCondVal:  metav1.ConditionFalse,
+		},
+		{
+			name:         "missing image config → Failed with PVCConfigMissing",
+			bm:           bm(),
+			seed:         []client.Object{newBoundPVC("models", "my-pvc")},
+			cfg:          MetadataJobConfig{},
+			wantState:    v1beta1.LifeCycleStateFailed,
+			wantReason:   v1beta1.ModelConditionReasonPVCConfigMissing,
+			wantCondType: v1beta1.ModelConditionSourceReachable,
+			wantCondVal:  metav1.ConditionFalse,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := append([]client.Object{tc.bm}, tc.seed...)
+			c := ctrlclientfake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				WithStatusSubresource(&v1beta1.BaseModel{}).
+				Build()
+
+			if _, err := Reconcile(ctx, c, scheme, log, tc.bm, &tc.bm.Spec, false, tc.cfg); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := &v1beta1.BaseModel{}
+			if err := c.Get(ctx, types.NamespacedName{Name: tc.bm.Name, Namespace: tc.bm.Namespace}, got); err != nil {
+				t.Fatalf("get baseModel: %v", err)
+			}
+			// wantState == "" means the reconciler must not write state.
+			if tc.wantState != "" && got.Status.State != tc.wantState {
+				t.Errorf("state = %q, want %q", got.Status.State, tc.wantState)
+			}
+			if tc.wantState == "" && got.Status.State != "" {
+				t.Errorf("state was written (%q) but wantState is empty — reconciler must defer to ConfigMap path", got.Status.State)
+			}
+			if tc.wantCondType != "" {
+				cond := meta.FindStatusCondition(got.Status.Conditions, tc.wantCondType)
+				if cond == nil {
+					t.Fatalf("expected condition %q to be set", tc.wantCondType)
+				}
+				if cond.Status != tc.wantCondVal {
+					t.Errorf("cond status = %q, want %q", cond.Status, tc.wantCondVal)
+				}
+				if cond.Reason != tc.wantReason {
+					t.Errorf("cond reason = %q, want %q", cond.Reason, tc.wantReason)
+				}
+			}
+
+			if tc.wantJobCount > 0 {
+				jobs := &batchv1.JobList{}
+				if err := c.List(ctx, jobs, client.InNamespace(tc.bm.Namespace)); err != nil {
+					t.Fatalf("list jobs: %v", err)
+				}
+				if len(jobs.Items) != tc.wantJobCount {
+					t.Errorf("got %d jobs, want %d", len(jobs.Items), tc.wantJobCount)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyPVCStatusFromConfigMap covers the new direct-Get path. PVC
+// status flows from a single ConfigMap (not the per-node List), and
+// Status.NodesReady stays empty because there is no node concept here.
+func TestApplyPVCStatusFromConfigMap(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	ctx := context.Background()
+	log := logf.Log.WithName("test")
+
+	makeCM := func(modelName, ns string, isCluster bool, status shared.ModelStatus, cfg *shared.ModelConfig, errMsg string) *corev1.ConfigMap {
+		t.Helper()
+		entry := shared.ModelEntry{Name: modelName, Status: status, Config: cfg}
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		labels := map[string]string{
+			constants.PVCStorageConfigMapLabel:  "true",
+			constants.PVCMetadataModelNameLabel: modelName,
+		}
+		var ann map[string]string
+		if errMsg != "" {
+			ann = map[string]string{constants.PVCMetadataLastErrorAnnotation: errMsg}
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        constants.GetPVCMetadataConfigMapName(modelName, ns, isCluster),
+				Namespace:   constants.OMENamespace,
+				Labels:      labels,
+				Annotations: ann,
+			},
+			Data: map[string]string{
+				constants.GetModelConfigMapKey(ns, modelName, isCluster): string(data),
+			},
+		}
+	}
+
+	t.Run("Ready: state→Ready, spec updated, NodesReady empty", func(t *testing.T) {
+		bm := &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+			Spec:       v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/p")}},
+		}
+		cm := makeCM("llama-7b", "models", false, shared.ModelStatusReady, &shared.ModelConfig{
+			ModelType: "llama", ModelArchitecture: "LlamaForCausalLM", MaxTokens: 4096,
+		}, "")
+		c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(bm, cm).
+			WithStatusSubresource(&v1beta1.BaseModel{}).
+			Build()
+
+		_, err := applyPVCStatusFromConfigMap(ctx, c, log, bm, false, nil)
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got := &v1beta1.BaseModel{}
+		if err := c.Get(ctx, types.NamespacedName{Name: bm.Name, Namespace: bm.Namespace}, got); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if got.Status.State != v1beta1.LifeCycleStateReady {
+			t.Errorf("state = %q, want Ready", got.Status.State)
+		}
+		if len(got.Status.NodesReady) != 0 {
+			t.Errorf("PVC NodesReady must be empty; got %v", got.Status.NodesReady)
+		}
+		if got.Spec.ModelType == nil || *got.Spec.ModelType != "llama" {
+			t.Errorf("spec.ModelType not applied: %+v", got.Spec.ModelType)
+		}
+	})
+
+	t.Run("Failed: state→Failed with extraction reason + agent error", func(t *testing.T) {
+		bm := &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+			Spec:       v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/p")}},
+		}
+		cm := makeCM("llama-7b", "models", false, shared.ModelStatusFailed, nil, "config.json missing")
+		c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(bm, cm).
+			WithStatusSubresource(&v1beta1.BaseModel{}).
+			Build()
+
+		_, err := applyPVCStatusFromConfigMap(ctx, c, log, bm, false, nil)
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got := &v1beta1.BaseModel{}
+		if err := c.Get(ctx, types.NamespacedName{Name: bm.Name, Namespace: bm.Namespace}, got); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if got.Status.State != v1beta1.LifeCycleStateFailed {
+			t.Errorf("state = %q, want Failed", got.Status.State)
+		}
+		ready := meta.FindStatusCondition(got.Status.Conditions, v1beta1.ModelConditionReady)
+		if ready == nil || ready.Reason != v1beta1.ModelConditionReasonPVCMetadataExtractionFailed {
+			t.Errorf("Ready condition wrong: %+v", ready)
+		}
+	})
+
+	t.Run("ConfigMap absent: state untouched", func(t *testing.T) {
+		bm := &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+			Spec:       v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/p")}},
+		}
+		c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(bm).
+			WithStatusSubresource(&v1beta1.BaseModel{}).
+			Build()
+		// Pass a still-running Job (no JobFailed condition) so the
+		// new JobFailed branch in applyPVCStatusFromConfigMap is NOT taken.
+		runningJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "models"}}
+		res, err := applyPVCStatusFromConfigMap(ctx, c, log, bm, false, runningJob)
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if res.RequeueAfter == 0 {
+			t.Errorf("expected requeue when ConfigMap absent")
+		}
+		got := &v1beta1.BaseModel{}
+		_ = c.Get(ctx, types.NamespacedName{Name: bm.Name, Namespace: bm.Namespace}, got)
+		if got.Status.State != "" {
+			t.Errorf("state was written %q despite missing ConfigMap", got.Status.State)
+		}
+	})
+
+	t.Run("ConfigMap absent + Job Failed: state→Failed with Job message", func(t *testing.T) {
+		bm := &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+			Spec:       v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/p")}},
+		}
+		c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(bm).
+			WithStatusSubresource(&v1beta1.BaseModel{}).
+			Build()
+
+		// Simulate a Job that exhausted its BackoffLimit. The agent
+		// pod was OOM-killed before its SIGTERM handler could run, so
+		// no per-PVC ConfigMap was ever written.
+		failedJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "models"},
+			Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+				Type:    batchv1.JobFailed,
+				Status:  corev1.ConditionTrue,
+				Reason:  "BackoffLimitExceeded",
+				Message: "Job has reached the specified backoff limit",
+			}}},
+		}
+
+		if _, err := applyPVCStatusFromConfigMap(ctx, c, log, bm, false, failedJob); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got := &v1beta1.BaseModel{}
+		if err := c.Get(ctx, types.NamespacedName{Name: bm.Name, Namespace: bm.Namespace}, got); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if got.Status.State != v1beta1.LifeCycleStateFailed {
+			t.Errorf("state = %q, want Failed (Job exhausted BackoffLimit)", got.Status.State)
+		}
+		ready := meta.FindStatusCondition(got.Status.Conditions, v1beta1.ModelConditionReady)
+		if ready == nil || ready.Reason != v1beta1.ModelConditionReasonPVCMetadataExtractionFailed {
+			t.Errorf("Ready condition wrong: %+v", ready)
+		}
+		if ready != nil && !strings.Contains(ready.Message, "BackoffLimitExceeded") {
+			t.Errorf("expected Job condition reason in message, got %q", ready.Message)
+		}
+	})
+}
+
+// TestJobFailedConditionMessage exhaustively covers the JobFailed
+// detection helper. Catches regressions in either the predicate
+// (wrong condition type / wrong status) or the message assembly.
+func TestJobFailedConditionMessage(t *testing.T) {
+	cases := []struct {
+		name    string
+		job     *batchv1.Job
+		wantOk  bool
+		wantSub string // substring expected in the returned message
+	}{
+		{name: "nil job", job: nil},
+		{name: "no conditions", job: &batchv1.Job{}},
+		{
+			name: "JobFailed=True with Reason+Message",
+			job: &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+				Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+				Reason: "DeadlineExceeded", Message: "Job was active longer than specified deadline",
+			}}}},
+			wantOk:  true,
+			wantSub: "DeadlineExceeded: Job was active longer than specified deadline",
+		},
+		{
+			name: "JobFailed=True with empty Message: synthesizes a default",
+			job: &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+				Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+			}}}},
+			wantOk:  true,
+			wantSub: "exhausted its retry budget",
+		},
+		{
+			name: "JobFailed=False (transient): not yet terminal",
+			job: &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+				Type: batchv1.JobFailed, Status: corev1.ConditionFalse,
+			}}}},
+		},
+		{
+			name: "JobComplete=True: success, never reports Failed",
+			job: &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+				Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+			}}}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, msg := jobFailedConditionMessage(tc.job)
+			if ok != tc.wantOk {
+				t.Errorf("ok = %v, want %v (msg=%q)", ok, tc.wantOk, msg)
+			}
+			if tc.wantSub != "" && !strings.Contains(msg, tc.wantSub) {
+				t.Errorf("msg %q missing %q", msg, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestProcessModelStatus_NonPVCConfigMapStillRequiresNode is a regression
+// guard so the relaxation in C13 doesn't accidentally let per-node
+// ConfigMaps pass when their Node is gone.
+
+func TestReconcilePVCStorage_ClusterBaseModel(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	ctx := context.Background()
+	log := logf.Log.WithName("test")
+
+	cbm := func() *v1beta1.ClusterBaseModel {
+		return &v1beta1.ClusterBaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "shared-llama", UID: "uid-cbm"},
+			Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+				StorageUri: ptr.To("pvc://shared:my-pvc/models/llama"),
+			}},
+		}
+	}
+
+	t.Run("valid bound PVC → creates Job in PVC namespace", func(t *testing.T) {
+		c := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cbm(), newBoundPVC("shared", "my-pvc")).
+			WithStatusSubresource(&v1beta1.ClusterBaseModel{}).
+			Build()
+
+		_, err := Reconcile(ctx, c, scheme, log, cbm(), &cbm().Spec, true, testMetadataJobConfig())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &v1beta1.ClusterBaseModel{}
+		if err := c.Get(ctx, types.NamespacedName{Name: cbm().Name}, got); err != nil {
+			t.Fatalf("get clusterBaseModel: %v", err)
+		}
+		if got.Status.State != v1beta1.LifeCycleStateInTransit {
+			t.Errorf("state = %q, want In_Transit", got.Status.State)
+		}
+
+		jobs := &batchv1.JobList{}
+		if err := c.List(ctx, jobs, client.InNamespace("shared")); err != nil {
+			t.Fatalf("list jobs: %v", err)
+		}
+		if len(jobs.Items) != 1 {
+			t.Fatalf("expected 1 Job in 'shared' ns, got %d", len(jobs.Items))
+		}
+	})
+
+	t.Run("missing namespace prefix is rejected", func(t *testing.T) {
+		bad := cbm()
+		bad.Spec.Storage.StorageUri = ptr.To("pvc://my-pvc/models/llama")
+		c := ctrlclientfake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(bad).
+			WithStatusSubresource(&v1beta1.ClusterBaseModel{}).
+			Build()
+
+		if _, err := Reconcile(ctx, c, scheme, log, bad, &bad.Spec, true, testMetadataJobConfig()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &v1beta1.ClusterBaseModel{}
+		if err := c.Get(ctx, types.NamespacedName{Name: bad.Name}, got); err != nil {
+			t.Fatalf("get clusterBaseModel: %v", err)
+		}
+		if got.Status.State != v1beta1.LifeCycleStateFailed {
+			t.Errorf("state = %q, want Failed", got.Status.State)
+		}
+		cond := meta.FindStatusCondition(got.Status.Conditions, v1beta1.ModelConditionSourceReachable)
+		if cond == nil || cond.Reason != v1beta1.ModelConditionReasonPVCInvalid {
+			t.Errorf("expected PVCInvalid reason, got %+v", cond)
+		}
+	})
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/watches_test.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/watches_test.go
@@ -1,0 +1,102 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestMapToBaseModels(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	ctx := context.Background()
+	log := logf.Log.WithName("test")
+
+	matching := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://my-pvc/sub"),
+		}},
+	}
+	otherPVC := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-pvc", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://different-pvc/sub"),
+		}},
+	}
+	notPVC := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-pvc", Namespace: "models"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("oci://n/ns/b/bucket/o/path"),
+		}},
+	}
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(matching, otherPVC, notPVC).Build()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "models"},
+	}
+	got := MapToBaseModels(ctx, c, log, pvc)
+	if len(got) != 1 {
+		t.Fatalf("got %d requests, want 1", len(got))
+	}
+	if got[0].Name != "matching" || got[0].Namespace != "models" {
+		t.Errorf("got %+v, want models/matching", got[0])
+	}
+}
+
+func TestMapToClusterBaseModels(t *testing.T) {
+	scheme := newPVCTestScheme(t)
+	ctx := context.Background()
+	log := logf.Log.WithName("test")
+
+	matching := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://shared:my-pvc/sub"),
+		}},
+	}
+	wrongNs := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-ns"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("pvc://other-ns:my-pvc/sub"),
+		}},
+	}
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(matching, wrongNs).Build()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "shared"},
+	}
+	got := MapToClusterBaseModels(ctx, c, log, pvc)
+	if len(got) != 1 {
+		t.Fatalf("got %d requests, want 1", len(got))
+	}
+	if got[0].Name != "matching" {
+		t.Errorf("got %+v, want matching", got[0])
+	}
+}
+
+func TestCreatePhasePredicate(t *testing.T) {
+	p := CreatePhasePredicate()
+	pending := &corev1.PersistentVolumeClaim{Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending}}
+	bound := &corev1.PersistentVolumeClaim{Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound}}
+
+	if !p.Create(event.CreateEvent{Object: pending}) {
+		t.Errorf("Create event must fire")
+	}
+	if p.Update(event.UpdateEvent{ObjectOld: pending, ObjectNew: pending}) {
+		t.Errorf("phase-unchanged update must NOT fire")
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: pending, ObjectNew: bound}) {
+		t.Errorf("Pending→Bound update must fire")
+	}
+	if !p.Delete(event.DeleteEvent{Object: bound}) {
+		t.Errorf("Delete event must fire")
+	}
+}

--- a/pkg/controller/v1beta1/basemodel/controller.go
+++ b/pkg/controller/v1beta1/basemodel/controller.go
@@ -37,7 +37,6 @@ import (
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
 
-// BaseModelReconciler reconciles BaseModel objects
 type BaseModelReconciler struct {
 	client.Client
 	Log            logr.Logger
@@ -45,7 +44,6 @@ type BaseModelReconciler struct {
 	OmeAgentConfig *controllerconfig.OmeAgentConfig
 }
 
-// ClusterBaseModelReconciler reconciles ClusterBaseModel objects
 type ClusterBaseModelReconciler struct {
 	client.Client
 	Log            logr.Logger
@@ -54,7 +52,7 @@ type ClusterBaseModelReconciler struct {
 }
 
 // backends builds the dispatch slice in match order: pvc → pernode.
-// perNodeBackend always matches, so it goes last as the fallback.
+// perNodeBackend always matches, so it goes last.
 func (r *BaseModelReconciler) backends() []shared.Backend {
 	return []shared.Backend{
 		pvc.New(r.OmeAgentConfig),
@@ -69,14 +67,12 @@ func (r *ClusterBaseModelReconciler) backends() []shared.Backend {
 	}
 }
 
-// Reconcile handles BaseModel reconciliation
 func (r *BaseModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("basemodel", req.NamespacedName)
 
 	baseModel := &v1beta1.BaseModel{}
 	if err := r.Get(ctx, req.NamespacedName, baseModel); err != nil {
 		if errors.IsNotFound(err) {
-			// Object not found, return without error since it was likely deleted
 			return ctrl.Result{}, nil
 		}
 		log.Error(err, "Failed to get BaseModel")
@@ -85,14 +81,12 @@ func (r *BaseModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return reconcileModel(ctx, r.Client, r.Scheme, log, r.backends(), baseModel, constants.BaseModelFinalizer, false, "BaseModel")
 }
 
-// Reconcile handles ClusterBaseModel reconciliation
 func (r *ClusterBaseModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("clusterbasemodel", req.NamespacedName)
 
 	clusterBaseModel := &v1beta1.ClusterBaseModel{}
 	if err := r.Get(ctx, req.NamespacedName, clusterBaseModel); err != nil {
 		if errors.IsNotFound(err) {
-			// Object not found, return without error since it was likely deleted
 			return ctrl.Result{}, nil
 		}
 		log.Error(err, "Failed to get ClusterBaseModel")
@@ -101,9 +95,6 @@ func (r *ClusterBaseModelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return reconcileModel(ctx, r.Client, r.Scheme, log, r.backends(), clusterBaseModel, constants.ClusterBaseModelFinalizer, true, "ClusterBaseModel")
 }
 
-// reconcileModel is the backend-agnostic reconcile core: resolve the
-// spec/status, pick the backend, add the finalizer, and dispatch
-// deletion/reconcile to that backend.
 func reconcileModel(ctx context.Context, c client.Client, scheme *runtime.Scheme, log logr.Logger, backends []shared.Backend, obj client.Object, finalizer string, isClusterScoped bool, kind string) (ctrl.Result, error) {
 	spec, status, err := shared.ModelSpecAndStatus(obj)
 	if err != nil {
@@ -125,13 +116,11 @@ func reconcileModel(ctx context.Context, c client.Client, scheme *runtime.Scheme
 		Kind:            kind,
 	}
 
-	// Handle deletion
 	if !obj.GetDeletionTimestamp().IsZero() {
 		log.Info("Handling " + kind + " deletion via " + backend.Name() + " backend")
 		return backend.HandleDeletion(ctx, args)
 	}
 
-	// Add finalizer if not present
 	if !controllerutil.ContainsFinalizer(obj, finalizer) {
 		log.Info("Adding finalizer to " + kind)
 		controllerutil.AddFinalizer(obj, finalizer)
@@ -145,7 +134,6 @@ func reconcileModel(ctx context.Context, c client.Client, scheme *runtime.Scheme
 	return backend.Reconcile(ctx, args)
 }
 
-// SetupWithManager sets up the BaseModel controller with the Manager
 func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.BaseModel{}).
@@ -153,11 +141,11 @@ func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-				return pernode.MapConfigMapToModelRequests(obj, r.Log, true) // true = namespaced
+				return pernode.MapConfigMapToModelRequests(obj, r.Log, true)
 			}),
-			// OR'd: per-node basemodel-status ConfigMaps (agent flow) +
-			// per-PVC pvc-status ConfigMaps (extraction Job output). Both are
-			// keyed by GetModelConfigMapKey, so one mapper fits both.
+			// OR'd: per-node basemodel-status ConfigMaps (agent flow)
+			// + per-PVC pvc-status ConfigMaps (extraction Job output).
+			// Both keyed by GetModelConfigMapKey, so one mapper fits both.
 			builder.WithPredicates(predicate.Or(pernode.CreateModelStatusConfigMapPredicate(), createPVCStatusConfigMapPredicate())),
 		).
 		Watches(
@@ -177,7 +165,6 @@ func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// SetupWithManager sets up the ClusterBaseModel controller with the Manager
 func (r *ClusterBaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.ClusterBaseModel{}).
@@ -185,7 +172,7 @@ func (r *ClusterBaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-				return pernode.MapConfigMapToModelRequests(obj, r.Log, false) // false = cluster-scoped
+				return pernode.MapConfigMapToModelRequests(obj, r.Log, false)
 			}),
 			builder.WithPredicates(predicate.Or(pernode.CreateModelStatusConfigMapPredicate(), createPVCStatusConfigMapPredicate())),
 		).
@@ -206,9 +193,9 @@ func (r *ClusterBaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// createPVCStatusConfigMapPredicate fires on ConfigMaps in the OME namespace
-// carrying the PVC-status label. Lives here (not in pvc/) because it's OR'd
-// with pernode's predicate in the single ConfigMap watch.
+// createPVCStatusConfigMapPredicate fires on ConfigMaps in the OME
+// namespace carrying the PVC-status label. Lives here (not in pvc/)
+// because it's OR'd with pernode's predicate in one watch.
 func createPVCStatusConfigMapPredicate() predicate.Predicate {
 	isPVC := func(obj client.Object) bool {
 		if obj.GetNamespace() != constants.OMENamespace {

--- a/pkg/controller/v1beta1/basemodel/controller_test.go
+++ b/pkg/controller/v1beta1/basemodel/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
-	"sigs.k8s.io/ome/pkg/modelagent"
 )
 
 func TestBaseModelReconcile(t *testing.T) {
@@ -31,6 +30,9 @@ func TestBaseModelReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	// batchv1 needed for cleanupStalePVCArtifacts which lists Jobs on
+	// every non-PVC reconcile (idempotent no-op when none exist; the
+	// List itself still requires the scheme).
 	g.Expect(batchv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 
 	tests := []struct {
@@ -106,9 +108,9 @@ func TestBaseModelReconcile(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Create ConfigMap with Ready status
-				modelEntry := modelagent.ModelEntry{
-					Status: modelagent.ModelStatusReady,
-					Config: &modelagent.ModelConfig{
+				modelEntry := shared.ModelEntry{
+					Status: shared.ModelStatusReady,
+					Config: &shared.ModelConfig{
 						ModelType:         "gpt2",
 						ModelArchitecture: "GPT2LMHeadModel",
 						MaxTokens:         2048,
@@ -190,14 +192,14 @@ func TestBaseModelReconcile(t *testing.T) {
 				}
 
 				// Create ConfigMaps with different statuses
-				statuses := map[string]modelagent.ModelStatus{
-					"node-1": modelagent.ModelStatusReady,
-					"node-2": modelagent.ModelStatusFailed,
-					"node-3": modelagent.ModelStatusUpdating,
+				statuses := map[string]shared.ModelStatus{
+					"node-1": shared.ModelStatusReady,
+					"node-2": shared.ModelStatusFailed,
+					"node-3": shared.ModelStatusUpdating,
 				}
 
 				for nodeName, status := range statuses {
-					modelEntry := modelagent.ModelEntry{
+					modelEntry := shared.ModelEntry{
 						Status: status,
 					}
 					entryData, _ := json.Marshal(modelEntry)
@@ -314,8 +316,8 @@ func TestBaseModelReconcile(t *testing.T) {
 
 				// Create ConfigMaps with entries not yet deleted
 				for _, nodeName := range []string{"node-1", "node-2"} {
-					modelEntry := modelagent.ModelEntry{
-						Status: modelagent.ModelStatusReady, // Not marked for deletion
+					modelEntry := shared.ModelEntry{
+						Status: shared.ModelStatusReady, // Not marked for deletion
 					}
 					entryData, _ := json.Marshal(modelEntry)
 
@@ -388,8 +390,8 @@ func TestBaseModelReconcile(t *testing.T) {
 
 				// Create ConfigMaps with entries marked as deleted
 				for _, nodeName := range []string{"node-1", "node-2"} {
-					modelEntry := modelagent.ModelEntry{
-						Status: modelagent.ModelStatusDeleted, // Marked for deletion
+					modelEntry := shared.ModelEntry{
+						Status: shared.ModelStatusDeleted, // Marked for deletion
 					}
 					entryData, _ := json.Marshal(modelEntry)
 
@@ -461,14 +463,14 @@ func TestBaseModelReconcile(t *testing.T) {
 				}
 
 				// Create ConfigMaps with mixed deletion status
-				statuses := map[string]modelagent.ModelStatus{
-					"node-1": modelagent.ModelStatusDeleted, // Marked for deletion
-					"node-2": modelagent.ModelStatusReady,   // Not deleted
-					"node-3": modelagent.ModelStatusFailed,  // Not deleted
+				statuses := map[string]shared.ModelStatus{
+					"node-1": shared.ModelStatusDeleted, // Marked for deletion
+					"node-2": shared.ModelStatusReady,   // Not deleted
+					"node-3": shared.ModelStatusFailed,  // Not deleted
 				}
 
 				for nodeName, status := range statuses {
-					modelEntry := modelagent.ModelEntry{
+					modelEntry := shared.ModelEntry{
 						Status: status,
 					}
 					entryData, _ := json.Marshal(modelEntry)
@@ -517,8 +519,8 @@ func TestBaseModelReconcile(t *testing.T) {
 			},
 			setupMocks: func(c client.Client) {
 				// Create ConfigMap for non-existent node
-				modelEntry := modelagent.ModelEntry{
-					Status: modelagent.ModelStatusReady,
+				modelEntry := shared.ModelEntry{
+					Status: shared.ModelStatusReady,
 				}
 				entryData, _ := json.Marshal(modelEntry)
 
@@ -598,6 +600,9 @@ func TestClusterBaseModelReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	// batchv1 needed for cleanupStalePVCArtifacts which lists Jobs on
+	// every non-PVC reconcile (idempotent no-op when none exist; the
+	// List itself still requires the scheme).
 	g.Expect(batchv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 
 	tests := []struct {
@@ -665,9 +670,9 @@ func TestClusterBaseModelReconcile(t *testing.T) {
 
 				// Create ConfigMaps - all ready
 				for i := 1; i <= 3; i++ {
-					modelEntry := modelagent.ModelEntry{
-						Status: modelagent.ModelStatusReady,
-						Config: &modelagent.ModelConfig{
+					modelEntry := shared.ModelEntry{
+						Status: shared.ModelStatusReady,
+						Config: &shared.ModelConfig{
 							ModelFramework: map[string]string{
 								"name":    "transformers",
 								"version": "4.21.0",
@@ -757,7 +762,7 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 	tests := []struct {
 		name         string
 		initialSpec  *v1beta1.BaseModelSpec
-		config       *modelagent.ModelConfig
+		config       *shared.ModelConfig
 		expectUpdate bool
 		validateSpec func(*v1beta1.BaseModelSpec)
 	}{
@@ -768,9 +773,10 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 					Name: "", // Empty so it can be updated
 				},
 			},
-			config: &modelagent.ModelConfig{
+			config: &shared.ModelConfig{
 				ModelType:          "llama",
 				ModelArchitecture:  "LlamaForCausalLM",
+				Quantization:       "nvfp4",
 				ModelParameterSize: "7B",
 				ModelCapabilities:  []string{"TEXT_GENERATION", "CHAT"},
 				ModelFramework: map[string]string{
@@ -789,6 +795,8 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 				g.Expect(*spec.ModelType).To(gomega.Equal("llama"))
 				g.Expect(spec.ModelArchitecture).ToNot(gomega.BeNil())
 				g.Expect(*spec.ModelArchitecture).To(gomega.Equal("LlamaForCausalLM"))
+				g.Expect(spec.Quantization).ToNot(gomega.BeNil())
+				g.Expect(*spec.Quantization).To(gomega.Equal(v1beta1.ModelQuantization("nvfp4")))
 				g.Expect(spec.ModelParameterSize).ToNot(gomega.BeNil())
 				g.Expect(*spec.ModelParameterSize).To(gomega.Equal("7B"))
 				g.Expect(spec.ModelCapabilities).To(gomega.Equal([]string{"TEXT_GENERATION", "CHAT"}))
@@ -806,15 +814,17 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 			initialSpec: &v1beta1.BaseModelSpec{
 				ModelType:         stringPtr("existing-type"),
 				ModelArchitecture: stringPtr("existing-arch"),
+				Quantization:      quantPtr("existing-quant"),
 				ModelFormat: v1beta1.ModelFormat{
 					Name:    "existing-format",
 					Version: stringPtr("1.0.0"),
 				},
 				MaxTokens: int32Ptr(2048),
 			},
-			config: &modelagent.ModelConfig{
+			config: &shared.ModelConfig{
 				ModelType:         "new-type",
 				ModelArchitecture: "new-arch",
+				Quantization:      "new-quant",
 				ModelFormat: map[string]string{
 					"name":    "new-format",
 					"version": "2.0.0",
@@ -826,6 +836,7 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 				// Values should remain unchanged
 				g.Expect(*spec.ModelType).To(gomega.Equal("existing-type"))
 				g.Expect(*spec.ModelArchitecture).To(gomega.Equal("existing-arch"))
+				g.Expect(*spec.Quantization).To(gomega.Equal(v1beta1.ModelQuantization("existing-quant")))
 				g.Expect(spec.ModelFormat.Name).To(gomega.Equal("existing-format"))
 				g.Expect(*spec.ModelFormat.Version).To(gomega.Equal("1.0.0"))
 				g.Expect(*spec.MaxTokens).To(gomega.Equal(int32(2048)))
@@ -834,7 +845,7 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 		{
 			name:         "Nil inputs return false",
 			initialSpec:  nil,
-			config:       &modelagent.ModelConfig{},
+			config:       &shared.ModelConfig{},
 			expectUpdate: false,
 		},
 		{
@@ -859,9 +870,12 @@ func TestUpdateSpecWithConfig(t *testing.T) {
 	}
 }
 
-// Helper functions
 func stringPtr(s string) *string {
 	return &s
+}
+
+func quantPtr(q v1beta1.ModelQuantization) *v1beta1.ModelQuantization {
+	return &q
 }
 
 func int32Ptr(i int32) *int32 {

--- a/pkg/controller/v1beta1/basemodel/shared/shared.go
+++ b/pkg/controller/v1beta1/basemodel/shared/shared.go
@@ -1,11 +1,12 @@
 // Package shared holds the Backend interface + cross-cutting helpers
-// (RetryUpdate, ModelSpecAndStatus, UpdateSpecWithConfig). It lives apart
-// from basemodel/ so the backend sub-packages can implement/consume the
-// interface without importing basemodel (which would be an import cycle).
+// (RetryUpdate, ModelSpecAndStatus, UpdateSpecWithConfig). Lives apart
+// from basemodel/ so the backend sub-packages can implement the
+// interface without importing basemodel.
 package shared
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -17,13 +18,136 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
-	"sigs.k8s.io/ome/pkg/modelagent"
+	"sigs.k8s.io/ome/pkg/modelparser"
 )
 
+// ModelStatus represents the status of a model on a node.
+type ModelStatus string
+
+const (
+	ModelStatusReady    ModelStatus = "Ready"
+	ModelStatusUpdating ModelStatus = "Updating"
+	ModelStatusFailed   ModelStatus = "Failed"
+	ModelStatusDeleted  ModelStatus = "Deleted"
+)
+
+// ModelConfig is the structured per-model entry stored in per-node
+// ConfigMaps by the model-agent daemon. The controller reads it back to
+// fill in BaseModelSpec fields the operator left blank.
+type ModelConfig struct {
+	ModelType                 string                 `json:"modelType,omitempty"`
+	ModelArchitecture         string                 `json:"modelArchitecture,omitempty"`
+	ModelFramework            map[string]string      `json:"modelFramework,omitempty"`
+	ModelFormat               map[string]string      `json:"modelFormat,omitempty"`
+	ModelParameterSize        string                 `json:"modelParameterSize,omitempty"`
+	MaxTokens                 int32                  `json:"maxTokens,omitempty"`
+	ModelCapabilities         []string               `json:"modelCapabilities,omitempty"`
+	ApiCapabilities           []string               `json:"apiCapabilities,omitempty"`
+	DecodedModelConfiguration map[string]interface{} `json:"decodedModelConfiguration,omitempty"`
+	Quantization              string                 `json:"quantization,omitempty"`
+	Artifact                  modelparser.Artifact   `json:"artifact,omitempty"`
+}
+
+// DownloadProgress is the in-flight download progress reported by the
+// model-agent daemon for a single model.
+type DownloadProgress struct {
+	Phase            string  `json:"phase"`
+	TotalBytes       uint64  `json:"totalBytes"`
+	CompletedBytes   uint64  `json:"completedBytes"`
+	TotalFiles       uint32  `json:"totalFiles"`
+	CompletedFiles   uint32  `json:"completedFiles"`
+	SpeedBytesPerSec float64 `json:"speedBytesPerSec"`
+	LastUpdated      string  `json:"lastUpdated"`
+}
+
+func (p *DownloadProgress) Percentage() float64 {
+	if p == nil || p.TotalBytes == 0 {
+		return 0
+	}
+	return float64(p.CompletedBytes) / float64(p.TotalBytes) * 100
+}
+
+// ModelEntry is the top-level per-model record in the node ConfigMap.
+type ModelEntry struct {
+	Name     string            `json:"name"`
+	Status   ModelStatus       `json:"status"`
+	Config   *ModelConfig      `json:"config,omitempty"`
+	Progress *DownloadProgress `json:"progress,omitempty"`
+}
+
+// ConvertMetadataToModelConfig converts parser-produced metadata into
+// the on-wire ModelConfig the daemon writes to ConfigMaps.
+func ConvertMetadataToModelConfig(metadata modelparser.ModelMetadata) *ModelConfig {
+	var modelFramework map[string]string
+	if metadata.ModelFramework != nil {
+		modelFramework = map[string]string{"name": metadata.ModelFramework.Name}
+		if metadata.ModelFramework.Version != nil {
+			modelFramework["version"] = *metadata.ModelFramework.Version
+		}
+	}
+
+	var modelFormat map[string]string
+	if metadata.ModelFormat.Name != "" {
+		modelFormat = map[string]string{"name": metadata.ModelFormat.Name}
+		if metadata.ModelFormat.Version != nil {
+			modelFormat["version"] = *metadata.ModelFormat.Version
+		}
+	}
+
+	var quantization string
+	if metadata.Quantization != "" {
+		quantization = string(metadata.Quantization)
+	}
+
+	decodedConfig := metadata.DecodedModelConfiguration
+	if decodedConfig == nil && len(metadata.ModelConfiguration) > 0 {
+		var configMap map[string]interface{}
+		if err := json.Unmarshal(metadata.ModelConfiguration, &configMap); err == nil {
+			decodedConfig = configMap
+		}
+	}
+
+	var artifact modelparser.Artifact
+	if metadata.Artifact.Sha != "" || metadata.Artifact.ParentPath != nil || metadata.Artifact.ChildrenPaths != nil {
+		currentArtifact := metadata.Artifact
+		var parent map[string]string
+		if currentArtifact.ParentPath != nil {
+			parent = make(map[string]string, len(currentArtifact.ParentPath))
+			for k, v := range currentArtifact.ParentPath {
+				parent[k] = v
+			}
+		}
+		var children []string
+		if currentArtifact.ChildrenPaths != nil {
+			children = make([]string, len(currentArtifact.ChildrenPaths))
+			copy(children, currentArtifact.ChildrenPaths)
+		}
+		artifact = modelparser.Artifact{
+			Sha:           currentArtifact.Sha,
+			ParentPath:    parent,
+			ChildrenPaths: children,
+		}
+	}
+
+	return &ModelConfig{
+		ModelType:                 metadata.ModelType,
+		ModelArchitecture:         metadata.ModelArchitecture,
+		ModelFramework:            modelFramework,
+		ModelFormat:               modelFormat,
+		ModelParameterSize:        metadata.ModelParameterSize,
+		MaxTokens:                 metadata.MaxTokens,
+		ModelCapabilities:         metadata.ModelCapabilities,
+		ApiCapabilities:           metadata.ApiCapabilities,
+		DecodedModelConfiguration: decodedConfig,
+		Quantization:              quantization,
+		Artifact:                  artifact,
+	}
+}
+
 // Backend is one of OME's BaseModel distribution backends. The
-// controller dispatches Reconcile / HandleDeletion to the first backend
-// whose Matches(spec) returns true; per-node is the default fallback and
-// must be registered last.
+// controller dispatches Reconcile / HandleDeletion to the first
+// backend whose Matches(spec) returns true; per-node is the default
+// fallback and must be registered last.
 type Backend interface {
 	Name() string
 	Matches(spec *v1beta1.BaseModelSpec) bool
@@ -31,9 +155,9 @@ type Backend interface {
 	HandleDeletion(ctx context.Context, args BackendArgs) (ctrl.Result, error)
 }
 
-// BackendArgs bundles per-reconcile state. Construction-time deps come in
-// through backend constructors instead, so this stays free of
-// backend-specific imports.
+// BackendArgs bundles per-reconcile state. Construction-time deps
+// (ModelCache, OmeAgentConfig) come in through backend constructors
+// instead, so this stays free of backend-specific imports.
 type BackendArgs struct {
 	Client          client.Client
 	Scheme          *runtime.Scheme
@@ -46,8 +170,6 @@ type BackendArgs struct {
 	Kind            string
 }
 
-// ModelSpecAndStatus returns pointers to the embedded spec and status of
-// either a BaseModel or ClusterBaseModel.
 func ModelSpecAndStatus(obj client.Object) (*v1beta1.BaseModelSpec, *v1beta1.ModelStatusSpec, error) {
 	switch model := obj.(type) {
 	case *v1beta1.BaseModel:
@@ -59,10 +181,6 @@ func ModelSpecAndStatus(obj client.Object) (*v1beta1.BaseModelSpec, *v1beta1.Mod
 	}
 }
 
-// StampObservedReconcile records that the controller has observed the
-// object's current generation and stamps the reconcile wall-clock time.
-// A no-op-safe helper the condition-writing backends call on every status
-// write so ObservedGeneration/LastReconcileTime stay fresh.
 func StampObservedReconcile(obj client.Object, status *v1beta1.ModelStatusSpec) {
 	if status == nil {
 		return
@@ -81,16 +199,13 @@ func RetryUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger,
 	const maxRetries = 3
 
 	for i := 0; i < maxRetries; i++ {
-		// Get the latest version
 		latest := obj.DeepCopyObject().(client.Object)
 		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(obj), latest); err != nil {
 			return fmt.Errorf("failed to get latest object version: %w", err)
 		}
 
-		// Execute the update function
 		if err := updateFunc(ctx, kubeClient, latest); err != nil {
 			if errors.IsConflict(err) && i < maxRetries-1 {
-				// Exponential backoff: wait 100ms, 200ms, 400ms
 				backoff := time.Millisecond * time.Duration(100<<uint(i))
 				log.V(1).Info("Resource conflict during update, retrying with backoff",
 					"updateType", updateType, "retry", i+1, "backoff", backoff, "object", client.ObjectKeyFromObject(obj))
@@ -107,45 +222,46 @@ func RetryUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger,
 	return fmt.Errorf("failed to update %s after %d retries", updateType, maxRetries)
 }
 
-// UpdateSpecWithConfig applies fields from config onto spec when spec is
-// empty for that field. Fill-only — never overwrites operator-set values.
-// Returns true iff anything changed.
-func UpdateSpecWithConfig(spec *v1beta1.BaseModelSpec, config *modelagent.ModelConfig) bool {
+// UpdateSpecWithConfig applies fields from config onto spec when spec
+// is empty for that field. Fill-only — never overwrites operator-set
+// values. Returns true iff anything changed.
+func UpdateSpecWithConfig(spec *v1beta1.BaseModelSpec, config *ModelConfig) bool {
 	if spec == nil || config == nil {
 		return false
 	}
 
 	updated := false
 
-	// Update ModelType if not set
 	if spec.ModelType == nil && config.ModelType != "" {
 		modelType := config.ModelType
 		spec.ModelType = &modelType
 		updated = true
 	}
 
-	// Update ModelArchitecture if not set
 	if spec.ModelArchitecture == nil && config.ModelArchitecture != "" {
 		architecture := config.ModelArchitecture
 		spec.ModelArchitecture = &architecture
 		updated = true
 	}
 
-	// Update ModelParameterSize if not set
+	if spec.Quantization == nil && config.Quantization != "" {
+		quant := v1beta1.ModelQuantization(config.Quantization)
+		spec.Quantization = &quant
+		updated = true
+	}
+
 	if spec.ModelParameterSize == nil && config.ModelParameterSize != "" {
 		paramSize := config.ModelParameterSize
 		spec.ModelParameterSize = &paramSize
 		updated = true
 	}
 
-	// Update capabilities if not set
 	if len(spec.ModelCapabilities) == 0 && len(config.ModelCapabilities) > 0 {
 		spec.ModelCapabilities = make([]string, len(config.ModelCapabilities))
 		copy(spec.ModelCapabilities, config.ModelCapabilities)
 		updated = true
 	}
 
-	// Update framework if not set
 	if spec.ModelFramework == nil && config.ModelFramework != nil {
 		name := config.ModelFramework["name"]
 		version := config.ModelFramework["version"]
@@ -159,7 +275,6 @@ func UpdateSpecWithConfig(spec *v1beta1.BaseModelSpec, config *modelagent.ModelC
 		}
 	}
 
-	// Update model format if not set
 	if config.ModelFormat != nil {
 		name := config.ModelFormat["name"]
 		version := config.ModelFormat["version"]
@@ -176,7 +291,6 @@ func UpdateSpecWithConfig(spec *v1beta1.BaseModelSpec, config *modelagent.ModelC
 		}
 	}
 
-	// Update MaxTokens if not set and valid
 	if spec.MaxTokens == nil && config.MaxTokens > 0 {
 		spec.MaxTokens = &config.MaxTokens
 		updated = true

--- a/pkg/controller/v1beta1/controllerconfig/configmap.go
+++ b/pkg/controller/v1beta1/controllerconfig/configmap.go
@@ -1,36 +1,54 @@
 package controllerconfig
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
+	"sync"
 	"text/template"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 
-	"strings"
+	"golang.org/x/sync/singleflight"
 
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/ome/pkg/constants"
+	workloadtypes "sigs.k8s.io/ome/pkg/controller/v1beta1/workload/types"
+	omevalidation "sigs.k8s.io/ome/pkg/validation"
 )
 
 const (
-	IngressConfigKeyName   = "ingress"
-	DeployConfigName       = "deploy"
-	BenchmarkJobConfigName = "benchmarkjob"
-	OmeAgentConfigName     = "omeAgent"
+	IngressConfigKeyName          = "ingress"
+	DeployConfigName              = "deploy"
+	OmeAgentConfigName            = "omeAgent"
+	CanaryAnalysisConfigName      = "canaryAnalysis"
+	CoordinationConfigName        = "coordination"
+	PodMonitorConfigName          = "podMonitor"
+	LifecycleConfigName           = "lifecycle"
+	PodDisruptionBudgetConfigName = "podDisruptionBudget"
 
 	DefaultDomainTemplate = "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"
 	DefaultIngressDomain  = "example.com"
 
 	DefaultUrlScheme = "http"
+
+	// Operational fallbacks for the canary metric-analysis sampler, applied by the
+	// loader only when the ConfigMap omits them (the chart sets the real values).
+	// These tune the sampler, not deployment identity, so an in-loader fallback is
+	// appropriate (mirroring DefaultDomainTemplate); the source address has no such
+	// fallback (see CanaryAnalysisConfig.BundledPrometheusAddress).
+	DefaultAnalysisQueryTimeout   = "5s"
+	DefaultAnalysisCacheTTL       = "2m"
+	DefaultAnalysisMaxConcurrency = 8
 )
 
-// DefaultConsistentHashHeaders is the fallback request-header list used as the
-// consistent-hash key for generated backend traffic policies when the ingress
-// config does not set consistentHashHeaders.
 var DefaultConsistentHashHeaders = []string{"x-routing-key"}
 
 type SecretConfig struct {
@@ -39,41 +57,85 @@ type SecretConfig struct {
 	SecretName             string `json:"secretName"`
 }
 
-type BenchmarkJobConfig struct {
-	// PodConfig contains all Pod Configuration
-	PodConfig PodConfig `json:"podConfig"`
-}
-
-type PodConfig struct {
-	Image         string `json:"image"`
-	CPURequest    string `json:"cpuRequest"`
-	MemoryRequest string `json:"memoryRequest"`
-	CPULimit      string `json:"cpuLimit"`
-	MemoryLimit   string `json:"memoryLimit"`
-}
-
 // +kubebuilder:object:generate=false
 type InferenceServicesConfig struct {
+	// PodMonitor carries cluster-scope defaults applied to every generated
+	// PodMonitor (metadata labels + endpoint relabelings). Loaded from the
+	// "podMonitor" key of the inferenceservice-config ConfigMap.
+	PodMonitor PodMonitorConfig `json:"podMonitor,omitempty"`
+	// PodDisruptionBudget carries per-deployment-mode disruption budget policy.
+	PodDisruptionBudget PodDisruptionBudgetConfig `json:"podDisruptionBudget,omitempty"`
+}
+
+// PodDisruptionBudgetPolicy configures one deployment mode's availability
+// budget. A configured policy requires exactly one field to be set.
+type PodDisruptionBudgetPolicy struct {
+	MinAvailable   *intstr.IntOrString `json:"minAvailable,omitempty"`
+	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
+}
+
+// PodDisruptionBudgetConfig contains optional disruption budget policies for
+// deployment modes that generate PodDisruptionBudgets.
+type PodDisruptionBudgetConfig struct {
+	RawDeployment *PodDisruptionBudgetPolicy `json:"rawDeployment,omitempty"`
+	OMENative     *PodDisruptionBudgetPolicy `json:"omeNative,omitempty"`
+}
+
+// PodMonitorConfig configures the PodMonitor objects OME generates for each
+// InferenceService Component. Both fields have NO in-code default — they are
+// supplied via the inferenceservice-config ConfigMap (Helm chart / GitOps), so
+// scrape-pipeline-specific values are never hardcoded magic strings.
+//
+// +kubebuilder:object:generate=false
+type PodMonitorConfig struct {
+	// Labels are merged into each generated PodMonitor's metadata.labels (NOT
+	// its spec.selector, which continues to select pods by the component's own
+	// labels). Use this to opt the PodMonitor into an external scrape pipeline
+	// that selects monitors by label — e.g. an OpenTelemetry target
+	// allocator whose podMonitorSelector is {scrape.example.com/tier: cluster}.
+	// Empty leaves the PodMonitor with only OME's own labels, in which case a
+	// label-selecting collector will not scrape it.
+	Labels map[string]string `json:"labels,omitempty"`
+	// Relabelings are appended to every PodMetricsEndpoint of every generated
+	// PodMonitor. They map Kubernetes service-discovery meta labels onto the
+	// stable metric labels dashboards key on (e.g.
+	// __meta_kubernetes_pod_label_ome_io_inferenceservice -> inferenceservice),
+	// so PodMonitor-scraped series carry the same label schema as the legacy
+	// pod-annotation ("kubernetes-pods") scrape path. Empty means OME adds no
+	// relabelings and the collector's own defaults apply.
+	Relabelings []RelabelConfig `json:"relabelings,omitempty"`
+	// MetricRelabelings are appended to every PodMetricsEndpoint's
+	// metricRelabelings (Prometheus metric_relabel_configs, applied AFTER the
+	// scrape on each sample). Unlike Relabelings — which run before the scrape on
+	// the target's label set and cannot see a sample's __name__ — these can
+	// rewrite the metric name itself. Use this to normalize engine metric names,
+	// e.g. a router that re-exports vLLM metrics under underscore names (vllm_*)
+	// back to the colon form (vllm:*) that dashboards query. Empty means OME adds
+	// no metric relabelings. Safe cluster-wide when the regex is scoped (e.g.
+	// "vllm_(.+)"): it no-ops on series that don't match.
+	MetricRelabelings []RelabelConfig `json:"metricRelabelings,omitempty"`
+}
+
+// RelabelConfig is a JSON-friendly subset of the Prometheus-operator
+// monitoringv1.RelabelConfig. It is converted to the operator type by the
+// podmonitor reconciler. Only the fields OME needs are exposed; extend as
+// required.
+//
+// +kubebuilder:object:generate=false
+type RelabelConfig struct {
+	SourceLabels []string `json:"sourceLabels,omitempty"`
+	Separator    string   `json:"separator,omitempty"`
+	TargetLabel  string   `json:"targetLabel,omitempty"`
+	Regex        string   `json:"regex,omitempty"`
+	Replacement  string   `json:"replacement,omitempty"`
+	Action       string   `json:"action,omitempty"`
 }
 
 // +kubebuilder:object:generate=false
 type IngressConfig struct {
-	// Deprecated: IngressGateway and IngressServiceName are no longer consumed by any
-	// ingress strategy (they were only used by the removed Serverless/Istio VirtualService
-	// path). They are retained, still shipped in the config map, and no longer required,
-	// so that a controller image that predates the Serverless removal keeps starting
-	// against a newer config map.
-	//
-	// TODO: remove these two fields once no controller image that requires them is still
-	// running. Removing them is a breaking change for that image, which validates both at
-	// startup and exits if either is empty. Delete together with the "ingressGateway" and
-	// "ingressService" keys in config/configmap/inferenceservice.yaml and
-	// charts/ome-resources/templates/ome-controller/configmap.yaml, and the gateway /
-	// gatewayService values in charts/ome-resources/values.yaml.
 	IngressGateway     string `json:"ingressGateway,omitempty"`
 	IngressServiceName string `json:"ingressService,omitempty"`
-
-	OmeIngressGateway string `json:"omeIngressGateway,omitempty"`
+	OmeIngressGateway  string `json:"omeIngressGateway,omitempty"`
 	// OmeIngressGatewayClass labels the primary (OmeIngressGateway) gateway's
 	// endpoints in status ("internal", "external", ...) — the analogue of
 	// IngressGatewaySpec.Class for the cluster-default primary gateway. Free-form;
@@ -87,8 +149,8 @@ type IngressConfig struct {
 	AdditionalIngressDomains *[]string `json:"additionalIngressDomains,omitempty"`
 	DomainTemplate           string    `json:"domainTemplate,omitempty"`
 	UrlScheme                string    `json:"urlScheme,omitempty"`
-	DisableIstioVirtualHost  bool      `json:"disableIstioVirtualHost,omitempty"`
 	PathTemplate             string    `json:"pathTemplate,omitempty"`
+	DisableIstioVirtualHost  bool      `json:"disableIstioVirtualHost,omitempty"`
 	DisableIngressCreation   bool      `json:"disableIngressCreation,omitempty"`
 	EnableGatewayAPI         bool      `json:"enableGatewayAPI,omitempty"`
 	ConsistentHashHeaders    []string  `json:"consistentHashHeaders,omitempty"`
@@ -124,9 +186,9 @@ type IngressConfig struct {
 	// gateway (OmeIngressGateway/IngressDomain) and AdditionalIngressGateways for
 	// ISVCs in that namespace. Namespaces absent from the map fall back to the
 	// cluster defaults. This lets one OME controller serve per-namespace Gateways
-	// (each with its own TLS cert and DNS) while the route hostname is unchanged —
-	// it is still rendered from DomainTemplate, which already embeds the
-	// namespace ("<isvc>.<namespace>.<domain>").
+	// (each with its own TLS cert and DNS, e.g. "prod-int-gw-https" for the "prod"
+	// namespace) while the route hostname is unchanged — it is still rendered from
+	// DomainTemplate, which already embeds the namespace ("<isvc>.<namespace>.<domain>").
 	// A per-ISVC "ome.io/ingress-gateway" (or "ome.io/ingress-additional-gateways")
 	// annotation still takes precedence over this namespace default.
 	NamespaceIngressGateways map[string]NamespaceIngressGateway `json:"namespaceIngressGateways,omitempty"`
@@ -168,20 +230,544 @@ type NamespaceIngressGateway struct {
 // +kubebuilder:object:generate=false
 type DeployConfig struct {
 	DefaultDeploymentMode string `json:"defaultDeploymentMode,omitempty"`
+	// Replicas carries the admission-time component replica defaults the
+	// ISVC defaulter stamps on unset minReplicas/maxReplicas fields. There
+	// are intentionally NO in-code defaults — the values are supplied via
+	// the inferenceservice-config ConfigMap (Helm chart / GitOps). Absent
+	// (nil block or nil field) means unconfigured: the defaulter leaves the
+	// corresponding field as authored, never a silent fallback to baked-in
+	// numbers. Configured values must be > 0 (rejected at config-load).
+	Replicas *ReplicasDefaultsConfig `json:"replicas,omitempty"`
 }
 
-// OmeAgentConfig configures the metadata-extraction Job the BaseModel
-// controller spawns for PVC-backed models. Unlike the model-agent
-// DaemonSet (whose image is Helm-only), the controller creates this Job in
-// Go and therefore needs the agent image + Job settings at runtime.
+// ReplicasDefaultsConfig is the admission-time replica-defaulting policy
+// loaded from the "deploy.replicas" block of the inferenceservice-config
+// ConfigMap. Every field is optional; a nil field disables defaulting of
+// that value only.
+//
 // +kubebuilder:object:generate=false
+type ReplicasDefaultsConfig struct {
+	// DefaultMinReplicas fills an unset component minReplicas (all
+	// components share one floor default).
+	DefaultMinReplicas *int `json:"defaultMinReplicas,omitempty"`
+	// DefaultMaxReplicas fills an unset component maxReplicas, per
+	// component. The defaulter raises the filled value to an authored
+	// minReplicas so it never manufactures a min>max conflict.
+	DefaultMaxReplicas ComponentMaxReplicasDefaults `json:"defaultMaxReplicas,omitempty"`
+}
+
+// ComponentMaxReplicasDefaults holds the per-component maxReplicas defaults.
+//
+// +kubebuilder:object:generate=false
+type ComponentMaxReplicasDefaults struct {
+	Engine  *int `json:"engine,omitempty"`
+	Decoder *int `json:"decoder,omitempty"`
+	Router  *int `json:"router,omitempty"`
+}
+
+// Min returns the configured minReplicas default; nil (including a nil
+// receiver) means unconfigured — the defaulter leaves the field as authored.
+func (c *ReplicasDefaultsConfig) Min() *int {
+	if c == nil {
+		return nil
+	}
+	return c.DefaultMinReplicas
+}
+
+// EngineMax returns the configured engine maxReplicas default; nil
+// (including a nil receiver) means unconfigured.
+func (c *ReplicasDefaultsConfig) EngineMax() *int {
+	if c == nil {
+		return nil
+	}
+	return c.DefaultMaxReplicas.Engine
+}
+
+// DecoderMax returns the configured decoder maxReplicas default; nil
+// (including a nil receiver) means unconfigured.
+func (c *ReplicasDefaultsConfig) DecoderMax() *int {
+	if c == nil {
+		return nil
+	}
+	return c.DefaultMaxReplicas.Decoder
+}
+
+// RouterMax returns the configured router maxReplicas default; nil
+// (including a nil receiver) means unconfigured.
+func (c *ReplicasDefaultsConfig) RouterMax() *int {
+	if c == nil {
+		return nil
+	}
+	return c.DefaultMaxReplicas.Router
+}
+
+// validate rejects non-positive configured values. A replica default of
+// zero or below can never be a sane admission stamp, so it is a config
+// error surfaced at load time rather than a bad object stored later.
+func (c *ReplicasDefaultsConfig) validate() error {
+	fields := []struct {
+		name  string
+		value *int
+	}{
+		{"defaultMinReplicas", c.DefaultMinReplicas},
+		{"defaultMaxReplicas.engine", c.DefaultMaxReplicas.Engine},
+		{"defaultMaxReplicas.decoder", c.DefaultMaxReplicas.Decoder},
+		{"defaultMaxReplicas.router", c.DefaultMaxReplicas.Router},
+	}
+	for _, f := range fields {
+		if f.value != nil && *f.value <= 0 {
+			return fmt.Errorf("invalid deploy config, replicas.%s must be > 0, got %d", f.name, *f.value)
+		}
+	}
+	return nil
+}
+
+// +kubebuilder:object:generate=false
+// CanaryAnalysisConfig holds operator-level defaults for metric-gated canary
+// promotion: the default Prometheus source and the sampler's tuning. A per-CR
+// spec.rollout.canary.prometheus.serverAddress overrides BundledPrometheusAddress.
+type CanaryAnalysisConfig struct {
+	// BundledPrometheusAddress is the metrics source queried when a canary does not
+	// set its own spec.rollout.canary.prometheus.serverAddress. There is
+	// intentionally NO in-code default — the value is supplied via the
+	// inferenceservice-config ConfigMap (set by the Helm chart / GitOps), so the
+	// address is never a hardcoded magic string. Empty means a canary with no
+	// per-CR source has no source, and its samples read as inconclusive — it does
+	// not silently fall back to a baked-in address.
+	BundledPrometheusAddress string `json:"bundledPrometheusAddress,omitempty"`
+	// QueryTimeout bounds one sampling pass (all of a step's metric queries). A
+	// duration string (e.g. "5s"); the loader falls back to DefaultAnalysisQueryTimeout.
+	QueryTimeout string `json:"queryTimeout,omitempty"`
+	// MaxConcurrency caps how many analysis queries run in the background at once,
+	// across all canaries. It is a fleet-wide ceiling: with many concurrent canaries
+	// queries queue behind it and the effective sample interval degrades (watch the
+	// ome_canary_sampler_queue_depth / _starved_total metrics), so scale this with
+	// fleet size. The loader falls back to DefaultAnalysisMaxConcurrency.
+	MaxConcurrency int32 `json:"maxConcurrency,omitempty"`
+	// CacheTTL is how long a sampled result stays usable before the sampler evicts
+	// it. A duration string; the loader falls back to DefaultAnalysisCacheTTL.
+	CacheTTL string `json:"cacheTTL,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+// CoordinationConfig holds operator-level tuning for the OMENative cross-Component
+// coordination layer (the pod-proportional per-revision traffic producer).
+type CoordinationConfig struct {
+	// TrafficWeightDeadbandPercent is the per-revision hysteresis band applied to
+	// the pod-proportional traffic writer: a recomputed weight set whose every
+	// per-revision percent moves by strictly less than this from what is already in
+	// Status.Components.<c>.Traffic is treated as pod-count jitter and the status
+	// write (plus the HTTPRoute re-enqueue it triggers) is suppressed. Dampens the
+	// continuous churn from pods momentarily Pending between reconciles at scale.
+	//
+	// There is intentionally NO in-code default — the value is supplied via the
+	// inferenceservice-config ConfigMap (set by the Helm chart / GitOps). Zero
+	// (absent config) disables the band and preserves the exact prior
+	// write-on-any-diff behavior, so eventual correctness is never traded away
+	// silently.
+	TrafficWeightDeadbandPercent int32 `json:"trafficWeightDeadbandPercent,omitempty"`
+
+	// DefaultRatioTolerancePercent fills spec.rollout.groups[].maintainRatio
+	// .tolerance when a group sets maintainRatio but omits the tolerance. An
+	// explicit per-group tolerance (including 0) always wins. There is
+	// intentionally NO in-code default — the value is supplied via the
+	// inferenceservice-config ConfigMap (set by the Helm chart / GitOps).
+	// Nil (absent config) means unconfigured: a group that omits tolerance
+	// then rolls with no drift bound, never a silently baked-in number.
+	DefaultRatioTolerancePercent *int32 `json:"defaultRatioTolerancePercent,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+// LifecycleConfig holds operator-level tuning for the OMENative per-Instance
+// lifecycle state machine, loaded from the "lifecycle" key of the
+// inferenceservice-config ConfigMap.
+type LifecycleConfig struct {
+	// UpdateRetry bounds automatic same-target update retries (RetryBlock).
+	// There are intentionally NO in-code defaults — the values are supplied
+	// via the inferenceservice-config ConfigMap (Helm chart / GitOps). Absent
+	// means unconfigured: the workload layer fails safe (the first same-target
+	// failure Holds), never a silent fallback to baked-in numbers.
+	UpdateRetry *UpdateRetryConfig `json:"updateRetry,omitempty"`
+	// StuckPodGracePeriod is the wait window after pod creation before a
+	// terminal kubelet waiting state escalates to Phase=Failed. A duration
+	// string ("60s"); absence or parse failure disables fast escalation
+	// this pass (the InstanceReadyTimeout backstop remains).
+	StuckPodGracePeriod string `json:"stuckPodGracePeriod,omitempty"`
+	// AutoMigrate configures the deadline-disposition relocation budget.
+	// Absence disables the relocation branch.
+	AutoMigrate *AutoMigrateConfig `json:"autoMigrate,omitempty"`
+	// ForceDelete configures the stuck-Terminating force-delete
+	// escalation. Absence means the escalation does not exist — there
+	// are intentionally NO in-code defaults.
+	ForceDelete *ForceDeleteConfig `json:"forceDelete,omitempty"`
+	// Teardown configures the finalizer-gated IR teardown deadline.
+	// Absence means the finalizer holds strictly until clean (NO
+	// deadline, the fully supported default). When present, Deadline is
+	// REQUIRED and bounds how long the finalizer holds.
+	Teardown *TeardownConfig `json:"teardown,omitempty"`
+	// ScaleUpPodBatchSize bounds missing-Pod create selection in Pod units.
+	// An Instance (including a leader/worker gang) remains indivisible: all of
+	// its missing Pods are selected together and its durable Creating intent is
+	// committed before any corresponding Pod create is issued. The first
+	// eligible Instance may exceed a positive budget and proceeds alone. Nil
+	// preserves this field's unbounded compatibility behavior.
+	ScaleUpPodBatchSize *int32 `json:"scaleUpPodBatchSize,omitempty"`
+	// ScaleDownPodBatchSize bounds active delete selection in Pod-equivalent
+	// units: its live and Terminating Pods, with a cost-1 floor for Podless
+	// status work. An Instance (including a leader/worker gang) remains
+	// indivisible. The first eligible Instance may exceed a positive budget and
+	// proceeds alone. Nil preserves this field's unbounded compatibility behavior.
+	ScaleDownPodBatchSize *int32 `json:"scaleDownPodBatchSize,omitempty"`
+	// ScaleDownRequeueInterval is the periodic wake-up cadence while destructive
+	// work remains in flight. The controller also watches Pods, EndpointSlices,
+	// PodGroups, and its owner. Absence disables only cadence polling; configured
+	// force-delete and teardown deadlines still schedule their exact wake-ups.
+	// There is intentionally no in-code default.
+	ScaleDownRequeueInterval *string `json:"scaleDownRequeueInterval,omitempty"`
+	// RevisionHistoryLimit is the operator-level cap on non-live
+	// ControllerRevisions retained per InferenceReplica when the parent
+	// InferenceService does not set the ome.io/revision-history-limit
+	// annotation. Live revisions are never deleted regardless of the cap.
+	// There is intentionally NO in-code default — the value is supplied via
+	// the inferenceservice-config ConfigMap (Helm chart / GitOps). Absent
+	// means unconfigured: without a per-ISVC annotation the retention sweep
+	// prunes nothing, never a silent fallback to a baked-in number.
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+}
+
+// PodBatchSizes contains the process-scoped OMENative scale settings loaded
+// from one lifecycle ConfigMap snapshot. Nil batch fields preserve that
+// direction's unbounded compatibility behavior; a zero requeue interval leaves
+// progress to watched resources and exact configured lifecycle deadlines.
+//
+// +kubebuilder:object:generate=false
+type PodBatchSizes struct {
+	ScaleUp                  *int32
+	ScaleDown                *int32
+	ScaleDownRequeueInterval time.Duration
+}
+
+// UpdateRetryConfig is the same-target update retry policy: a failed rollout
+// toward an unchanged target revision backs off exponentially
+// (initialDelay * multiplier^(attempt-1), capped at maxDelay) and Holds after
+// maxAttempts. Delays are duration strings ("1m", "30m").
+//
+// +kubebuilder:object:generate=false
+type UpdateRetryConfig struct {
+	MaxAttempts  int32   `json:"maxAttempts"`
+	InitialDelay string  `json:"initialDelay"`
+	MaxDelay     string  `json:"maxDelay"`
+	Multiplier   float64 `json:"multiplier"`
+}
+
+// AutoMigrateConfig configures the deadline-disposition relocation budget.
+//
+// +kubebuilder:object:generate=false
+type AutoMigrateConfig struct {
+	// MaxAttempts bounds the number of relocation attempts for one expired
+	// Instance before the disposition falls through to terminal failure.
+	MaxAttempts int32 `json:"maxAttempts"`
+}
+
+// ForceDeleteConfig configures the stuck-Terminating force-delete
+// escalation. Both fields are duration strings ("2m", "5m") and are
+// REQUIRED when the block is present — there are no in-code defaults.
+//
+// +kubebuilder:object:generate=false
+type ForceDeleteConfig struct {
+	// OverdueSlack is how long past a Terminating pod's own
+	// deletionTimestamp (request time + the pod's own grace period) the
+	// pod must be before it counts as wedged.
+	OverdueSlack string `json:"overdueSlack"`
+	// NodeUnreachableThreshold is the minimum age of the node's
+	// unreachable evidence (taint TimeAdded / NotReady
+	// LastTransitionTime, or the Node object gone) before the
+	// escalation may act.
+	NodeUnreachableThreshold string `json:"nodeUnreachableThreshold"`
+}
+
+// TeardownConfig configures the finalizer-gated IR teardown deadline.
+// The Deadline field is a duration string ("30m") and is REQUIRED when
+// the block is present — there is no in-code default.
+//
+// +kubebuilder:object:generate=false
+type TeardownConfig struct {
+	// Deadline bounds how long a deleting InferenceReplica may hold its
+	// finalizer while draining pods. Past it, the finalizer warns and
+	// lifts (degrading to plain GC). Absence (of the entire block) is
+	// the fully supported default: the finalizer holds strictly until
+	// clean, NO deadline.
+	Deadline string `json:"deadline"`
+}
+
+// ToDeadline validates the config and converts Deadline to a
+// *time.Duration. A nil receiver (absent block) yields (nil, nil) —
+// unconfigured, no deadline, the finalizer holds strictly until clean
+// (fully supported). Empty, unparsable, or non-positive Deadline is an
+// error; callers treat invalid config as unconfigured (no deadline).
+func (c *TeardownConfig) ToDeadline() (*time.Duration, error) {
+	if c == nil {
+		return nil, nil
+	}
+	if c.Deadline == "" {
+		return nil, fmt.Errorf("invalid lifecycle.teardown: deadline is required when the block is present")
+	}
+	d, err := time.ParseDuration(c.Deadline)
+	if err != nil {
+		return nil, fmt.Errorf("invalid lifecycle.teardown: deadline %q: %w", c.Deadline, err)
+	}
+	if d <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.teardown: deadline must be > 0, got %s", d)
+	}
+	return &d, nil
+}
+
+// ToPolicy validates the config and converts it to the workload-side
+// ForceDeletePolicy. A nil receiver (absent block) yields (nil, nil) —
+// unconfigured, the escalation is disabled. Any violation — either
+// field missing, unparsable, or non-positive — is an error; callers
+// treat an invalid policy as unconfigured (escalation OFF), never patch
+// it up with fallback numbers.
+func (c *ForceDeleteConfig) ToPolicy() (*workloadtypes.ForceDeletePolicy, error) {
+	if c == nil {
+		return nil, nil
+	}
+	overdue, err := time.ParseDuration(c.OverdueSlack)
+	if err != nil {
+		return nil, fmt.Errorf("invalid lifecycle.forceDelete: overdueSlack %q: %w", c.OverdueSlack, err)
+	}
+	if overdue <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.forceDelete: overdueSlack must be > 0, got %s", overdue)
+	}
+	threshold, err := time.ParseDuration(c.NodeUnreachableThreshold)
+	if err != nil {
+		return nil, fmt.Errorf("invalid lifecycle.forceDelete: nodeUnreachableThreshold %q: %w", c.NodeUnreachableThreshold, err)
+	}
+	if threshold <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.forceDelete: nodeUnreachableThreshold must be > 0, got %s", threshold)
+	}
+	return &workloadtypes.ForceDeletePolicy{
+		OverdueSlack:             overdue,
+		NodeUnreachableThreshold: threshold,
+	}, nil
+}
+
+// ToPolicy validates the config and converts it to the workload-side
+// RetryPolicy. Any violation is an error — callers treat an invalid policy
+// as unconfigured (fail-safe Held), never patch it up with fallback numbers.
+func (c *UpdateRetryConfig) ToPolicy() (*workloadtypes.RetryPolicy, error) {
+	if c.MaxAttempts <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: maxAttempts must be > 0, got %d", c.MaxAttempts)
+	}
+	if c.Multiplier < 1 {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: multiplier must be >= 1, got %v", c.Multiplier)
+	}
+	initial, err := time.ParseDuration(c.InitialDelay)
+	if err != nil {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: initialDelay %q: %w", c.InitialDelay, err)
+	}
+	maxDelay, err := time.ParseDuration(c.MaxDelay)
+	if err != nil {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: maxDelay %q: %w", c.MaxDelay, err)
+	}
+	if initial <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: initialDelay must be > 0, got %s", initial)
+	}
+	if maxDelay <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: maxDelay must be > 0, got %s", maxDelay)
+	}
+	if maxDelay < initial {
+		return nil, fmt.Errorf("invalid lifecycle.updateRetry: maxDelay %s must be >= initialDelay %s", maxDelay, initial)
+	}
+	return &workloadtypes.RetryPolicy{
+		MaxAttempts:  c.MaxAttempts,
+		InitialDelay: initial,
+		MaxDelay:     maxDelay,
+		Multiplier:   c.Multiplier,
+	}, nil
+}
+
+// ToGracePeriod validates and parses StuckPodGracePeriod. Returns an
+// error when the value is malformed or non-positive; absence (empty
+// string) is NOT an error (the caller distinguishes unconfigured from
+// invalid via the returned zero value).
+func (c *LifecycleConfig) ToGracePeriod() (time.Duration, error) {
+	if c.StuckPodGracePeriod == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(c.StuckPodGracePeriod)
+	if err != nil {
+		return 0, fmt.Errorf("invalid lifecycle.stuckPodGracePeriod %q: %w", c.StuckPodGracePeriod, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid lifecycle.stuckPodGracePeriod: must be > 0, got %s", d)
+	}
+	return d, nil
+}
+
+// Validate checks AutoMigrateConfig constraints.
+func (c *AutoMigrateConfig) Validate() error {
+	if c.MaxAttempts <= 0 {
+		return fmt.Errorf("invalid lifecycle.autoMigrate: maxAttempts must be > 0, got %d", c.MaxAttempts)
+	}
+	return nil
+}
+
+// ToScaleUpPodBatchSize validates the configured missing-Pod batch size. A nil
+// LifecycleConfig or absent field means only this field uses its unbounded
+// compatibility behavior; it does not fabricate a default. Explicit zero or
+// negative values are invalid so manager startup can reject bad configuration.
+func (c *LifecycleConfig) ToScaleUpPodBatchSize() (*int32, error) {
+	if c == nil {
+		return nil, nil
+	}
+	return positivePodBatchSize("scaleUpPodBatchSize", c.ScaleUpPodBatchSize)
+}
+
+// ToScaleDownPodBatchSize validates the configured delete Pod-equivalent batch
+// size. A nil LifecycleConfig or absent field preserves unbounded candidate
+// selection. Explicit zero or negative values are invalid so manager startup
+// can reject bad configuration.
+func (c *LifecycleConfig) ToScaleDownPodBatchSize() (*int32, error) {
+	if c == nil {
+		return nil, nil
+	}
+	return positivePodBatchSize("scaleDownPodBatchSize", c.ScaleDownPodBatchSize)
+}
+
+// ToScaleDownRequeueInterval validates the configured destructive-work polling
+// cadence. A nil LifecycleConfig or absent field disables periodic polling
+// without disabling exact configured lifecycle-deadline wake-ups or fabricating
+// a binary default. Explicit malformed, zero, or negative durations are
+// rejected at startup.
+func (c *LifecycleConfig) ToScaleDownRequeueInterval() (time.Duration, error) {
+	if c == nil || c.ScaleDownRequeueInterval == nil {
+		return 0, nil
+	}
+	interval, err := time.ParseDuration(*c.ScaleDownRequeueInterval)
+	if err != nil {
+		return 0, fmt.Errorf("invalid lifecycle.scaleDownRequeueInterval %q: %w", *c.ScaleDownRequeueInterval, err)
+	}
+	if interval <= 0 {
+		return 0, fmt.Errorf("invalid lifecycle.scaleDownRequeueInterval: must be > 0, got %s", interval)
+	}
+	return interval, nil
+}
+
+// ToRevisionHistoryLimit validates the configured non-live revision
+// retention cap. A nil LifecycleConfig or absent field means
+// unconfigured (nil, nil) — the caller prunes nothing rather than
+// fabricating a default. Explicit zero or negative values are invalid;
+// callers treat invalid config as unconfigured.
+func (c *LifecycleConfig) ToRevisionHistoryLimit() (*int32, error) {
+	if c == nil || c.RevisionHistoryLimit == nil {
+		return nil, nil
+	}
+	if *c.RevisionHistoryLimit <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.revisionHistoryLimit: must be > 0, got %d", *c.RevisionHistoryLimit)
+	}
+	limit := *c.RevisionHistoryLimit
+	return &limit, nil
+}
+
+func positivePodBatchSize(field string, configured *int32) (*int32, error) {
+	if configured == nil {
+		return nil, nil
+	}
+	if *configured <= 0 {
+		return nil, fmt.Errorf("invalid lifecycle.%s: must be > 0, got %d", field, *configured)
+	}
+	size := *configured
+	return &size, nil
+}
+
+// LoadPodBatchSizes reads one lifecycle ConfigMap snapshot and validates the
+// process-scoped scale settings. Callers keep the returned values for the
+// lifetime of the controller process.
+func LoadPodBatchSizes(clientset kubernetes.Interface) (PodBatchSizes, error) {
+	lifecycleConfig, err := NewLifecycleConfig(clientset)
+	if err != nil {
+		return PodBatchSizes{}, fmt.Errorf("load lifecycle configuration: %w", err)
+	}
+	scaleUp, err := lifecycleConfig.ToScaleUpPodBatchSize()
+	if err != nil {
+		return PodBatchSizes{}, fmt.Errorf("validate lifecycle.scaleUpPodBatchSize: %w", err)
+	}
+	scaleDown, err := lifecycleConfig.ToScaleDownPodBatchSize()
+	if err != nil {
+		return PodBatchSizes{}, fmt.Errorf("validate lifecycle.scaleDownPodBatchSize: %w", err)
+	}
+	scaleDownRequeueInterval, err := lifecycleConfig.ToScaleDownRequeueInterval()
+	if err != nil {
+		return PodBatchSizes{}, fmt.Errorf("validate lifecycle.scaleDownRequeueInterval: %w", err)
+	}
+	return PodBatchSizes{
+		ScaleUp:                  scaleUp,
+		ScaleDown:                scaleDown,
+		ScaleDownRequeueInterval: scaleDownRequeueInterval,
+	}, nil
+}
+
+// LoadScaleUpPodBatchSize reads and validates only the process-scoped scale-up
+// budget. The manager uses LoadPodBatchSizes so both directions share one
+// ConfigMap snapshot; this field-specific loader remains available to callers
+// that do not consume scale-down configuration.
+func LoadScaleUpPodBatchSize(clientset kubernetes.Interface) (*int32, error) {
+	lifecycleConfig, err := NewLifecycleConfig(clientset)
+	if err != nil {
+		return nil, fmt.Errorf("load lifecycle configuration: %w", err)
+	}
+	size, err := lifecycleConfig.ToScaleUpPodBatchSize()
+	if err != nil {
+		return nil, fmt.Errorf("validate lifecycle.scaleUpPodBatchSize: %w", err)
+	}
+	return size, nil
+}
+
+// NewLifecycleConfig loads the lifecycle block from the inferenceservice
+// ConfigMap. An absent "lifecycle" key yields (nil, nil); each caller applies
+// the compatibility or fail-safe semantics of the field it consumes.
+func NewLifecycleConfig(clientset kubernetes.Interface) (*LifecycleConfig, error) {
+	configMap, err := getInferenceServiceConfigMap(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseLifecycleConfig(configMap)
+}
+
+// NewLifecycleConfigCached is the ConfigCache-backed variant of
+// NewLifecycleConfig used on the reconcile hot path.
+func NewLifecycleConfigCached(cache *ConfigCache, clientset kubernetes.Interface) (*LifecycleConfig, error) {
+	configMap, err := cache.get(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseLifecycleConfig(configMap)
+}
+
+func parseLifecycleConfig(configMap *v1.ConfigMap) (*LifecycleConfig, error) {
+	data, ok := configMap.Data[LifecycleConfigName]
+	if !ok || strings.TrimSpace(data) == "" {
+		return nil, nil
+	}
+	cfg := &LifecycleConfig{}
+	if err := json.Unmarshal([]byte(data), cfg); err != nil {
+		return nil, fmt.Errorf("unable to parse lifecycle config json: %w", err)
+	}
+	return cfg, nil
+}
+
+// +kubebuilder:object:generate=false
+// OmeAgentConfig configures the metadata-extraction Job spawned by the
+// BaseModel/ClusterBaseModel controller for PVC-backed models. The Job runs
+// `ome-agent model-metadata` against the PVC.
 type OmeAgentConfig struct {
 	// Image is the ome-agent container image. Required.
 	Image string `json:"image"`
 	// ServiceAccount the metadata Job pod runs as. Must have RBAC to
-	// get/list/create/update/patch ConfigMaps in the OME namespace — the
-	// agent surfaces extracted metadata via a per-model status ConfigMap,
-	// not via direct CR updates.
+	// get/list/create/update/patch ConfigMaps in the OME namespace —
+	// the agent surfaces extracted metadata via a per-model status
+	// ConfigMap, not via direct CR updates.
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 	// CPURequest/MemoryRequest/CPULimit/MemoryLimit follow the standard
 	// resource shape; empty strings fall back to the K8s default.
@@ -205,18 +791,307 @@ type OmeAgentConfig struct {
 	PriorityClassName string            `json:"priorityClassName,omitempty"`
 }
 
-func NewInferenceServicesConfig(clientset kubernetes.Interface) (*InferenceServicesConfig, error) {
-	if _, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{}); err != nil {
-		return nil, err
-	}
-	return &InferenceServicesConfig{}, nil
+// getInferenceServiceConfigMap fetches the inferenceservice-config ConfigMap
+// directly from the apiserver via the clientset. This is the single point all
+// config constructors below resolve through; a ConfigCache (see below) wraps it
+// with a short TTL so a single reconcile pass does not issue one uncached GET
+// per config block.
+func getInferenceServiceConfigMap(clientset kubernetes.Interface) (*v1.ConfigMap, error) {
+	return clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
 }
 
-func NewIngressConfig(clientset kubernetes.Interface) (*IngressConfig, error) {
+// ConfigCache caches the inferenceservice-config ConfigMap for a configurable
+// TTL so the per-reconcile config constructors share one apiserver GET instead
+// of issuing one each. The TTL is supplied by the caller (flag/chart-driven —
+// no in-code behavioral default); a short TTL preserves the property that a
+// ConfigMap edit takes effect without a controller restart, since the entry is
+// re-fetched once the TTL elapses.
+//
+// A zero (or negative) TTL disables caching: every call falls through to the
+// apiserver, exactly reproducing the pre-cache behavior.
+//
+// +kubebuilder:object:generate=false
+type ConfigCache struct {
+	ttl time.Duration
+	now func() time.Time
+
+	// sf collapses concurrent refreshes (under MaxConcurrentReconciles>1) so an
+	// expiry triggers exactly one apiserver GET: callers that miss the cache at
+	// the same time share the single in-flight fetch instead of each issuing
+	// their own. Keyed on the ConfigMap name.
+	sf singleflight.Group
+
+	mu        sync.Mutex
+	cm        *v1.ConfigMap
+	fetchedAt time.Time
+}
+
+// NewConfigCache returns a ConfigCache with the given TTL.
+func NewConfigCache(ttl time.Duration) *ConfigCache {
+	return &ConfigCache{ttl: ttl, now: time.Now}
+}
+
+// get returns the cached ConfigMap when the entry is fresh, otherwise fetches
+// it from the apiserver and refreshes the entry. A non-positive TTL never
+// caches. The returned ConfigMap is shared (read-only): the config constructors
+// only read .Data, never mutate it.
+//
+// The lock is held only to check freshness and to swap in a result — never
+// across the apiserver GET. Concurrent refreshes after an expiry are collapsed
+// via singleflight, so the TTL window costs exactly one apiserver GET no matter
+// how many reconciles race into it.
+func (c *ConfigCache) get(clientset kubernetes.Interface) (*v1.ConfigMap, error) {
+	if c == nil || c.ttl <= 0 {
+		return getInferenceServiceConfigMap(clientset)
+	}
+
+	// Fast path: serve a fresh entry without touching the apiserver.
+	c.mu.Lock()
+	if c.cm != nil && c.now().Sub(c.fetchedAt) < c.ttl {
+		cm := c.cm
+		c.mu.Unlock()
+		return cm, nil
+	}
+	c.mu.Unlock()
+
+	// Miss/expiry: collapse concurrent refreshes onto a single GET. The result
+	// is shared with every caller that joins this in-flight fetch.
+	v, err, _ := c.sf.Do(constants.InferenceServiceConfigMapName, func() (interface{}, error) {
+		// Re-check freshness now that we hold the singleflight slot: a refresh
+		// may have completed between our fast-path miss and acquiring it,
+		// leaving the entry fresh again (avoids a redundant back-to-back GET).
+		c.mu.Lock()
+		if c.cm != nil && c.now().Sub(c.fetchedAt) < c.ttl {
+			cm := c.cm
+			c.mu.Unlock()
+			return cm, nil
+		}
+		c.mu.Unlock()
+
+		// GET happens outside the lock so concurrent readers are never blocked
+		// on apiserver I/O.
+		cm, err := getInferenceServiceConfigMap(clientset)
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if err != nil {
+			// On error, drop any stale entry so the next call retries rather
+			// than serving a config that may no longer exist.
+			c.cm = nil
+			return nil, err
+		}
+		c.cm = cm
+		c.fetchedAt = c.now()
+		return cm, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*v1.ConfigMap), nil
+}
+
+// NewInferenceServicesConfig verifies that the inferenceservice ConfigMap
+// exists (callers fail fast otherwise) and returns an empty config struct.
+// ModelCache is loaded separately via NewModelCacheConfig.
+func NewInferenceServicesConfig(clientset kubernetes.Interface) (*InferenceServicesConfig, error) {
+	cm, err := getInferenceServiceConfigMap(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return inferenceServicesConfigFromConfigMap(cm)
+}
+
+// NewInferenceServicesConfigCached is the ConfigCache-backed variant of
+// NewInferenceServicesConfig used on the reconcile hot path.
+func NewInferenceServicesConfigCached(cache *ConfigCache, clientset kubernetes.Interface) (*InferenceServicesConfig, error) {
+	cm, err := cache.get(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return inferenceServicesConfigFromConfigMap(cm)
+}
+
+// inferenceServicesConfigFromConfigMap builds the InferenceServicesConfig from
+// the ConfigMap. ModelCache is populated separately by the reconciler.
+func inferenceServicesConfigFromConfigMap(cm *v1.ConfigMap) (*InferenceServicesConfig, error) {
+	cfg := &InferenceServicesConfig{}
+	if cm == nil {
+		return cfg, nil
+	}
+	if data, ok := cm.Data[PodMonitorConfigName]; ok && strings.TrimSpace(data) != "" {
+		if err := json.Unmarshal([]byte(data), &cfg.PodMonitor); err != nil {
+			return nil, fmt.Errorf("unable to parse %q config json: %w", PodMonitorConfigName, err)
+		}
+	}
+	if data, ok := cm.Data[PodDisruptionBudgetConfigName]; ok && strings.TrimSpace(data) != "" {
+		if err := validatePodDisruptionBudgetJSONKeys([]byte(data)); err != nil {
+			return nil, fmt.Errorf("unable to parse %q config json: %w", PodDisruptionBudgetConfigName, err)
+		}
+		decoder := json.NewDecoder(strings.NewReader(data))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&cfg.PodDisruptionBudget); err != nil {
+			return nil, fmt.Errorf("unable to parse %q config json: %w", PodDisruptionBudgetConfigName, err)
+		}
+		var trailing json.RawMessage
+		if err := decoder.Decode(&trailing); err != io.EOF {
+			if err == nil {
+				return nil, fmt.Errorf("unable to parse %q config json: multiple JSON values", PodDisruptionBudgetConfigName)
+			}
+			return nil, fmt.Errorf("unable to parse %q config json: %w", PodDisruptionBudgetConfigName, err)
+		}
+		policies := []struct {
+			name   string
+			policy *PodDisruptionBudgetPolicy
+		}{
+			{name: "rawDeployment", policy: cfg.PodDisruptionBudget.RawDeployment},
+			{name: "omeNative", policy: cfg.PodDisruptionBudget.OMENative},
+		}
+		for _, mode := range policies {
+			if mode.policy == nil {
+				continue
+			}
+			path := PodDisruptionBudgetConfigName + "." + mode.name
+			if (mode.policy.MinAvailable == nil) == (mode.policy.MaxUnavailable == nil) {
+				return nil, fmt.Errorf("exactly one of %s.minAvailable or %s.maxUnavailable must be set", path, path)
+			}
+			if err := omevalidation.ValidatePodDisruptionBudget(
+				path,
+				mode.policy.MinAvailable,
+				mode.policy.MaxUnavailable,
+			); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return cfg, nil
+}
+
+func validatePodDisruptionBudgetJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	start, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if start == nil {
+		return nil
+	}
+	delim, ok := start.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("expected JSON object")
+	}
+
+	seen := make(map[string]struct{}, 2)
+	for decoder.More() {
+		fieldToken, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		field, ok := fieldToken.(string)
+		if !ok {
+			return fmt.Errorf("expected JSON object field")
+		}
+		if _, duplicate := seen[field]; duplicate {
+			return fmt.Errorf("json: duplicate field %q", field)
+		}
+		seen[field] = struct{}{}
+
+		var policy json.RawMessage
+		if err := decoder.Decode(&policy); err != nil {
+			return err
+		}
+		switch field {
+		case "rawDeployment", "omeNative":
+			if err := validatePodDisruptionBudgetPolicyJSONKeys(policy); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("json: unknown field %q", field)
+		}
+	}
+	_, err = decoder.Token()
+	return err
+}
+
+func validatePodDisruptionBudgetPolicyJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	start, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if start == nil {
+		return nil
+	}
+	delim, ok := start.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("expected JSON object or null")
+	}
+
+	seen := make(map[string]struct{}, 2)
+	for decoder.More() {
+		fieldToken, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		field, ok := fieldToken.(string)
+		if !ok {
+			return fmt.Errorf("expected JSON object field")
+		}
+		if _, duplicate := seen[field]; duplicate {
+			return fmt.Errorf("json: duplicate field %q", field)
+		}
+		seen[field] = struct{}{}
+
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return err
+		}
+		switch field {
+		case "minAvailable", "maxUnavailable":
+		default:
+			return fmt.Errorf("json: unknown field %q", field)
+		}
+	}
+	_, err = decoder.Token()
+	return err
+}
+
+// NewOmeAgentConfig loads the ome-agent block from the inferenceservice
+// ConfigMap. Returns a zero-value config (with no Image) if the block is
+// absent so the BaseModel reconciler can surface a clearer error to the
+// user via the model status when a PVC-backed model needs the Job.
+func NewOmeAgentConfig(clientset kubernetes.Interface) (*OmeAgentConfig, error) {
 	configMap, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
+	cfg := &OmeAgentConfig{}
+	if data, ok := configMap.Data[OmeAgentConfigName]; ok {
+		if err := json.Unmarshal([]byte(data), cfg); err != nil {
+			return nil, fmt.Errorf("unable to parse omeAgent config json: %w", err)
+		}
+	}
+	return cfg, nil
+}
+
+func NewIngressConfig(clientset kubernetes.Interface) (*IngressConfig, error) {
+	configMap, err := getInferenceServiceConfigMap(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseIngressConfig(configMap)
+}
+
+// NewIngressConfigCached is the ConfigCache-backed variant of NewIngressConfig
+// used on the reconcile hot path.
+func NewIngressConfigCached(cache *ConfigCache, clientset kubernetes.Interface) (*IngressConfig, error) {
+	configMap, err := cache.get(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseIngressConfig(configMap)
+}
+
+func parseIngressConfig(configMap *v1.ConfigMap) (*IngressConfig, error) {
 	ingressConfig := &IngressConfig{}
 	if ingress, ok := configMap.Data[IngressConfigKeyName]; ok {
 		err := json.Unmarshal([]byte(ingress), &ingressConfig)
@@ -224,6 +1099,9 @@ func NewIngressConfig(clientset kubernetes.Interface) (*IngressConfig, error) {
 			return nil, fmt.Errorf("unable to parse ingress config json: %w", err)
 		}
 
+		if ingressConfig.IngressGateway == "" || ingressConfig.IngressServiceName == "" {
+			return nil, fmt.Errorf("invalid ingress config - ingressGateway and ingressService are required")
+		}
 		if ingressConfig.PathTemplate != "" {
 			// TODO: ensure that the generated path is valid, that is:
 			// * both Name and Namespace are used to avoid collisions
@@ -317,10 +1195,24 @@ func getComponentConfig(key string, configMap *v1.ConfigMap, componentConfig int
 }
 
 func NewDeployConfig(clientset kubernetes.Interface) (*DeployConfig, error) {
-	configMap, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
+	configMap, err := getInferenceServiceConfigMap(clientset)
 	if err != nil {
 		return nil, err
 	}
+	return parseDeployConfig(configMap)
+}
+
+// NewDeployConfigCached is the ConfigCache-backed variant of NewDeployConfig
+// used on the reconcile hot path.
+func NewDeployConfigCached(cache *ConfigCache, clientset kubernetes.Interface) (*DeployConfig, error) {
+	configMap, err := cache.get(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseDeployConfig(configMap)
+}
+
+func parseDeployConfig(configMap *v1.ConfigMap) (*DeployConfig, error) {
 	deployConfig := &DeployConfig{}
 	if deploy, ok := configMap.Data[DeployConfigName]; ok {
 		err := json.Unmarshal([]byte(deploy), &deployConfig)
@@ -333,10 +1225,122 @@ func NewDeployConfig(clientset kubernetes.Interface) (*DeployConfig, error) {
 		}
 
 		if deployConfig.DefaultDeploymentMode != string(constants.RawDeployment) {
-			return nil, fmt.Errorf("invalid deployment mode %q. The only supported mode is %s", deployConfig.DefaultDeploymentMode, constants.RawDeployment)
+			return nil, fmt.Errorf("invalid deployment mode. Supported default mode is %s", constants.RawDeployment)
+		}
+
+		if deployConfig.Replicas != nil {
+			if err := deployConfig.Replicas.validate(); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return deployConfig, nil
+}
+
+// NewCanaryAnalysisConfig loads the canary metric-analysis defaults from the
+// inferenceservice-config ConfigMap, applying operational fallbacks for the
+// sampler tunables. BundledPrometheusAddress has no fallback (the chart is the
+// source of truth); empty leaves canaries without a default metrics source.
+func NewCanaryAnalysisConfig(clientset kubernetes.Interface) (*CanaryAnalysisConfig, error) {
+	configMap, err := getInferenceServiceConfigMap(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseCanaryAnalysisConfig(configMap)
+}
+
+// NewCanaryAnalysisConfigCached is the ConfigCache-backed variant of
+// NewCanaryAnalysisConfig used on the reconcile hot path.
+func NewCanaryAnalysisConfigCached(cache *ConfigCache, clientset kubernetes.Interface) (*CanaryAnalysisConfig, error) {
+	configMap, err := cache.get(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseCanaryAnalysisConfig(configMap)
+}
+
+func parseCanaryAnalysisConfig(configMap *v1.ConfigMap) (*CanaryAnalysisConfig, error) {
+	cfg := &CanaryAnalysisConfig{}
+	if err := getComponentConfig(CanaryAnalysisConfigName, configMap, cfg); err != nil {
+		return nil, fmt.Errorf("unable to parse canaryAnalysis config json: %w", err)
+	}
+	if cfg.QueryTimeout == "" {
+		cfg.QueryTimeout = DefaultAnalysisQueryTimeout
+	}
+	if cfg.MaxConcurrency <= 0 {
+		cfg.MaxConcurrency = DefaultAnalysisMaxConcurrency
+	}
+	if cfg.CacheTTL == "" {
+		cfg.CacheTTL = DefaultAnalysisCacheTTL
+	}
+	return cfg, nil
+}
+
+// NewCoordinationConfig loads the OMENative coordination tuning from the
+// inferenceservice-config ConfigMap. There are no in-code defaults: an absent
+// "coordination" key yields a zero-valued config (deadband disabled), preserving
+// the prior write-on-any-diff behavior.
+func NewCoordinationConfig(clientset kubernetes.Interface) (*CoordinationConfig, error) {
+	configMap, err := getInferenceServiceConfigMap(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseCoordinationConfig(configMap)
+}
+
+// NewCoordinationConfigCached is the ConfigCache-backed variant of
+// NewCoordinationConfig used on the reconcile hot path.
+func NewCoordinationConfigCached(cache *ConfigCache, clientset kubernetes.Interface) (*CoordinationConfig, error) {
+	configMap, err := cache.get(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseCoordinationConfig(configMap)
+}
+
+func parseCoordinationConfig(configMap *v1.ConfigMap) (*CoordinationConfig, error) {
+	cfg := &CoordinationConfig{}
+	if err := getComponentConfig(CoordinationConfigName, configMap, cfg); err != nil {
+		return nil, fmt.Errorf("unable to parse coordination config json: %w", err)
+	}
+	return cfg, nil
+}
+
+// QueryTimeoutDuration parses QueryTimeout, falling back to the known-good
+// DefaultAnalysisQueryTimeout when an operator wrote an unparsable or
+// non-positive value. The timeout MUST be positive: a zero/negative value would
+// leave a background analysis query unbounded, so a hung Prometheus could park a
+// sampler goroutine indefinitely.
+func (c *CanaryAnalysisConfig) QueryTimeoutDuration() time.Duration {
+	return parseDurationOr(c.QueryTimeout, DefaultAnalysisQueryTimeout)
+}
+
+// CacheTTLDuration parses CacheTTL, falling back to the known-good
+// DefaultAnalysisCacheTTL when an operator wrote an unparsable or non-positive
+// value. The TTL MUST be positive: a zero/negative value disables cache eviction
+// (unbounded growth).
+func (c *CanaryAnalysisConfig) CacheTTLDuration() time.Duration {
+	return parseDurationOr(c.CacheTTL, DefaultAnalysisCacheTTL)
+}
+
+// parseDurationOr parses s, returning the parse of fallback (a compile-time
+// constant known to parse) when s is empty, malformed, or non-positive — callers
+// rely on a strictly positive result.
+func parseDurationOr(s, fallback string) time.Duration {
+	if d, err := time.ParseDuration(s); err == nil && d > 0 {
+		return d
+	}
+	d, _ := time.ParseDuration(fallback)
+	return d
+}
+
+// BenchmarkJobConfigName is the inferenceservice-config key holding the
+// benchmark-job image/resource block.
+const BenchmarkJobConfigName = "benchmarkjob"
+
+type BenchmarkJobConfig struct {
+	// PodConfig contains all Pod Configuration
+	PodConfig PodConfig `json:"podConfig"`
 }
 
 func NewBenchmarkJobConfig(clientset kubernetes.Interface) (*BenchmarkJobConfig, error) {
@@ -357,24 +1361,13 @@ func NewBenchmarkJobConfig(clientset kubernetes.Interface) (*BenchmarkJobConfig,
 
 // getInferenceServiceConfigMap fetches the inferenceservice-config ConfigMap
 // from the OME namespace.
-func getInferenceServiceConfigMap(clientset kubernetes.Interface) (*v1.ConfigMap, error) {
-	return clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
+
+type PodConfig struct {
+	Image         string `json:"image"`
+	CPURequest    string `json:"cpuRequest"`
+	MemoryRequest string `json:"memoryRequest"`
+	CPULimit      string `json:"cpuLimit"`
+	MemoryLimit   string `json:"memoryLimit"`
 }
 
-// NewOmeAgentConfig loads the omeAgent block from the inferenceservice-config
-// ConfigMap in the OME namespace. A missing block yields a zero-value config
-// (not an error) so the PVC path can surface PVCConfigMissing via status
-// rather than failing controller startup.
-func NewOmeAgentConfig(clientset kubernetes.Interface) (*OmeAgentConfig, error) {
-	configMap, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	cfg := &OmeAgentConfig{}
-	if data, ok := configMap.Data[OmeAgentConfigName]; ok {
-		if err := json.Unmarshal([]byte(data), cfg); err != nil {
-			return nil, fmt.Errorf("unable to parse omeAgent config json: %w", err)
-		}
-	}
-	return cfg, nil
-}
+// +kubebuilder:object:generate=false

--- a/pkg/controller/v1beta1/controllerconfig/configmap_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/configmap_test.go
@@ -3,13 +3,19 @@ package controllerconfig
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"sigs.k8s.io/ome/pkg/constants"
 )
@@ -54,7 +60,7 @@ func TestNewInferenceServicesConfig(t *testing.T) {
 		validateConfig func(*testing.T, *InferenceServicesConfig)
 	}{
 		{
-			name:          "valid config",
+			name:          "valid empty config",
 			configMapData: map[string]string{},
 			expectedError: false,
 			validateConfig: func(t *testing.T, cfg *InferenceServicesConfig) {
@@ -99,6 +105,267 @@ func TestNewInferenceServicesConfig(t *testing.T) {
 	}
 }
 
+func TestInferenceServicesConfigFromConfigMapParsesPodDisruptionBudget(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]string
+		validate func(*testing.T, *InferenceServicesConfig)
+	}{
+		{
+			name: "missing key",
+			data: map[string]string{},
+			validate: func(t *testing.T, cfg *InferenceServicesConfig) {
+				assert.Nil(t, cfg.PodDisruptionBudget.RawDeployment)
+				assert.Nil(t, cfg.PodDisruptionBudget.OMENative)
+			},
+		},
+		{
+			name: "empty key",
+			data: map[string]string{PodDisruptionBudgetConfigName: " \n\t"},
+			validate: func(t *testing.T, cfg *InferenceServicesConfig) {
+				assert.Nil(t, cfg.PodDisruptionBudget.RawDeployment)
+				assert.Nil(t, cfg.PodDisruptionBudget.OMENative)
+			},
+		},
+		{
+			name: "explicitly null modes",
+			data: map[string]string{
+				PodDisruptionBudgetConfigName: `{
+					"rawDeployment": null,
+					"omeNative": null
+				}`,
+			},
+			validate: func(t *testing.T, cfg *InferenceServicesConfig) {
+				assert.Nil(t, cfg.PodDisruptionBudget.RawDeployment)
+				assert.Nil(t, cfg.PodDisruptionBudget.OMENative)
+			},
+		},
+		{
+			name: "per mode policies",
+			data: map[string]string{
+				PodDisruptionBudgetConfigName: `{
+					"rawDeployment": {"maxUnavailable": 1},
+					"omeNative": {"minAvailable": "50%"}
+				}`,
+			},
+			validate: func(t *testing.T, cfg *InferenceServicesConfig) {
+				require.NotNil(t, cfg.PodDisruptionBudget.RawDeployment)
+				require.NotNil(t, cfg.PodDisruptionBudget.RawDeployment.MaxUnavailable)
+				assert.Equal(t, intstr.FromInt(1), *cfg.PodDisruptionBudget.RawDeployment.MaxUnavailable)
+				require.NotNil(t, cfg.PodDisruptionBudget.OMENative)
+				require.NotNil(t, cfg.PodDisruptionBudget.OMENative.MinAvailable)
+				assert.Equal(t, intstr.FromString("50%"), *cfg.PodDisruptionBudget.OMENative.MinAvailable)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := inferenceServicesConfigFromConfigMap(&v1.ConfigMap{Data: tt.data})
+			require.NoError(t, err)
+			tt.validate(t, cfg)
+		})
+	}
+}
+
+func TestInferenceServicesConfigFromConfigMapRejectsInvalidPodDisruptionBudget(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       string
+		wantErrors []string
+	}{
+		{
+			name:       "malformed json",
+			data:       `{not-json`,
+			wantErrors: []string{PodDisruptionBudgetConfigName},
+		},
+		{
+			name: "raw deployment sets both fields",
+			data: `{
+				"rawDeployment": {"minAvailable": 1, "maxUnavailable": 1}
+			}`,
+			wantErrors: []string{
+				"podDisruptionBudget.rawDeployment.minAvailable",
+				"podDisruptionBudget.rawDeployment.maxUnavailable",
+			},
+		},
+		{
+			name: "OMENative percentage exceeds one hundred",
+			data: `{
+				"omeNative": {"maxUnavailable": "101%"}
+			}`,
+			wantErrors: []string{"podDisruptionBudget.omeNative.maxUnavailable"},
+		},
+		{
+			name: "unknown top-level field",
+			data: `{
+				"rawDeployment": {"maxUnavailable": 1},
+				"unexpected": {}
+			}`,
+			wantErrors: []string{`unknown field "unexpected"`},
+		},
+		{
+			name: "unknown mode field",
+			data: `{
+				"rawDeployment": {"maxUnavailable": 1, "unexpected": 2}
+			}`,
+			wantErrors: []string{`unknown field "unexpected"`},
+		},
+		{
+			name: "empty raw deployment policy",
+			data: `{
+				"rawDeployment": {}
+			}`,
+			wantErrors: []string{
+				"podDisruptionBudget.rawDeployment.minAvailable",
+				"podDisruptionBudget.rawDeployment.maxUnavailable",
+			},
+		},
+		{
+			name: "explicit null-only OMENative policy",
+			data: `{
+				"omeNative": {"maxUnavailable": null}
+			}`,
+			wantErrors: []string{
+				"podDisruptionBudget.omeNative.minAvailable",
+				"podDisruptionBudget.omeNative.maxUnavailable",
+			},
+		},
+		{
+			name: "misspelled budget field",
+			data: `{
+				"rawDeployment": {"maxUnavailble": 1}
+			}`,
+			wantErrors: []string{`unknown field "maxUnavailble"`},
+		},
+		{
+			name: "case-variant top-level field",
+			data: `{
+				"RawDeployment": {"maxUnavailable": 1}
+			}`,
+			wantErrors: []string{`unknown field "RawDeployment"`},
+		},
+		{
+			name: "case-variant policy field",
+			data: `{
+				"rawDeployment": {"MaxUnavailable": 1}
+			}`,
+			wantErrors: []string{`unknown field "MaxUnavailable"`},
+		},
+		{
+			name: "duplicate top-level field",
+			data: `{
+				"rawDeployment": {"maxUnavailable": 1},
+				"rawDeployment": {"maxUnavailable": 2}
+			}`,
+			wantErrors: []string{`duplicate field "rawDeployment"`},
+		},
+		{
+			name: "duplicate policy field",
+			data: `{
+				"rawDeployment": {
+					"maxUnavailable": 1,
+					"maxUnavailable": 2
+				}
+			}`,
+			wantErrors: []string{`duplicate field "maxUnavailable"`},
+		},
+		{
+			name: "trailing JSON value",
+			data: `{
+				"rawDeployment": {"maxUnavailable": 1}
+			} {}`,
+			wantErrors: []string{PodDisruptionBudgetConfigName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := inferenceServicesConfigFromConfigMap(&v1.ConfigMap{Data: map[string]string{
+				PodDisruptionBudgetConfigName: tt.data,
+			}})
+			require.Error(t, err)
+			for _, want := range tt.wantErrors {
+				assert.ErrorContains(t, err, want)
+			}
+		})
+	}
+}
+
+func TestNewOmeAgentConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMapData map[string]string
+		expectedError bool
+		validate      func(*testing.T, *OmeAgentConfig)
+	}{
+		{
+			name: "valid config",
+			configMapData: map[string]string{
+				OmeAgentConfigName: `{
+					"image": "ghcr.io/example/ome-agent:v1.0.0",
+					"serviceAccount": "ome-model-metadata",
+					"cpuRequest": "100m",
+					"memoryRequest": "256Mi",
+					"cpuLimit": "500m",
+					"memoryLimit": "512Mi",
+					"backoffLimit": 3,
+					"ttlSecondsAfterFinished": 600
+				}`,
+			},
+			validate: func(t *testing.T, cfg *OmeAgentConfig) {
+				assert.Equal(t, "ghcr.io/example/ome-agent:v1.0.0", cfg.Image)
+				assert.Equal(t, "ome-model-metadata", cfg.ServiceAccount)
+				assert.Equal(t, "100m", cfg.CPURequest)
+				assert.Equal(t, "256Mi", cfg.MemoryRequest)
+				assert.Equal(t, int32(3), cfg.BackoffLimit)
+				assert.Equal(t, int32(600), cfg.TTLSecondsAfterFinished)
+			},
+		},
+		{
+			name:          "missing block returns zero-value config",
+			configMapData: map[string]string{},
+			validate: func(t *testing.T, cfg *OmeAgentConfig) {
+				assert.Empty(t, cfg.Image)
+				assert.Empty(t, cfg.ServiceAccount)
+			},
+		},
+		{
+			name: "malformed json fails",
+			configMapData: map[string]string{
+				OmeAgentConfigName: `{not-json`,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.OMENamespace,
+				},
+				Data: tt.configMapData,
+			}
+			_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			cfg, err := NewOmeAgentConfig(clientset)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			if tt.validate != nil {
+				tt.validate(t, cfg)
+			}
+		})
+	}
+}
+
 func TestNewIngressConfig(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -119,7 +386,13 @@ func TestNewIngressConfig(t *testing.T) {
 					"additionalIngressDomains": ["extra.example.com"],
 					"domainTemplate": "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}",
 					"urlScheme": "https",
-					"pathTemplate": "/{{ .Namespace }}/{{ .Name }}"
+					"pathTemplate": "/{{ .Namespace }}/{{ .Name }}",
+					"perISVCSubdomain": true,
+					"sharedHostPrefix": "serving",
+					"omeIngressGatewayClass": "internal",
+					"additionalIngressGateways": [
+						{"omeIngressGateway": "envoy-gateway-system/ext-gw", "ingressDomain": "ext.example.com", "class": "external"}
+					]
 				}`,
 			},
 			expectedError: false,
@@ -129,13 +402,59 @@ func TestNewIngressConfig(t *testing.T) {
 				assert.Equal(t, "example.com", cfg.IngressDomain)
 				assert.Equal(t, "nginx", *cfg.IngressClassName)
 				assert.Equal(t, "https", cfg.UrlScheme)
+				assert.True(t, cfg.PerISVCSubdomain)
+				assert.Equal(t, "serving", cfg.SharedHostPrefix)
+				assert.Equal(t, "internal", cfg.OmeIngressGatewayClass)
+				require.Len(t, cfg.AdditionalIngressGateways, 1)
+				assert.Equal(t, "envoy-gateway-system/ext-gw", cfg.AdditionalIngressGateways[0].OmeIngressGateway)
+				assert.Equal(t, "ext.example.com", cfg.AdditionalIngressGateways[0].IngressDomain)
+				assert.Equal(t, "external", cfg.AdditionalIngressGateways[0].Class)
 			},
 		},
 		{
-			name: "pathTemplate without ingressDomain",
+			name: "invalid primary gateway class rejected",
 			configMapData: map[string]string{
 				IngressConfigKeyName: `{
-					"pathTemplate": "/{{ .Namespace }}/{{ .Name }}"
+					"ingressGateway": "istio-ingress",
+					"ingressService": "istio-ingress",
+					"omeIngressGatewayClass": "Internal"
+				}`,
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid additional gateway class rejected",
+			configMapData: map[string]string{
+				IngressConfigKeyName: `{
+					"ingressGateway": "istio-ingress",
+					"ingressService": "istio-ingress",
+					"additionalIngressGateways": [
+						{"omeIngressGateway": "envoy-gateway-system/ext-gw", "ingressDomain": "ext.example.com", "class": "ext_gw"}
+					]
+				}`,
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid per-namespace gateway class rejected",
+			configMapData: map[string]string{
+				IngressConfigKeyName: `{
+					"ingressGateway": "istio-ingress",
+					"ingressService": "istio-ingress",
+					"namespaceIngressGateways": {
+						"prod": {
+							"primary": {"omeIngressGateway": "istio-system/prod-int-gw", "ingressDomain": "int.example.com", "class": "prod internal"}
+						}
+					}
+				}`,
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing required fields",
+			configMapData: map[string]string{
+				IngressConfigKeyName: `{
+					"ingressDomain": "example.com"
 				}`,
 			},
 			expectedError: true,
@@ -159,6 +478,8 @@ func TestNewIngressConfig(t *testing.T) {
 				assert.Equal(t, DefaultDomainTemplate, cfg.DomainTemplate)
 				assert.Equal(t, DefaultIngressDomain, cfg.IngressDomain)
 				assert.Equal(t, DefaultUrlScheme, cfg.UrlScheme)
+				assert.False(t, cfg.PerISVCSubdomain, "perISVCSubdomain must default to false")
+				assert.Empty(t, cfg.SharedHostPrefix, "sharedHostPrefix must have NO in-code default (supplied via config)")
 			},
 		},
 	}
@@ -224,7 +545,75 @@ func TestNewDeployConfig(t *testing.T) {
 			expectedError: false,
 			validateConfig: func(t *testing.T, cfg *DeployConfig) {
 				assert.Empty(t, cfg.DefaultDeploymentMode)
+				assert.Nil(t, cfg.Replicas)
+				// Nil-receiver accessors report unconfigured, never a number.
+				assert.Nil(t, cfg.Replicas.Min())
+				assert.Nil(t, cfg.Replicas.EngineMax())
+				assert.Nil(t, cfg.Replicas.DecoderMax())
+				assert.Nil(t, cfg.Replicas.RouterMax())
 			},
+		},
+		{
+			name: "replicas block parsed with per-component max defaults",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"replicas": {
+						"defaultMinReplicas": 1,
+						"defaultMaxReplicas": {"engine": 3, "decoder": 3, "router": 2}
+					}
+				}`,
+			},
+			expectedError: false,
+			validateConfig: func(t *testing.T, cfg *DeployConfig) {
+				require.NotNil(t, cfg.Replicas)
+				require.NotNil(t, cfg.Replicas.Min())
+				assert.Equal(t, 1, *cfg.Replicas.Min())
+				require.NotNil(t, cfg.Replicas.EngineMax())
+				assert.Equal(t, 3, *cfg.Replicas.EngineMax())
+				require.NotNil(t, cfg.Replicas.DecoderMax())
+				assert.Equal(t, 3, *cfg.Replicas.DecoderMax())
+				require.NotNil(t, cfg.Replicas.RouterMax())
+				assert.Equal(t, 2, *cfg.Replicas.RouterMax())
+			},
+		},
+		{
+			name: "partial replicas block leaves omitted fields unconfigured",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"replicas": {"defaultMaxReplicas": {"engine": 3}}
+				}`,
+			},
+			expectedError: false,
+			validateConfig: func(t *testing.T, cfg *DeployConfig) {
+				require.NotNil(t, cfg.Replicas)
+				assert.Nil(t, cfg.Replicas.Min())
+				require.NotNil(t, cfg.Replicas.EngineMax())
+				assert.Equal(t, 3, *cfg.Replicas.EngineMax())
+				assert.Nil(t, cfg.Replicas.DecoderMax())
+				assert.Nil(t, cfg.Replicas.RouterMax())
+			},
+		},
+		{
+			name: "zero replica default rejected at config-load",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"replicas": {"defaultMinReplicas": 0}
+				}`,
+			},
+			expectedError: true,
+		},
+		{
+			name: "negative per-component max default rejected at config-load",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"replicas": {"defaultMaxReplicas": {"router": -2}}
+				}`,
+			},
+			expectedError: true,
 		},
 	}
 
@@ -307,4 +696,326 @@ func TestGetComponentConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedData, result)
 		})
 	}
+}
+
+// TestCanaryAnalysisDurationAccessors verifies the query-timeout and cache-TTL
+// accessors fall back to the documented defaults for empty, malformed, zero, or
+// negative values. The zero/negative cases matter: a non-positive query timeout
+// would leave a background sampler query unbounded, and a non-positive TTL would
+// disable cache eviction.
+func TestCanaryAnalysisDurationAccessors(t *testing.T) {
+	defQuery, _ := time.ParseDuration(DefaultAnalysisQueryTimeout)
+	defTTL, _ := time.ParseDuration(DefaultAnalysisCacheTTL)
+
+	tests := []struct {
+		name      string
+		query     string
+		ttl       string
+		wantQuery time.Duration
+		wantTTL   time.Duration
+	}{
+		{"valid values pass through", "9s", "3m", 9 * time.Second, 3 * time.Minute},
+		{"empty falls back", "", "", defQuery, defTTL},
+		{"malformed falls back", "nope", "huh", defQuery, defTTL},
+		{"zero falls back", "0s", "0s", defQuery, defTTL},
+		{"negative falls back", "-5s", "-1m", defQuery, defTTL},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CanaryAnalysisConfig{QueryTimeout: tt.query, CacheTTL: tt.ttl}
+			assert.Equal(t, tt.wantQuery, c.QueryTimeoutDuration())
+			assert.Equal(t, tt.wantTTL, c.CacheTTLDuration())
+		})
+	}
+}
+
+// countingClientset returns a fake clientset plus an atomic counter that is
+// incremented on every GET against the inferenceservice-config ConfigMap, so a
+// test can assert exactly how many apiserver round-trips a ConfigCache issues.
+func countingClientset(t *testing.T, data map[string]string) (*fake.Clientset, *int64) {
+	t.Helper()
+	clientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.OMENamespace,
+		},
+		Data: data,
+	})
+	var gets int64
+	clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.(k8stesting.GetAction).GetName() == constants.InferenceServiceConfigMapName {
+			atomic.AddInt64(&gets, 1)
+		}
+		// Fall through to the default tracker so the object is actually returned.
+		return false, nil, nil
+	})
+	return clientset, &gets
+}
+
+// TestConfigCache exercises the hit / expiry / disabled / error behaviors of
+// ConfigCache: within the TTL the constructors share one apiserver GET, after
+// the TTL the entry is re-fetched (so ConfigMap edits apply without a restart),
+// a non-positive TTL disables caching, and a GET error is surfaced (not served
+// from a stale entry).
+func TestConfigCache(t *testing.T) {
+	deployData := map[string]string{
+		DeployConfigName: `{"defaultDeploymentMode":"RawDeployment"}`,
+		IngressConfigKeyName: `{
+			"ingressGateway":"istio-ingress",
+			"ingressService":"istio-ingress",
+			"ingressDomain":"example.com"
+		}`,
+	}
+
+	t.Run("hit: four cached loads share one GET within TTL", func(t *testing.T) {
+		clientset, gets := countingClientset(t, deployData)
+		fakeNow := time.Unix(0, 0)
+		cache := &ConfigCache{ttl: 30 * time.Second, now: func() time.Time { return fakeNow }}
+
+		// Mirror the reconcile hot path: four config loads in one pass.
+		_, err := NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		_, err = NewInferenceServicesConfigCached(cache, clientset)
+		require.NoError(t, err)
+		ing, err := NewIngressConfigCached(cache, clientset)
+		require.NoError(t, err)
+		_, err = NewCanaryAnalysisConfigCached(cache, clientset)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), atomic.LoadInt64(gets), "all four loads must share one apiserver GET")
+		// Parsed values must be identical to the uncached path.
+		assert.Equal(t, "example.com", ing.IngressDomain)
+	})
+
+	t.Run("expiry: re-fetches after TTL elapses", func(t *testing.T) {
+		clientset, gets := countingClientset(t, deployData)
+		fakeNow := time.Unix(0, 0)
+		cache := &ConfigCache{ttl: 30 * time.Second, now: func() time.Time { return fakeNow }}
+
+		_, err := NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), atomic.LoadInt64(gets))
+
+		// Still within TTL: served from cache.
+		fakeNow = fakeNow.Add(29 * time.Second)
+		_, err = NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), atomic.LoadInt64(gets))
+
+		// Past TTL: re-fetched.
+		fakeNow = fakeNow.Add(2 * time.Second)
+		_, err = NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), atomic.LoadInt64(gets))
+	})
+
+	t.Run("expiry picks up a ConfigMap edit without restart", func(t *testing.T) {
+		clientset, _ := countingClientset(t, map[string]string{
+			DeployConfigName: `{"defaultDeploymentMode":"RawDeployment"}`,
+		})
+		fakeNow := time.Unix(0, 0)
+		cache := &ConfigCache{ttl: 30 * time.Second, now: func() time.Time { return fakeNow }}
+
+		cfg, err := NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, "RawDeployment", cfg.DefaultDeploymentMode)
+
+		// Edit the ConfigMap to clear the deploy block.
+		_, err = clientset.CoreV1().ConfigMaps(constants.OMENamespace).Update(context.TODO(), &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{},
+		}, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// Within TTL the edit is not yet visible.
+		cfg, err = NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, "RawDeployment", cfg.DefaultDeploymentMode)
+
+		// After TTL the edit applies.
+		fakeNow = fakeNow.Add(31 * time.Second)
+		cfg, err = NewDeployConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.DefaultDeploymentMode)
+	})
+
+	t.Run("disabled: non-positive TTL reads apiserver every call", func(t *testing.T) {
+		clientset, gets := countingClientset(t, deployData)
+		cache := NewConfigCache(0)
+
+		for i := 0; i < 3; i++ {
+			_, err := NewDeployConfigCached(cache, clientset)
+			require.NoError(t, err)
+		}
+		assert.Equal(t, int64(3), atomic.LoadInt64(gets), "TTL<=0 must not cache")
+	})
+
+	t.Run("nil cache reads apiserver every call", func(t *testing.T) {
+		clientset, gets := countingClientset(t, deployData)
+
+		for i := 0; i < 2; i++ {
+			_, err := NewDeployConfigCached(nil, clientset)
+			require.NoError(t, err)
+		}
+		assert.Equal(t, int64(2), atomic.LoadInt64(gets))
+	})
+
+	t.Run("error: GET failure is surfaced, not served stale", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset() // no ConfigMap
+		cache := NewConfigCache(30 * time.Second)
+
+		_, err := NewDeployConfigCached(cache, clientset)
+		assert.Error(t, err, "missing ConfigMap must surface as an error")
+	})
+}
+
+// TestConfigCacheSingleflight proves that when many reconciles race into the
+// same TTL expiry, the cache issues exactly ONE apiserver GET (and never holds
+// its lock across that GET). The reactor blocks all in-flight GETs on a gate so
+// the goroutines pile up inside get() simultaneously; without singleflight each
+// would issue its own GET, so the counter would exceed one.
+func TestConfigCacheSingleflight(t *testing.T) {
+	const goroutines = 64
+
+	clientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.OMENamespace,
+		},
+		Data: map[string]string{
+			DeployConfigName: `{"defaultDeploymentMode":"RawDeployment"}`,
+		},
+	})
+
+	var gets int64
+	release := make(chan struct{})
+	var first sync.Once
+	firstInFlight := make(chan struct{})
+	clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.(k8stesting.GetAction).GetName() == constants.InferenceServiceConfigMapName {
+			atomic.AddInt64(&gets, 1)
+			// Signal that a GET has begun, then block until the test releases
+			// it — this widens the window so concurrent callers must dedupe via
+			// singleflight rather than each issuing their own GET.
+			first.Do(func() { close(firstInFlight) })
+			<-release
+		}
+		return false, nil, nil
+	})
+
+	cache := NewConfigCache(30 * time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			cfg, err := NewDeployConfigCached(cache, clientset)
+			assert.NoError(t, err)
+			if cfg != nil {
+				assert.Equal(t, "RawDeployment", cfg.DefaultDeploymentMode)
+			}
+		}()
+	}
+
+	// Wait until at least one GET is in flight (all callers should now be
+	// joined onto the single singleflight call), then release the apiserver.
+	<-firstInFlight
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&gets),
+		"concurrent loads across one expiry window must collapse to exactly one apiserver GET")
+}
+
+// TestNewCoordinationConfigCached verifies the cached coordination loader shares
+// one apiserver GET within the TTL and re-fetches after it elapses so a
+// ConfigMap edit applies without a restart — mirroring the other cached loaders
+// (the coordination loader runs on every ISVC reconcile).
+func TestNewCoordinationConfigCached(t *testing.T) {
+	t.Run("hit: repeated loads share one GET within TTL", func(t *testing.T) {
+		clientset, gets := countingClientset(t, map[string]string{
+			CoordinationConfigName: `{"trafficWeightDeadbandPercent":5}`,
+		})
+		fakeNow := time.Unix(0, 0)
+		cache := &ConfigCache{ttl: 30 * time.Second, now: func() time.Time { return fakeNow }}
+
+		cfg, err := NewCoordinationConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int32(5), cfg.TrafficWeightDeadbandPercent)
+
+		_, err = NewCoordinationConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), atomic.LoadInt64(gets), "both loads must share one apiserver GET")
+	})
+
+	t.Run("expiry picks up a ConfigMap edit without restart", func(t *testing.T) {
+		clientset, _ := countingClientset(t, map[string]string{
+			CoordinationConfigName: `{"trafficWeightDeadbandPercent":5}`,
+		})
+		fakeNow := time.Unix(0, 0)
+		cache := &ConfigCache{ttl: 30 * time.Second, now: func() time.Time { return fakeNow }}
+
+		cfg, err := NewCoordinationConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int32(5), cfg.TrafficWeightDeadbandPercent)
+
+		// Edit the ConfigMap to bump the deadband.
+		_, err = clientset.CoreV1().ConfigMaps(constants.OMENamespace).Update(context.TODO(), &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				CoordinationConfigName: `{"trafficWeightDeadbandPercent":10}`,
+			},
+		}, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// Within TTL the edit is not yet visible.
+		cfg, err = NewCoordinationConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int32(5), cfg.TrafficWeightDeadbandPercent)
+
+		// After TTL the edit applies.
+		fakeNow = fakeNow.Add(31 * time.Second)
+		cfg, err = NewCoordinationConfigCached(cache, clientset)
+		require.NoError(t, err)
+		assert.Equal(t, int32(10), cfg.TrafficWeightDeadbandPercent)
+	})
+}
+
+// TestCoordinationConfigDefaultRatioTolerance verifies the ratio-tolerance
+// default distinguishes configured (pointer set, zero included) from absent
+// (nil — a group that omits tolerance rolls with no drift bound).
+func TestCoordinationConfigDefaultRatioTolerance(t *testing.T) {
+	load := func(t *testing.T, payload string) *CoordinationConfig {
+		clientset, _ := countingClientset(t, map[string]string{
+			CoordinationConfigName: payload,
+		})
+		cache := &ConfigCache{ttl: 30 * time.Second, now: func() time.Time { return time.Unix(0, 0) }}
+		cfg, err := NewCoordinationConfigCached(cache, clientset)
+		require.NoError(t, err)
+		return cfg
+	}
+
+	t.Run("configured value parses to a pointer", func(t *testing.T) {
+		cfg := load(t, `{"trafficWeightDeadbandPercent":0,"defaultRatioTolerancePercent":5}`)
+		require.NotNil(t, cfg.DefaultRatioTolerancePercent)
+		assert.Equal(t, int32(5), *cfg.DefaultRatioTolerancePercent)
+	})
+
+	t.Run("configured zero stays distinguishable from absent", func(t *testing.T) {
+		cfg := load(t, `{"defaultRatioTolerancePercent":0}`)
+		require.NotNil(t, cfg.DefaultRatioTolerancePercent)
+		assert.Equal(t, int32(0), *cfg.DefaultRatioTolerancePercent)
+	})
+
+	t.Run("absent key resolves to nil", func(t *testing.T) {
+		cfg := load(t, `{"trafficWeightDeadbandPercent":0}`)
+		assert.Nil(t, cfg.DefaultRatioTolerancePercent)
+	})
 }

--- a/pkg/controller/v1beta1/controllerconfig/lifecycle_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/lifecycle_test.go
@@ -1,0 +1,801 @@
+package controllerconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// TestNewLifecycleConfig pins the load contract for the "lifecycle"
+// ConfigMap key: present + valid parses into LifecycleConfig; absent
+// yields (nil, nil) — unconfigured, the caller fails safe (Held) —
+// never an error and never a fabricated default.
+func TestNewLifecycleConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMapData map[string]string
+		expectNil     bool
+		expectedError bool
+		validate      func(*testing.T, *LifecycleConfig)
+	}{
+		{
+			name: "valid updateRetry block",
+			configMapData: map[string]string{
+				LifecycleConfigName: `{"updateRetry":{"maxAttempts":3,"initialDelay":"1m","maxDelay":"30m","multiplier":2.0}}`,
+			},
+			validate: func(t *testing.T, cfg *LifecycleConfig) {
+				require.NotNil(t, cfg.UpdateRetry)
+				assert.Equal(t, int32(3), cfg.UpdateRetry.MaxAttempts)
+				assert.Equal(t, "1m", cfg.UpdateRetry.InitialDelay)
+				assert.Equal(t, "30m", cfg.UpdateRetry.MaxDelay)
+				assert.Equal(t, 2.0, cfg.UpdateRetry.Multiplier)
+			},
+		},
+		{
+			name: "valid scale settings",
+			configMapData: map[string]string{
+				LifecycleConfigName: `{"scaleUpPodBatchSize":100,"scaleDownPodBatchSize":75,"scaleDownRequeueInterval":"7s"}`,
+			},
+			validate: func(t *testing.T, cfg *LifecycleConfig) {
+				require.NotNil(t, cfg.ScaleUpPodBatchSize)
+				assert.Equal(t, int32(100), *cfg.ScaleUpPodBatchSize)
+				require.NotNil(t, cfg.ScaleDownPodBatchSize)
+				assert.Equal(t, int32(75), *cfg.ScaleDownPodBatchSize)
+				require.NotNil(t, cfg.ScaleDownRequeueInterval)
+				assert.Equal(t, "7s", *cfg.ScaleDownRequeueInterval)
+			},
+		},
+		{
+			// Absent lifecycle key: unconfigured, NOT an error. The nil
+			// config is the fail-safe-Held signal for the IR reconciler.
+			name:          "absent lifecycle key yields nil config, no error",
+			configMapData: map[string]string{},
+			expectNil:     true,
+		},
+		{
+			name: "lifecycle key without updateRetry yields config with nil UpdateRetry",
+			configMapData: map[string]string{
+				LifecycleConfigName: `{}`,
+			},
+			validate: func(t *testing.T, cfg *LifecycleConfig) {
+				assert.Nil(t, cfg.UpdateRetry)
+			},
+		},
+		{
+			name: "malformed json is an error",
+			configMapData: map[string]string{
+				LifecycleConfigName: `{not-json`,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.OMENamespace,
+				},
+				Data: tt.configMapData,
+			}
+			_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			cfg, err := NewLifecycleConfig(clientset)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.expectNil {
+				assert.Nil(t, cfg)
+				return
+			}
+			require.NotNil(t, cfg)
+			if tt.validate != nil {
+				tt.validate(t, cfg)
+			}
+		})
+	}
+}
+
+func TestLifecycleConfig_ToScaleDownPodBatchSize(t *testing.T) {
+	t.Run("nil config is unconfigured", func(t *testing.T) {
+		var cfg *LifecycleConfig
+		size, err := cfg.ToScaleDownPodBatchSize()
+		require.NoError(t, err)
+		assert.Nil(t, size)
+	})
+
+	t.Run("absent field is unconfigured", func(t *testing.T) {
+		cfg := &LifecycleConfig{}
+		size, err := cfg.ToScaleDownPodBatchSize()
+		require.NoError(t, err)
+		assert.Nil(t, size)
+	})
+
+	t.Run("positive value passes through as a copy", func(t *testing.T) {
+		configured := int32(100)
+		cfg := &LifecycleConfig{ScaleDownPodBatchSize: &configured}
+		size, err := cfg.ToScaleDownPodBatchSize()
+		require.NoError(t, err)
+		require.NotNil(t, size)
+		assert.Equal(t, int32(100), *size)
+
+		configured = 200
+		assert.Equal(t, int32(100), *size)
+	})
+
+	for _, configured := range []int32{0, -1} {
+		configured := configured
+		t.Run(fmt.Sprintf("rejects %d", configured), func(t *testing.T) {
+			cfg := &LifecycleConfig{ScaleDownPodBatchSize: &configured}
+			size, err := cfg.ToScaleDownPodBatchSize()
+			require.ErrorContains(t, err, "lifecycle.scaleDownPodBatchSize")
+			assert.Nil(t, size)
+		})
+	}
+}
+
+func TestLifecycleConfig_ToScaleDownRequeueInterval(t *testing.T) {
+	t.Run("nil config disables periodic polling", func(t *testing.T) {
+		var cfg *LifecycleConfig
+		interval, err := cfg.ToScaleDownRequeueInterval()
+		require.NoError(t, err)
+		assert.Zero(t, interval)
+	})
+
+	t.Run("absent field disables periodic polling", func(t *testing.T) {
+		cfg := &LifecycleConfig{}
+		interval, err := cfg.ToScaleDownRequeueInterval()
+		require.NoError(t, err)
+		assert.Zero(t, interval)
+	})
+
+	t.Run("positive duration passes through", func(t *testing.T) {
+		cfg := &LifecycleConfig{ScaleDownRequeueInterval: stringPointer("37s")}
+		interval, err := cfg.ToScaleDownRequeueInterval()
+		require.NoError(t, err)
+		assert.Equal(t, 37*time.Second, interval)
+	})
+
+	for _, value := range []string{"", "many", "0s", "-1s"} {
+		value := value
+		t.Run("rejects "+value, func(t *testing.T) {
+			cfg := &LifecycleConfig{ScaleDownRequeueInterval: &value}
+			interval, err := cfg.ToScaleDownRequeueInterval()
+			require.ErrorContains(t, err, "lifecycle.scaleDownRequeueInterval")
+			assert.Zero(t, interval)
+		})
+	}
+}
+
+func TestLoadPodBatchSizes(t *testing.T) {
+	tests := []struct {
+		name          string
+		lifecycle     *string
+		omitConfigMap bool
+		wantScaleUp   *int32
+		wantScaleDown *int32
+		wantInterval  time.Duration
+		wantError     string
+	}{
+		{
+			name:          "scale settings come from one snapshot",
+			lifecycle:     stringPointer(`{"scaleUpPodBatchSize":37,"scaleDownPodBatchSize":41,"scaleDownRequeueInterval":"7s"}`),
+			wantScaleUp:   int32Pointer(37),
+			wantScaleDown: int32Pointer(41),
+			wantInterval:  7 * time.Second,
+		},
+		{
+			name:        "scale-up alone leaves scale-down unbounded",
+			lifecycle:   stringPointer(`{"scaleUpPodBatchSize":37}`),
+			wantScaleUp: int32Pointer(37),
+		},
+		{
+			name:          "scale-down alone leaves scale-up unbounded",
+			lifecycle:     stringPointer(`{"scaleDownPodBatchSize":41}`),
+			wantScaleDown: int32Pointer(41),
+		},
+		{
+			name:         "requeue interval alone leaves both directions unbounded",
+			lifecycle:    stringPointer(`{"scaleDownRequeueInterval":"11s"}`),
+			wantInterval: 11 * time.Second,
+		},
+		{
+			name: "absent lifecycle key leaves both directions unbounded",
+		},
+		{
+			name:      "empty lifecycle object leaves both directions unbounded",
+			lifecycle: stringPointer(`{}`),
+		},
+		{
+			name:          "missing ConfigMap is rejected",
+			omitConfigMap: true,
+			wantError:     `configmaps "inferenceservice-config" not found`,
+		},
+		{
+			name:      "malformed lifecycle JSON is rejected",
+			lifecycle: stringPointer(`{not-json`),
+			wantError: "unable to parse lifecycle config json",
+		},
+		{
+			name:      "malformed scale-down field type is rejected",
+			lifecycle: stringPointer(`{"scaleDownPodBatchSize":"many"}`),
+			wantError: "cannot unmarshal string",
+		},
+		{
+			name:      "malformed requeue interval is rejected",
+			lifecycle: stringPointer(`{"scaleDownRequeueInterval":"many"}`),
+			wantError: "lifecycle.scaleDownRequeueInterval",
+		},
+		{
+			name:      "explicit empty requeue interval is rejected",
+			lifecycle: stringPointer(`{"scaleDownRequeueInterval":""}`),
+			wantError: "lifecycle.scaleDownRequeueInterval",
+		},
+		{
+			name:      "zero requeue interval is rejected",
+			lifecycle: stringPointer(`{"scaleDownRequeueInterval":"0s"}`),
+			wantError: "must be > 0, got 0s",
+		},
+		{
+			name:      "negative requeue interval is rejected",
+			lifecycle: stringPointer(`{"scaleDownRequeueInterval":"-1s"}`),
+			wantError: "must be > 0, got -1s",
+		},
+		{
+			name:      "zero scale-up is rejected",
+			lifecycle: stringPointer(`{"scaleUpPodBatchSize":0,"scaleDownPodBatchSize":41}`),
+			wantError: "lifecycle.scaleUpPodBatchSize: must be > 0, got 0",
+		},
+		{
+			name:      "negative scale-up is rejected",
+			lifecycle: stringPointer(`{"scaleUpPodBatchSize":-1,"scaleDownPodBatchSize":41}`),
+			wantError: "lifecycle.scaleUpPodBatchSize: must be > 0, got -1",
+		},
+		{
+			name:      "zero scale-down is rejected",
+			lifecycle: stringPointer(`{"scaleUpPodBatchSize":37,"scaleDownPodBatchSize":0}`),
+			wantError: "lifecycle.scaleDownPodBatchSize: must be > 0, got 0",
+		},
+		{
+			name:      "negative scale-down is rejected",
+			lifecycle: stringPointer(`{"scaleUpPodBatchSize":37,"scaleDownPodBatchSize":-1}`),
+			wantError: "lifecycle.scaleDownPodBatchSize: must be > 0, got -1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			if !tt.omitConfigMap {
+				data := map[string]string{}
+				if tt.lifecycle != nil {
+					data[LifecycleConfigName] = *tt.lifecycle
+				}
+				_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(
+					context.Background(),
+					&v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            constants.InferenceServiceConfigMapName,
+							Namespace:       constants.OMENamespace,
+							ResourceVersion: "one-snapshot",
+						},
+						Data: data,
+					},
+					metav1.CreateOptions{},
+				)
+				require.NoError(t, err)
+			}
+
+			before := len(clientset.Actions())
+			got, err := LoadPodBatchSizes(clientset)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				assert.Equal(t, PodBatchSizes{}, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantScaleUp, got.ScaleUp)
+				assert.Equal(t, tt.wantScaleDown, got.ScaleDown)
+				assert.Equal(t, tt.wantInterval, got.ScaleDownRequeueInterval)
+			}
+
+			getCount := 0
+			for _, action := range clientset.Actions()[before:] {
+				if action.GetVerb() == "get" && action.GetResource().Resource == "configmaps" {
+					getCount++
+				}
+			}
+			assert.Equal(t, 1, getCount, "scale settings must share one ConfigMap GET")
+		})
+	}
+}
+
+func TestLoadScaleUpPodBatchSize_IgnoresScaleDownValidation(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.OMENamespace,
+		},
+		Data: map[string]string{
+			LifecycleConfigName: `{"scaleUpPodBatchSize":37,"scaleDownPodBatchSize":0}`,
+		},
+	})
+
+	got, err := LoadScaleUpPodBatchSize(clientset)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(37), *got)
+}
+
+func int32Pointer(value int32) *int32 {
+	return &value
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+// TestLifecycleConfig_ToScaleUpPodBatchSize pins the field-specific contract:
+// absent configuration preserves this field's unbounded compatibility path, a
+// positive missing-Pod budget passes through exactly, and an explicitly
+// non-positive value is rejected during manager startup.
+func TestLifecycleConfig_ToScaleUpPodBatchSize(t *testing.T) {
+	t.Run("nil config is unconfigured", func(t *testing.T) {
+		var cfg *LifecycleConfig
+		size, err := cfg.ToScaleUpPodBatchSize()
+		require.NoError(t, err)
+		assert.Nil(t, size)
+	})
+
+	t.Run("absent field is unconfigured", func(t *testing.T) {
+		cfg := &LifecycleConfig{}
+		size, err := cfg.ToScaleUpPodBatchSize()
+		require.NoError(t, err)
+		assert.Nil(t, size)
+	})
+
+	t.Run("positive value passes through", func(t *testing.T) {
+		configured := int32(100)
+		cfg := &LifecycleConfig{ScaleUpPodBatchSize: &configured}
+		size, err := cfg.ToScaleUpPodBatchSize()
+		require.NoError(t, err)
+		require.NotNil(t, size)
+		assert.Equal(t, int32(100), *size)
+
+		// The conversion returns a value copy, not an alias into the parsed
+		// ConfigMap object that a cached reader may share with other callers.
+		configured = 200
+		assert.Equal(t, int32(100), *size)
+	})
+
+	for _, configured := range []int32{0, -1} {
+		configured := configured
+		t.Run(fmt.Sprintf("rejects %d", configured), func(t *testing.T) {
+			cfg := &LifecycleConfig{ScaleUpPodBatchSize: &configured}
+			size, err := cfg.ToScaleUpPodBatchSize()
+			assert.Error(t, err)
+			assert.Nil(t, size)
+		})
+	}
+}
+
+// TestLifecycleConfig_ToRevisionHistoryLimit pins the field-specific
+// contract: absent configuration is unconfigured (the retention sweep
+// prunes nothing rather than fabricating a default), a positive cap
+// passes through as a value copy, and an explicitly non-positive value
+// is invalid (the caller treats it as unconfigured).
+func TestLifecycleConfig_ToRevisionHistoryLimit(t *testing.T) {
+	t.Run("nil config is unconfigured", func(t *testing.T) {
+		var cfg *LifecycleConfig
+		limit, err := cfg.ToRevisionHistoryLimit()
+		require.NoError(t, err)
+		assert.Nil(t, limit)
+	})
+
+	t.Run("absent field is unconfigured", func(t *testing.T) {
+		cfg := &LifecycleConfig{}
+		limit, err := cfg.ToRevisionHistoryLimit()
+		require.NoError(t, err)
+		assert.Nil(t, limit)
+	})
+
+	t.Run("positive value passes through as a copy", func(t *testing.T) {
+		configured := int32(10)
+		cfg := &LifecycleConfig{RevisionHistoryLimit: &configured}
+		limit, err := cfg.ToRevisionHistoryLimit()
+		require.NoError(t, err)
+		require.NotNil(t, limit)
+		assert.Equal(t, int32(10), *limit)
+
+		// The conversion returns a value copy, not an alias into the parsed
+		// ConfigMap object that a cached reader may share with other callers.
+		configured = 42
+		assert.Equal(t, int32(10), *limit)
+	})
+
+	for _, configured := range []int32{0, -1} {
+		configured := configured
+		t.Run(fmt.Sprintf("rejects %d", configured), func(t *testing.T) {
+			cfg := &LifecycleConfig{RevisionHistoryLimit: &configured}
+			limit, err := cfg.ToRevisionHistoryLimit()
+			assert.Error(t, err)
+			assert.Nil(t, limit)
+		})
+	}
+}
+
+// TestUpdateRetryConfig_ToPolicy pins the validation contract: the chart
+// defaults convert 1:1, and every violation is an error (the caller
+// treats an invalid policy as unconfigured — fail-safe Held — rather
+// than silently patching it with fallback numbers).
+func TestUpdateRetryConfig_ToPolicy(t *testing.T) {
+	t.Run("happy path matches chart defaults", func(t *testing.T) {
+		cfg := &UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "1m", MaxDelay: "30m", Multiplier: 2.0}
+		policy, err := cfg.ToPolicy()
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		assert.Equal(t, int32(3), policy.MaxAttempts)
+		assert.Equal(t, time.Minute, policy.InitialDelay)
+		assert.Equal(t, 30*time.Minute, policy.MaxDelay)
+		assert.Equal(t, 2.0, policy.Multiplier)
+	})
+
+	invalid := []struct {
+		name string
+		cfg  UpdateRetryConfig
+	}{
+		{"maxAttempts zero", UpdateRetryConfig{MaxAttempts: 0, InitialDelay: "1m", MaxDelay: "30m", Multiplier: 2.0}},
+		{"invalid initialDelay duration", UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "not-a-duration", MaxDelay: "30m", Multiplier: 2.0}},
+		{"invalid maxDelay duration", UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "1m", MaxDelay: "30 minutes", Multiplier: 2.0}},
+		{"multiplier below one", UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "1m", MaxDelay: "30m", Multiplier: 0.5}},
+		{"zero initialDelay", UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "0s", MaxDelay: "30m", Multiplier: 2.0}},
+		{"zero maxDelay", UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "1m", MaxDelay: "0s", Multiplier: 2.0}},
+		{"maxDelay below initialDelay", UpdateRetryConfig{MaxAttempts: 3, InitialDelay: "10m", MaxDelay: "1m", Multiplier: 2.0}},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := tt.cfg.ToPolicy()
+			assert.Error(t, err)
+			assert.Nil(t, policy)
+		})
+	}
+}
+
+// TestLifecycleConfig_ToGracePeriod pins the validation contract:
+// chart default 60s parses cleanly, absent key yields zero (not an
+// error), invalid duration is an error.
+func TestLifecycleConfig_ToGracePeriod(t *testing.T) {
+	t.Run("happy path matches chart default", func(t *testing.T) {
+		cfg := &LifecycleConfig{StuckPodGracePeriod: "60s"}
+		grace, err := cfg.ToGracePeriod()
+		require.NoError(t, err)
+		assert.Equal(t, 60*time.Second, grace)
+	})
+
+	t.Run("absent key yields zero, no error", func(t *testing.T) {
+		cfg := &LifecycleConfig{StuckPodGracePeriod: ""}
+		grace, err := cfg.ToGracePeriod()
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), grace)
+	})
+
+	invalid := []struct {
+		name  string
+		value string
+	}{
+		{"invalid duration", "not-a-duration"},
+		{"zero duration", "0s"},
+		{"negative duration", "-5s"},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &LifecycleConfig{StuckPodGracePeriod: tt.value}
+			grace, err := cfg.ToGracePeriod()
+			assert.Error(t, err)
+			assert.Equal(t, time.Duration(0), grace)
+		})
+	}
+}
+
+// TestAutoMigrateConfig_Validate pins the validation contract: the
+// chart default converts cleanly, zero/negative maxAttempts is an error.
+func TestAutoMigrateConfig_Validate(t *testing.T) {
+	t.Run("happy path matches chart default", func(t *testing.T) {
+		cfg := &AutoMigrateConfig{MaxAttempts: 3}
+		err := cfg.Validate()
+		require.NoError(t, err)
+	})
+
+	invalid := []struct {
+		name        string
+		maxAttempts int32
+	}{
+		{"zero maxAttempts", 0},
+		{"negative maxAttempts", -1},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &AutoMigrateConfig{MaxAttempts: tt.maxAttempts}
+			err := cfg.Validate()
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestNewLifecycleConfig_StuckPodGracePeriod pins the load contract
+// for the stuckPodGracePeriod key: present + valid parses, absent
+// leaves the field empty (no error).
+func TestNewLifecycleConfig_StuckPodGracePeriod(t *testing.T) {
+	t.Run("valid stuckPodGracePeriod block", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{"stuckPodGracePeriod":"60s"}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "60s", cfg.StuckPodGracePeriod)
+	})
+
+	t.Run("lifecycle key without stuckPodGracePeriod yields config with empty field", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "", cfg.StuckPodGracePeriod)
+	})
+}
+
+// TestForceDeleteConfig_ToPolicy pins the validation contract: a nil
+// receiver (absent block) is unconfigured — nil policy, no error — the
+// chart example converts 1:1, and every violation (either field missing,
+// unparsable, or non-positive) is an error the caller treats as
+// unconfigured (escalation OFF), never patched with fallback numbers.
+func TestForceDeleteConfig_ToPolicy(t *testing.T) {
+	t.Run("nil receiver yields nil policy, no error", func(t *testing.T) {
+		var cfg *ForceDeleteConfig
+		policy, err := cfg.ToPolicy()
+		require.NoError(t, err)
+		assert.Nil(t, policy)
+	})
+
+	t.Run("happy path matches chart example", func(t *testing.T) {
+		cfg := &ForceDeleteConfig{OverdueSlack: "2m", NodeUnreachableThreshold: "5m"}
+		policy, err := cfg.ToPolicy()
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		assert.Equal(t, 2*time.Minute, policy.OverdueSlack)
+		assert.Equal(t, 5*time.Minute, policy.NodeUnreachableThreshold)
+	})
+
+	invalid := []struct {
+		name string
+		cfg  ForceDeleteConfig
+	}{
+		{"missing overdueSlack", ForceDeleteConfig{OverdueSlack: "", NodeUnreachableThreshold: "5m"}},
+		{"missing nodeUnreachableThreshold", ForceDeleteConfig{OverdueSlack: "2m", NodeUnreachableThreshold: ""}},
+		{"invalid overdueSlack duration", ForceDeleteConfig{OverdueSlack: "not-a-duration", NodeUnreachableThreshold: "5m"}},
+		{"invalid nodeUnreachableThreshold duration", ForceDeleteConfig{OverdueSlack: "2m", NodeUnreachableThreshold: "5 minutes"}},
+		{"zero overdueSlack", ForceDeleteConfig{OverdueSlack: "0s", NodeUnreachableThreshold: "5m"}},
+		{"zero nodeUnreachableThreshold", ForceDeleteConfig{OverdueSlack: "2m", NodeUnreachableThreshold: "0s"}},
+		{"negative overdueSlack", ForceDeleteConfig{OverdueSlack: "-2m", NodeUnreachableThreshold: "5m"}},
+		{"negative nodeUnreachableThreshold", ForceDeleteConfig{OverdueSlack: "2m", NodeUnreachableThreshold: "-5m"}},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := tt.cfg.ToPolicy()
+			assert.Error(t, err)
+			assert.Nil(t, policy)
+		})
+	}
+}
+
+// TestNewLifecycleConfig_ForceDelete pins the load contract for the
+// forceDelete key: present + valid parses, absent leaves the field nil
+// (unconfigured — the escalation does not exist).
+func TestNewLifecycleConfig_ForceDelete(t *testing.T) {
+	t.Run("valid forceDelete block", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{"forceDelete":{"overdueSlack":"2m","nodeUnreachableThreshold":"5m"}}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.ForceDelete)
+		assert.Equal(t, "2m", cfg.ForceDelete.OverdueSlack)
+		assert.Equal(t, "5m", cfg.ForceDelete.NodeUnreachableThreshold)
+	})
+
+	t.Run("lifecycle key without forceDelete yields config with nil ForceDelete", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Nil(t, cfg.ForceDelete)
+	})
+}
+
+// TestTeardownConfig_ToDeadline pins the validation contract: a nil
+// receiver (absent block) is unconfigured — nil deadline, no error —
+// the chart default converts 1:1, and every violation (missing
+// deadline, unparsable, or non-positive) is an error the caller
+// treats as unconfigured (no deadline), never patched with fallback.
+func TestTeardownConfig_ToDeadline(t *testing.T) {
+	t.Run("nil receiver yields nil deadline, no error", func(t *testing.T) {
+		var cfg *TeardownConfig
+		deadline, err := cfg.ToDeadline()
+		require.NoError(t, err)
+		assert.Nil(t, deadline)
+	})
+
+	t.Run("happy path matches chart default", func(t *testing.T) {
+		cfg := &TeardownConfig{Deadline: "30m"}
+		deadline, err := cfg.ToDeadline()
+		require.NoError(t, err)
+		require.NotNil(t, deadline)
+		assert.Equal(t, 30*time.Minute, *deadline)
+	})
+
+	invalid := []struct {
+		name string
+		cfg  TeardownConfig
+	}{
+		{"missing deadline", TeardownConfig{Deadline: ""}},
+		{"invalid deadline duration", TeardownConfig{Deadline: "not-a-duration"}},
+		{"zero deadline", TeardownConfig{Deadline: "0s"}},
+		{"negative deadline", TeardownConfig{Deadline: "-30m"}},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			deadline, err := tt.cfg.ToDeadline()
+			assert.Error(t, err)
+			assert.Nil(t, deadline)
+		})
+	}
+}
+
+// TestNewLifecycleConfig_Teardown pins the load contract for the
+// teardown key: present + valid parses, absent leaves the field nil.
+func TestNewLifecycleConfig_Teardown(t *testing.T) {
+	t.Run("valid teardown block", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{"teardown":{"deadline":"30m"}}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.Teardown)
+		assert.Equal(t, "30m", cfg.Teardown.Deadline)
+	})
+
+	t.Run("lifecycle key without teardown yields config with nil Teardown", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Nil(t, cfg.Teardown)
+	})
+}
+
+// TestNewLifecycleConfig_AutoMigrate pins the load contract for the
+// autoMigrate key: present + valid parses, absent leaves the field nil.
+func TestNewLifecycleConfig_AutoMigrate(t *testing.T) {
+	t.Run("valid autoMigrate block", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{"autoMigrate":{"maxAttempts":3}}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.AutoMigrate)
+		assert.Equal(t, int32(3), cfg.AutoMigrate.MaxAttempts)
+	})
+
+	t.Run("lifecycle key without autoMigrate yields config with nil AutoMigrate", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.OMENamespace,
+			},
+			Data: map[string]string{
+				LifecycleConfigName: `{}`,
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cfg, err := NewLifecycleConfig(clientset)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Nil(t, cfg.AutoMigrate)
+	})
+}

--- a/pkg/controller/v1beta1/controllerconfig/multicluster.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster.go
@@ -31,6 +31,9 @@ const MultiClusterConfigName = "multicluster"
 // each knob stays single-sourced in the package that owns it — never duplicated
 // as a literal here — and an absent "multicluster" block reproduces the
 // built-in behavior exactly.
+//
+// A knob that is stated but unusable is a startup error, not a silent fallback:
+// Validate gates the loaded config before any controller is wired.
 type MultiClusterConfig struct {
 	WorkloadCluster WorkloadClusterConfig `json:"workloadCluster,omitempty"`
 	Placement       PlacementConfig       `json:"placement,omitempty"`
@@ -113,7 +116,7 @@ type PlacementConfig struct {
 	// LocalQueue is the Kueue LocalQueue that a derived workload's pods join on
 	// the target cluster when the InferenceService carries no per-ISVC queue
 	// annotation. It names a resource the operator created, so it has no in-code
-	// default: empty leaves the placement package's own fallback in place.
+	// default: empty leaves the choice to the placement package.
 	LocalQueue string `json:"localQueue,omitempty"`
 }
 
@@ -294,7 +297,8 @@ func (c PlacementConfig) DispatcherRoundTimeoutDuration() time.Duration {
 // parseDurationOrZero parses s, returning 0 when it is empty, malformed, or
 // non-positive. Callers hand the zero to a workloadcluster/placement option,
 // which then applies its own in-package default — so the fallback stays
-// single-sourced in the consuming package, not duplicated here.
+// single-sourced in the consuming package, not duplicated here. Only the empty
+// case reaches a running manager; Validate rejects the rest at startup.
 func parseDurationOrZero(s string) time.Duration {
 	if d, err := time.ParseDuration(s); err == nil && d > 0 {
 		return d

--- a/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
@@ -163,7 +163,7 @@ func TestNewMultiClusterConfig(t *testing.T) {
 	}
 }
 
-// A stated-but-unparsable duration must fail at startup rather than read as
+// A stated-but-unparseable duration must fail at startup rather than read as
 // "not set": the forgiving accessors would discard the operator's intended
 // value for the life of the process, with the built-in default silently
 // standing in.

--- a/pkg/controller/v1beta1/servingruntime/inheritance_controller.go
+++ b/pkg/controller/v1beta1/servingruntime/inheritance_controller.go
@@ -1,0 +1,238 @@
+package servingruntime
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
+)
+
+// +kubebuilder:rbac:groups=ome.io,resources=clusterservingruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ome.io,resources=clusterservingruntimes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ome.io,resources=servingruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ome.io,resources=servingruntimes/status,verbs=get;update;patch
+
+// InheritanceReconciler resolves runtime inheritance for both
+// cluster- and namespace-scoped runtimes. Reconcile branches on
+// request namespace: empty → ClusterServingRuntime, set →
+// ServingRuntime in that namespace.
+type InheritanceReconciler struct {
+	client.Client
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+func (r *InheritanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.Namespace == "" {
+		return r.reconcileCluster(ctx, req.Name)
+	}
+	return r.reconcileNamespaced(ctx, req.Namespace, req.Name)
+}
+
+func (r *InheritanceReconciler) reconcileCluster(ctx context.Context, name string) (ctrl.Result, error) {
+	csr := &v1beta1.ClusterServingRuntime{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name}, csr); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	start := &runtimeinheritance.RuntimeRef{
+		Name:       csr.Name,
+		Spec:       &csr.Spec,
+		ParentName: csr.Annotations[constants.RuntimeInheritFromAnnotationKey],
+	}
+	_, chain, err := runtimeinheritance.Resolve(ctx, start, r.clusterFetcher(), constants.RuntimeInheritMaxDepth)
+	if err != nil {
+		r.Log.WithValues("clusterservingruntime", name).Info("inheritance resolution failed",
+			"reason", classifyResolveError(err), "error", err.Error())
+		r.Recorder.Eventf(csr, "Warning", classifyResolveError(err), "%v", err)
+	}
+
+	newStatus := projectInheritanceResult(csr.Status, csr.Generation, chain, err)
+	if equality.Semantic.DeepEqual(csr.Status, newStatus) {
+		return ctrl.Result{}, nil
+	}
+	csr.Status = newStatus
+	if updateErr := r.Status().Update(ctx, csr); updateErr != nil {
+		if apierrors.IsConflict(updateErr) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, updateErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *InheritanceReconciler) reconcileNamespaced(ctx context.Context, namespace, name string) (ctrl.Result, error) {
+	sr := &v1beta1.ServingRuntime{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, sr); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	start := &runtimeinheritance.RuntimeRef{
+		Name:       sr.Name,
+		Spec:       &sr.Spec,
+		ParentName: sr.Annotations[constants.RuntimeInheritFromAnnotationKey],
+	}
+	_, chain, err := runtimeinheritance.Resolve(ctx, start, r.namespacedFetcher(namespace), constants.RuntimeInheritMaxDepth)
+	if err != nil {
+		r.Log.WithValues("servingruntime", name, "namespace", namespace).Info("inheritance resolution failed",
+			"reason", classifyResolveError(err), "error", err.Error())
+		r.Recorder.Eventf(sr, "Warning", classifyResolveError(err), "%v", err)
+	}
+
+	newStatus := projectInheritanceResult(sr.Status, sr.Generation, chain, err)
+	if equality.Semantic.DeepEqual(sr.Status, newStatus) {
+		return ctrl.Result{}, nil
+	}
+	sr.Status = newStatus
+	if updateErr := r.Status().Update(ctx, sr); updateErr != nil {
+		if apierrors.IsConflict(updateErr) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, updateErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *InheritanceReconciler) clusterFetcher() runtimeinheritance.Fetcher {
+	return func(ctx context.Context, name string) (*runtimeinheritance.RuntimeRef, error) {
+		parent := &v1beta1.ClusterServingRuntime{}
+		if err := r.Get(ctx, types.NamespacedName{Name: name}, parent); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, errors.Join(runtimeinheritance.ErrParentNotFound, err)
+			}
+			return nil, err
+		}
+		return &runtimeinheritance.RuntimeRef{
+			Name:       parent.Name,
+			Spec:       &parent.Spec,
+			ParentName: parent.Annotations[constants.RuntimeInheritFromAnnotationKey],
+		}, nil
+	}
+}
+
+func (r *InheritanceReconciler) namespacedFetcher(namespace string) runtimeinheritance.Fetcher {
+	return func(ctx context.Context, name string) (*runtimeinheritance.RuntimeRef, error) {
+		sr := &v1beta1.ServingRuntime{}
+		err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, sr)
+		if err == nil {
+			return &runtimeinheritance.RuntimeRef{
+				Name:       sr.Name,
+				Spec:       &sr.Spec,
+				ParentName: sr.Annotations[constants.RuntimeInheritFromAnnotationKey],
+			}, nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		csr := &v1beta1.ClusterServingRuntime{}
+		if err := r.Get(ctx, types.NamespacedName{Name: name}, csr); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, errors.Join(runtimeinheritance.ErrParentNotFound, err)
+			}
+			return nil, err
+		}
+		return &runtimeinheritance.RuntimeRef{
+			Name:       csr.Name,
+			Spec:       &csr.Spec,
+			ParentName: csr.Annotations[constants.RuntimeInheritFromAnnotationKey],
+		}, nil
+	}
+}
+
+// dependentsOfCluster enqueues self + every CSR/SR that inherits from
+// the changed CSR. Drives cluster→cluster and cluster→namespaced
+// cascade on parent profile updates.
+func (r *InheritanceReconciler) dependentsOfCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+	name := obj.GetName()
+	reqs := []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name}}}
+
+	var csrs v1beta1.ClusterServingRuntimeList
+	if err := r.List(ctx, &csrs); err == nil {
+		for _, item := range csrs.Items {
+			if item.Name == name {
+				continue
+			}
+			if item.Annotations[constants.RuntimeInheritFromAnnotationKey] == name {
+				reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name}})
+			}
+		}
+	} else {
+		r.Log.Error(err, "dependentsOfCluster: list ClusterServingRuntimes failed")
+	}
+	var srs v1beta1.ServingRuntimeList
+	if err := r.List(ctx, &srs); err == nil {
+		for _, item := range srs.Items {
+			if item.Annotations[constants.RuntimeInheritFromAnnotationKey] == name {
+				reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: item.Namespace, Name: item.Name}})
+			}
+		}
+	} else {
+		r.Log.Error(err, "dependentsOfCluster: list ServingRuntimes failed")
+	}
+	return reqs
+}
+
+// dependentsOfNamespaced enqueues self + same-namespace SRs that
+// inherit from the changed SR. Drives namespaced→namespaced cascade.
+// SRs cannot be inherited from outside their namespace.
+func (r *InheritanceReconciler) dependentsOfNamespaced(ctx context.Context, obj client.Object) []reconcile.Request {
+	name := obj.GetName()
+	namespace := obj.GetNamespace()
+	reqs := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
+
+	var srs v1beta1.ServingRuntimeList
+	if err := r.List(ctx, &srs, client.InNamespace(namespace)); err != nil {
+		r.Log.Error(err, "dependentsOfNamespaced: list ServingRuntimes failed", "namespace", namespace)
+		return reqs
+	}
+	for _, item := range srs.Items {
+		if item.Name == name {
+			continue
+		}
+		if item.Annotations[constants.RuntimeInheritFromAnnotationKey] == name {
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: item.Namespace, Name: item.Name}})
+		}
+	}
+	return reqs
+}
+
+// SetupWithManager registers a single controller watching both CSR and
+// SR via Watches() with fan-out map functions. A cluster-scoped parent
+// update cascades into all cluster- and namespace-scoped children;
+// a namespace-scoped parent update cascades into same-namespace
+// children only. Reconcile branches on req.Namespace.
+func (r *InheritanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("servingruntime-inheritance").
+		For(&v1beta1.ClusterServingRuntime{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&v1beta1.ClusterServingRuntime{},
+			handler.EnqueueRequestsFromMapFunc(r.dependentsOfCluster),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&v1beta1.ServingRuntime{},
+			handler.EnqueueRequestsFromMapFunc(r.dependentsOfNamespaced),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r)
+}

--- a/pkg/controller/v1beta1/servingruntime/inheritance_controller_test.go
+++ b/pkg/controller/v1beta1/servingruntime/inheritance_controller_test.go
@@ -1,0 +1,276 @@
+package servingruntime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func newReconciler(t *testing.T, objs ...client.Object) (*InheritanceReconciler, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	c := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1beta1.ClusterServingRuntime{}, &v1beta1.ServingRuntime{}).
+		WithObjects(objs...).
+		Build()
+	return &InheritanceReconciler{
+		Client:   c,
+		Log:      testr.New(t),
+		Scheme:   scheme,
+		Recorder: &record.FakeRecorder{},
+	}, c
+}
+
+func runReconcile(t *testing.T, r *InheritanceReconciler, namespace, name string) {
+	t.Helper()
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}})
+	if err != nil {
+		t.Fatalf("Reconcile(%s/%s): %v", namespace, name, err)
+	}
+}
+
+func envSpec(envs ...corev1.EnvVar) v1beta1.ServingRuntimeSpec {
+	return v1beta1.ServingRuntimeSpec{
+		ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{
+			Containers: []corev1.Container{{Name: "ome-container", Env: envs}},
+		},
+	}
+}
+
+func mkCSR(name, inheritFrom string, spec v1beta1.ServingRuntimeSpec) *v1beta1.ClusterServingRuntime {
+	annotations := map[string]string{}
+	if inheritFrom != "" {
+		annotations[constants.RuntimeInheritFromAnnotationKey] = inheritFrom
+	}
+	return &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations, Generation: 1},
+		Spec:       spec,
+	}
+}
+
+func mkSR(name, namespace, inheritFrom string, spec v1beta1.ServingRuntimeSpec) *v1beta1.ServingRuntime {
+	annotations := map[string]string{}
+	if inheritFrom != "" {
+		annotations[constants.RuntimeInheritFromAnnotationKey] = inheritFrom
+	}
+	return &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Annotations: annotations, Generation: 1},
+		Spec:       spec,
+	}
+}
+
+func mustGetCSR(t *testing.T, c client.Client, name string) *v1beta1.ClusterServingRuntime {
+	t.Helper()
+	out := &v1beta1.ClusterServingRuntime{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: name}, out); err != nil {
+		t.Fatalf("Get(%s): %v", name, err)
+	}
+	return out
+}
+
+func mustGetSR(t *testing.T, c client.Client, ns, name string) *v1beta1.ServingRuntime {
+	t.Helper()
+	out := &v1beta1.ServingRuntime{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, out); err != nil {
+		t.Fatalf("Get(%s/%s): %v", ns, name, err)
+	}
+	return out
+}
+
+// Cluster scope
+
+func TestReconcile_Cluster_NoInheritance(t *testing.T) {
+	g := gomega.NewWithT(t)
+	solo := mkCSR("solo", "", v1beta1.ServingRuntimeSpec{Disabled: ptr.To(true)})
+	r, c := newReconciler(t, solo)
+
+	runReconcile(t, r, "", "solo")
+
+	got := mustGetCSR(t, c, "solo")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"solo"}))
+	g.Expect(got.Status.Conditions).To(gomega.HaveLen(1))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
+}
+
+func TestReconcile_Cluster_TwoLevelChain(t *testing.T) {
+	g := gomega.NewWithT(t)
+	profile := mkCSR("profile-infra", "",
+		envSpec(corev1.EnvVar{Name: "NCCL_DEBUG", Value: "INFO"}))
+	rt := mkCSR("rt-sglang", "profile-infra",
+		envSpec(corev1.EnvVar{Name: "FROM_RT", Value: "yes"}))
+	r, c := newReconciler(t, profile, rt)
+
+	runReconcile(t, r, "", "rt-sglang")
+
+	got := mustGetCSR(t, c, "rt-sglang")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"profile-infra", "rt-sglang"}))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
+}
+
+func TestReconcile_Cluster_ParentMissing_PreservesPriorChain(t *testing.T) {
+	g := gomega.NewWithT(t)
+	rt := mkCSR("rt", "ghost-parent", v1beta1.ServingRuntimeSpec{})
+	rt.Status = v1beta1.ServingRuntimeStatus{
+		InheritanceChain: []string{"some-old-parent", "rt"},
+	}
+	r, c := newReconciler(t, rt)
+
+	runReconcile(t, r, "", "rt")
+
+	got := mustGetCSR(t, c, "rt")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"some-old-parent", "rt"}))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(got.Status.Conditions[0].Reason).To(gomega.Equal(ReasonParentNotFound))
+}
+
+func TestReconcile_Cluster_Cycle(t *testing.T) {
+	g := gomega.NewWithT(t)
+	a := mkCSR("a", "b", v1beta1.ServingRuntimeSpec{})
+	b := mkCSR("b", "a", v1beta1.ServingRuntimeSpec{})
+	r, c := newReconciler(t, a, b)
+
+	runReconcile(t, r, "", "a")
+
+	got := mustGetCSR(t, c, "a")
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(got.Status.Conditions[0].Reason).To(gomega.Equal(ReasonCycle))
+}
+
+func TestReconcile_Cluster_Idempotent(t *testing.T) {
+	g := gomega.NewWithT(t)
+	solo := mkCSR("solo", "", v1beta1.ServingRuntimeSpec{Disabled: ptr.To(true)})
+	r, c := newReconciler(t, solo)
+
+	runReconcile(t, r, "", "solo")
+	firstRV := mustGetCSR(t, c, "solo").ResourceVersion
+	runReconcile(t, r, "", "solo")
+	g.Expect(mustGetCSR(t, c, "solo").ResourceVersion).To(gomega.Equal(firstRV),
+		"second reconcile must be a no-op (no status diff → no API write)")
+}
+
+// Namespaced scope
+
+func TestReconcile_Namespaced_NoInheritance(t *testing.T) {
+	g := gomega.NewWithT(t)
+	sr := mkSR("solo", "team-a", "", v1beta1.ServingRuntimeSpec{Disabled: ptr.To(false)})
+	r, c := newReconciler(t, sr)
+
+	runReconcile(t, r, "team-a", "solo")
+
+	got := mustGetSR(t, c, "team-a", "solo")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"solo"}))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
+}
+
+func TestReconcile_Namespaced_SameNamespaceParent(t *testing.T) {
+	g := gomega.NewWithT(t)
+	parent := mkSR("ns-profile", "team-a", "",
+		envSpec(corev1.EnvVar{Name: "FROM_NS_PROFILE", Value: "yes"}))
+	child := mkSR("rt", "team-a", "ns-profile",
+		envSpec(corev1.EnvVar{Name: "FROM_CHILD", Value: "yes"}))
+	r, c := newReconciler(t, parent, child)
+
+	runReconcile(t, r, "team-a", "rt")
+
+	got := mustGetSR(t, c, "team-a", "rt")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"ns-profile", "rt"}))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
+}
+
+func TestReconcile_Namespaced_ClusterFallback(t *testing.T) {
+	g := gomega.NewWithT(t)
+	clusterProfile := mkCSR("cluster-infra", "",
+		envSpec(corev1.EnvVar{Name: "FROM_CLUSTER", Value: "yes"}))
+	child := mkSR("rt", "team-a", "cluster-infra", v1beta1.ServingRuntimeSpec{})
+	r, c := newReconciler(t, clusterProfile, child)
+
+	runReconcile(t, r, "team-a", "rt")
+
+	got := mustGetSR(t, c, "team-a", "rt")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"cluster-infra", "rt"}))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
+}
+
+func TestReconcile_Namespaced_CrossNamespaceRejected(t *testing.T) {
+	g := gomega.NewWithT(t)
+	otherNS := mkSR("shared", "other-team", "", v1beta1.ServingRuntimeSpec{})
+	child := mkSR("rt", "team-a", "shared", v1beta1.ServingRuntimeSpec{})
+	r, c := newReconciler(t, otherNS, child)
+
+	runReconcile(t, r, "team-a", "rt")
+
+	got := mustGetSR(t, c, "team-a", "rt")
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(got.Status.Conditions[0].Reason).To(gomega.Equal(ReasonParentNotFound))
+}
+
+func TestReconcile_Namespaced_NamespacedShadowsCluster(t *testing.T) {
+	g := gomega.NewWithT(t)
+	// Same name in both scopes; namespaced wins — the reconciler's
+	// chain reflects the local parent, not the cluster one.
+	clusterParent := mkCSR("infra", "", envSpec(corev1.EnvVar{Name: "FROM_CLUSTER", Value: "yes"}))
+	nsParent := mkSR("infra", "team-a", "", envSpec(corev1.EnvVar{Name: "FROM_NS", Value: "yes"}))
+	child := mkSR("rt", "team-a", "infra", v1beta1.ServingRuntimeSpec{})
+	r, c := newReconciler(t, clusterParent, nsParent, child)
+
+	runReconcile(t, r, "team-a", "rt")
+
+	got := mustGetSR(t, c, "team-a", "rt")
+	g.Expect(got.Status.InheritanceChain).To(gomega.Equal([]string{"infra", "rt"}))
+	g.Expect(got.Status.Conditions[0].Status).To(gomega.Equal(metav1.ConditionTrue))
+}
+
+// Cascade fan-out (handler-level)
+
+func TestOnClusterEvent_FanoutToBothScopes(t *testing.T) {
+	g := gomega.NewWithT(t)
+	root := mkCSR("root", "", v1beta1.ServingRuntimeSpec{})
+	clusterChild := mkCSR("c1", "root", v1beta1.ServingRuntimeSpec{})
+	nsChild1 := mkSR("n1", "team-a", "root", v1beta1.ServingRuntimeSpec{})
+	nsChild2 := mkSR("n2", "team-b", "root", v1beta1.ServingRuntimeSpec{})
+	unrelated := mkCSR("other", "", v1beta1.ServingRuntimeSpec{})
+	r, _ := newReconciler(t, root, clusterChild, nsChild1, nsChild2, unrelated)
+
+	reqs := r.dependentsOfCluster(context.Background(), root)
+	keys := []string{}
+	for _, req := range reqs {
+		keys = append(keys, req.Namespace+"/"+req.Name)
+	}
+	g.Expect(keys).To(gomega.ConsistOf("/root", "/c1", "team-a/n1", "team-b/n2"),
+		"CSR event should enqueue self + cluster dependents + ns dependents across all namespaces")
+}
+
+func TestOnNamespacedEvent_FanoutWithinNamespace(t *testing.T) {
+	g := gomega.NewWithT(t)
+	parent := mkSR("parent", "team-a", "", v1beta1.ServingRuntimeSpec{})
+	sibling := mkSR("sibling", "team-a", "parent", v1beta1.ServingRuntimeSpec{})
+	otherNS := mkSR("other-ns-child", "team-b", "parent", v1beta1.ServingRuntimeSpec{})
+	unrelated := mkSR("unrelated", "team-a", "", v1beta1.ServingRuntimeSpec{})
+	r, _ := newReconciler(t, parent, sibling, otherNS, unrelated)
+
+	reqs := r.dependentsOfNamespaced(context.Background(), parent)
+	keys := []string{}
+	for _, req := range reqs {
+		keys = append(keys, req.Namespace+"/"+req.Name)
+	}
+	g.Expect(keys).To(gomega.ConsistOf("team-a/parent", "team-a/sibling"),
+		"SR event should enqueue self + same-ns dependents only (cross-ns inheritance is disallowed)")
+}

--- a/pkg/controller/v1beta1/servingruntime/status.go
+++ b/pkg/controller/v1beta1/servingruntime/status.go
@@ -1,0 +1,88 @@
+// Package servingruntime hosts the runtime inheritance controllers
+// (one reconciler per CRD scope).
+package servingruntime
+
+import (
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
+)
+
+// Reasons surfaced on the InheritanceReady condition.
+const (
+	ReasonResolved         = "Resolved"
+	ReasonParentNotFound   = "ParentNotFound"
+	ReasonCycle            = "InheritanceCycle"
+	ReasonMaxDepthExceeded = "MaxDepthExceeded"
+	ReasonResolverInternal = "ResolverError"
+)
+
+// projectInheritanceResult applies a resolver outcome onto a copy of
+// the current status. On error, the prior InheritanceChain is preserved
+// (operator history) and only the condition flips.
+func projectInheritanceResult(
+	current v1beta1.ServingRuntimeStatus,
+	generation int64,
+	chain []string,
+	resolveErr error,
+) v1beta1.ServingRuntimeStatus {
+	updated := *current.DeepCopy()
+	cond := metav1.Condition{
+		Type:               constants.InheritanceReadyConditionType,
+		ObservedGeneration: generation,
+	}
+
+	if resolveErr != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = classifyResolveError(resolveErr)
+		cond.Message = resolveErr.Error()
+	} else {
+		updated.InheritanceChain = chain
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = ReasonResolved
+		cond.Message = "inheritance chain resolved"
+	}
+
+	setCondition(&updated.Conditions, cond)
+	return updated
+}
+
+// classifyResolveError maps a resolver error onto a stable Reason.
+func classifyResolveError(err error) string {
+	var pnf *runtimeinheritance.ParentNotFoundError
+	if errors.As(err, &pnf) {
+		return ReasonParentNotFound
+	}
+	var ce *runtimeinheritance.CycleError
+	if errors.As(err, &ce) {
+		return ReasonCycle
+	}
+	var de *runtimeinheritance.MaxDepthExceededError
+	if errors.As(err, &de) {
+		return ReasonMaxDepthExceeded
+	}
+	return ReasonResolverInternal
+}
+
+// setCondition upserts cond on the slice, preserving LastTransitionTime
+// when Status didn't flip.
+func setCondition(conditions *[]metav1.Condition, cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range *conditions {
+		if (*conditions)[i].Type != cond.Type {
+			continue
+		}
+		if (*conditions)[i].Status == cond.Status {
+			cond.LastTransitionTime = (*conditions)[i].LastTransitionTime
+		}
+		(*conditions)[i] = cond
+		return
+	}
+	*conditions = append(*conditions, cond)
+}

--- a/pkg/controller/v1beta1/servingruntime/status_test.go
+++ b/pkg/controller/v1beta1/servingruntime/status_test.go
@@ -1,0 +1,98 @@
+package servingruntime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
+)
+
+func TestProjectInheritanceResult_SuccessSetsChainAndCondition(t *testing.T) {
+	g := gomega.NewWithT(t)
+	current := v1beta1.ServingRuntimeStatus{}
+	chain := []string{"profile", "rt"}
+
+	got := projectInheritanceResult(current, 7, chain, nil)
+
+	g.Expect(got.InheritanceChain).To(gomega.Equal(chain))
+	g.Expect(got.Conditions).To(gomega.HaveLen(1))
+	cond := got.Conditions[0]
+	g.Expect(cond.Type).To(gomega.Equal(constants.InheritanceReadyConditionType))
+	g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(gomega.Equal(ReasonResolved))
+	g.Expect(cond.ObservedGeneration).To(gomega.BeNumerically("==", 7))
+}
+
+func TestProjectInheritanceResult_ErrorPreservesLastChain(t *testing.T) {
+	g := gomega.NewWithT(t)
+	current := v1beta1.ServingRuntimeStatus{
+		InheritanceChain: []string{"profile", "rt"},
+	}
+
+	pnf := &runtimeinheritance.ParentNotFoundError{Parent: "ghost", Chain: []string{"rt"}}
+	got := projectInheritanceResult(current, 3, nil, pnf)
+
+	// Previously-recorded chain is preserved so operators can see what
+	// was last known-good while debugging the broken parent.
+	g.Expect(got.InheritanceChain).To(gomega.Equal([]string{"profile", "rt"}))
+	g.Expect(got.Conditions).To(gomega.HaveLen(1))
+	g.Expect(got.Conditions[0].Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(got.Conditions[0].Reason).To(gomega.Equal(ReasonParentNotFound))
+}
+
+func TestClassifyResolveError(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(classifyResolveError(&runtimeinheritance.ParentNotFoundError{})).To(gomega.Equal(ReasonParentNotFound))
+	g.Expect(classifyResolveError(&runtimeinheritance.CycleError{})).To(gomega.Equal(ReasonCycle))
+	g.Expect(classifyResolveError(&runtimeinheritance.MaxDepthExceededError{})).To(gomega.Equal(ReasonMaxDepthExceeded))
+	g.Expect(classifyResolveError(errors.New("apiserver unreachable"))).To(gomega.Equal(ReasonResolverInternal))
+}
+
+func TestSetCondition_PreservesLastTransitionTimeOnNoChange(t *testing.T) {
+	g := gomega.NewWithT(t)
+	earlier := metav1.NewTime(metav1.Now().Add(-1))
+	conds := []metav1.Condition{
+		{
+			Type:               constants.InheritanceReadyConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonResolved,
+			LastTransitionTime: earlier,
+		},
+	}
+
+	setCondition(&conds, metav1.Condition{
+		Type:   constants.InheritanceReadyConditionType,
+		Status: metav1.ConditionTrue,
+		Reason: ReasonResolved,
+	})
+
+	g.Expect(conds).To(gomega.HaveLen(1))
+	g.Expect(conds[0].LastTransitionTime).To(gomega.Equal(earlier))
+}
+
+func TestSetCondition_BumpsLastTransitionTimeOnStatusFlip(t *testing.T) {
+	g := gomega.NewWithT(t)
+	earlier := metav1.NewTime(metav1.Now().Add(-1))
+	conds := []metav1.Condition{
+		{
+			Type:               constants.InheritanceReadyConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonResolved,
+			LastTransitionTime: earlier,
+		},
+	}
+
+	setCondition(&conds, metav1.Condition{
+		Type:   constants.InheritanceReadyConditionType,
+		Status: metav1.ConditionFalse,
+		Reason: ReasonCycle,
+	})
+
+	g.Expect(conds[0].Status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(conds[0].LastTransitionTime).NotTo(gomega.Equal(earlier), "must bump when status flips")
+}

--- a/pkg/controller/v1beta1/workload/types/conditions.go
+++ b/pkg/controller/v1beta1/workload/types/conditions.go
@@ -1,0 +1,33 @@
+package types
+
+// ConditionType / ConditionReason are workload-internal identifiers
+// stamped on metav1.Condition entries. Values match the legacy
+// omenative/status strings byte-for-byte so operator dashboards keep
+// matching.
+type ConditionType string
+
+func (t ConditionType) String() string { return string(t) }
+
+type ConditionReason string
+
+func (r ConditionReason) String() string { return string(r) }
+
+const (
+	// ConditionGangSchedulingUnavailable is True when the Component
+	// has at least one multi-pod Instance but the scheduler-plugins
+	// PodGroup CRD is missing. The reconciler still creates pods —
+	// gang scheduling is a soft requirement so workloads proceed
+	// without blocking — but partial-gang placement is possible and
+	// the runtime may hang.
+	ConditionGangSchedulingUnavailable ConditionType = "GangSchedulingUnavailable"
+)
+
+const (
+	// ReasonPodGroupCRDNotInstalled stamps the
+	// GangSchedulingUnavailable condition when the
+	// scheduler-plugins PodGroup CRD is missing.
+	ReasonPodGroupCRDNotInstalled ConditionReason = "PodGroupCRDNotInstalled"
+	// ReasonGangSchedulingAvailable stamps Status=False (CRD present,
+	// or Component is single-pod).
+	ReasonGangSchedulingAvailable ConditionReason = "GangSchedulingAvailable"
+)

--- a/pkg/controller/v1beta1/workload/types/deps.go
+++ b/pkg/controller/v1beta1/workload/types/deps.go
@@ -1,0 +1,117 @@
+package types
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ObservationReader is a watch-backed (cached) reader; it may lag the
+// API server. Safe wherever a later live read or optimistic-concurrency
+// write re-validates the observation.
+type ObservationReader = client.Reader
+
+// AuthoritativeReader reads live from the API server. Required where
+// cache lag is a correctness bug: revision bookkeeping, audit ledger,
+// EndpointSlice drain checks, gang topology proofs.
+type AuthoritativeReader = client.Reader
+
+// Deps is the manager-scoped wiring the workload reconciler needs.
+// Shared across every workload the same controller manages (unlike
+// the per-workload ReconcileInput).
+type Deps struct {
+	// Client is the controller-runtime cached client used for the
+	// vast majority of read/write operations.
+	Client client.Client
+
+	// APIReader is the AuthoritativeReader role (see type docs).
+	// Used for revision bookkeeping and immutable topology observations where
+	// stale cache contents could cause a collision or split a live gang. When
+	// nil the cached Client is used.
+	APIReader client.Reader
+
+	// Recorder emits K8s Events at lifecycle transitions. nil-safe:
+	// when unset, event helpers are no-ops.
+	Recorder record.EventRecorder
+
+	// Expectations is the create/delete bookkeeping cache used to
+	// avoid re-issuing batches before the controller-runtime watch
+	// has confirmed prior writes. Adapters wire the same instance
+	// into the Pod event handler so observed create / delete events
+	// release expectations immediately. nil falls back to
+	// DefaultExpectations.
+	Expectations *Expectations
+
+	// RenderHook is an optional per-pod template mutator invoked
+	// after composing the canonical pod (name, hostname, labels,
+	// controller env, owner ref) but before c.Create. The IR
+	// reconciler (the sole workload.Reconcile caller) wires this to
+	// coordination.InjectPeerEnv via core.ISVCRenderHook so
+	// OME_<PEER>_ENDPOINT vars land on every container.
+	//
+	// The hook MUST be idempotent — Render may be invoked twice in
+	// the same reconcile (e.g., cache-lag retry after AlreadyExists).
+	RenderHook RenderHook
+
+	// EnsureGangPodGroup, when set, creates the scheduler-plugins
+	// PodGroup for one multi-pod surge Instance just before its pods are
+	// created. The gang-surge op needs PodGroup-before-pods to hold even
+	// in the window before the surge index lands in the plan the
+	// top-level EnsurePodGroups keys off (else a gang scheduler rejects
+	// the surge pods with "PodGroup not found"). The callback lives on
+	// Deps rather than as a direct call so the workload/ops package stays
+	// free of the workload/podgroup dependency (ops is imported by
+	// podgroup's test deps; a direct edge would close a cycle). The gang
+	// package wires it; nil callback / single-pod Instance / absent CRD
+	// all no-op. Idempotent.
+	EnsureGangPodGroup EnsureGangPodGroupFn
+
+	// Clock supplies wall-clock time for deadlines and status
+	// timestamps. nil falls back to the real clock — inject a fake
+	// (k8s.io/utils/clock/testing) for deterministic boundary tests.
+	Clock clock.Clock
+}
+
+// RenderHook is the optional adapter-specific render-time mutator.
+// Receives the pod under construction; may mutate any field except
+// Name/Namespace/OwnerReferences (workload-controlled).
+type RenderHook func(pod *corev1.Pod, runnerName string, ordinal int32, revisionHash string)
+
+// EnsureGangPodGroupFn ensures the PodGroup for one multi-pod surge Instance
+// and returns the effective topology key selected for its live pods. See
+// Deps.EnsureGangPodGroup.
+type EnsureGangPodGroupFn func(ctx context.Context, input ReconcileInput, plan ComponentPlan, inst InstancePlan) (string, error)
+
+// Reader returns the live API reader when APIReader is set, otherwise
+// the cached Client. Use for reads that must not observe a stale
+// cache.
+func (d *Deps) Reader() client.Reader {
+	if d.APIReader != nil {
+		return d.APIReader
+	}
+	return d.Client
+}
+
+// ExpectationsCache returns the per-controller cache threaded through
+// Deps when set, otherwise the DefaultExpectations singleton.
+func (d *Deps) ExpectationsCache() *Expectations {
+	if d.Expectations != nil {
+		return d.Expectations
+	}
+	return DefaultExpectations
+}
+
+// Now returns the injected clock's time, or time.Now() when no clock
+// is wired. Lifecycle code holding a Deps or ReconcileInput should read
+// time through Now, not time.Now(); subpackages without a seam
+// (audit, podreadiness, gang) still read real time.
+func (d *Deps) Now() time.Time {
+	if d.Clock != nil {
+		return d.Clock.Now()
+	}
+	return time.Now()
+}

--- a/pkg/controller/v1beta1/workload/types/events.go
+++ b/pkg/controller/v1beta1/workload/types/events.go
@@ -1,0 +1,143 @@
+package types
+
+// EventReason is the workload-internal event-reason identifier the ops
+// state machines stamp on K8s Events. Values match the legacy
+// omenative/status reason strings byte-for-byte so existing operator
+// dashboards and `kubectl describe` output keep matching.
+type EventReason string
+
+func (r EventReason) String() string { return string(r) }
+
+const (
+	// Create / scale-up (workload/ops/create.go).
+	EventReasonInstanceCreated EventReason = "InstanceCreated"
+	EventReasonInstanceReady   EventReason = "InstanceReady"
+
+	// In-place update (workload/ops/update.go).
+	EventReasonInPlaceUpdateStarted     EventReason = "InPlaceUpdateStarted"
+	EventReasonInPlaceUpdateCompleted   EventReason = "InPlaceUpdateCompleted"
+	EventReasonInPlaceUpdateNotPossible EventReason = "InPlaceUpdateNotPossible"
+
+	// Recreate / surge update (workload/ops/update.go).
+	EventReasonRecreateUpdateStarted   EventReason = "RecreateUpdateStarted"
+	EventReasonRecreateUpdateCompleted EventReason = "RecreateUpdateCompleted"
+
+	// Restart (workload/ops/restart.go).
+	EventReasonRestartTriggered EventReason = "RestartTriggered"
+	EventReasonRestartCompleted EventReason = "RestartCompleted"
+
+	// EventReasonFoundOrphan fires when Restart or recreate-Update
+	// finds a pod under the OMENative selector but missing the
+	// ome.io/instance-incarnation label. The reconciler refuses to
+	// delete it; the operator must re-classify or remove the pod
+	// manually.
+	EventReasonFoundOrphan EventReason = "FoundOrphan"
+
+	// EventReasonSupersededWreckageCleaned fires when the corrective-
+	// edit cleanup deletes pods keyed to a superseded revision — debris
+	// a failed rollout left behind that no revision-diff trigger could
+	// reach.
+	EventReasonSupersededWreckageCleaned EventReason = "SupersededWreckageCleaned"
+
+	// EventReasonAutoMigrationTriggered fires when the deadline
+	// disposition records a relocation directive (terminal AutoRecover
+	// ledger entry) for a stuck Instance — its rebuild will be steered
+	// off the recorded node. Value matches the legacy omenative
+	// detector's reason string.
+	EventReasonAutoMigrationTriggered EventReason = "AutoMigrationTriggered"
+
+	// EventReasonAutoMigrationCapReached fires exactly once per budget
+	// fill — when the disposition records the relocation directive that
+	// exhausts the (component, instance) AutoRecover budget
+	// (lifecycle.autoMigrate.maxAttempts). Subsequent over-budget
+	// dispositions dispose terminal silently. Operator intervention (or
+	// an instance reaching Ready, which prunes its records) is required
+	// before relocation resumes.
+	EventReasonAutoMigrationCapReached EventReason = "AutoMigrationCapReached"
+
+	// EventReasonInstanceFailed fires when an escalation backstop (the
+	// stuck-pod fast path or the deadline disposition) stamps an
+	// Instance Phase=Failed. Emitted by adapters through
+	// ReconcileInput.WarnInstanceFailed.
+	EventReasonInstanceFailed EventReason = "InstanceFailed"
+
+	// EventReasonRetryHeld fires once, at the RetryBlock transition into
+	// State=Held — same-target update retries exhausted; a corrected
+	// revision (or raised retry limits) is required. Emitted by adapters
+	// through ReconcileInput.WarnRetryHeld.
+	EventReasonRetryHeld EventReason = "RetryHeld"
+
+	// EventReasonRetryBlockReleased fires when the operator release
+	// annotation (ome.io/release-held-revision) removes a Held
+	// RetryBlock — the manual exit from the terminal Held state. Names
+	// the released revision and that the removal was operator-requested.
+	EventReasonRetryBlockReleased EventReason = "RetryBlockReleased"
+
+	// EventReasonRetryBlockReleaseSkipped fires when the release
+	// annotation names no releasable block — no RetryBlock exists for
+	// the requested revision, or the matched block is not State=Held.
+	// The annotation is still consumed; the event explains why nothing
+	// changed.
+	EventReasonRetryBlockReleaseSkipped EventReason = "RetryBlockReleaseSkipped"
+
+	// EventReasonPodForceDeleted fires when scale-down escalation
+	// force-deletes (grace 0, UID-preconditioned) a Terminating pod
+	// overdue past its own deletion deadline on a node that provably
+	// cannot acknowledge the termination (gone, or unreachable-tainted /
+	// NotReady beyond the configured threshold). Names the pod, node,
+	// evidence branch, and overdue duration.
+	EventReasonPodForceDeleted EventReason = "PodForceDeleted"
+
+	// EventReasonPodDeleteBlockedByFinalizer fires (once per pod UID)
+	// when a Terminating pod is overdue past its deletion deadline but
+	// pinned by foreign finalizers. Report-only: OME never strips
+	// another controller's finalizer, so the teardown stays blocked
+	// until the finalizer owner resolves it.
+	EventReasonPodDeleteBlockedByFinalizer EventReason = "PodDeleteBlockedByFinalizer"
+
+	// Migration (workload/ops/migrate.go + the IR accept pass).
+	EventReasonMigrationRequestAccepted EventReason = "MigrationRequestAccepted"
+	EventReasonMigrationRequestRejected EventReason = "MigrationRequestRejected"
+	// EventReasonUnsupportedSchemaVersion fires when a migration-request
+	// annotation carries a schemaVersion the controller doesn't
+	// understand. Kept distinct from MigrationRequestRejected so
+	// dashboards can alert on requester/controller version skew.
+	EventReasonUnsupportedSchemaVersion EventReason = "UnsupportedSchemaVersion"
+	EventReasonMigrationCompleted       EventReason = "MigrationCompleted"
+	// EventReasonMigrationExpired fires when a non-terminal Manual
+	// migration record passes its Deadline: the record is closed
+	// Failed, the pair's Migrate ops are cleared, the surge is torn
+	// down by the ordinary scale-down batch pipeline, and the source
+	// phase is restored from observation.
+	EventReasonMigrationExpired              EventReason = "MigrationExpired"
+	EventReasonRateLimited                   EventReason = "RateLimited"
+	EventReasonMigrationSurgeCreateBlocked   EventReason = "MigrationSurgeCreateBlocked"
+	EventReasonMigrationFromNodeMismatch     EventReason = "MigrationFromNodeMismatch"
+	EventReasonMigrationNodeAffinityConflict EventReason = "MigrationNodeAffinityConflict"
+
+	// EventReasonMaybeNoGangScheduler is a soft Warning fired the first
+	// time a multi-pod Instance's PodGroup is created under a pod
+	// template whose `spec.schedulerName` is unset or equals the
+	// upstream default ("default-scheduler"). A stock kube-scheduler
+	// does NOT read scheduling.x-k8s.io/v1alpha1 PodGroup objects, so
+	// the gang contract degrades to per-pod scheduling silently.
+	// Operators install scheduler-plugins as a secondary scheduler
+	// (`scheduler-plugins-scheduler`) or as a default-scheduler plugin
+	// (in which case the warning is a false positive the controller
+	// can't detect from inside the cluster). Dedup'd per (owner,
+	// Component) per process.
+	EventReasonMaybeNoGangScheduler EventReason = "MaybeNoGangScheduler"
+
+	// EventReasonGangSplitRisk is a soft Warning fired the first time a
+	// multi-node gang WORKER pod is created with no co-location
+	// podAffinity at all — neither an OME-injected topologyKey term nor a
+	// user-declared one. Such a gang may schedule across separate
+	// network / NVLink / TPU topology domains, which breaks the
+	// tightly-coupled collectives a multi-node runtime needs (NCCL/RCCL/
+	// NIXL all-reduce, multi-host TPU sessions). The operator sets
+	// engine.topologyKey / decoder.topologyKey (e.g. a NVLink/RDMA domain
+	// label, or the GKE TPU topology label) or declares a worker
+	// podAffinity. Advisory only — never blocks the create. Dedup'd per
+	// (owner, Component) per process.
+	EventReasonGangSplitRisk EventReason = "GangSplitRisk"
+)

--- a/pkg/controller/v1beta1/workload/types/expectations.go
+++ b/pkg/controller/v1beta1/workload/types/expectations.go
@@ -1,0 +1,162 @@
+package types
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// expectationsTTL is how long an Instance's expectation stays in the
+// cache before falling back to a fresh observation. Two minutes is
+// generous; even slow watch propagation should converge well before.
+const expectationsTTL = 2 * time.Minute
+
+// Expectations is a per-Instance counter cache. Before issuing a batch
+// of pod creates or deletes, the controller calls ExpectCreates / ExpectDeletes
+// so subsequent reconciles can tell when the watch event chain has caught
+// up. Subsequent reconciles call Satisfied to check whether they can
+// safely issue another batch (or proceed past the create step).
+//
+// Pattern borrowed from sigs.k8s.io/controller-runtime samples and the
+// kubernetes/kubernetes ReplicaSet/StatefulSet controllers.
+//
+// Concurrency: all methods are safe for concurrent use; an in-process
+// singleton (DefaultExpectations) is provided for the dispatch path.
+type Expectations struct {
+	mu      sync.Mutex
+	entries map[expectationKey]*expectationEntry
+	clock   clock.Clock
+}
+
+// expectationKey is the per-Instance cache key. OwnerName mirrors
+// types.Key.OwnerName — the workload-side owner identifier shared by
+// every adapter (ISVC.Name, IR.Name, future owners) rather than the
+// CRD-specific "ISVC" name.
+type expectationKey struct {
+	Namespace string
+	OwnerName string
+	Component ComponentType
+	Instance  int32
+}
+
+type expectationEntry struct {
+	Adds     int
+	Deletes  int
+	Deadline time.Time
+}
+
+// NewExpectations builds an empty cache.
+func NewExpectations() *Expectations {
+	return &Expectations{
+		entries: make(map[expectationKey]*expectationEntry),
+		clock:   clock.RealClock{},
+	}
+}
+
+// NewExpectationsWithClock is NewExpectations with an injected clock,
+// for TTL-boundary tests.
+func NewExpectationsWithClock(c clock.Clock) *Expectations {
+	e := NewExpectations()
+	if c != nil {
+		e.clock = c
+	}
+	return e
+}
+
+// DefaultExpectations is the in-process singleton used by the workload
+// dispatcher. Tests construct their own via NewExpectations.
+var DefaultExpectations = NewExpectations()
+
+// ExpectCreates records that n pod creates are in flight for the given
+// (OwnerName, Component, Instance). Satisfied returns false until all
+// of them are observed via ObservedCreate, or the deadline elapses.
+func (e *Expectations) ExpectCreates(namespace, ownerName string, component ComponentType, instance int32, n int) {
+	if n <= 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	k := expectationKey{namespace, ownerName, component, instance}
+	ent, ok := e.entries[k]
+	if !ok {
+		ent = &expectationEntry{}
+		e.entries[k] = ent
+	}
+	ent.Adds += n
+	ent.Deadline = e.clock.Now().Add(expectationsTTL)
+}
+
+// ExpectDeletes records that n pod deletes are in flight.
+func (e *Expectations) ExpectDeletes(namespace, ownerName string, component ComponentType, instance int32, n int) {
+	if n <= 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	k := expectationKey{namespace, ownerName, component, instance}
+	ent, ok := e.entries[k]
+	if !ok {
+		ent = &expectationEntry{}
+		e.entries[k] = ent
+	}
+	ent.Deletes += n
+	ent.Deadline = e.clock.Now().Add(expectationsTTL)
+}
+
+// ObservedCreate decrements the create counter, called when a pod
+// belonging to (OwnerName, Component, Instance) appears in the watch
+// cache.
+func (e *Expectations) ObservedCreate(namespace, ownerName string, component ComponentType, instance int32) {
+	e.observed(namespace, ownerName, component, instance, true)
+}
+
+// ObservedDelete decrements the delete counter, called when a pod
+// belonging to (OwnerName, Component, Instance) disappears.
+func (e *Expectations) ObservedDelete(namespace, ownerName string, component ComponentType, instance int32) {
+	e.observed(namespace, ownerName, component, instance, false)
+}
+
+func (e *Expectations) observed(namespace, ownerName string, component ComponentType, instance int32, isAdd bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	k := expectationKey{namespace, ownerName, component, instance}
+	ent, ok := e.entries[k]
+	if !ok {
+		return
+	}
+	if isAdd && ent.Adds > 0 {
+		ent.Adds--
+	}
+	if !isAdd && ent.Deletes > 0 {
+		ent.Deletes--
+	}
+	if ent.Adds == 0 && ent.Deletes == 0 {
+		delete(e.entries, k)
+	}
+}
+
+// Satisfied returns true when no outstanding creates or deletes are
+// expected for the Instance — either the watch cache has caught up,
+// the entry expired, or no expectations were ever recorded.
+func (e *Expectations) Satisfied(namespace, ownerName string, component ComponentType, instance int32) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	k := expectationKey{namespace, ownerName, component, instance}
+	ent, ok := e.entries[k]
+	if !ok {
+		return true
+	}
+	if e.clock.Now().After(ent.Deadline) {
+		delete(e.entries, k)
+		return true
+	}
+	return ent.Adds <= 0 && ent.Deletes <= 0
+}
+
+// Forget clears the entry, e.g., when the Instance is deleted entirely.
+func (e *Expectations) Forget(namespace, ownerName string, component ComponentType, instance int32) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.entries, expectationKey{namespace, ownerName, component, instance})
+}

--- a/pkg/controller/v1beta1/workload/types/expectations_clock_test.go
+++ b/pkg/controller/v1beta1/workload/types/expectations_clock_test.go
@@ -1,0 +1,35 @@
+package types
+
+// Verifies the Expectations TTL failsafe against the injected clock: an
+// unobserved expectation blocks Satisfied until expectationsTTL elapses,
+// then expires (treated satisfied) without any watch event.
+
+import (
+	"testing"
+	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestExpectations_TTLBoundary(t *testing.T) {
+	t0 := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	fc := clocktesting.NewFakeClock(t0)
+	e := NewExpectationsWithClock(fc)
+
+	e.ExpectCreates("ns", "isvc", ComponentEngine, 0, 1)
+	if e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("outstanding create must block Satisfied")
+	}
+
+	// Just inside the TTL: still blocked.
+	fc.SetTime(t0.Add(expectationsTTL - time.Second))
+	if e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("1s before TTL expiry must still block Satisfied")
+	}
+
+	// Past the TTL: the entry expires and Satisfied reports true.
+	fc.SetTime(t0.Add(expectationsTTL + time.Second))
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("expired expectation must be treated satisfied (TTL failsafe)")
+	}
+}

--- a/pkg/controller/v1beta1/workload/types/input.go
+++ b/pkg/controller/v1beta1/workload/types/input.go
@@ -1,0 +1,345 @@
+package types
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReconcileInput carries everything a workload reconcile needs as
+// plain data. Callers populate this struct from their source-of-truth
+// types; workload code reads it and never reaches back. The boundary
+// lets one workload package serve both the ISVC and IR control
+// planes without sharing a type system.
+type ReconcileInput struct {
+	// OwnerObject is the K8s object whose UID/Kind/APIVersion becomes
+	// the controllerOwner on every emitted pod / revision / service /
+	// PodGroup / PDB.
+	OwnerObject client.Object
+
+	// OwnerGVK is the GroupVersionKind stamped on emitted pods'
+	// OwnerReference. Passed alongside OwnerObject because
+	// controller-runtime strips TypeMeta during deserialization, so
+	// the workload package cannot reliably derive the GVK.
+	OwnerGVK schema.GroupVersionKind
+
+	// EventTarget is the object emitted events are stamped against.
+	// Usually OwnerObject; the IR caller may set this to the parent
+	// ISVC instead so user-facing event streams stay coherent. Nil
+	// falls back to OwnerObject.
+	EventTarget client.Object
+
+	// LedgerOwner owns the migration audit-ledger ConfigMap (load +
+	// persist + its controller OwnerReference). Usually OwnerObject; the
+	// IR caller sets it to the parent ISVC so the migration ledger lives
+	// on the same user-facing resource as the operator's migration-request
+	// annotation (the IR owns the pods; the ISVC owns the migration audit
+	// trail). Nil falls back to OwnerObject. LedgerOwnerGVK is its GVK.
+	LedgerOwner    client.Object
+	LedgerOwnerGVK schema.GroupVersionKind
+
+	// Key is the workload-owned identity. Adapters compose it from the
+	// owner-CRD shape; workload code reads it opaquely.
+	Key Key
+
+	// DesiredSpec is the per-reconcile projection of the source spec
+	// the workload pipeline drives toward.
+	DesiredSpec WorkloadDesiredSpec
+
+	// ObservedState is the per-reconcile snapshot of the source status
+	// subtree. Read-only from workload code; status writes go through
+	// MutateInstance.
+	ObservedState WorkloadObservedState
+
+	// MutateInstance applies the mutate callback to the idx-th
+	// InstanceStatus entry. Callers wrap persistence (apiserver round-
+	// trip under retry.RetryOnConflict, in-memory mirror) inside the
+	// closure. The mutate callback returns true when a real change was
+	// made; false short-circuits the status write.
+	//
+	// MUST be set when ObservedState carries any Instance entries —
+	// workload code panics on a nil callback rather than silently
+	// dropping status updates.
+	MutateInstance func(ctx context.Context, idx int32, mutate func(*InstanceStatus) bool) error
+
+	// ApplyInstanceMutations applies a batch of InstanceMutations in ONE
+	// status write: one fresh read, every mutation applied to its slot,
+	// one persist, retried on conflict as a whole. Only mutations whose
+	// Mutate reports a change are persisted; a batch with no changes
+	// writes nothing. Write-ahead mutations may be batched only when the
+	// complete batch is persisted before any corresponding external effect.
+	//
+	// Optional: nil falls back to one MutateInstance call per mutation.
+	ApplyInstanceMutations func(ctx context.Context, muts []InstanceMutation) error
+
+	// ApplyInstanceMutationsWithRetryBlock atomically applies InstanceStatus
+	// mutations and an optional RetryBlock mutation in one owner-status write.
+	// The adapter re-reads once per conflict attempt, applies both mutation sets
+	// to that fresh snapshot, and persists either all reported changes or none.
+	// A nil mutateRetryBlock callback skips the RetryBlock mutation; an empty or
+	// all-no-op mutation set writes nothing.
+	//
+	// Optional: nil preserves the separate InstanceStatus and RetryBlock writes
+	// used by adapters that do not expose this stronger capability.
+	ApplyInstanceMutationsWithRetryBlock func(ctx context.Context, muts []InstanceMutation, targetRevision string, mutateRetryBlock func(*RetryBlock) RetryBlockDisposition) error
+
+	// ScaleUpPodBatchSize bounds the number of missing Pods selected by one
+	// Create pass. Selection remains atomic at the Instance boundary, so a gang
+	// is either selected in full or deferred. The first eligible Instance may
+	// exceed a positive budget and proceeds alone. A nil pointer preserves the
+	// unbounded compatibility behavior. A non-nil zero value fails closed.
+	ScaleUpPodBatchSize *int32
+
+	// ScaleDownPodBatchSize bounds active delete work in Pod-equivalent units.
+	// Selection remains atomic at the Instance boundary, so a gang is either
+	// selected in full or deferred. The first eligible Instance may exceed a
+	// positive budget and proceeds alone. A nil pointer preserves unbounded
+	// candidate selection. A non-nil zero value fails closed.
+	ScaleDownPodBatchSize *int32
+
+	// ScaleDownRequeueInterval is the configured poll cadence while a delete
+	// wave is waiting on drain or resource disappearance. Zero disables cadence
+	// polling; watched resources and exact force-delete deadlines still wake it.
+	ScaleDownRequeueInterval time.Duration
+
+	// AuthoritativePods is a live Component-wide Pod observation shared by
+	// every destructive consumer in one reconcile pass. Nil means the caller
+	// did not preload an observation; a non-nil snapshot is authoritative even
+	// when Pods and ByInstance are empty.
+	AuthoritativePods *ComponentPodSnapshot
+
+	// FinalizeInstanceResources removes optional per-Instance resources after
+	// the authoritative Pod snapshot is empty. It reports complete only after
+	// those resources are authoritatively absent.
+	FinalizeInstanceResources func(ctx context.Context, idx int32) (complete bool, err error)
+
+	// RemoveInstance drops the InstanceStatus entry for idx and
+	// returns (true, nil) when a real removal happened, (false, nil)
+	// when already absent. Compatibility lifecycle paths use this seam
+	// when they remove one status slot outside an atomic batch.
+	//
+	// It must be set whenever a caller can enter one of those paths; nil
+	// fails closed rather than silently leaking a status entry.
+	RemoveInstance func(ctx context.Context, idx int32) (bool, error)
+
+	// WriteAggregateCondition merges cond into the owner's per-Component
+	// condition list so workload code can stamp top-level Component-
+	// scoped conditions (today only GangSchedulingUnavailable) without
+	// reaching into the owner-CRD typed status.
+	//
+	// MUST be set on every constructed ReconcileInput — nil panics.
+	// No-op adapters wire an explicit
+	// `func(_ context.Context, _ metav1.Condition) error { return nil }`.
+	WriteAggregateCondition func(ctx context.Context, cond metav1.Condition) error
+
+	// WarnInstanceFailed emits a Warning event against EventTarget
+	// reporting that the (idx) Instance escalated to Phase=Failed.
+	//
+	// MUST be set on every constructed ReconcileInput — nil panics.
+	// No-op adapters wire `func(_ int32, _, _ string) {}`.
+	WarnInstanceFailed func(idx int32, podName, reason string)
+
+	// WarnRetryHeld emits the operator-facing Warning when a revision's
+	// retry budget exhausts (spec: emitted at the Held transition, once).
+	// Nil-safe: unset means no event.
+	WarnRetryHeld func(targetRevision string, attempts int32, reason string)
+
+	// MutateMigration reads-modifies-writes the owner's persisted
+	// MigrationRecord for requestUUID (status.migrations). mutate
+	// receives the existing record and returns true when a real change
+	// was made; false short-circuits the status write. A missing record
+	// (trimmed, or the owner was recreated) is a clean no-op — the
+	// callback is not invoked.
+	//
+	// MUST be set when ObservedState.Migrations carries any records —
+	// the Migrate executor errors on a nil callback rather than
+	// silently dropping phase advancement.
+	MutateMigration func(ctx context.Context, requestUUID string, mutate func(*MigrationRecord) bool) error
+
+	// AppendMigration appends a NEW MigrationRecord to the owner's
+	// persisted status.migrations. Idempotent: a record with the same
+	// RequestUUID already present writes nothing. Deliberately separate
+	// from MutateMigration — mutate-on-missing stays a no-op (a stamper
+	// must never resurrect a trimmed record as a phantom), so record
+	// CREATION gets its own seam. Optional: nil disables workload-side
+	// record creation; callers treat the write as a best-effort mirror.
+	AppendMigration func(ctx context.Context, rec MigrationRecord) error
+
+	// UpdateGate, when non-nil, is called per Instance in the Update
+	// pass before starting a fresh Update operation. Lets the adapter
+	// inject cross-Component coordination gates (ratio-balanced
+	// pacing, surge / unavailability budgets, sequential rollout
+	// ordering) that workload code MUST NOT know about.
+	//
+	// allowed=false skips this Instance for this reconcile pass; the
+	// dispatcher emits a short requeue. inFlightSurge / inFlightUnavail
+	// are the dispatcher's within-pass counters so the gate can
+	// project against the post-this-pass shape.
+	//
+	// Nil is treated as always-allowed.
+	UpdateGate func(strategy UpdateStrategyType, inFlightSurge, inFlightUnavail int32) (allowed bool, denyReason string)
+
+	// MutateRetryBlock reads-modifies-writes the owner's persisted
+	// RetryBlock for targetRevision. mutate receives the existing block
+	// (or a zero block with TargetRevision set) and returns whether to
+	// persist, remove, or leave it. Nil closure disables retry-block
+	// WRITES only; the update-trigger gate still honors blocks present
+	// in ObservedState.RetryBlocks.
+	MutateRetryBlock func(ctx context.Context, targetRevision string, mutate func(*RetryBlock) RetryBlockDisposition) error
+
+	// UpdateRetryPolicy bounds automatic same-target update retries.
+	// nil = unconfigured → fail-safe: first failure Holds.
+	UpdateRetryPolicy *RetryPolicy
+
+	// ForceDelete gates the stuck-Terminating force-delete escalation.
+	// nil = unconfigured → the escalation is disabled entirely (does not
+	// exist); when non-nil both durations are > 0 — config validation
+	// guarantees it, consumers never re-check.
+	ForceDelete *ForceDeletePolicy
+
+	// StuckPodGrace is the wait window before the terminal-failure
+	// escalation pass fast-fails an Instance on a pod parked in a
+	// terminal kubelet waiting state. Operator config
+	// (lifecycle.stuckPodGracePeriod); zero or negative disables fast
+	// escalation (the InstanceReadyTimeout backstop still fires).
+	StuckPodGrace time.Duration
+
+	// Disposition carries the operator-config inputs the terminal-failure
+	// disposition (DisposeExpiredAttempt) branches on. The zero value
+	// fails safe (no relocation, terminal branch for non-workload-caused
+	// failures). MigrationMode is plan-derived: the escalation pass
+	// overlays ComponentPlan.MigrationMode, so adapters leave it zero.
+	Disposition DispositionDeps
+
+	// Teardown marks this reconcile as owner-deletion teardown. When
+	// set, the dispatcher treats the planned index set as empty — every
+	// observed Instance is a scale-down extra and runs the scale-down batch
+	// pipeline (drain gate, graceful delete, stuck-Terminating
+	// force-delete escalation, audit) — and runs NOTHING else: no
+	// Paused gate, no Restart / Migrate / Update / Create. The caller
+	// owns completion detection (live component pod list) and all
+	// finalizer decisions.
+	Teardown bool
+
+	// Clock mirrors Deps.Clock for helpers that receive only the input.
+	// See Deps.Now for the rule.
+	Clock clock.Clock
+}
+
+// ErrStatusOwnerGone reports that the object owning a requested atomic status
+// transition disappeared before the transition could commit. Callers that
+// guard an external effect must treat it as an aborted write, even though
+// ordinary idempotent status writers may translate it to a successful no-op.
+var ErrStatusOwnerGone = errors.New("status owner is gone")
+
+// ErrStatusMutationPrecondition reports that an authoritative owner/status
+// snapshot does not match the decision that produced a mutation batch.
+// The complete batch is rejected and callers must replan before effects.
+var ErrStatusMutationPrecondition = errors.New("status mutation precondition failed")
+
+// ComponentPodSnapshot is one authoritative Component Pod LIST represented
+// both as the complete set and as per-Instance buckets. OwnerUID identifies
+// the controller owner that filtered the set. The two views share Pod pointers
+// and are immutable for the lifetime of a reconcile pass.
+type ComponentPodSnapshot struct {
+	OwnerUID   k8stypes.UID
+	Pods       []*corev1.Pod
+	ByInstance map[int32][]*corev1.Pod
+}
+
+// InstanceMutationSnapshot is the authoritative owner/status view presented
+// to a batch precondition on every conflict attempt.
+type InstanceMutationSnapshot struct {
+	OwnerUID        k8stypes.UID
+	OwnerGeneration int64
+	Instances       map[int32]InstanceStatus
+}
+
+// InstanceMutation is one buffered InstanceStatus mutation, keyed by Instance
+// index. An upsert sets Mutate; a removal sets Remove and leaves Mutate nil.
+// Precondition can reject a mutation against the fresh status snapshot.
+// OnCommit receives isolated copies of the exact before/after values only after
+// the containing status write commits; nil identifies an absent side. A
+// mutation with OnCommit requires its index to appear only once in the batch.
+type InstanceMutation struct {
+	Index        int32
+	Mutate       func(*InstanceStatus) bool
+	Remove       bool
+	Precondition func(*InstanceStatus) bool
+	// BatchPrecondition guards the complete mutation set. When any batch
+	// precondition rejects the fresh snapshot, no mutation in the set is
+	// applied. Callers normally attach one shared guard to the first mutation.
+	BatchPrecondition func(InstanceMutationSnapshot) bool
+	// Postcondition identifies this mutation's committed representation after
+	// an ambiguous status-update response. Every mutation in a confirmable
+	// batch supplies one; removals are confirmed by authoritative absence.
+	Postcondition func(*InstanceStatus) bool
+	OnCommit      func(previous, current *InstanceStatus)
+}
+
+// DispositionDeps carries the operator-config inputs and adapter hooks
+// the disposition branches on. Resolved once per reconcile by the
+// adapter.
+type DispositionDeps struct {
+	// AutoMigrateMaxAttempts bounds the relocation branch per
+	// (component, instance) against the audit ledger's AutoRecover
+	// entry count. <= 0 (unconfigured) disables relocation entirely.
+	AutoMigrateMaxAttempts int32
+	// MigrationMode is the effective migration disposition from the
+	// plan (MigrationModeOrDefault). Only Auto (and its Surge spelling
+	// alias) enables relocation; the zero value fails safe to the
+	// terminal branch.
+	MigrationMode MigrationMode
+	// PodSpec / WorkerPodSpec are the Component's desired pod templates
+	// (leader/single-pod and worker role). The relocation branch
+	// consults their REQUIRED node affinity before recording a
+	// directive: when excluding the suspect node (plus the instance's
+	// already-recorded exclusions) would leave a template unschedulable
+	// — e.g. a required In[node] pin on the wedged node — the attempt
+	// disposes terminal instead of recording an unsatisfiable exclusion
+	// that would leave the rebuild permanently Pending. Nil skips the
+	// guard.
+	PodSpec       *corev1.PodSpec
+	WorkerPodSpec *corev1.PodSpec
+	// OnRelocationDirective, when non-nil, is invoked once per recorded
+	// relocation directive with the component name — the adapter's
+	// metrics hook (the IR adapter wires the auto-migration counter).
+	OnRelocationDirective func(component string)
+}
+
+// ForceDeletePolicy configures the stuck-Terminating force-delete
+// escalation: a Terminating pod overdue past its own deletion deadline
+// by OverdueSlack, on a node whose unreachable evidence is at least
+// NodeUnreachableThreshold old, may be force-deleted. Config-driven
+// (chart values → inferenceservice-config); nil means unconfigured and
+// the escalation is disabled entirely. Both durations are always > 0
+// when the policy is non-nil (config validation rejects anything else).
+type ForceDeletePolicy struct {
+	// OverdueSlack is how long past the pod's own DeletionTimestamp
+	// (which already includes the pod's own grace period) a Terminating
+	// pod must be before it counts as wedged.
+	OverdueSlack time.Duration
+	// NodeUnreachableThreshold is the minimum age of the node's
+	// unreachable evidence (taint TimeAdded / NotReady
+	// LastTransitionTime, or the Node object gone) before the
+	// escalation may act.
+	NodeUnreachableThreshold time.Duration
+}
+
+// Now returns the injected clock's time, or time.Now() when no clock
+// is wired. Lifecycle code holding a Deps or ReconcileInput should read
+// time through Now, not time.Now(); subpackages without a seam
+// (audit, podreadiness, gang) still read real time.
+func (r *ReconcileInput) Now() time.Time {
+	if r.Clock != nil {
+		return r.Clock.Now()
+	}
+	return time.Now()
+}

--- a/pkg/controller/v1beta1/workload/types/migration.go
+++ b/pkg/controller/v1beta1/workload/types/migration.go
@@ -1,0 +1,152 @@
+package types
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Workload-side mirror of the InferenceReplica MigrationStatus entry.
+// The adapter converts field-for-field (like RetryBlock / InstanceStatus);
+// workload code never sees the CRD type. status.migrations on the owner
+// is the single source of truth for migration work: the dispatcher
+// selects work from non-terminal Manual records and the Migrate executor
+// resumes from the record's SurgeInstance + Phase.
+
+// MigrationTrigger identifies who initiated a migration record.
+type MigrationTrigger string
+
+const (
+	// MigrationTriggerManual marks an operator-requested migration —
+	// a resumable process born Accepted.
+	MigrationTriggerManual MigrationTrigger = "Manual"
+	// MigrationTriggerAuto marks a controller-initiated relocation —
+	// a born-terminal Relocated record, never resumable work.
+	MigrationTriggerAuto MigrationTrigger = "Auto"
+)
+
+// MigrationPhase is the lifecycle phase of a migration record. Manual
+// records walk Accepted -> SurgePending -> SurgeReady -> Draining ->
+// Completed | Failed; Auto records are born terminal (Relocated).
+type MigrationPhase string
+
+const (
+	MigrationPhaseAccepted     MigrationPhase = "Accepted"
+	MigrationPhaseSurgePending MigrationPhase = "SurgePending"
+	MigrationPhaseSurgeReady   MigrationPhase = "SurgeReady"
+	MigrationPhaseDraining     MigrationPhase = "Draining"
+	MigrationPhaseCompleted    MigrationPhase = "Completed"
+	MigrationPhaseFailed       MigrationPhase = "Failed"
+	MigrationPhaseRelocated    MigrationPhase = "Relocated"
+)
+
+// Terminal reports whether p is a terminal phase. Executors and the
+// dispatcher select work on non-terminal phase only — terminal records
+// are records, never work.
+func (p MigrationPhase) Terminal() bool {
+	switch p {
+	case MigrationPhaseCompleted, MigrationPhaseFailed, MigrationPhaseRelocated:
+		return true
+	}
+	return false
+}
+
+// migrationPhaseRank orders the Manual phase chain for forward-only
+// advancement. Terminal phases rank above every transient phase.
+func migrationPhaseRank(p MigrationPhase) int {
+	switch p {
+	case MigrationPhaseAccepted:
+		return 0
+	case MigrationPhaseSurgePending:
+		return 1
+	case MigrationPhaseSurgeReady:
+		return 2
+	case MigrationPhaseDraining:
+		return 3
+	default: // Completed / Failed / Relocated
+		return 4
+	}
+}
+
+// MigrationPhaseAtOrPast reports whether p has already reached (or
+// passed) the given phase in the Manual chain — the guard the executor's
+// forward-only phase advancement uses so a stale write can never move a
+// record backward.
+func MigrationPhaseAtOrPast(p, target MigrationPhase) bool {
+	return migrationPhaseRank(p) >= migrationPhaseRank(target)
+}
+
+// MigrationRecord mirrors v1beta1.MigrationStatus field-for-field.
+type MigrationRecord struct {
+	// RequestUUID uniquely identifies the migration request.
+	RequestUUID string
+
+	Trigger MigrationTrigger
+
+	// SourceInstance is the Instance index being migrated away from.
+	SourceInstance int32
+
+	// SurgeInstance is the allocated surge Instance index; nil until
+	// the executor allocates it (0 is a valid surge index).
+	SurgeInstance *int32
+
+	// AllocatedAt is when the surge index was allocated — execution
+	// start. Nil while the record is queued (Accepted, not yet picked
+	// up). Capacity counts execution from this stamp.
+	AllocatedAt *metav1.Time
+
+	// FromNode is the node the source is being moved off.
+	FromNode string
+
+	// HintTargetNodes are preferred placement targets for the surge.
+	HintTargetNodes []string
+
+	Phase MigrationPhase
+
+	// Attempt is the relocation attempt ordinal (Auto records).
+	Attempt int32
+
+	// Reason is the requester-supplied reason (Manual) or disposition
+	// branch (Auto).
+	Reason string
+
+	// Message describes the current blocker (non-terminal) or the
+	// terminal outcome.
+	Message string
+
+	StartedAt metav1.Time
+
+	// Deadline is when a non-terminal record expires.
+	Deadline metav1.Time
+
+	CompletedAt *metav1.Time
+
+	Succeeded *bool
+}
+
+// FindMigrationRecord returns a pointer to the record for requestUUID
+// (aliasing the slice element), or nil.
+func FindMigrationRecord(records []MigrationRecord, requestUUID string) *MigrationRecord {
+	for i := range records {
+		if records[i].RequestUUID == requestUUID {
+			return &records[i]
+		}
+	}
+	return nil
+}
+
+// NextManualMigration selects the migration the dispatcher should drive
+// this pass: the oldest-StartedAt Manual record whose phase is
+// non-terminal. Auto records are excluded structurally — born terminal,
+// they never rank. Returns nil when no work exists.
+func NextManualMigration(records []MigrationRecord) *MigrationRecord {
+	var picked *MigrationRecord
+	for i := range records {
+		r := &records[i]
+		if r.Trigger != MigrationTriggerManual || r.Phase.Terminal() {
+			continue
+		}
+		if picked == nil || r.StartedAt.Time.Before(picked.StartedAt.Time) {
+			picked = r
+		}
+	}
+	return picked
+}

--- a/pkg/controller/v1beta1/workload/types/plan.go
+++ b/pkg/controller/v1beta1/workload/types/plan.go
@@ -1,0 +1,178 @@
+package types
+
+import (
+	"time"
+)
+
+// ComponentPlan is the desired Component → Instance → Runner → Pod
+// shape computed each reconcile from desired + observed state. Not
+// persisted; policy fields hold the effective values after defaults.
+type ComponentPlan struct {
+	// Component identifies which of router / engine / decoder this plan
+	// describes. Typed as the workload-side ComponentType so the
+	// workload package stays free of v1beta1 imports; adapters convert
+	// from v1beta1.ComponentType at the boundary.
+	Component ComponentType
+
+	// Replicas is the desired number of Instances for this Component
+	// (= MinReplicas, or 1 when MinReplicas is unset).
+	Replicas int32
+
+	// Instances enumerates the desired Instances. Normally one entry
+	// per index 0..Replicas-1; indices may be sparse while a surge
+	// migration is in flight (the surge Instance carries an
+	// out-of-band index until promotion settles the plan).
+	Instances []InstancePlan
+
+	// RestartPolicy is the effective Instance-group restart policy.
+	RestartPolicy RestartPolicy
+
+	// UpdateStrategy is the effective rollout policy across Instances.
+	UpdateStrategy UpdateStrategy
+
+	// ReadyPolicy is the effective Instance-level readiness aggregation.
+	ReadyPolicy InstanceReadyPolicy
+
+	// InstanceReadyTimeout is the wait ceiling on a newly-created
+	// Instance becoming Ready.
+	InstanceReadyTimeout time.Duration
+
+	// MigrationMode is the effective migration disposition (auto / surge /
+	// never).
+	MigrationMode MigrationMode
+
+	// Paused stops the dispatcher before it starts or advances Restart,
+	// Migration, Update, or Create operations. Scale-down remains active so a
+	// reduced desired replica count can still release capacity while paused.
+	Paused bool
+
+	// TopologyKey is the resolved gang co-location node-label key for
+	// this Component (e.g. an NVLink/RDMA fabric-domain label). Empty for
+	// single-pod Components or when unset. When non-empty on a multi-pod
+	// Component, Render auto-generates the per-Instance worker→leader
+	// podAffinity and the PodGroup carries the same key for topology-aware
+	// gang schedulers. Both constraints therefore select the same configured
+	// topology domain.
+	TopologyKey string
+
+	// InstanceTopologyKeys holds a temporary per-Instance override while live
+	// pods still carry affinity rendered from an older revision. Missing pods in
+	// that active gang must use the same immutable topology contract; fresh
+	// Instances and surge indices fall back to TopologyKey.
+	InstanceTopologyKeys map[int32]string
+}
+
+// TopologyKeyForInstance returns the live-safe topology contract for an
+// Instance, falling back to the Component's current desired key when the group
+// has no active revision-specific override.
+func (p ComponentPlan) TopologyKeyForInstance(index int32) string {
+	if key, ok := p.InstanceTopologyKeys[index]; ok {
+		return key
+	}
+	return p.TopologyKey
+}
+
+// InstancePlan is the desired state for one Instance — the atomic
+// unit of gang scheduling, restart, and migration.
+type InstancePlan struct {
+	// Index is the stable Instance ordinal. Sparse after surge
+	// migration.
+	Index int32
+
+	// Incarnation is the monotonic lifecycle token for this
+	// (Component, Index) pair. Initial create stamps 1; full recreate
+	// / restart-on-loss bumps it; in-place update does not. Distinguishes
+	// old pod materializations from current ones when stable names get
+	// reused after a recreate.
+	Incarnation int64
+
+	// Runners enumerates the Runners that constitute this Instance.
+	// Single-pod has one "default" Runner of size 1; multi-pod has
+	// leader + worker.
+	Runners []RunnerPlan
+
+	// MigrationOverlay carries placement hints from an in-flight surge
+	// migration. Render injects hard anti-affinity from the source node
+	// and preferred affinity to hint target nodes. Nil for non-migration
+	// paths.
+	MigrationOverlay *MigrationOverlay
+
+	// ExcludedNodes lists nodes this Instance's pods must not land on —
+	// the relocation-directive memory (AutoRecover ledger entries)
+	// projected through WorkloadObservedState.ExcludedNodesByInstance.
+	// Render materializes each entry as the same required NotIn
+	// hostname term the migration overlay uses. Empty for normal
+	// Instances.
+	ExcludedNodes []string
+
+	// PeerHostnames is an optional render-time cache of the Instance's
+	// ordered peer-DNS host list (one entry per pod, flat gang-rank
+	// order). The list is identical for every pod in the gang, so the
+	// gang-render loop computes it once and stashes it here to avoid the
+	// O(gangsize^2) per-pod recompute. Nil when unset; Render then
+	// derives the list from Runners as before. Transient render scratch,
+	// not part of the desired state and never persisted.
+	PeerHostnames []string
+}
+
+// MigrationOverlay records the per-Instance placement constraints a
+// surge migration carries onto the rendered pod. Materialized as pod
+// affinity in Render and intentionally absent from the canonical
+// revision payload — transient operation overlay, not a steady-state
+// template field.
+type MigrationOverlay struct {
+	// FromNode surfaces as RequiredDuringScheduling anti-affinity on
+	// kubernetes.io/hostname.
+	FromNode string
+	// HintTargetNodes surface as PreferredDuringScheduling affinity;
+	// the scheduler is free to pick another node when these are
+	// unavailable.
+	HintTargetNodes []string
+}
+
+// RunnerPlan is the desired state for one Runner within an Instance.
+type RunnerPlan struct {
+	// Name is "leader", "worker", or "default" (single-pod).
+	Name string
+	// Size is the number of pods of this Runner within the Instance.
+	Size int32
+}
+
+// TotalPods returns the total desired pod count across all Runners —
+// 1 for single-pod, 1+N for leader+worker.
+func (i InstancePlan) TotalPods() int32 {
+	var n int32
+	for _, r := range i.Runners {
+		n += r.Size
+	}
+	return n
+}
+
+// AllocateSurgeIndex returns the lowest int32 not present in any of
+// the InstanceStatuses — the slot the migration op picks for its +1
+// surge pod without colliding with steady-state indices or other
+// in-flight surges.
+func AllocateSurgeIndex(instances []InstanceStatus) int32 {
+	used := make(map[int32]struct{}, len(instances)*2)
+	for _, s := range instances {
+		used[s.Index] = struct{}{}
+		// Also exclude in-flight surge slots. A source mid-surge records its
+		// replacement's index in Operation.SurgeIndex BEFORE the replacement
+		// Instance exists (it's created a pass later, and within a single
+		// reconcile pass a sibling that just claimed a slot has it recorded
+		// here but not yet as a real Index). Without excluding these, every
+		// Instance surging in the same pass collides on the same lowest-free
+		// index; when that single shared surge becomes Ready the drain-on-ready
+		// logic releases ALL sharing sources at once — a full-fleet wipe.
+		if s.Operation != nil && s.Operation.SurgeIndex != nil {
+			used[*s.Operation.SurgeIndex] = struct{}{}
+		}
+	}
+	// Lowest-free exists at or below |used| (distinct ints), so an unbounded
+	// scan terminates; keep it unbounded so the 2x-entry set can't off-by-one.
+	for i := int32(0); ; i++ {
+		if _, taken := used[i]; !taken {
+			return i
+		}
+	}
+}

--- a/pkg/controller/v1beta1/workload/types/retryblock.go
+++ b/pkg/controller/v1beta1/workload/types/retryblock.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"math"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Workload-side mirror of the InferenceReplica RetryBlock status. The
+// adapter converts field-for-field; workload code never sees the CRD
+// type. Revision-scoped: one block per target revision.
+type RetryBlockState string
+
+const (
+	RetryBlockBackoff         RetryBlockState = "Backoff"
+	RetryBlockHeld            RetryBlockState = "Held"
+	RetryBlockRetryInProgress RetryBlockState = "RetryInProgress"
+)
+
+type RetryBlock struct {
+	TargetRevision  string
+	State           RetryBlockState
+	AttemptsStarted int32
+	NextRetryAt     *metav1.Time
+	FirstFailureAt  *metav1.Time
+	LastFailureAt   *metav1.Time
+	Reason          string
+}
+
+// RetryBlockDisposition is the MutateRetryBlock callback's verdict.
+type RetryBlockDisposition int
+
+const (
+	RetryBlockUnchanged RetryBlockDisposition = iota // no write
+	RetryBlockPersist                                // upsert the mutated block
+	RetryBlockRemove                                 // delete the block (success prune)
+)
+
+// RetryPolicy bounds automatic same-target update retries. Config-driven
+// (chart values → inferenceservice-config); nil means unconfigured and
+// fails safe: Exhausted is always true, so the first failure Holds.
+type RetryPolicy struct {
+	MaxAttempts  int32
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	Multiplier   float64
+}
+
+// NextRetryDelay returns the backoff before attempt attemptsStarted+1:
+// InitialDelay * Multiplier^(attemptsStarted-1), capped at MaxDelay.
+func (p *RetryPolicy) NextRetryDelay(attemptsStarted int32) time.Duration {
+	d := time.Duration(float64(p.InitialDelay) * math.Pow(p.Multiplier, float64(attemptsStarted-1)))
+	if d > p.MaxDelay || d <= 0 {
+		return p.MaxDelay
+	}
+	return d
+}
+
+// Exhausted reports whether no automatic attempts remain. A nil policy
+// (unconfigured) is always exhausted — fail-safe Held.
+func (p *RetryPolicy) Exhausted(attemptsStarted int32) bool {
+	if p == nil {
+		return true
+	}
+	return attemptsStarted >= p.MaxAttempts
+}
+
+// FindRetryBlock returns a pointer to the block for targetRevision
+// (aliasing the slice element), or nil.
+func FindRetryBlock(blocks []RetryBlock, targetRevision string) *RetryBlock {
+	for i := range blocks {
+		if blocks[i].TargetRevision == targetRevision {
+			return &blocks[i]
+		}
+	}
+	return nil
+}

--- a/pkg/controller/v1beta1/workload/types/retryblock_test.go
+++ b/pkg/controller/v1beta1/workload/types/retryblock_test.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextRetryDelay(t *testing.T) {
+	p := &RetryPolicy{MaxAttempts: 3, InitialDelay: time.Minute, MaxDelay: 30 * time.Minute, Multiplier: 2.0}
+	cases := []struct {
+		attempts int32
+		want     time.Duration
+	}{
+		{1, time.Minute},       // first failure → initial
+		{2, 2 * time.Minute},   // initial * m^1
+		{3, 4 * time.Minute},   // initial * m^2
+		{10, 30 * time.Minute}, // capped at MaxDelay
+	}
+	for _, c := range cases {
+		if got := p.NextRetryDelay(c.attempts); got != c.want {
+			t.Errorf("NextRetryDelay(%d) = %v, want %v", c.attempts, got, c.want)
+		}
+	}
+}
+
+func TestRetryPolicyExhausted(t *testing.T) {
+	p := &RetryPolicy{MaxAttempts: 3, InitialDelay: time.Minute, MaxDelay: 30 * time.Minute, Multiplier: 2.0}
+	if p.Exhausted(2) {
+		t.Error("2 < 3 attempts must not be exhausted")
+	}
+	if !p.Exhausted(3) {
+		t.Error("3 >= 3 attempts must be exhausted")
+	}
+	var nilP *RetryPolicy
+	if !nilP.Exhausted(0) {
+		t.Error("nil policy (unconfigured) is always exhausted → fail-safe Held")
+	}
+}
+
+func TestFindRetryBlock(t *testing.T) {
+	blocks := []RetryBlock{{TargetRevision: "a"}, {TargetRevision: "b"}}
+	if got := FindRetryBlock(blocks, "b"); got == nil || got.TargetRevision != "b" {
+		t.Errorf("FindRetryBlock(b) = %v", got)
+	}
+	if got := FindRetryBlock(blocks, "c"); got != nil {
+		t.Errorf("FindRetryBlock(missing) must be nil, got %v", got)
+	}
+	// Returned pointer aliases the slice element (callers mutate in place).
+	FindRetryBlock(blocks, "a").AttemptsStarted = 7
+	if blocks[0].AttemptsStarted != 7 {
+		t.Error("FindRetryBlock must return a pointer into the slice")
+	}
+}

--- a/pkg/controller/v1beta1/workload/types/retryblock_writer.go
+++ b/pkg/controller/v1beta1/workload/types/retryblock_writer.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RecordUpdateFailureInRetryBlock upserts the RetryBlock for targetRev
+// after a terminal same-target attempt failure (failed update rollout,
+// deadline-disposed create/update attempt). Wave counting: an existing
+// Backoff block means this wave already recorded — refresh evidence
+// only. Policy nil (unconfigured) or exhausted → Held; else Backoff
+// with persisted NextRetryAt. No-op when the adapter did not wire
+// MutateRetryBlock. Callers hold the writer-ordering invariant: the
+// failed attempt's Operation is cleared in the same transition (block
+// write first — a crash between the two re-enters the caller's failed
+// branch, where the wave dedup refreshes without recounting).
+//
+// Lives in the leaf types package so both workload/ops (gang abandon)
+// and the workload-root disposition share ONE implementation without
+// closing the workload → workload/ops import cycle.
+func RecordUpdateFailureInRetryBlock(ctx context.Context, input ReconcileInput, targetRev, reason string) error {
+	if input.MutateRetryBlock == nil || targetRev == "" {
+		return nil
+	}
+	now := metav1.NewTime(input.Now())
+	// heldAttempts captures the Held transition inside the mutate; the
+	// warning is emitted only after the write COMMITS so RMW conflict
+	// retries cannot duplicate the event.
+	var heldAttempts int32
+	err := input.MutateRetryBlock(ctx, targetRev, func(b *RetryBlock) RetryBlockDisposition {
+		var disposition RetryBlockDisposition
+		disposition, heldAttempts = ApplyUpdateFailureToRetryBlock(b, input.UpdateRetryPolicy, now, reason)
+		return disposition
+	})
+	if err == nil && heldAttempts > 0 && input.WarnRetryHeld != nil {
+		input.WarnRetryHeld(targetRev, heldAttempts, reason)
+	}
+	return err
+}
+
+// ApplyUpdateFailureToRetryBlock applies one terminal failure wave to a
+// RetryBlock value. It is pure apart from mutating b, so callers can compose
+// the transition into a larger atomic owner-status update. heldAttempts is
+// non-zero only for a new transition into Held.
+func ApplyUpdateFailureToRetryBlock(b *RetryBlock, policy *RetryPolicy, now metav1.Time, reason string) (RetryBlockDisposition, int32) {
+	if b == nil {
+		return RetryBlockUnchanged, 0
+	}
+	if b.FirstFailureAt == nil {
+		b.FirstFailureAt = &now
+	}
+	b.LastFailureAt = &now
+	b.Reason = reason
+	switch b.State {
+	case RetryBlockBackoff, RetryBlockHeld:
+		// This wave is already recorded or terminally held; refresh only the
+		// failure evidence.
+		return RetryBlockPersist, 0
+	}
+	b.AttemptsStarted++
+	if policy.Exhausted(b.AttemptsStarted) {
+		b.State = RetryBlockHeld
+		b.NextRetryAt = nil
+		return RetryBlockPersist, b.AttemptsStarted
+	}
+	b.State = RetryBlockBackoff
+	next := metav1.NewTime(now.Add(policy.NextRetryDelay(b.AttemptsStarted)))
+	b.NextRetryAt = &next
+	return RetryBlockPersist, 0
+}

--- a/pkg/controller/v1beta1/workload/types/service.go
+++ b/pkg/controller/v1beta1/workload/types/service.go
@@ -1,0 +1,62 @@
+// service.go declares the typed input the workload package consumes
+// when rendering per-Component supporting Services. Splitting the spec
+// type out of the renderer keeps `workload/services.go` free of any
+// owner-CRD coupling: adapters (the ISVC OMENative dispatcher and the
+// InferenceReplica controller) populate PerComponentServiceSpec from
+// their respective owner shapes and hand it to
+// `workload.ReconcileHeadlessService`.
+//
+// Why this lives here and not under `workload/`: the parent workload
+// package's Service helpers in services.go must depend on this type,
+// and several of the other typed inputs (Deps, ReconcileInput, plan,
+// ...) already live in workload/types/. Co-locating the Service input
+// alongside them keeps the workload package boundary clean — every
+// data carrier the workload renderer reads is in the same subpackage,
+// and the parent workload package's helpers reach for them via a
+// single `workload/types` import.
+package types
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PerComponentServiceSpec is the typed input the workload package
+// consumes to render a per-Component supporting Service (today: the
+// headless Service that gives every pod a stable peer-DNS FQDN).
+// Adapters populate every field from their owner-CRD shape; workload
+// code reads the spec opaquely and never reaches back into the owner.
+//
+// One Service per (workload-key, component). The ISVC adapter
+// constructs one spec per Component reconcile pass; the IR adapter
+// constructs one spec per InferenceReplica reconcile.
+type PerComponentServiceSpec struct {
+	// Name is the Service object name. The workload renderer stamps it
+	// verbatim but does NOT compute it — adapters pass the canonical
+	// name (e.g., query.HeadlessServiceName(owner.Name, component) on
+	// the ISVC side) so the per-Component naming convention stays in
+	// the adapter where the owner-CRD details live.
+	Name string
+
+	// Namespace is the Service object namespace. Matches the owner CR
+	// namespace; adapters set it from owner.GetNamespace().
+	Namespace string
+
+	// Selector is the pod-label selector scoping which pods are members
+	// of this Service. Adapters set it so the Service only selects pods
+	// the workload owns (not legacy LWS / RawDeployment pods that may
+	// share the bare Component label). The ISVC adapter wires
+	// `ome.io/inferenceservice + component + managed-by=OMENative`; the
+	// IR adapter wires the IR-side equivalent.
+	Selector map[string]string
+
+	// Labels are stamped on the Service object metadata block for
+	// downstream tooling (`kubectl get svc -l`, dashboards). Typically
+	// the same key/value pairs as Selector plus the controller's
+	// `managed-by` label.
+	Labels map[string]string
+
+	// OwnerReferences point back to the workload's owner CR. Adapters
+	// pass `*metav1.NewControllerRef(owner, ownerGVK)` so deletion of
+	// the owner cascades to the Service via the K8s garbage collector.
+	OwnerReferences []metav1.OwnerReference
+}

--- a/pkg/controller/v1beta1/workload/types/source.go
+++ b/pkg/controller/v1beta1/workload/types/source.go
@@ -1,0 +1,211 @@
+package types
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// WorkloadDesiredSpec.Lifecycle and WorkloadAggregateStatus.Traffic
+// use workload-owned mirror types. Adapters project the CRD-shape
+// values into these structs at the boundary.
+
+// WorkloadDesiredSpec is the per-reconcile projection of the source
+// spec the workload pipeline drives toward. Read-only from workload
+// code.
+type WorkloadDesiredSpec struct {
+	// Replicas is the desired Instance count.
+	Replicas int32
+
+	// MinReadySeconds is the minimum age (in seconds) for an Instance
+	// to count as Available after becoming Ready.
+	//
+	// LATENT BUG: this field is populated by the IR converter
+	// (inferencereplica/convert.go, from IR spec.minReadySeconds) but is
+	// NEVER read by the rollout engine. Availability is computed from
+	// EndpointSlice membership, not a readiness-age gate, so IR
+	// spec.minReadySeconds is currently NOT honored. The
+	// AvailablePodCount doc in types.go ("ready for at least
+	// MinReadySeconds") is aspirational on this account. Documented
+	// rather than wired: nothing sets this field today.
+	MinReadySeconds int32
+
+	// Runners enumerates the Runner roles (default | leader | worker)
+	// and per-role pod counts that constitute one Instance.
+	Runners []Runner
+
+	// PodSpec is the rendered leader / single-pod template the
+	// renderer drives toward. May be nil when Replicas=0 (nothing to
+	// render).
+	PodSpec *corev1.PodSpec
+
+	// WorkerPodSpec is the rendered worker template for multi-pod
+	// Instances. Nil for single-pod Components.
+	WorkerPodSpec *corev1.PodSpec
+
+	// PodTemplateObjectMeta is the rendered per-Component metadata
+	// (labels, annotations, owner refs) the renderer stamps onto each
+	// emitted pod.
+	PodTemplateObjectMeta *metav1.ObjectMeta
+
+	// MultiPod indicates the workload uses Leader + Worker Runners
+	// (each Instance materializes more than one pod).
+	MultiPod bool
+
+	// TopologyKey is the resolved gang co-location node-label key for
+	// this Component (e.g. an NVLink/RDMA fabric-domain label). When non-empty on
+	// a multi-pod Component, the renderer auto-generates the per-Instance
+	// worker→leader podAffinity and stamps the same key on the PodGroup for
+	// topology-aware gang schedulers. Empty means no controller-generated
+	// topology constraint. Adapters project it from the owner-CRD component
+	// spec at the boundary.
+	TopologyKey string
+
+	// Lifecycle holds RestartPolicy / UpdateStrategy / ReadyPolicy /
+	// InstanceReadyTimeout / MigrationPolicy as workload-owned mirror
+	// values; adapters project the CRD-shape lifecycle into this struct
+	// at the boundary.
+	Lifecycle Lifecycle
+
+	// Pacing is the projected rollout pacing for this reconcile. Nil
+	// means "no pacing constraint" (treated as allowed).
+	Pacing *WorkloadPacing
+
+	// Paused, when true, stops the reconciler from starting any fresh
+	// Update / Restart / Create operations. In-flight operations
+	// resume on unpause.
+	Paused bool
+
+	// GangSchedulingAvailable is true when the scheduler-plugins
+	// PodGroup CRD was discovered at controller startup. Drives
+	// whether podgroup.EnsurePodGroup runs for multi-pod Instances.
+	GangSchedulingAvailable bool
+}
+
+// WorkloadObservedState is the per-reconcile snapshot of the source
+// status subtree the reconciler reasons about.
+type WorkloadObservedState struct {
+	// ObservedGeneration is the spec generation the last status flush
+	// reflects.
+	ObservedGeneration int64
+
+	// CollisionCount is the ControllerRevision-hash salt. nil on the
+	// first reconcile.
+	CollisionCount *int32
+
+	// CurrentRevision names the ControllerRevision currently serving
+	// traffic.
+	CurrentRevision string
+
+	// UpdateRevision names the ControllerRevision being rolled out.
+	UpdateRevision string
+
+	// InstanceStatuses reports per-Instance state. Read-only here;
+	// writes go through ReconcileInput.MutateInstance.
+	InstanceStatuses []InstanceStatus
+
+	// Conditions reports component-level conditions.
+	Conditions []metav1.Condition
+
+	// RetryBlocks mirrors the owner's persisted per-revision retry
+	// authority. Read-only from workload code; writes go through
+	// ReconcileInput.MutateRetryBlock.
+	RetryBlocks []RetryBlock
+
+	// Migrations mirrors the owner's persisted migration records
+	// (status.migrations) — the single source of truth for migration
+	// work. Read-only from workload code; writes go through
+	// ReconcileInput.MutateMigration.
+	Migrations []MigrationRecord
+
+	// ExcludedNodesByInstance maps Instance index → nodes its rebuild
+	// must avoid, projected per reconcile by the adapter from the
+	// audit ledger's AutoRecover relocation directives (bounded to the
+	// operator's autoMigrate.maxAttempts most recent entries). BuildPlan
+	// copies it onto InstancePlan.ExcludedNodes; Render materializes it
+	// as a required NodeAffinity NotIn overlay. Nil / missing index =
+	// no exclusion (zero change for normal instances).
+	ExcludedNodesByInstance map[int32][]string
+}
+
+// WorkloadAggregateStatus is the per-reconcile flush of counters,
+// conditions, and traffic that the reconciler hands off to
+// Source.WriteAggregateStatus.
+type WorkloadAggregateStatus struct {
+	ObservedGeneration   int64
+	Replicas             int32
+	ReadyReplicas        int32
+	ServingReplicas      int32
+	AvailableReplicas    int32
+	UpdatedReplicas      int32
+	UpdatedReadyReplicas int32
+	CurrentRevision      string
+	UpdateRevision       string
+	LabelSelector        string
+	Conditions           []metav1.Condition
+	Traffic              []ComponentTrafficTarget
+}
+
+// WorkloadPacing is the projected rollout pacing.
+// Adapters compute it once per reconcile.
+//
+// LATENT BUG: despite the "the reconciler reads" framing, NOTHING in the rollout
+// engine reads Partition / MaxUnavailable / Decisions. The IR converter
+// (inferencereplica/convert.go) populates Partition and MaxUnavailable
+// from IR spec.pacing, but pacing actually flows through
+// RollingUpdate.Partition + the UpdateGate callback instead, and
+// availability is computed from EndpointSlice membership — so IR
+// spec.pacing.partition and spec.pacing.maxUnavailable are currently NOT
+// honored. (IR spec.pacing.rollbackToRevision IS live, handled in
+// inferencereplica/reconciler.go — only partition/maxUnavailable are
+// dead.) Decisions/PacingDecisions is likewise never constructed in
+// production.
+// Documented rather than wired: nothing sets these fields today.
+type WorkloadPacing struct {
+	// Partition holds back updates for Instances whose index is less
+	// than Partition. 0 (the default) updates all Instances. Used
+	// for canary holds.
+	//
+	// NOT READ by the engine — see the WorkloadPacing type note above.
+	Partition *int32
+
+	// MaxUnavailable caps in-rollout disruption. nil falls back to
+	// the reconciler default (25%).
+	//
+	// NOT READ by the engine — see the WorkloadPacing type note above.
+	MaxUnavailable *intstr.IntOrString
+
+	// Decisions is the projected per-gate allow/deny map for this
+	// reconcile. The ISVC adapter fills it from coordination gates;
+	// the IR adapter leaves it nil. nil means allowed.
+	Decisions *PacingDecisions
+}
+
+// PacingDecisions is the workload-facing projection of cross-Component
+// coordination gates. Plain data — adapters compute it outside the
+// workload package.
+type PacingDecisions struct {
+	// UpdateAllowed is false when the reconciler MUST NOT start any
+	// fresh Update operations this reconcile.
+	UpdateAllowed bool
+
+	// UpdateDenyReason is the operator-visible reason recorded onto
+	// events / conditions when UpdateAllowed is false.
+	UpdateDenyReason string
+
+	// SurgeBudgetRemaining is the upper bound on in-flight surge pods
+	// the reconciler may keep alive concurrently. The dispatcher
+	// tracks its own in-flight count within a pass; this is a
+	// per-reconcile ceiling.
+	SurgeBudgetRemaining int32
+}
+
+// Runner is a named role within an Instance with a per-Instance pod
+// count. Single-pod has one "default" Runner of Size=1; multi-pod has
+// "leader" (Size=1) + "worker" (Size=N).
+type Runner struct {
+	// Name is "leader" | "worker" | "default".
+	Name string
+	// Size is the per-Instance pod count for this Runner.
+	Size int32
+}

--- a/pkg/controller/v1beta1/workload/types/termination.go
+++ b/pkg/controller/v1beta1/workload/types/termination.go
@@ -1,0 +1,222 @@
+package types
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodTermination extracts the most operator-relevant container failure
+// diagnostics from pod into an *InstanceTermination. Returns nil only when
+// pod is nil.
+//
+// Time records WHEN THE FAILURE HAPPENED, taken from kubelet's FinishedAt,
+// and NOT when this function ran. `now` is only a fallback for the cases
+// where no container-level termination timestamp survived (branch 4 below,
+// and a zero FinishedAt). This matters beyond cosmetics: InstanceTermination
+// is stored on InstanceStatus.LastFailure, which is part of the status the
+// no-op write guard DeepEquals before writing (see inferencereplica/
+// status.go). Stamping `now` made a permanently-failed Instance produce a
+// differing status on EVERY reconcile, defeating that guard and driving a
+// self-sustaining write -> watch -> reconcile loop.
+//
+// Selection precedence (the failure operators most want to see first):
+//
+//  1. A container terminated with a non-zero exit code — the canonical
+//     crash signal (OOMKilled exit 137, generic Error exit 1, ...). Both
+//     the live State and the LastTerminationState are consulted, since a
+//     CrashLoopBackOff pod shows the crash in LastTerminationState while
+//     its live State is Waiting.
+//  2. A container stuck in a terminal waiting state (CrashLoopBackOff,
+//     ImagePullBackOff, CreateContainerError, ...) — the wedge signal the
+//     stuck-pod escalator fires on. ExitCode is left nil (no process ran).
+//  3. Any terminated container at all (exit 0 but the pod is Failed — rare,
+//     e.g. a restartPolicy=Never sidecar exiting).
+//  4. Pod-level fallback: Reason="PodFailed" with the pod's status message,
+//     when the pod phase is Failed but no per-container detail survived.
+//
+// Init containers are consulted with the same precedence after regular
+// containers so an init-stage crash is still captured.
+func PodTermination(pod *corev1.Pod, now metav1.Time) *InstanceTermination {
+	if pod == nil {
+		return nil
+	}
+
+	allStatuses := func() []corev1.ContainerStatus {
+		out := make([]corev1.ContainerStatus, 0, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
+		out = append(out, pod.Status.ContainerStatuses...)
+		out = append(out, pod.Status.InitContainerStatuses...)
+		return out
+	}()
+
+	// 1. Non-zero terminated exit code (live or last-termination).
+	for _, cs := range allStatuses {
+		if t := nonZeroTerminated(cs); t != nil {
+			return terminationFromTerminated(pod, cs.Name, t, now)
+		}
+	}
+	// 2. Terminal waiting-state wedge. The waiting state itself carries no
+	// timestamp, but a backoff-looping container (CrashLoopBackOff) records
+	// the prior crash in LastTerminationState — prefer that over `now` so
+	// the record is stable across observations.
+	for _, cs := range allStatuses {
+		if cs.State.Waiting != nil && isTerminalWaitingReason(cs.State.Waiting.Reason) {
+			return &InstanceTermination{
+				PodName:       pod.Name,
+				ContainerName: cs.Name,
+				Reason:        cs.State.Waiting.Reason,
+				Message:       cs.State.Waiting.Message,
+				Time:          lastTerminationTimeOr(cs, now),
+			}
+		}
+	}
+	// 3. Any terminated container (exit 0 but pod Failed).
+	for _, cs := range allStatuses {
+		if cs.State.Terminated != nil {
+			return terminationFromTerminated(pod, cs.Name, cs.State.Terminated, now)
+		}
+		if cs.LastTerminationState.Terminated != nil {
+			return terminationFromTerminated(pod, cs.Name, cs.LastTerminationState.Terminated, now)
+		}
+	}
+	// 4. Pod-level fallback. No container-level FinishedAt survived, so `now`
+	// is the only timestamp available here.
+	if pod.Status.Phase == corev1.PodFailed {
+		return &InstanceTermination{
+			PodName: pod.Name,
+			Reason:  "PodFailed",
+			Message: pod.Status.Message,
+			Time:    now,
+		}
+	}
+	return nil
+}
+
+// PodTerminationWithReason is PodTermination with an explicit reason
+// override used by the stuck-pod escalator, which has already classified
+// the wedge reason from the live waiting state. When PodTermination can't
+// extract any per-container detail (e.g. the status snapshot raced the
+// kubelet write), the override still gives operators the classified reason
+// + pod name rather than an empty record. When PodTermination DID extract a
+// record but with an empty Reason, the override fills it in.
+func PodTerminationWithReason(pod *corev1.Pod, reason string, now metav1.Time) *InstanceTermination {
+	t := PodTermination(pod, now)
+	if t == nil {
+		name := ""
+		if pod != nil {
+			name = pod.Name
+		}
+		return &InstanceTermination{PodName: name, Reason: reason, Time: now}
+	}
+	if t.Reason == "" {
+		t.Reason = reason
+	}
+	return t
+}
+
+// nonZeroTerminated returns the terminated state (live or last) carrying a
+// non-zero exit code, or nil. Live State wins over LastTerminationState so
+// the freshest crash is reported.
+func nonZeroTerminated(cs corev1.ContainerStatus) *corev1.ContainerStateTerminated {
+	if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+		return cs.State.Terminated
+	}
+	if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.ExitCode != 0 {
+		return cs.LastTerminationState.Terminated
+	}
+	return nil
+}
+
+// terminationFromTerminated builds an InstanceTermination from a terminated
+// container state. Reason falls back to "Error" when kubelet left it blank
+// (it occasionally does for OOM races) so the record is never reason-less.
+// Time is kubelet's FinishedAt; `now` is used only when kubelet left it zero.
+func terminationFromTerminated(pod *corev1.Pod, container string, t *corev1.ContainerStateTerminated, now metav1.Time) *InstanceTermination {
+	reason := t.Reason
+	if reason == "" {
+		reason = "Error"
+	}
+	exit := t.ExitCode
+	return &InstanceTermination{
+		PodName:       pod.Name,
+		ContainerName: container,
+		Reason:        reason,
+		ExitCode:      &exit,
+		Message:       t.Message,
+		Time:          finishedAtOr(t, now),
+	}
+}
+
+// finishedAtOr returns kubelet's recorded termination time, or `fallback`
+// when it is absent. A zero FinishedAt means kubelet never stamped one, so
+// there is no event time to report and the observation time is the best
+// available answer.
+func finishedAtOr(t *corev1.ContainerStateTerminated, fallback metav1.Time) metav1.Time {
+	if t != nil && !t.FinishedAt.IsZero() {
+		return t.FinishedAt
+	}
+	return fallback
+}
+
+// lastTerminationTimeOr returns the FinishedAt of the container's previous
+// termination, or `fallback` when there is none. Used by the waiting-state
+// branch, where the live state carries no timestamp but a backoff-looping
+// container has one from the crash that put it there.
+func lastTerminationTimeOr(cs corev1.ContainerStatus, fallback metav1.Time) metav1.Time {
+	return finishedAtOr(cs.LastTerminationState.Terminated, fallback)
+}
+
+// isTerminalWaitingReason mirrors the workload escalator's
+// terminalPullFailureReasons set. Duplicated here (rather than imported
+// from the root workload package) to keep workload/types free of an import
+// edge back to its parent — the set is small and changes rarely.
+func isTerminalWaitingReason(reason string) bool {
+	switch reason {
+	case "ErrImagePull",
+		"ImagePullBackOff",
+		"InvalidImageName",
+		"CreateContainerConfigError",
+		"CreateContainerError",
+		"CrashLoopBackOff",
+		"RunContainerError":
+		return true
+	}
+	return false
+}
+
+// ShortString renders an InstanceTermination as a compact, grep-friendly
+// fragment for K8s event messages, e.g. `pod foo-0 container main failed
+// (OOMKilled, exit 137)` or `pod foo-0 container main stuck
+// (ImagePullBackOff)`. Returns "" for a nil receiver so callers can embed
+// it unconditionally.
+func (t *InstanceTermination) ShortString() string {
+	if t == nil {
+		return ""
+	}
+	var b string
+	if t.PodName != "" {
+		b = "pod " + t.PodName
+	} else {
+		b = "pod <unknown>"
+	}
+	if t.ContainerName != "" {
+		b += " container " + t.ContainerName
+	}
+	switch {
+	case t.ExitCode != nil:
+		b += fmt.Sprintf(" failed (%s, exit %d)", reasonOrUnknown(t.Reason), *t.ExitCode)
+	case t.Reason == "PodFailed":
+		b += " failed (PodFailed)"
+	default:
+		b += fmt.Sprintf(" stuck (%s)", reasonOrUnknown(t.Reason))
+	}
+	return b
+}
+
+func reasonOrUnknown(reason string) string {
+	if reason == "" {
+		return "unknown"
+	}
+	return reason
+}

--- a/pkg/controller/v1beta1/workload/types/termination_test.go
+++ b/pkg/controller/v1beta1/workload/types/termination_test.go
@@ -1,0 +1,192 @@
+package types
+
+// InstanceTermination.Time must record WHEN THE FAILURE HAPPENED (kubelet's
+// FinishedAt), not when the controller observed it. LastFailure is part of the
+// InstanceStatus that the no-op status-write guard DeepEquals before writing,
+// so an observation timestamp makes a permanently-failed Instance produce a
+// differing status on every reconcile — defeating the guard and driving a
+// self-sustaining write -> watch -> reconcile loop.
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// failedAt is when kubelet says the container died.
+	failedAt = metav1.NewTime(time.Date(2026, 8, 19, 4, 28, 38, 0, time.UTC))
+	// observedAt is when a reconcile happened to look. Always later, and
+	// different per observation.
+	observedAt = metav1.NewTime(time.Date(2026, 8, 21, 15, 40, 0, 0, time.UTC))
+)
+
+func podWithStatus(name string, cs corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "inf-prod"},
+		Status:     corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{cs}},
+	}
+}
+
+// Branch 1: a container terminated with a non-zero exit code.
+func TestPodTermination_UsesFinishedAtNotNow(t *testing.T) {
+	pod := podWithStatus("router-0-default-0", corev1.ContainerStatus{
+		Name: "ome-container",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode:   1,
+				Reason:     "Error",
+				FinishedAt: failedAt,
+			},
+		},
+	})
+
+	got := PodTermination(pod, observedAt)
+	if got == nil {
+		t.Fatal("expected a termination record")
+	}
+	if !got.Time.Equal(&failedAt) {
+		t.Fatalf("Time = %v, want kubelet FinishedAt %v (got the observation time instead?)", got.Time, failedAt)
+	}
+	if got.ExitCode == nil || *got.ExitCode != 1 {
+		t.Fatalf("ExitCode = %v, want 1", got.ExitCode)
+	}
+}
+
+// Branch 2: the exact shape from the usc1-1 incident — live state is Waiting
+// with CrashLoopBackOff, and the crash that caused it is in
+// LastTerminationState. Exit code is zero there, so branch 1 does not match.
+func TestPodTermination_CrashLoopBackOffUsesLastTerminationFinishedAt(t *testing.T) {
+	pod := podWithStatus("router-0-default-0", corev1.ContainerStatus{
+		Name: "ome-container",
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{
+				Reason:  "CrashLoopBackOff",
+				Message: "back-off 5m0s restarting failed container",
+			},
+		},
+		LastTerminationState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode:   0,
+				FinishedAt: failedAt,
+			},
+		},
+	})
+
+	got := PodTermination(pod, observedAt)
+	if got == nil {
+		t.Fatal("expected a termination record")
+	}
+	if got.Reason != "CrashLoopBackOff" {
+		t.Fatalf("Reason = %q, want CrashLoopBackOff", got.Reason)
+	}
+	if !got.Time.Equal(&failedAt) {
+		t.Fatalf("Time = %v, want last-termination FinishedAt %v", got.Time, failedAt)
+	}
+}
+
+// The regression test for the write-storm bug: observing an unchanged failed
+// pod twice, at two different times, must produce byte-identical records.
+// If this fails, the status DeepEqual guard cannot converge.
+func TestPodTermination_StableAcrossObservations(t *testing.T) {
+	cases := map[string]corev1.ContainerStatus{
+		"non-zero exit": {
+			Name: "ome-container",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 1, Reason: "Error", FinishedAt: failedAt,
+				},
+			},
+		},
+		"crashloopbackoff": {
+			Name: "ome-container",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			},
+			LastTerminationState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{FinishedAt: failedAt},
+			},
+		},
+		"exit zero but terminated": {
+			Name: "ome-container",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, FinishedAt: failedAt},
+			},
+		},
+	}
+
+	for name, cs := range cases {
+		t.Run(name, func(t *testing.T) {
+			pod := podWithStatus("router-0-default-0", cs)
+
+			first := PodTermination(pod, observedAt)
+			second := PodTermination(pod, metav1.NewTime(observedAt.Add(437*time.Millisecond)))
+
+			if first == nil || second == nil {
+				t.Fatalf("expected records, got %v / %v", first, second)
+			}
+			if !reflect.DeepEqual(first, second) {
+				t.Fatalf("record changed across observations of an unchanged pod:\n first  = %+v\n second = %+v", first, second)
+			}
+		})
+	}
+}
+
+// The fallback must stay intact: with no kubelet timestamp there is no event
+// time to report, so the observation time is correct.
+func TestPodTermination_FallsBackToNowWhenFinishedAtZero(t *testing.T) {
+	pod := podWithStatus("router-0-default-0", corev1.ContainerStatus{
+		Name: "ome-container",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"},
+		},
+	})
+
+	got := PodTermination(pod, observedAt)
+	if got == nil {
+		t.Fatal("expected a termination record")
+	}
+	if !got.Time.Equal(&observedAt) {
+		t.Fatalf("Time = %v, want fallback to now %v", got.Time, observedAt)
+	}
+}
+
+// Branch 4 has no container-level timestamp available, so it keeps `now`.
+func TestPodTermination_PodLevelFallbackUsesNow(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "router-0-default-0", Namespace: "inf-prod"},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed, Message: "evicted"},
+	}
+
+	got := PodTermination(pod, observedAt)
+	if got == nil {
+		t.Fatal("expected a termination record")
+	}
+	if got.Reason != "PodFailed" {
+		t.Fatalf("Reason = %q, want PodFailed", got.Reason)
+	}
+	if !got.Time.Equal(&observedAt) {
+		t.Fatalf("Time = %v, want now %v", got.Time, observedAt)
+	}
+}
+
+// PodTerminationWithReason must not undo the FinishedAt selection.
+func TestPodTerminationWithReason_PreservesFinishedAt(t *testing.T) {
+	pod := podWithStatus("router-0-default-0", corev1.ContainerStatus{
+		Name: "ome-container",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, FinishedAt: failedAt},
+		},
+	})
+
+	got := PodTerminationWithReason(pod, "CrashLoopBackOff", observedAt)
+	if got == nil {
+		t.Fatal("expected a termination record")
+	}
+	if !got.Time.Equal(&failedAt) {
+		t.Fatalf("Time = %v, want kubelet FinishedAt %v", got.Time, failedAt)
+	}
+}

--- a/pkg/controller/v1beta1/workload/types/types.go
+++ b/pkg/controller/v1beta1/workload/types/types.go
@@ -1,0 +1,411 @@
+// Package types holds the workload package's value types — the
+// per-Instance / per-Component / per-Plan data structures every layer
+// of the workload pipeline reads and writes. Lives separately from
+// the parent `workload` package so `workload/ops` and
+// `workload.Reconcile` can both depend on these types without closing
+// an import cycle.
+//
+// The workload package owns its own status / operation / component /
+// phase / key types and does NOT depend on the OME CRD API package.
+// Every type here mirrors the corresponding v1beta1 status type
+// field-for-field; the v1beta1convert helpers
+// (`controller/v1beta1/v1beta1convert`) perform the conversion, and
+// the InferenceReplica adapter (inferencereplica) wires those
+// converters into its reconcile loop.
+//
+// External callers reference these types as `workload.X` — the parent
+// `workload` package re-exports them as Go aliases.
+package types
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ComponentType identifies router | engine | decoder. String-mirrors
+// the CRD ComponentType so the adapter conversion is a verbatim cast;
+// the distinct Go type catches accidental cross-package coupling.
+type ComponentType string
+
+const (
+	ComponentRouter  ComponentType = "router"
+	ComponentEngine  ComponentType = "engine"
+	ComponentDecoder ComponentType = "decoder"
+)
+
+// InstancePhase is the per-Instance lifecycle phase. String-mirrors
+// the CRD OMENativeInstancePhase.
+type InstancePhase string
+
+const (
+	// InstancePhaseEmpty is the zero value used before the first
+	// observation lands on a freshly-allocated InstanceStatus.
+	InstancePhaseEmpty      InstancePhase = ""
+	InstancePhasePending    InstancePhase = "Pending"
+	InstancePhaseCreating   InstancePhase = "Creating"
+	InstancePhaseReady      InstancePhase = "Ready"
+	InstancePhaseUpdating   InstancePhase = "Updating"
+	InstancePhaseRestarting InstancePhase = "Restarting"
+	InstancePhaseMigrating  InstancePhase = "Migrating"
+	InstancePhaseFailed     InstancePhase = "Failed"
+	InstancePhaseDeleting   InstancePhase = "Deleting"
+)
+
+// UpdateStrategyType is the rollout-mechanism selector. String-mirrors
+// the CRD UpdateStrategyType; the distinct Go type catches accidental
+// drift between workload-side dispatch logic and the v1beta1 enum.
+type UpdateStrategyType string
+
+const (
+	// UpdateStrategySurgeThenDrain creates a new pod for the target
+	// revision, waits for it to serve, then drains + deletes the old.
+	UpdateStrategySurgeThenDrain UpdateStrategyType = "SurgeThenDrain"
+	// UpdateStrategyRecreatePod always deletes pods and recreates them
+	// at a bumped Incarnation.
+	UpdateStrategyRecreatePod UpdateStrategyType = "RecreatePod"
+	// UpdateStrategyInPlaceIfPossible tries image-patch in place; falls
+	// through to recreate on non-image-only diffs.
+	UpdateStrategyInPlaceIfPossible UpdateStrategyType = "InPlaceIfPossible"
+	// UpdateStrategyInPlaceOnly image-patches in place when eligible;
+	// errors otherwise.
+	UpdateStrategyInPlaceOnly UpdateStrategyType = "InPlaceOnly"
+)
+
+// RestartPolicy is the Instance-group restart policy. String-mirrors
+// the CRD InstanceRestartPolicy.
+type RestartPolicy string
+
+const (
+	// RestartPolicyNone restarts only the failed pod; OMENative leaves
+	// the Instance Phase=Ready and lets the kubelet recover in place.
+	RestartPolicyNone RestartPolicy = "None"
+	// RestartPolicyRecreateInstance drains, deletes, and recreates
+	// every pod in the Instance at a bumped Incarnation.
+	RestartPolicyRecreateInstance RestartPolicy = "RecreateInstanceOnPodRestart"
+)
+
+// MigrationMode is the migration disposition. String-mirrors the CRD
+// MigrationPolicyMode.
+type MigrationMode string
+
+const (
+	// MigrationModeAuto / MigrationModeSurge — operator may trigger
+	// migration via the per-UUID annotation; controller drives the
+	// surge cycle. Surge is a spelling alias for Auto.
+	MigrationModeAuto  MigrationMode = "Auto"
+	MigrationModeSurge MigrationMode = "Surge"
+	// MigrationModeNever — controller refuses any migration;
+	// annotations are ignored.
+	MigrationModeNever MigrationMode = "Never"
+)
+
+// InstanceOperationType identifies the kind of an in-flight
+// destructive operation against one Instance. String-mirrors the CRD
+// InstanceOperationType.
+type InstanceOperationType string
+
+const (
+	InstanceOperationCreate  InstanceOperationType = "Create"
+	InstanceOperationUpdate  InstanceOperationType = "Update"
+	InstanceOperationRestart InstanceOperationType = "Restart"
+	InstanceOperationMigrate InstanceOperationType = "Migrate"
+	InstanceOperationDelete  InstanceOperationType = "Delete"
+)
+
+// UpdateStepGangSurgeTarget is the InstanceOperation.Step marking the
+// surge-target (replacement) Instance of an in-flight multi-pod (gang)
+// SurgeThenDrain update. Lives here in the leaf types package so both the
+// plan (root workload) and the ops dispatcher reference one canonical
+// value. The gang SOURCE uses Step="Surge" so the surge budget counts it.
+const UpdateStepGangSurgeTarget = "GangSurgeTarget"
+
+// UpdateStepGangSurgeTargetCleanup marks a replacement gang whose terminal
+// cleanup owns its Pods and PodGroup until the marker status is removed.
+const UpdateStepGangSurgeTargetCleanup = "GangSurgeTargetCleanup"
+
+// UpdateStepSurgeDrain marks a SurgeThenDrain source whose replacement is
+// ready and whose source pods are being drained.
+const UpdateStepSurgeDrain = "SurgeDrain"
+
+// InstanceOperation is the durable recovery anchor written before any
+// destructive action against an Instance and cleared on completion.
+// Mirrors the CRD InstanceOperation field-for-field.
+type InstanceOperation struct {
+	// ID is the idempotency key. Retries with the same ID are a no-op.
+	ID string
+
+	Type InstanceOperationType
+
+	// Step is the fine-grained resume point within the operation
+	// (e.g., Drain, DeletePods, WaitZero, Recreate, WaitReady).
+	Step string
+
+	StartedAt metav1.Time
+	// LastProgressAt is when the operation last advanced. Used for
+	// stall detection.
+	LastProgressAt metav1.Time
+	// Deadline is the hard timeout for the current Step.
+	Deadline metav1.Time
+	// RetryCount is the per-step escalation counter.
+	RetryCount int32
+
+	// TargetRevision is the ControllerRevision the operation is
+	// converging toward.
+	TargetRevision string
+
+	Reason string
+
+	// Migrate-only fields. The Operation is a pin: SurgeIndex correlates
+	// the source/surge pair and RequestUUID keys the authoritative
+	// status.migrations record.
+	SurgeIndex  *int32
+	RequestUUID string
+
+	// FromNode / HintTargetNodes are no longer stamped (migration facts
+	// live on the owner's status.migrations record) and have no readers;
+	// retained only so the CRD InstanceOperation mirror round-trips
+	// pre-existing stamped values unchanged. Do not add new writers.
+	FromNode        string
+	HintTargetNodes []string
+}
+
+// InstanceStatus is the per-Instance status. Mirrors the CRD
+// OMENativeInstanceStatus field-for-field; adapters round-trip between
+// this type and the CRD type.
+type InstanceStatus struct {
+	// Index is the stable Instance ordinal. Values may be sparse
+	// after surge migration.
+	Index int32
+
+	// Incarnation increments each time the Instance is recreated
+	// (full recreate update, restart-on-loss). In-place updates do
+	// not increment.
+	Incarnation int64
+
+	Phase InstancePhase
+
+	// RunningRevision / TargetRevision are the ControllerRevision the
+	// live pods are running and converging toward, respectively.
+	RunningRevision string
+	TargetRevision  string
+
+	PodCount int32
+	// ReadyPodCount counts pods reporting Ready=True.
+	ReadyPodCount int32
+	// ServingPodCount counts pods that are BOTH ContainersReady AND
+	// have serving=True on the controller-managed readiness gate.
+	ServingPodCount int32
+	// AvailablePodCount counts pods ready for at least MinReadySeconds.
+	AvailablePodCount int32
+	// ScheduledPodCount counts pods with Spec.NodeName set.
+	ScheduledPodCount int32
+	// Admitted reports that the Instance has pods and none remain behind an
+	// admission scheduling gate.
+	Admitted bool
+
+	// NodesOccupied is the set of node names hosting pods of this
+	// Instance.
+	NodesOccupied []string
+
+	Conditions []metav1.Condition
+
+	// Operation is the durable record of an in-flight destructive
+	// action against this Instance. Set before the action starts,
+	// cleared after it completes.
+	Operation *InstanceOperation
+
+	// ActiveOrdinal identifies which of two pod-naming slots (0 or 1)
+	// currently holds the canonical pod for this single-pod Instance.
+	ActiveOrdinal int32
+
+	// LastFailure preserves the container-termination diagnostics of the
+	// pod whose failure (or stuck-pod escalation) last triggered a
+	// recreate of this Instance. Survives the drain+recreate that deletes
+	// the failing pod. Mirrors the CRD OMENativeInstanceStatus.LastFailure.
+	LastFailure *InstanceTermination
+}
+
+// InstanceTermination captures the container-termination diagnostics of a
+// pod that failed or was escalated. Mirrors the CRD InstanceTermination
+// field-for-field; the v1beta1convert helpers round-trip it at the adapter
+// boundary.
+type InstanceTermination struct {
+	// PodName is the name of the pod that failed or was escalated.
+	PodName string
+
+	// ContainerName is the container the diagnostics were read from.
+	// Empty when only a pod-level signal was available.
+	ContainerName string
+
+	// Reason is the kubelet terminated- or waiting-state reason
+	// (OOMKilled, Error, CrashLoopBackOff, ImagePullBackOff, ...), or
+	// "PodFailed" when only the pod phase was available.
+	Reason string
+
+	// ExitCode is the container exit code when the signal came from a
+	// terminated state; nil for a stuck waiting-state signal.
+	ExitCode *int32
+
+	// Message is the kubelet-supplied detail message, if any.
+	Message string
+
+	// Time is when OMENative recorded this termination.
+	Time metav1.Time
+}
+
+// Key uniquely identifies one logical workload (a per-Component slice
+// of an owner). Adapters populate every field; workload code reads
+// them opaquely.
+type Key struct {
+	Namespace string
+	Component ComponentType
+
+	// OwnerName is the bare name of the workload's owner object
+	// (ISVC.Name or IR.Name). workload composes pod / Service names
+	// from this — never reaches back into OwnerObject for the field.
+	OwnerName string
+
+	// OwnerLabels is the seed label set stamped on every emitted
+	// ControllerRevision / PodGroup / pod's metadata labels block.
+	// Read-only from workload code.
+	OwnerLabels map[string]string
+
+	// SelectorLabels is the seed label set used in every pod LIST
+	// selector and per-revision Service selector. Read-only from
+	// workload code.
+	SelectorLabels map[string]string
+}
+
+// WorkloadName is the composed identity used for ControllerRevision
+// naming and as the prefix on emitted pod / PodGroup / PDB names.
+// Always "<OwnerName>-<Component>" — the pod-naming convention every
+// adapter shares so existing selectors keep matching.
+func (k Key) WorkloadName() string {
+	return k.OwnerName + "-" + string(k.Component)
+}
+
+// Lifecycle is the workload-owned mirror of the v1beta1 LifecycleSpec.
+// Adapters project the CRD-shape lifecycle into this struct so the
+// workload package can read it without importing v1beta1. Fields
+// match the CRD field-for-field; nil pointers signal "unset, default
+// at planning time".
+type Lifecycle struct {
+	// RestartPolicy is the per-Instance restart disposition. nil falls
+	// back to the per-shape default (multi-pod → RecreateInstance,
+	// single-pod → None) in BuildPlan.
+	RestartPolicy *RestartPolicy
+
+	// UpdateStrategy controls how OMENative rolls template changes
+	// across the Component's Instances. nil falls back to defaults.
+	UpdateStrategy *UpdateStrategy
+
+	// ReadyPolicy controls how Instance-level readiness is aggregated
+	// from the underlying pods. nil falls back to the per-shape default.
+	ReadyPolicy *InstanceReadyPolicy
+
+	// InstanceReadyTimeout is the wait ceiling on a newly-created
+	// Instance becoming Ready. nil falls back to the 30m default.
+	InstanceReadyTimeout *metav1.Duration
+
+	// MigrationPolicy controls whether and how OMENative honors a
+	// migration request annotation for this Component. nil falls back
+	// to the Auto default.
+	MigrationPolicy *MigrationPolicy
+}
+
+// UpdateStrategy is the workload-owned mirror of the v1beta1
+// UpdateStrategy struct. Adapters project the CRD-shape strategy onto
+// this struct so the workload package can read it without importing
+// v1beta1.
+type UpdateStrategy struct {
+	// Type selects the rollout mechanism. Empty defaults to
+	// SurgeThenDrain in BuildPlan.
+	Type UpdateStrategyType
+
+	// RollingUpdate paces the rollout across Instances of the
+	// Component.
+	RollingUpdate *RollingUpdate
+
+	// InPlaceUpdateStrategy tunes lifecycle drain timing. Its grace period
+	// also provides the post-unroute connection-settle window before a
+	// SurgeThenDrain source pod is deleted.
+	InPlaceUpdateStrategy *InPlaceUpdateStrategy
+}
+
+// RollingUpdate paces rollout across Instances of one Component.
+// Workload-owned mirror of v1beta1.RollingUpdate.
+type RollingUpdate struct {
+	// Partition holds back updates for Instances whose index is <
+	// Partition. 0 (the default) updates all Instances.
+	Partition *int32
+
+	// MaxUnavailable is the maximum number of Instances (or percent
+	// expression) allowed to be in a non-Ready state during the rollout.
+	// nil falls back to the reconciler default. Mirrors
+	// v1beta1.RollingUpdate.MaxUnavailable.
+	MaxUnavailable *intstr.IntOrString
+
+	// MaxSurge is the maximum number of extra Instances (or percent
+	// expression) the rollout may create above the Component's desired
+	// replica count during a rolling update. nil falls back to the
+	// reconciler default. Mirrors v1beta1.RollingUpdate.MaxSurge.
+	MaxSurge *intstr.IntOrString
+}
+
+// InPlaceUpdateStrategy tunes the per-pod in-place update sequence.
+// Workload-owned mirror of v1beta1.InPlaceUpdateStrategy.
+type InPlaceUpdateStrategy struct {
+	// GracePeriodSeconds is the time OMENative waits between marking
+	// the pod not-ready and applying an in-place mutation. SurgeThenDrain
+	// also waits this long after EndpointSlice removal before deletion so
+	// persistent load-balancer connections can drain while workers live.
+	GracePeriodSeconds *int32
+
+	// MarkNotReadyDuringLifecycle, when true, flips ome.io/serving=False
+	// on the pod before the in-place mutation so EndpointSlice drains
+	// traffic first.
+	MarkNotReadyDuringLifecycle *bool
+}
+
+// InstanceReadyPolicy controls how Instance-level readiness is
+// aggregated from the underlying pods. Workload-owned mirror of the
+// v1beta1.InstanceReadyPolicy enum.
+type InstanceReadyPolicy string
+
+const (
+	// InstanceReadyPolicyAllPodReady reports the Instance Ready only
+	// when every pod has Ready=True. Default for multi-pod Instances.
+	InstanceReadyPolicyAllPodReady InstanceReadyPolicy = "AllPodReady"
+	// InstanceReadyPolicyNone disables Instance-level aggregation; pods
+	// are reported individually. Default for single-pod Instances.
+	InstanceReadyPolicyNone InstanceReadyPolicy = "None"
+)
+
+// MigrationPolicy controls whether and how OMENative honors a
+// migration request annotation for this Component. Workload-owned
+// mirror of v1beta1.MigrationPolicy.
+type MigrationPolicy struct {
+	// Mode selects the migration disposition. Empty defaults to Auto.
+	Mode MigrationMode
+}
+
+// ComponentTrafficTarget describes the percentage of traffic routed to
+// one revision of one Component. Workload-owned mirror of
+// v1beta1.ComponentTrafficTarget; serialized field-for-field by the
+// adapter when projecting onto ISVC status.
+type ComponentTrafficTarget struct {
+	// RevisionName is the per-revision Service name for this target.
+	RevisionName string
+
+	// Percent is the percentage of traffic the consumer should route to
+	// RevisionName. Sum across all entries for one Component is 100.
+	Percent int32
+
+	// Tag is an optional short identifier for the target (e.g.
+	// "latest", "prev"). Cosmetic; not used by the consumer.
+	Tag string
+
+	// LatestRevision is true when this entry corresponds to the
+	// LatestRolledoutRevision for the Component.
+	LatestRevision bool
+}

--- a/pkg/controller/v1beta1/workload/types/types_test.go
+++ b/pkg/controller/v1beta1/workload/types/types_test.go
@@ -1,0 +1,282 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExpectations_SatisfiedWhenEmpty(t *testing.T) {
+	e := NewExpectations()
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("empty cache should be satisfied")
+	}
+}
+
+func TestExpectations_BlocksUntilObserved(t *testing.T) {
+	e := NewExpectations()
+	e.ExpectCreates("ns", "isvc", ComponentEngine, 0, 2)
+
+	if e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("should NOT be satisfied with 2 pending adds")
+	}
+
+	e.ObservedCreate("ns", "isvc", ComponentEngine, 0)
+	if e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("should NOT be satisfied with 1 pending add still")
+	}
+
+	e.ObservedCreate("ns", "isvc", ComponentEngine, 0)
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("should be satisfied after observing both creates")
+	}
+}
+
+func TestExpectations_DeadlineForcesSatisfied(t *testing.T) {
+	e := NewExpectations()
+	e.ExpectCreates("ns", "isvc", ComponentEngine, 0, 1)
+	// Manually expire the entry.
+	e.mu.Lock()
+	for _, v := range e.entries {
+		v.Deadline = time.Now().Add(-1 * time.Second)
+	}
+	e.mu.Unlock()
+
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("expired entry should be reported as satisfied")
+	}
+}
+
+func TestExpectations_ScopedByKey(t *testing.T) {
+	e := NewExpectations()
+	e.ExpectCreates("ns", "isvc", ComponentEngine, 0, 1)
+	// Different instance index — should be unaffected.
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 1) {
+		t.Fatal("instance 1 should still be satisfied")
+	}
+	// Different component — should be unaffected.
+	if !e.Satisfied("ns", "isvc", ComponentDecoder, 0) {
+		t.Fatal("decoder instance 0 should still be satisfied")
+	}
+}
+
+func TestExpectations_Forget(t *testing.T) {
+	e := NewExpectations()
+	e.ExpectCreates("ns", "isvc", ComponentEngine, 0, 3)
+	if e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("should not be satisfied before Forget")
+	}
+	e.Forget("ns", "isvc", ComponentEngine, 0)
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("Forget should clear the entry")
+	}
+}
+
+func TestExpectations_DeletesTracked(t *testing.T) {
+	e := NewExpectations()
+	e.ExpectDeletes("ns", "isvc", ComponentEngine, 0, 1)
+	if e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("should not be satisfied with pending delete")
+	}
+	e.ObservedDelete("ns", "isvc", ComponentEngine, 0)
+	if !e.Satisfied("ns", "isvc", ComponentEngine, 0) {
+		t.Fatal("delete observation should satisfy")
+	}
+}
+
+func int32p(v int32) *int32 { return &v }
+
+func podWith(name string, phase corev1.PodPhase, css ...corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.PodStatus{Phase: phase, ContainerStatuses: css},
+	}
+}
+
+func TestPodTermination_NilPod(t *testing.T) {
+	if got := PodTermination(nil, metav1.Now()); got != nil {
+		t.Fatalf("PodTermination(nil) = %+v, want nil", got)
+	}
+}
+
+// A non-zero terminated exit code is the highest-precedence signal — the
+// canonical crash the operator most wants to see (OOMKilled, exit 137).
+func TestPodTermination_NonZeroTerminatedWins(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodFailed, corev1.ContainerStatus{
+		Name: "main",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason:   "OOMKilled",
+			ExitCode: 137,
+			Message:  "out of memory",
+		}},
+	})
+	got := PodTermination(pod, metav1.Now())
+	if got == nil {
+		t.Fatal("PodTermination = nil, want a record")
+	}
+	if got.PodName != "engine-0" || got.ContainerName != "main" || got.Reason != "OOMKilled" {
+		t.Errorf("identity: %+v", got)
+	}
+	if got.ExitCode == nil || *got.ExitCode != 137 {
+		t.Errorf("ExitCode: got %v want 137", got.ExitCode)
+	}
+	if got.Message != "out of memory" {
+		t.Errorf("Message: got %q", got.Message)
+	}
+	if got.ShortString() != "pod engine-0 container main failed (OOMKilled, exit 137)" {
+		t.Errorf("ShortString: %q", got.ShortString())
+	}
+}
+
+// CrashLoopBackOff surfaces the crash in LastTerminationState while the
+// live State is Waiting — the extractor must read LastTerminationState's
+// non-zero exit code in preference to the bare waiting reason.
+func TestPodTermination_CrashLoopReadsLastTerminationState(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodRunning, corev1.ContainerStatus{
+		Name:  "main",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+		LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason:   "Error",
+			ExitCode: 1,
+		}},
+	})
+	got := PodTermination(pod, metav1.Now())
+	if got == nil || got.Reason != "Error" || got.ExitCode == nil || *got.ExitCode != 1 {
+		t.Fatalf("want Error/exit 1 from LastTerminationState, got %+v", got)
+	}
+}
+
+// A terminal waiting state with no terminated history (ImagePullBackOff)
+// yields a reason with a nil ExitCode and a "stuck" ShortString.
+func TestPodTermination_TerminalWaitingNoExitCode(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodPending, corev1.ContainerStatus{
+		Name:  "main",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "back-off pulling"}},
+	})
+	got := PodTermination(pod, metav1.Now())
+	if got == nil {
+		t.Fatal("want a record")
+	}
+	if got.Reason != "ImagePullBackOff" || got.ExitCode != nil {
+		t.Errorf("want ImagePullBackOff/nil exit, got %+v", got)
+	}
+	if got.ShortString() != "pod engine-0 container main stuck (ImagePullBackOff)" {
+		t.Errorf("ShortString: %q", got.ShortString())
+	}
+}
+
+// A non-terminal waiting reason (ContainerCreating) is not a failure
+// signal; with no other signal and a non-Failed phase, return nil.
+func TestPodTermination_TransientWaitingIgnored(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodPending, corev1.ContainerStatus{
+		Name:  "main",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+	})
+	if got := PodTermination(pod, metav1.Now()); got != nil {
+		t.Fatalf("ContainerCreating must not produce a record, got %+v", got)
+	}
+}
+
+// Pod phase Failed with no per-container detail falls back to a
+// pod-level PodFailed record.
+func TestPodTermination_PodLevelFallback(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodFailed)
+	pod.Status.Message = "node shutdown"
+	got := PodTermination(pod, metav1.Now())
+	if got == nil || got.Reason != "PodFailed" || got.ContainerName != "" {
+		t.Fatalf("want pod-level PodFailed, got %+v", got)
+	}
+	if got.Message != "node shutdown" {
+		t.Errorf("Message: got %q", got.Message)
+	}
+	if got.ShortString() != "pod engine-0 failed (PodFailed)" {
+		t.Errorf("ShortString: %q", got.ShortString())
+	}
+}
+
+// A Running pod with no termination signal yields nil (no false-positive
+// capture during healthy operation).
+func TestPodTermination_HealthyRunningNil(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodRunning, corev1.ContainerStatus{
+		Name:  "main",
+		Ready: true,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	})
+	if got := PodTermination(pod, metav1.Now()); got != nil {
+		t.Fatalf("healthy running pod must yield nil, got %+v", got)
+	}
+}
+
+// Init-container failures are captured with the same precedence after
+// regular containers.
+func TestPodTermination_InitContainerCrash(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine-0"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "init-model",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason:   "Error",
+					ExitCode: 2,
+				}},
+			}},
+		},
+	}
+	got := PodTermination(pod, metav1.Now())
+	if got == nil || got.ContainerName != "init-model" || got.ExitCode == nil || *got.ExitCode != 2 {
+		t.Fatalf("want init-model/exit 2, got %+v", got)
+	}
+}
+
+// kubelet occasionally leaves the terminated Reason blank; the extractor
+// must still produce a non-empty reason ("Error") so the record is
+// never reason-less.
+func TestPodTermination_BlankReasonFallsBackToError(t *testing.T) {
+	pod := podWith("engine-0", corev1.PodFailed, corev1.ContainerStatus{
+		Name:  "main",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 139}},
+	})
+	got := PodTermination(pod, metav1.Now())
+	if got == nil || got.Reason != "Error" {
+		t.Fatalf("want fallback reason Error, got %+v", got)
+	}
+}
+
+// PodTerminationWithReason fills a missing reason from the override but
+// keeps container/exit detail when the extractor found it.
+func TestPodTerminationWithReason(t *testing.T) {
+	// No per-container detail at all → override supplies the whole record.
+	bare := podWith("engine-0", corev1.PodPending)
+	got := PodTerminationWithReason(bare, "ImagePullBackOff", metav1.Now())
+	if got == nil || got.PodName != "engine-0" || got.Reason != "ImagePullBackOff" {
+		t.Fatalf("override path: got %+v", got)
+	}
+
+	// Extractor already produced detail with a reason → override does not
+	// clobber it.
+	rich := podWith("engine-1", corev1.PodFailed, corev1.ContainerStatus{
+		Name:  "main",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137}},
+	})
+	got = PodTerminationWithReason(rich, "ImagePullBackOff", metav1.Now())
+	if got.Reason != "OOMKilled" || got.ExitCode == nil || *got.ExitCode != 137 {
+		t.Fatalf("override must not clobber richer record, got %+v", got)
+	}
+}
+
+func TestInstanceTermination_ShortStringNil(t *testing.T) {
+	var t0 *InstanceTermination
+	if got := t0.ShortString(); got != "" {
+		t.Fatalf("nil ShortString = %q, want empty", got)
+	}
+}
+
+func TestInstanceTermination_ShortStringUnknownPod(t *testing.T) {
+	tm := &InstanceTermination{Reason: "OOMKilled", ExitCode: int32p(137)}
+	if got := tm.ShortString(); got != "pod <unknown> failed (OOMKilled, exit 137)" {
+		t.Fatalf("ShortString = %q", got)
+	}
+}

--- a/pkg/controller/v1beta1/workloadcluster/connection.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -33,10 +34,17 @@ type ExecCredentialPolicy struct {
 }
 
 func (p ExecCredentialPolicy) commandAllowed(cmd string) bool {
+	if cmd == "" {
+		return false
+	}
+	// A command carrying a path separator is only ever authorized by an entry
+	// that is that exact absolute path: a bare entry must never let an
+	// attacker-controlled path through because its basename matches, and a
+	// relative path resolves against an unknown working directory.
+	if strings.ContainsAny(cmd, `/\`) && !filepath.IsAbs(cmd) {
+		return false
+	}
 	for _, a := range p.AllowedCommands {
-		// Exact matching permits either a bare command resolved through PATH or
-		// an explicitly allowlisted absolute path. It must never let an
-		// attacker-controlled path through merely because its basename matches.
 		if a == cmd {
 			return true
 		}
@@ -66,8 +74,9 @@ func RESTConfigFromKubeConfig(raw []byte, exec ExecCredentialPolicy) (*rest.Conf
 
 // validateKubeConfigBytes inspects the raw kubeconfig at the API-config level
 // (across ALL clusters and users, not just the current context) and rejects:
-// per-user on-disk token files, per-cluster insecure TLS, CA file paths
-// (require inline certificate-authority-data), and a missing server URL.
+// per-user on-disk token and client certificate/key files, per-cluster insecure
+// TLS, CA file paths (require inline certificate-authority-data), and a missing
+// server URL.
 func validateKubeConfigBytes(raw []byte, exec ExecCredentialPolicy) error {
 	cfg, err := clientcmd.Load(raw)
 	if err != nil {
@@ -99,9 +108,11 @@ func validateKubeConfigBytes(raw []byte, exec ExecCredentialPolicy) error {
 }
 
 // validateRESTConfig rejects unsafe settings on the flattened rest.Config:
-// exec/auth-provider plugins, on-disk token files, basic auth, disabled TLS, a
-// CA file path, or an untrusted server endpoint. BearerToken (service-account
-// token) and inline CA data are allowed.
+// exec/auth-provider plugins, on-disk token or client certificate/key files,
+// basic auth, disabled TLS, a CA file path, or an untrusted server endpoint.
+// BearerToken (service-account token) and inline CA data are allowed. Every
+// check is independent: an accepted exec provider still has to clear the
+// transport and endpoint checks below.
 func validateRESTConfig(cfg *rest.Config, exec ExecCredentialPolicy) error {
 	if cfg.ExecProvider != nil {
 		if !exec.Allowed {
@@ -157,29 +168,27 @@ func isValidHostname(server string) bool {
 	return len(validation.IsDNS1123Subdomain(host)) == 0
 }
 
-// DefaultProbeTimeout bounds the reachability probe's single /version request
-// when no per-call timeout is configured. An unbounded probe would let one
-// black-holed endpoint hold a reconcile worker indefinitely.
-const DefaultProbeTimeout = 10 * time.Second
-
 // probeViaServerVersion is the default reachability probe: build a discovery
 // client and fetch the remote /version. Cheap and needs no extra RBAC. It is
 // assigned to Reconciler.Probe by SetupWithManager and overridden in tests.
-// A non-positive timeout falls back to DefaultProbeTimeout.
-func probeViaServerVersion(_ context.Context, raw []byte, exec ExecCredentialPolicy, timeout time.Duration) error {
+//
+// timeout bounds the request at the client level; a non-positive value leaves
+// the request bounded only by ctx, matching the perCallTimeout convention.
+func probeViaServerVersion(ctx context.Context, raw []byte, exec ExecCredentialPolicy, timeout time.Duration) error {
 	cfg, err := RESTConfigFromKubeConfig(raw, exec)
 	if err != nil {
 		return err
 	}
-	if timeout <= 0 {
-		timeout = DefaultProbeTimeout
+	if timeout > 0 {
+		cfg.Timeout = timeout
 	}
-	cfg.Timeout = timeout
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("build discovery client: %w", err)
 	}
-	if _, err := dc.ServerVersion(); err != nil {
+	// Go through the REST client rather than ServerVersion() so the probe
+	// observes ctx cancellation instead of running to its own timeout.
+	if err := dc.RESTClient().Get().AbsPath("/version").Do(ctx).Error(); err != nil {
 		return fmt.Errorf("connect to cluster: %w", err)
 	}
 	return nil

--- a/pkg/controller/v1beta1/workloadcluster/connection_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection_test.go
@@ -22,8 +22,13 @@ func TestValidateRESTConfig(t *testing.T) {
 		{"basic auth", &rest.Config{Host: "https://h", Username: "u", Password: "p"}, ExecCredentialPolicy{}, true},
 		{"ca file path", &rest.Config{Host: "https://h", TLSClientConfig: rest.TLSClientConfig{CAFile: "/etc/ca.crt"}}, ExecCredentialPolicy{}, true},
 		{"client certificate file path", &rest.Config{Host: "https://h", TLSClientConfig: rest.TLSClientConfig{CertFile: "/etc/client.crt", KeyFile: "/etc/client.key"}}, ExecCredentialPolicy{}, true},
-		{"allowed exec still validates host", &rest.Config{Host: "http://h", ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"}}, ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, true},
+		{"client key file path", &rest.Config{Host: "https://h", TLSClientConfig: rest.TLSClientConfig{KeyFile: "/etc/client.key"}}, ExecCredentialPolicy{}, true},
 		{"untrusted host", &rest.Config{Host: "https://bad_host"}, ExecCredentialPolicy{}, true},
+		// An accepted exec provider must not short-circuit the endpoint and
+		// basic-auth checks; the credential would otherwise go out in the clear.
+		{"allowed exec still validates host", &rest.Config{Host: "http://h", ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"}}, ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, true},
+		{"allowed exec still rejects basic auth", &rest.Config{Host: "https://h", Username: "u", Password: "p", ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"}}, ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, true},
+		{"allowed exec over https", &rest.Config{Host: "https://h", ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"}}, ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -36,8 +41,9 @@ func TestValidateRESTConfig(t *testing.T) {
 }
 
 // TestValidateKubeConfigBytes pins the raw-kubeconfig-level checks (run across
-// ALL clusters/users, before flattening): per-user token files, per-cluster
-// insecure TLS, and CA file paths are rejected; a server URL is required.
+// ALL clusters/users, before flattening): per-user token and client
+// certificate/key files, per-cluster insecure TLS, and CA file paths are
+// rejected; a server URL is required.
 func TestValidateKubeConfigBytes(t *testing.T) {
 	const clean = `apiVersion: v1
 kind: Config
@@ -81,13 +87,6 @@ clusters:
     server: https://example.com
     certificate-authority: /etc/ca.crt
 `
-	const noServer = `apiVersion: v1
-kind: Config
-clusters:
-- name: c
-  cluster:
-    certificate-authority-data: ZHVtbXk=
-`
 	const clientCertificatePath = `apiVersion: v1
 kind: Config
 clusters:
@@ -99,6 +98,23 @@ users:
     client-certificate: /etc/client.crt
     client-key: /etc/client.key
 `
+	const clientKeyPath = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: {server: https://example.com, certificate-authority-data: ZHVtbXk=}
+users:
+- name: u
+  user:
+    client-key: /etc/client.key
+`
+	const noServer = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    certificate-authority-data: ZHVtbXk=
+`
 	cases := []struct {
 		name    string
 		raw     string
@@ -109,6 +125,7 @@ users:
 		{"per-cluster insecure", insecure, true},
 		{"ca file path", caPath, true},
 		{"client certificate file path", clientCertificatePath, true},
+		{"client key file path", clientKeyPath, true},
 		{"missing server", noServer, true},
 		{"malformed", "this is not a kubeconfig", true},
 	}
@@ -122,16 +139,34 @@ users:
 	}
 }
 
+// TestExecCredentialPolicy_CommandAllowed pins exact matching: a bare entry
+// permits only that bare command, and a path-qualified command needs an entry
+// that is that exact absolute path.
 func TestExecCredentialPolicy_CommandAllowed(t *testing.T) {
-	p := ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws", "/usr/local/bin/kubelogin"}}
-	if !p.commandAllowed("aws") {
-		t.Fatal("bare allowlisted command was rejected")
+	p := ExecCredentialPolicy{
+		Allowed:         true,
+		AllowedCommands: []string{"aws", "/usr/local/bin/kubelogin", "./bin/aws", `bin\aws`},
 	}
-	if !p.commandAllowed("/usr/local/bin/kubelogin") {
-		t.Fatal("exact allowlisted command path was rejected")
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"bare allowlisted command", "aws", true},
+		{"exact allowlisted absolute path", "/usr/local/bin/kubelogin", true},
+		{"path-qualified command with bare entry", "/tmp/attacker/aws", false},
+		{"absolute path not allowlisted", "/usr/local/bin/aws", false},
+		{"relative path even when allowlisted", "./bin/aws", false},
+		{"backslash path even when allowlisted", `bin\aws`, false},
+		{"bare command not allowlisted", "kubelogin", false},
+		{"empty command", "", false},
 	}
-	if p.commandAllowed("/tmp/attacker/aws") {
-		t.Fatal("path-qualified command matched a bare allowlist entry")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := p.commandAllowed(tc.cmd); got != tc.want {
+				t.Errorf("commandAllowed(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -186,18 +221,62 @@ users:
       command: aws
       args: ["eks","get-token","--cluster-name","c"]
 `
+	// Same shape, but the plugin is named by an attacker-controlled path whose
+	// basename matches an allowlisted bare command.
+	const pathQualifiedExecKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    certificate-authority-data: ZHVtbXk=
+contexts:
+- name: ctx
+  context: {cluster: c, user: u}
+current-context: ctx
+users:
+- name: u
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: /tmp/attacker/aws
+`
+	// Allowed exec plugin, plaintext endpoint: the credential must not leave
+	// the control plane in the clear.
+	const httpExecKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: http://example.com
+    certificate-authority-data: ZHVtbXk=
+contexts:
+- name: ctx
+  context: {cluster: c, user: u}
+current-context: ctx
+users:
+- name: u
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+`
+	allowAWS := ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}
 	cases := []struct {
 		name    string
+		raw     string
 		exec    ExecCredentialPolicy
 		wantErr bool
 	}{
-		{"deny exec (zero policy)", ExecCredentialPolicy{}, true},
-		{"allow aws command", ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, false},
-		{"command not in allowlist", ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"kubelogin"}}, true},
+		{"deny exec (zero policy)", execKubeconfig, ExecCredentialPolicy{}, true},
+		{"allow aws command", execKubeconfig, allowAWS, false},
+		{"command not in allowlist", execKubeconfig, ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"kubelogin"}}, true},
+		{"path-qualified command with bare entry", pathQualifiedExecKubeconfig, allowAWS, true},
+		{"allowed exec over http", httpExecKubeconfig, allowAWS, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := RESTConfigFromKubeConfig([]byte(execKubeconfig), tc.exec)
+			_, err := RESTConfigFromKubeConfig([]byte(tc.raw), tc.exec)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("RESTConfigFromKubeConfig() err=%v wantErr=%v", err, tc.wantErr)
 			}

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -77,8 +77,9 @@ type Reconciler struct {
 	ConnectionGracePeriod time.Duration
 	// ProbeTimeout bounds the default reachability probe's single request. It is
 	// the same budget as a remote per-call timeout, so the control-plane wiring
-	// feeds it the configured per-call value; zero defaults to
-	// DefaultProbeTimeout.
+	// feeds it the configured per-call value. Zero falls back to the health
+	// interval, which is always positive: the probe must never outlast the
+	// cadence that schedules the next one, and this controller runs one worker.
 	ProbeTimeout time.Duration
 
 	// mu guards firstFailure. The reconciler runs single-worker per key, but
@@ -191,6 +192,13 @@ func (r *Reconciler) finish(ctx context.Context, wc *v1beta1.WorkloadCluster, re
 	if err := r.Status().Update(ctx, wc); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
+		}
+		// wc was read through the cache, so a pass that runs before the cache
+		// caught up writes at a stale resourceVersion and loses the race. The
+		// next pass recomputes the same status from fresh state, so requeue
+		// rather than reporting a failure that did not happen.
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("workloadcluster %s: update status: %w", wc.Name, err)
 	}
@@ -368,14 +376,20 @@ func (r *Reconciler) secretReader() client.Reader {
 	return r.Client
 }
 
+// probeTimeout is the client-level bound for one reachability probe. It comes
+// from config (workloadCluster.perCallTimeout); when that is unset the health
+// interval bounds it instead, so an unreachable endpoint can never hold the
+// single reconcile worker past the next scheduled probe.
 func (r *Reconciler) probeTimeout() time.Duration {
 	if r.cfg != nil {
-		return r.cfg.probeTimeout
+		if r.cfg.probeTimeout > 0 {
+			return r.cfg.probeTimeout
+		}
+		if r.cfg.healthInterval > 0 {
+			return r.cfg.healthInterval
+		}
 	}
-	if r.ProbeTimeout > 0 {
-		return r.ProbeTimeout
-	}
-	return DefaultProbeTimeout
+	return r.ProbeTimeout
 }
 
 // SetupWithManager wires the reconciler: watch WorkloadClusters, and re-enqueue

--- a/pkg/controller/v1beta1/workloadcluster/manager.go
+++ b/pkg/controller/v1beta1/workloadcluster/manager.go
@@ -294,9 +294,13 @@ func (m *Manager) buildRemoteClient(ctx context.Context, raw []byte, scheme *run
 	// base ctx so the cache's informers are scoped to the manager lifetime, and
 	// return its cancel so Disconnect tears the cache down (no leaked watches).
 	cacheCtx, cancel := context.WithCancel(ctx)
+	// The initial cache sync is a watch establishment, so it takes the configured
+	// establish budget: a cache that cannot sync must fail the connection rather
+	// than count as connected.
 	cl, err := NewSelectivelyCachingClient(
 		cacheCtx, restConfig, wc, scheme,
 		cacheOpts.CachedKinds, cacheOpts.Indexes, cacheOpts.DefaultSelector,
+		m.ReconnectBackoff().establishInitial,
 	)
 	if err != nil {
 		cancel()

--- a/pkg/controller/v1beta1/workloadcluster/options.go
+++ b/pkg/controller/v1beta1/workloadcluster/options.go
@@ -94,14 +94,15 @@ type controllerConfig struct {
 	// previously-reachable cluster tolerates transient probe failures before it
 	// is flipped Ready=False and disconnected.
 	connectionGracePeriod time.Duration
-	// probeTimeout bounds the default reachability probe's single request.
-	probeTimeout time.Duration
 	// eventsBatchPeriod debounces Secret-change re-enqueues: a rotated kubeconfig
 	// Secret often updates several keys in quick succession, and batching folds
 	// that burst into one reconcile.
 	eventsBatchPeriod time.Duration
 	// reconnect governs (re)establish/retry backoff for the remote transport.
 	reconnect reconnectBackoff
+	// probeTimeout bounds one reachability probe at the client level.
+	// Non-positive leaves the probe bounded by its context alone.
+	probeTimeout time.Duration
 }
 
 // Option mutates the reconciler's timing configuration at Setup: the
@@ -187,9 +188,6 @@ func (r *Reconciler) resolveConfig(opts ...Option) controllerConfig {
 	// explicit "disable grace" and is preserved.
 	if c.connectionGracePeriod == 0 {
 		c.connectionGracePeriod = DefaultConnectionGracePeriod
-	}
-	if c.probeTimeout <= 0 {
-		c.probeTimeout = DefaultProbeTimeout
 	}
 	if c.eventsBatchPeriod <= 0 {
 		c.eventsBatchPeriod = DefaultEventsBatchPeriod

--- a/pkg/controller/v1beta1/workloadcluster/options_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/options_test.go
@@ -196,6 +196,15 @@ func (b *blockingWatchClient) Watch(ctx context.Context, _ client.ObjectList, _ 
 	return nil, ctx.Err()
 }
 
+// immediateWatchClient returns an empty watch right away (success path).
+type immediateWatchClient struct {
+	client.WithWatch
+}
+
+func (i *immediateWatchClient) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	return watch.NewEmptyWatch(), nil
+}
+
 // stubbornWatchClient simulates a broken client that ignores context
 // cancellation. establishWatch must still return at its timeout.
 type stubbornWatchClient struct {
@@ -208,19 +217,18 @@ func (s *stubbornWatchClient) Watch(context.Context, client.ObjectList, ...clien
 	return nil, errors.New("released")
 }
 
-// immediateWatchClient returns an empty watch right away (success path).
-type immediateWatchClient struct {
-	client.WithWatch
-}
-
-func (i *immediateWatchClient) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
-	return watch.NewEmptyWatch(), nil
-}
-
 func TestEstablishWatch_TimesOut(t *testing.T) {
 	c := &blockingWatchClient{WithWatch: fake.NewClientBuilder().Build()}
 	_, err := establishWatch(context.Background(), c, &corev1.PodList{}, 20*time.Millisecond)
 	require.ErrorIs(t, err, errWatchEstablishTimeout)
+}
+
+func TestEstablishWatch_Succeeds(t *testing.T) {
+	c := &immediateWatchClient{WithWatch: fake.NewClientBuilder().Build()}
+	w, err := establishWatch(context.Background(), c, &corev1.PodList{}, time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	w.Stop() // cancelOnStopWatcher.Stop must not panic
 }
 
 func TestEstablishWatch_TimeoutDoesNotWaitForClientCancellation(t *testing.T) {
@@ -233,14 +241,6 @@ func TestEstablishWatch_TimeoutDoesNotWaitForClientCancellation(t *testing.T) {
 	close(release)
 }
 
-func TestEstablishWatch_Succeeds(t *testing.T) {
-	c := &immediateWatchClient{WithWatch: fake.NewClientBuilder().Build()}
-	w, err := establishWatch(context.Background(), c, &corev1.PodList{}, time.Second)
-	require.NoError(t, err)
-	require.NotNil(t, w)
-	w.Stop() // cancelOnStopWatcher.Stop must not panic
-}
-
 // TestManager_EstablishWatch_NotConnected: a cluster with no client returns
 // (nil,false,nil) rather than erroring.
 func TestManager_EstablishWatch_NotConnected(t *testing.T) {
@@ -248,8 +248,8 @@ func TestManager_EstablishWatch_NotConnected(t *testing.T) {
 	w, generation, connected, err := m.EstablishWatch(context.Background(), "nope", &corev1.PodList{}, 1)
 	require.NoError(t, err)
 	assert.False(t, connected)
-	assert.Zero(t, generation)
 	assert.Nil(t, w)
+	assert.Zero(t, generation)
 }
 
 // TestManager_EstablishWatch_TimesOut wires a connected blocking client and a
@@ -269,8 +269,8 @@ func TestManager_EstablishWatch_TimesOut(t *testing.T) {
 
 	_, generation, connected, err := m.EstablishWatch(context.Background(), "c1", &corev1.PodList{}, 1)
 	assert.True(t, connected)
-	assert.NotZero(t, generation)
 	require.ErrorIs(t, err, errWatchEstablishTimeout)
+	assert.NotZero(t, generation)
 }
 
 // blockingCachingClient adapts blockingWatchClient to SelectivelyCachingClient
@@ -293,7 +293,6 @@ func TestResolveConfig_Defaults(t *testing.T) {
 	assert.Equal(t, DefaultHealthInterval, c.healthInterval)
 	assert.Equal(t, DefaultConnectionGracePeriod, c.connectionGracePeriod)
 	assert.Equal(t, DefaultEventsBatchPeriod, c.eventsBatchPeriod)
-	assert.Equal(t, DefaultProbeTimeout, c.probeTimeout)
 	assert.Equal(t, DefaultEstablishInitialTimeout, c.reconnect.establishInitial)
 	assert.Equal(t, DefaultEstablishMaxTimeout, c.reconnect.establishMax)
 	assert.Equal(t, DefaultReconnectRetryMax, c.reconnect.retryMax)
@@ -321,22 +320,6 @@ func TestResolveConfig_SeedsAndOptions(t *testing.T) {
 	assert.Equal(t, 6*time.Millisecond, c.reconnect.establishMax)
 	assert.Equal(t, 7*time.Millisecond, c.reconnect.retryInitial)
 	assert.Equal(t, 8*time.Millisecond, c.reconnect.retryMax)
-}
-
-// TestProbeTimeout_ConfiguredValueWins: the probe budget is config-driven — the
-// configured per-call value reaches the reachability probe, and only an unset
-// knob falls back to the in-package default.
-func TestProbeTimeout_ConfiguredValueWins(t *testing.T) {
-	r := &Reconciler{}
-	assert.Equal(t, DefaultProbeTimeout, r.probeTimeout())
-
-	r = &Reconciler{ProbeTimeout: 250 * time.Millisecond}
-	assert.Equal(t, 250*time.Millisecond, r.probeTimeout(), "struct field must apply before Setup")
-
-	c := r.resolveConfig()
-	assert.Equal(t, 250*time.Millisecond, c.probeTimeout, "struct field must seed the resolved config")
-	r.cfg = &c
-	assert.Equal(t, 250*time.Millisecond, r.probeTimeout(), "resolved config must win after Setup")
 }
 
 // TestResolveConfig_NegativeGraceDisables: a negative ConnectionGracePeriod is a
@@ -375,3 +358,19 @@ func TestReconcile_RetryBackoffSpacesRequeue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 4*time.Second, res3.RequeueAfter, "third failure -> doubled again")
 }
+
+// TestProbeTimeout_ConfiguredValueWins: the probe budget is config-driven — the
+// configured per-call value reaches the reachability probe, and only an unset
+// knob falls back to the in-package default.
+func TestProbeTimeout_ConfiguredValueWins(t *testing.T) {
+	r := &Reconciler{ProbeTimeout: 250 * time.Millisecond}
+	assert.Equal(t, 250*time.Millisecond, r.probeTimeout(), "struct field must apply before Setup")
+
+	c := r.resolveConfig()
+	assert.Equal(t, 250*time.Millisecond, c.probeTimeout, "struct field must seed the resolved config")
+	r.cfg = &c
+	assert.Equal(t, 250*time.Millisecond, r.probeTimeout(), "resolved config must win after Setup")
+}
+
+// TestResolveConfig_NegativeGraceDisables: a negative ConnectionGracePeriod is a
+// deliberate "disable grace" and must be preserved (not replaced by the default).

--- a/pkg/controller/v1beta1/workloadcluster/remoteclient.go
+++ b/pkg/controller/v1beta1/workloadcluster/remoteclient.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -44,11 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
-
-// DefaultRemoteCacheSyncTimeout bounds the initial informer LIST/sync during a
-// connection build. A remote cache that cannot start must fail the connection
-// rather than leave later reads or handler registration blocked indefinitely.
-const DefaultRemoteCacheSyncTimeout = time.Minute
 
 // cacheIndexOption defines a field to index on the cache before starting
 type CacheIndexOption struct {
@@ -85,34 +81,122 @@ type selectivelyCachingClient struct {
 	client.WithWatch
 	cachedReader client.Reader
 	cache        cache.Cache
-	scheme       *runtime.Scheme
-	cachedKinds  sets.Set[schema.GroupKind]
-	synced       *atomic.Bool
+	// cacheCtx is the context the background cache runs under. Disconnect
+	// cancels it to tear the cache down, and once that has happened the cache
+	// can never serve a read again — but controller-runtime does not surface
+	// that as an error. Informers.Start leaves `started` true when it stops and
+	// only sets `stopped`, so a kind whose informer does not exist yet is
+	// created, silently NOT started (startInformerLocked returns early on
+	// `stopped`), and still reported as started; Informers.Get then parks in
+	// WaitForCacheSync on an informer that can never sync, bounded only by the
+	// CALLER's context. For a reconcile that context is the manager's, i.e.
+	// effectively forever, and under the single-worker default one such read
+	// wedges the controller for the lifetime of the process. Every cached-path
+	// read therefore consults this and falls back to the direct client rather
+	// than handing the caller a hang.
+	//
+	// Nil means "always live", so hand-built clients in tests keep the
+	// pre-existing behavior.
+	cacheCtx    context.Context
+	scheme      *runtime.Scheme
+	cachedKinds sets.Set[schema.GroupKind]
+	synced      *atomic.Bool
+}
+
+// cacheStopped reports whether the background cache has been torn down.
+func (c *selectivelyCachingClient) cacheStopped() bool {
+	return c.cacheCtx != nil && c.cacheCtx.Err() != nil
+}
+
+// servesFromCache reports whether a read of gk should route to the cached
+// reader: the kind must be configured for caching AND the cache must still be
+// running. A stopped cache is skipped rather than consulted, because a read
+// that reaches it does not fail — it blocks (see cacheCtx).
+func (c *selectivelyCachingClient) servesFromCache(gk schema.GroupKind) bool {
+	return c.cachedKinds.Has(gk) && !c.cacheStopped()
+}
+
+// cacheReadContext derives the context for a cached-path read: it ends when
+// EITHER the caller's context ends or the cache is torn down. This closes the
+// window where the cache is live at the servesFromCache check and cancelled a
+// moment later, with the read already parked inside WaitForCacheSync. The
+// returned release func must be called to drop the AfterFunc registration.
+func (c *selectivelyCachingClient) cacheReadContext(ctx context.Context) (context.Context, func()) {
+	if c.cacheCtx == nil {
+		return ctx, func() {}
+	}
+	rctx, cancel := context.WithCancel(ctx)
+	stop := context.AfterFunc(c.cacheCtx, cancel)
+	return rctx, func() {
+		stop()
+		cancel()
+	}
+}
+
+// cacheDiedDuringRead reports whether a failed cached read should be retried
+// against the direct client: the cache went away mid-read while the caller's
+// own context is still live, so the failure is a teardown artifact rather than
+// a real read error the caller should have to interpret.
+func (c *selectivelyCachingClient) cacheDiedDuringRead(ctx context.Context) bool {
+	return c.cacheStopped() && ctx.Err() == nil
 }
 
 func (c *selectivelyCachingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	// Metadata-only reads use a distinct informer type from the structured
+	// objects configured in cachedKinds, so they must remain direct reads.
+	if _, metadataOnly := obj.(*metav1.PartialObjectMetadata); metadataOnly {
+		return c.WithWatch.Get(ctx, key, obj, opts...)
+	}
+
 	gvk, err := apiutil.GVKForObject(obj, c.scheme)
 	if err != nil {
 		return err
 	}
-	gk := gvk.GroupKind()
-	if c.cachedKinds.Has(gk) && (c.synced.Load() || c.cache.WaitForCacheSync(ctx)) {
-		return c.cachedReader.Get(ctx, key, obj, opts...)
+	if !c.servesFromCache(gvk.GroupKind()) {
+		return c.WithWatch.Get(ctx, key, obj, opts...)
 	}
-	return c.WithWatch.Get(ctx, key, obj, opts...)
+
+	rctx, release := c.cacheReadContext(ctx)
+	defer release()
+	if !c.synced.Load() && !c.cache.WaitForCacheSync(rctx) {
+		return c.WithWatch.Get(ctx, key, obj, opts...)
+	}
+	if err := c.cachedReader.Get(rctx, key, obj, opts...); err != nil {
+		if c.cacheDiedDuringRead(ctx) {
+			return c.WithWatch.Get(ctx, key, obj, opts...)
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *selectivelyCachingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, metadataOnly := list.(*metav1.PartialObjectMetadataList); metadataOnly {
+		return c.WithWatch.List(ctx, list, opts...)
+	}
+
 	gvk, err := apiutil.GVKForObject(list, c.scheme)
 	if err != nil {
 		return err
 	}
 	gk := gvk.GroupKind()
 	gk.Kind = strings.TrimSuffix(gk.Kind, "List")
-	if c.cachedKinds.Has(gk) && (c.synced.Load() || c.cache.WaitForCacheSync(ctx)) {
-		return c.cachedReader.List(ctx, list, opts...)
+	if !c.servesFromCache(gk) {
+		return c.WithWatch.List(ctx, list, opts...)
 	}
-	return c.WithWatch.List(ctx, list, opts...)
+
+	rctx, release := c.cacheReadContext(ctx)
+	defer release()
+	if !c.synced.Load() && !c.cache.WaitForCacheSync(rctx) {
+		return c.WithWatch.List(ctx, list, opts...)
+	}
+	if err := c.cachedReader.List(rctx, list, opts...); err != nil {
+		if c.cacheDiedDuringRead(ctx) {
+			return c.WithWatch.List(ctx, list, opts...)
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *selectivelyCachingClient) AddCacheEventHandler(ctx context.Context, obj client.Object, handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
@@ -124,7 +208,16 @@ func (c *selectivelyCachingClient) AddCacheEventHandler(ctx context.Context, obj
 	if !c.cachedKinds.Has(gk) {
 		return nil, fmt.Errorf("kind %s is not cached", gvk.String())
 	}
-	inf, err := c.cache.GetInformer(ctx, obj)
+	// GetInformer reaches the same lazily-created-informer path as a cached
+	// read, so registering a handler on a torn-down cache would block instead
+	// of failing. Report it: the caller's reconnect path can act on an error,
+	// never on a hang.
+	if c.cacheStopped() {
+		return nil, fmt.Errorf("cannot add event handler for kind %s: remote cache is stopped", gvk.String())
+	}
+	rctx, release := c.cacheReadContext(ctx)
+	defer release()
+	inf, err := c.cache.GetInformer(rctx, obj)
 	if err != nil {
 		return nil, fmt.Errorf("getting informer for caching: %w", err)
 	}
@@ -144,6 +237,11 @@ var podGroupKind = corev1.SchemeGroupVersion.WithKind("Pod").GroupKind()
 // unfiltered. There is intentionally no in-code default selector — the value is
 // the caller's to supply, per the repo's no-magic-values rule. Caching Pods is
 // rejected outright: the remote cache must never LIST+WATCH cluster-wide Pods.
+//
+// syncTimeout bounds the initial informer LIST/sync: a cache that cannot start
+// or sync fails the construction rather than leaving later reads and handler
+// registration blocked on a cache that never becomes usable. It is the caller's
+// to supply; non-positive bounds the wait by ctx alone.
 func NewSelectivelyCachingClient(
 	ctx context.Context,
 	restConfig *rest.Config,
@@ -152,6 +250,7 @@ func NewSelectivelyCachingClient(
 	cachedKinds sets.Set[schema.GroupKind],
 	indexes []CacheIndexOption,
 	defaultSelector labels.Selector,
+	syncTimeout time.Duration,
 ) (SelectivelyCachingClient, error) {
 	if cachedKinds.Has(podGroupKind) {
 		return nil, fmt.Errorf("refusing to cache kind %s: the remote cache must never hold cluster-wide Pods", podGroupKind.String())
@@ -188,8 +287,12 @@ func NewSelectivelyCachingClient(
 		defer cancelRun()
 		startErr <- remoteCache.Start(runCtx)
 	}()
-	syncCtx, cancelSync := context.WithTimeout(runCtx, DefaultRemoteCacheSyncTimeout)
-	defer cancelSync()
+	syncCtx := runCtx
+	if syncTimeout > 0 {
+		var cancelSync context.CancelFunc
+		syncCtx, cancelSync = context.WithTimeout(runCtx, syncTimeout)
+		defer cancelSync()
+	}
 	syncDone := make(chan bool, 1)
 	go func() { syncDone <- remoteCache.WaitForCacheSync(syncCtx) }()
 	select {
@@ -215,9 +318,13 @@ func NewSelectivelyCachingClient(
 		WithWatch:    directClient,
 		cachedReader: remoteCache,
 		cache:        remoteCache,
-		scheme:       scheme,
-		cachedKinds:  cachedKinds,
-		synced:       &synced,
+		// ctx is the caller's cache context (Manager.buildRemoteClient derives a
+		// cancellable one per connection and cancels it on Disconnect), which is
+		// exactly the lifetime the cached read paths must respect.
+		cacheCtx:    ctx,
+		scheme:      scheme,
+		cachedKinds: cachedKinds,
+		synced:      &synced,
 	}
 
 	return cachedClient, nil

--- a/pkg/controller/v1beta1/workloadcluster/remoteclient_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/remoteclient_test.go
@@ -2,14 +2,78 @@ package workloadcluster
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 )
+
+type recordingClient struct {
+	client.WithWatch
+	getCalls  int
+	listCalls int
+}
+
+func (c *recordingClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	c.getCalls++
+	return nil
+}
+
+func (c *recordingClient) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	c.listCalls++
+	return nil
+}
+
+type recordingReader struct {
+	getCalls  int
+	listCalls int
+}
+
+func (r *recordingReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	r.getCalls++
+	return nil
+}
+
+func (r *recordingReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	r.listCalls++
+	return nil
+}
+
+// blockingReader parks inside the cached read until its context ends, standing
+// in for controller-runtime's WaitForCacheSync on an informer that can never
+// sync. It signals entry so a test can tear the cache down at exactly the
+// moment a read is in flight.
+type blockingReader struct {
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingReader) enter() {
+	r.once.Do(func() { close(r.entered) })
+}
+
+func (r *blockingReader) Get(ctx context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	r.enter()
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (r *blockingReader) List(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	r.enter()
+	<-ctx.Done()
+	return ctx.Err()
+}
 
 func TestNeverCachingClient_NoCacheHandler(t *testing.T) {
 	fc := fake.NewClientBuilder().Build()
@@ -33,8 +97,168 @@ func TestNewSelectivelyCachingClient_RejectsPodKind(t *testing.T) {
 		sets.New(podGK),
 		nil,
 		nil,
+		time.Second,
 	)
 	if err == nil {
 		t.Fatalf("NewSelectivelyCachingClient with Pod in cachedKinds: got nil error, want rejection")
+	}
+}
+
+func TestSelectivelyCachingClient_MetadataOnlyReadsBypassCache(t *testing.T) {
+	direct := &recordingClient{WithWatch: fake.NewClientBuilder().Build()}
+	cached := &recordingReader{}
+	metadataGK := schema.GroupKind{Group: "ome.io", Kind: "InferenceService"}
+	var synced atomic.Bool
+	synced.Store(true)
+	c := &selectivelyCachingClient{
+		WithWatch:    direct,
+		cachedReader: cached,
+		cachedKinds:  sets.New(metadataGK),
+		synced:       &synced,
+	}
+
+	metadata := &metav1.PartialObjectMetadata{}
+	metadata.SetGroupVersionKind(metadataGK.WithVersion("v1beta1"))
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "example"}, metadata); err != nil {
+		t.Fatalf("Get PartialObjectMetadata: %v", err)
+	}
+
+	metadataList := &metav1.PartialObjectMetadataList{}
+	metadataList.SetGroupVersionKind(metadataGK.WithVersion("v1beta1").GroupVersion().WithKind("InferenceServiceList"))
+	if err := c.List(context.Background(), metadataList); err != nil {
+		t.Fatalf("List PartialObjectMetadataList: %v", err)
+	}
+
+	if direct.getCalls != 1 || direct.listCalls != 1 {
+		t.Fatalf("direct metadata reads: got Get=%d List=%d, want Get=1 List=1", direct.getCalls, direct.listCalls)
+	}
+	if cached.getCalls != 0 || cached.listCalls != 0 {
+		t.Fatalf("cached metadata reads: got Get=%d List=%d, want Get=0 List=0", cached.getCalls, cached.listCalls)
+	}
+}
+
+func omeScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("register ome scheme: %v", err)
+	}
+	return s
+}
+
+// newCachedTestClient builds a selectivelyCachingClient over recording halves,
+// caching isvcGK() — the kind the remote cache holds in production
+// (cmd/manager) and in the integration suites alike — and reporting the cache
+// as already synced.
+func newCachedTestClient(t *testing.T, cacheCtx context.Context) (*selectivelyCachingClient, *recordingClient, *recordingReader) {
+	t.Helper()
+	direct := &recordingClient{WithWatch: fake.NewClientBuilder().Build()}
+	cached := &recordingReader{}
+	var synced atomic.Bool
+	synced.Store(true)
+	return &selectivelyCachingClient{
+		WithWatch:    direct,
+		cachedReader: cached,
+		cacheCtx:     cacheCtx,
+		scheme:       omeScheme(t),
+		cachedKinds:  sets.New(isvcGK()),
+		synced:       &synced,
+	}, direct, cached
+}
+
+// A cached read against a torn-down cache must go direct. Routing it to the
+// cached reader is what wedges a reconcile: controller-runtime lazily creates
+// the informer, declines to start it because the cache is stopped, still
+// reports it as started, and then blocks in WaitForCacheSync on the CALLER's
+// context — which for a reconcile is the manager's, i.e. forever.
+func TestSelectivelyCachingClient_StoppedCacheReadsGoDirect(t *testing.T) {
+	cacheCtx, stopCache := context.WithCancel(context.Background())
+	c, direct, cached := newCachedTestClient(t, cacheCtx)
+	stopCache()
+
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "example"}, &v1beta1.InferenceService{}); err != nil {
+		t.Fatalf("Get on stopped cache: %v", err)
+	}
+	if err := c.List(context.Background(), &v1beta1.InferenceServiceList{}); err != nil {
+		t.Fatalf("List on stopped cache: %v", err)
+	}
+
+	if direct.getCalls != 1 || direct.listCalls != 1 {
+		t.Fatalf("direct reads after cache stop: got Get=%d List=%d, want Get=1 List=1", direct.getCalls, direct.listCalls)
+	}
+	if cached.getCalls != 0 || cached.listCalls != 0 {
+		t.Fatalf("cached reads after cache stop: got Get=%d List=%d, want Get=0 List=0", cached.getCalls, cached.listCalls)
+	}
+}
+
+// While the cache is live the cached reader still serves the read — the
+// teardown guard must not quietly turn every cached read into a direct one.
+func TestSelectivelyCachingClient_LiveCacheReadsUseCache(t *testing.T) {
+	c, direct, cached := newCachedTestClient(t, context.Background())
+
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "example"}, &v1beta1.InferenceService{}); err != nil {
+		t.Fatalf("Get on live cache: %v", err)
+	}
+	if err := c.List(context.Background(), &v1beta1.InferenceServiceList{}); err != nil {
+		t.Fatalf("List on live cache: %v", err)
+	}
+
+	if cached.getCalls != 1 || cached.listCalls != 1 {
+		t.Fatalf("cached reads on live cache: got Get=%d List=%d, want Get=1 List=1", cached.getCalls, cached.listCalls)
+	}
+	if direct.getCalls != 0 || direct.listCalls != 0 {
+		t.Fatalf("direct reads on live cache: got Get=%d List=%d, want Get=0 List=0", direct.getCalls, direct.listCalls)
+	}
+}
+
+// A cached read already in flight when the cache is torn down must be released
+// and served directly, not left parked. This is the narrow window that the
+// servesFromCache pre-check alone cannot cover.
+func TestSelectivelyCachingClient_CacheTeardownReleasesInFlightRead(t *testing.T) {
+	cacheCtx, stopCache := context.WithCancel(context.Background())
+	direct := &recordingClient{WithWatch: fake.NewClientBuilder().Build()}
+	blocking := &blockingReader{entered: make(chan struct{})}
+	var synced atomic.Bool
+	synced.Store(true)
+	c := &selectivelyCachingClient{
+		WithWatch:    direct,
+		cachedReader: blocking,
+		cacheCtx:     cacheCtx,
+		scheme:       omeScheme(t),
+		cachedKinds:  sets.New(isvcGK()),
+		synced:       &synced,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Get(context.Background(), client.ObjectKey{Name: "example"}, &v1beta1.InferenceService{})
+	}()
+
+	<-blocking.entered
+	stopCache() // Disconnect lands while the read is parked inside the cache.
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("in-flight read after cache teardown: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("in-flight cached read did not return after the cache was torn down")
+	}
+	if direct.getCalls != 1 {
+		t.Fatalf("direct Get after teardown: got %d, want 1", direct.getCalls)
+	}
+}
+
+// Registering a watch handler on a torn-down cache must report an error rather
+// than block in GetInformer, which reaches the same lazily-created-informer
+// path as a cached read.
+func TestSelectivelyCachingClient_AddCacheEventHandlerOnStoppedCache(t *testing.T) {
+	cacheCtx, stopCache := context.WithCancel(context.Background())
+	c, _, _ := newCachedTestClient(t, cacheCtx)
+	stopCache()
+
+	if _, err := c.AddCacheEventHandler(context.Background(), &v1beta1.InferenceService{}, nil); err == nil {
+		t.Fatal("AddCacheEventHandler on a stopped cache: got nil error, want error")
 	}
 }

--- a/pkg/controller/v1beta1/workloadcluster/statusconflict_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/statusconflict_test.go
@@ -1,0 +1,93 @@
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// The status write reads its object through the cache, so a pass that runs
+// before the cache catches up writes at a stale resourceVersion and loses the
+// race. That is not a failure -- the next pass recomputes the same status from
+// fresh state -- but reporting it as one has a cost beyond the misleading log
+// line: the integration framework fails a whole suite in teardown on any
+// error-level optimistic-lock entry, on the stated grounds that it marks a
+// reconciler with no conflict-aware path. The suite then reddens in AfterSuite
+// with every spec passed, which reads as an unexplained flake.
+func TestFinishStatusWriteOutcome(t *testing.T) {
+	gr := schema.GroupResource{Group: "ome.io", Resource: "workloadclusters"}
+
+	tests := []struct {
+		name       string
+		updateErr  error
+		wantResult ctrl.Result
+		wantErr    bool
+	}{
+		{
+			name:       "a clean write returns the steady requeue",
+			updateErr:  nil,
+			wantResult: ctrl.Result{RequeueAfter: DefaultHealthInterval},
+			wantErr:    false,
+		},
+		{
+			name:       "a lost optimistic-lock race requeues without an error",
+			updateErr:  apierrors.NewConflict(gr, "m1", errors.New("the object has been modified")),
+			wantResult: ctrl.Result{Requeue: true},
+			wantErr:    false,
+		},
+		{
+			// The object went away mid-pass; there is nothing left to report on.
+			name:       "a deleted object ends the pass quietly",
+			updateErr:  apierrors.NewNotFound(gr, "m1"),
+			wantResult: ctrl.Result{},
+			wantErr:    false,
+		},
+		{
+			name:       "any other write failure is still reported",
+			updateErr:  apierrors.NewForbidden(gr, "m1", errors.New("nope")),
+			wantResult: ctrl.Result{},
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scheme(t)
+			wc := wcWithSecret("m1")
+
+			builder := fakeclient.NewClientBuilder().WithScheme(s).
+				WithObjects(wc).
+				WithStatusSubresource(&v1beta1.WorkloadCluster{})
+			if tc.updateErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+						return tc.updateErr
+					},
+				})
+			}
+			c := builder.Build()
+			r := &Reconciler{Client: c, Scheme: s, Log: log.Log}
+
+			got, err := r.finish(context.Background(), wc, DefaultHealthInterval)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantResult, got)
+		})
+	}
+}

--- a/pkg/webhook/admission/isvc/inference_service_defaults.go
+++ b/pkg/webhook/admission/isvc/inference_service_defaults.go
@@ -89,21 +89,30 @@ func DefaultInferenceService(ctx context.Context, c client.Client, isvc *v1beta1
 		resolvedMode = &mm
 	}
 
+	// Replica defaults are config-driven (deploy.replicas in the
+	// inferenceservice-config ConfigMap). An unconfigured value disables
+	// defaulting of that field: the spec is stored as authored.
+	var replicas *controllerconfig.ReplicasDefaultsConfig
+	if deployConfig != nil {
+		replicas = deployConfig.Replicas
+	}
+
 	if isvc.Spec.Engine != nil {
-		defaultEngine(isvc.Spec.Engine, resolvedMode)
+		defaultEngine(isvc.Spec.Engine, resolvedMode, replicas)
 	}
 	if isvc.Spec.Decoder != nil {
-		defaultDecoder(isvc.Spec.Decoder, resolvedMode)
+		defaultDecoder(isvc.Spec.Decoder, resolvedMode, replicas)
 	}
 	if isvc.Spec.Router != nil {
-		defaultRouter(isvc.Spec.Router, resolvedMode)
+		defaultRouter(isvc.Spec.Router, resolvedMode, replicas)
 	}
 	// Rollout pacing/structure defaults are applied at runtime by the resolve
 	// layer (coordination.ResolveGroups), not at admission.
 	return nil
 }
 
-func defaultEngine(engine *v1beta1.EngineSpec, specMode *constants.DeploymentModeType) {
+func defaultEngine(engine *v1beta1.EngineSpec, specMode *constants.DeploymentModeType, replicas *controllerconfig.ReplicasDefaultsConfig) {
+	defaultReplicaBounds(&engine.ComponentExtensionSpec, replicas.Min(), replicas.EngineMax())
 	defaultWorkerSize(engine.Leader, engine.Worker)
 	// A raw spec without a runner shape may inherit Leader/Worker from its
 	// runtime.
@@ -114,7 +123,8 @@ func defaultEngine(engine *v1beta1.EngineSpec, specMode *constants.DeploymentMod
 	defaultOMENativeComponent(&engine.ComponentExtensionSpec, shape, specMode)
 }
 
-func defaultDecoder(decoder *v1beta1.DecoderSpec, specMode *constants.DeploymentModeType) {
+func defaultDecoder(decoder *v1beta1.DecoderSpec, specMode *constants.DeploymentModeType, replicas *controllerconfig.ReplicasDefaultsConfig) {
+	defaultReplicaBounds(&decoder.ComponentExtensionSpec, replicas.Min(), replicas.DecoderMax())
 	defaultWorkerSize(decoder.Leader, decoder.Worker)
 	// A raw spec without a runner shape may inherit Leader/Worker from its
 	// runtime.
@@ -124,6 +134,37 @@ func defaultDecoder(decoder *v1beta1.DecoderSpec, specMode *constants.Deployment
 	}
 	defaultOMENativeComponent(&decoder.ComponentExtensionSpec, shape, specMode)
 }
+
+// defaultReplicaBounds fills unset replica bounds from the configured
+// admission defaults. A nil default leaves the corresponding field as
+// authored (no defaulting) — the values come only from configuration,
+// never from literals baked into the binary. MaxReplicas is a
+// non-pointer int, so 0 means "not set".
+func defaultReplicaBounds(ext *v1beta1.ComponentExtensionSpec, defaultMin, defaultMax *int) {
+	if ext.MinReplicas == nil && defaultMin != nil {
+		minReplicas := *defaultMin
+		ext.MinReplicas = &minReplicas
+	}
+	if ext.MaxReplicas == 0 && defaultMax != nil {
+		ext.MaxReplicas = defaultedMaxReplicas(*defaultMax, ext.MinReplicas)
+	}
+}
+
+// defaultedMaxReplicas returns the value to stamp for an omitted
+// MaxReplicas: the configured default, raised to MinReplicas when the
+// operator authored a larger floor. Filling an unset max below an
+// explicit min would manufacture a min>max conflict that the
+// replica-bounds validator rejects on create and every later update.
+// An explicitly authored MaxReplicas is never adjusted.
+func defaultedMaxReplicas(configuredDefault int, minReplicas *int) int {
+	if minReplicas != nil && *minReplicas > configuredDefault {
+		return *minReplicas
+	}
+	return configuredDefault
+}
+
+// defaultWorkerSize sets Worker.Size=1 only for a declared Leader+Worker pair.
+// Explicit sizes and one-sided shapes are preserved for validation.
 func defaultWorkerSize(leader *v1beta1.LeaderSpec, worker *v1beta1.WorkerSpec) {
 	if leader == nil || worker == nil {
 		return
@@ -135,7 +176,8 @@ func defaultWorkerSize(leader *v1beta1.LeaderSpec, worker *v1beta1.WorkerSpec) {
 	worker.Size = &size
 }
 
-func defaultRouter(router *v1beta1.RouterSpec, specMode *constants.DeploymentModeType) {
+func defaultRouter(router *v1beta1.RouterSpec, specMode *constants.DeploymentModeType, replicas *controllerconfig.ReplicasDefaultsConfig) {
+	defaultReplicaBounds(&router.ComponentExtensionSpec, replicas.Min(), replicas.RouterMax())
 	// Router has no Leader/Worker; always single-pod.
 	defaultOMENativeComponent(&router.ComponentExtensionSpec, podShapeSingle, specMode)
 }

--- a/pkg/webhook/admission/isvc/inference_service_defaults_test.go
+++ b/pkg/webhook/admission/isvc/inference_service_defaults_test.go
@@ -50,6 +50,21 @@ func stringPtr(s string) *string {
 func intPtr(i int) *int {
 	return &i
 }
+
+// testReplicaDefaults mirrors the chart-shipped deploy.replicas block
+// (min=1, max engine/decoder=3, router=2).
+func testReplicaDefaults() *controllerconfig.ReplicasDefaultsConfig {
+	return &controllerconfig.ReplicasDefaultsConfig{
+		DefaultMinReplicas: intPtr(1),
+		DefaultMaxReplicas: controllerconfig.ComponentMaxReplicasDefaults{
+			Engine:  intPtr(3),
+			Decoder: intPtr(3),
+			Router:  intPtr(2),
+		},
+	}
+}
+
+// createBasicInferenceService creates a basic InferenceService for testing
 func createBasicInferenceService(name, namespace string) *v1beta1.InferenceService {
 	return &v1beta1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -253,6 +268,242 @@ func TestDefaultInferenceService_OMENativeBudgetViaAnnotationAndHeuristic(t *tes
 	}
 }
 
+func TestDefaultComponents(t *testing.T) {
+	t.Run("defaultEngine", func(t *testing.T) {
+		tests := []struct {
+			name            string
+			engine          *v1beta1.EngineSpec
+			wantMinReplicas int
+			wantMaxReplicas int
+		}{
+			{
+				name:            "nil MinReplicas should be set to 1",
+				engine:          &v1beta1.EngineSpec{},
+				wantMinReplicas: 1,
+				wantMaxReplicas: 3,
+			},
+			{
+				name: "existing values should be preserved",
+				engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(2),
+						MaxReplicas: 5,
+					},
+				},
+				wantMinReplicas: 2,
+				wantMaxReplicas: 5,
+			},
+			{
+				name: "unset MaxReplicas is clamped up to MinReplicas above the default",
+				engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(5),
+					},
+				},
+				wantMinReplicas: 5,
+				wantMaxReplicas: 5,
+			},
+			{
+				name: "unset MaxReplicas keeps the default when MinReplicas is below it",
+				engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(2),
+					},
+				},
+				wantMinReplicas: 2,
+				wantMaxReplicas: 3,
+			},
+			{
+				name: "explicit MaxReplicas below MinReplicas is preserved for validation",
+				engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(5),
+						MaxReplicas: 2,
+					},
+				},
+				wantMinReplicas: 5,
+				wantMaxReplicas: 2,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				defaultEngine(tt.engine, nil, testReplicaDefaults())
+				require.NotNil(t, tt.engine.MinReplicas)
+				assert.Equal(t, tt.wantMinReplicas, *tt.engine.MinReplicas)
+				assert.Equal(t, tt.wantMaxReplicas, tt.engine.MaxReplicas)
+			})
+		}
+	})
+
+	t.Run("defaultDecoder", func(t *testing.T) {
+		tests := []struct {
+			name            string
+			decoder         *v1beta1.DecoderSpec
+			wantMinReplicas int
+			wantMaxReplicas int
+		}{
+			{
+				name:            "nil MinReplicas should be set to 1",
+				decoder:         &v1beta1.DecoderSpec{},
+				wantMinReplicas: 1,
+				wantMaxReplicas: 3,
+			},
+			{
+				name: "existing values should be preserved",
+				decoder: &v1beta1.DecoderSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(2),
+						MaxReplicas: 5,
+					},
+				},
+				wantMinReplicas: 2,
+				wantMaxReplicas: 5,
+			},
+			{
+				name: "unset MaxReplicas is clamped up to MinReplicas above the default",
+				decoder: &v1beta1.DecoderSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(5),
+					},
+				},
+				wantMinReplicas: 5,
+				wantMaxReplicas: 5,
+			},
+			{
+				name: "explicit MaxReplicas below MinReplicas is preserved for validation",
+				decoder: &v1beta1.DecoderSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(5),
+						MaxReplicas: 2,
+					},
+				},
+				wantMinReplicas: 5,
+				wantMaxReplicas: 2,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				defaultDecoder(tt.decoder, nil, testReplicaDefaults())
+				require.NotNil(t, tt.decoder.MinReplicas)
+				assert.Equal(t, tt.wantMinReplicas, *tt.decoder.MinReplicas)
+				assert.Equal(t, tt.wantMaxReplicas, tt.decoder.MaxReplicas)
+			})
+		}
+	})
+
+	t.Run("defaultRouter", func(t *testing.T) {
+		tests := []struct {
+			name            string
+			router          *v1beta1.RouterSpec
+			wantMinReplicas int
+			wantMaxReplicas int
+		}{
+			{
+				name:            "nil MinReplicas should be set to 1",
+				router:          &v1beta1.RouterSpec{},
+				wantMinReplicas: 1,
+				wantMaxReplicas: 2,
+			},
+			{
+				name: "existing values should be preserved",
+				router: &v1beta1.RouterSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(2),
+						MaxReplicas: 5,
+					},
+				},
+				wantMinReplicas: 2,
+				wantMaxReplicas: 5,
+			},
+			{
+				name: "unset MaxReplicas is clamped up to MinReplicas above the default",
+				router: &v1beta1.RouterSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(5),
+					},
+				},
+				wantMinReplicas: 5,
+				wantMaxReplicas: 5,
+			},
+			{
+				name: "explicit MaxReplicas below MinReplicas is preserved for validation",
+				router: &v1beta1.RouterSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: intPtr(5),
+						MaxReplicas: 2,
+					},
+				},
+				wantMinReplicas: 5,
+				wantMaxReplicas: 2,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				defaultRouter(tt.router, nil, testReplicaDefaults())
+				require.NotNil(t, tt.router.MinReplicas)
+				assert.Equal(t, tt.wantMinReplicas, *tt.router.MinReplicas)
+				assert.Equal(t, tt.wantMaxReplicas, tt.router.MaxReplicas)
+			})
+		}
+	})
+}
+
+// TestDefaultComponents_UnconfiguredReplicaDefaults pins the degrade path:
+// without a deploy.replicas config block there is nothing to stamp — the
+// defaulter stores the spec exactly as authored instead of injecting
+// literals baked into the binary.
+func TestDefaultComponents_UnconfiguredReplicaDefaults(t *testing.T) {
+	t.Run("nil config leaves replica bounds as authored", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{}
+		defaultEngine(engine, nil, nil)
+		assert.Nil(t, engine.MinReplicas)
+		assert.Zero(t, engine.MaxReplicas)
+
+		decoder := &v1beta1.DecoderSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: intPtr(5)},
+		}
+		defaultDecoder(decoder, nil, nil)
+		assert.Equal(t, 5, *decoder.MinReplicas)
+		assert.Zero(t, decoder.MaxReplicas)
+
+		router := &v1beta1.RouterSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: intPtr(2), MaxReplicas: 4},
+		}
+		defaultRouter(router, nil, nil)
+		assert.Equal(t, 2, *router.MinReplicas)
+		assert.Equal(t, 4, router.MaxReplicas)
+	})
+
+	t.Run("partially configured block defaults only the configured fields", func(t *testing.T) {
+		// Only the min default configured: max stays unset.
+		minOnly := &controllerconfig.ReplicasDefaultsConfig{DefaultMinReplicas: intPtr(1)}
+		engine := &v1beta1.EngineSpec{}
+		defaultEngine(engine, nil, minOnly)
+		assert.Equal(t, 1, *engine.MinReplicas)
+		assert.Zero(t, engine.MaxReplicas)
+
+		// Only the engine max default configured: min stays unset, and
+		// the clamp still raises the filled max to an authored floor.
+		maxOnly := &controllerconfig.ReplicasDefaultsConfig{
+			DefaultMaxReplicas: controllerconfig.ComponentMaxReplicasDefaults{Engine: intPtr(3)},
+		}
+		clamped := &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: intPtr(5)},
+		}
+		defaultEngine(clamped, nil, maxOnly)
+		assert.Equal(t, 5, *clamped.MinReplicas)
+		assert.Equal(t, 5, clamped.MaxReplicas)
+
+		unset := &v1beta1.EngineSpec{}
+		defaultEngine(unset, nil, maxOnly)
+		assert.Nil(t, unset.MinReplicas)
+		assert.Equal(t, 3, unset.MaxReplicas)
+	})
+}
+
 func int32Ptr(v int32) *int32 { return &v }
 
 func assertUnresolvedShapePolicies(t *testing.T, lifecycle *v1beta1.LifecycleSpec) {
@@ -277,14 +528,14 @@ func TestDefaultOMENativeEngineAndDecoder_DeferPoliciesWhenRunnerShapeIsUnresolv
 
 	t.Run("Engine", func(t *testing.T) {
 		engine := &v1beta1.EngineSpec{}
-		defaultEngine(engine, &mode)
+		defaultEngine(engine, &mode, testReplicaDefaults())
 
 		assertUnresolvedShapePolicies(t, engine.Lifecycle)
 	})
 
 	t.Run("Decoder", func(t *testing.T) {
 		decoder := &v1beta1.DecoderSpec{}
-		defaultDecoder(decoder, &mode)
+		defaultDecoder(decoder, &mode, testReplicaDefaults())
 
 		assertUnresolvedShapePolicies(t, decoder.Lifecycle)
 	})
@@ -514,7 +765,7 @@ func TestDefaultEngine_OMENativeAnnotationTriggersDefaults(t *testing.T) {
 		Leader: &v1beta1.LeaderSpec{},
 		Worker: &v1beta1.WorkerSpec{Size: func() *int { v := 3; return &v }()},
 	}
-	defaultEngine(engine, nil)
+	defaultEngine(engine, nil, nil)
 	require.NotNil(t, engine.Lifecycle)
 	require.NotNil(t, engine.Lifecycle.RestartPolicy)
 	assert.Equal(t, v1beta1.InstanceRestartPolicyRecreateInstance, *engine.Lifecycle.RestartPolicy)
@@ -526,7 +777,7 @@ func TestDefaultRouter_OMENativeAlwaysSinglePod(t *testing.T) {
 			Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
 		},
 	}
-	defaultRouter(router, nil)
+	defaultRouter(router, nil, nil)
 	require.NotNil(t, router.Lifecycle)
 	require.NotNil(t, router.Lifecycle.RestartPolicy)
 	assert.Equal(t, v1beta1.InstanceRestartPolicyNone, *router.Lifecycle.RestartPolicy)
@@ -600,7 +851,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 			Leader: &v1beta1.LeaderSpec{},
 			Worker: &v1beta1.WorkerSpec{},
 		}
-		defaultEngine(engine, nil)
+		defaultEngine(engine, nil, nil)
 		require.NotNil(t, engine.Worker.Size)
 		assert.Equal(t, 1, *engine.Worker.Size)
 		// downstream multi-pod detection should kick in:
@@ -616,7 +867,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 			Leader: &v1beta1.LeaderSpec{},
 			Worker: &v1beta1.WorkerSpec{Size: intPtr(3)},
 		}
-		defaultEngine(engine, nil)
+		defaultEngine(engine, nil, nil)
 		require.NotNil(t, engine.Worker.Size)
 		assert.Equal(t, 3, *engine.Worker.Size)
 	})
@@ -629,7 +880,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 			Leader: &v1beta1.LeaderSpec{},
 			Worker: &v1beta1.WorkerSpec{Size: intPtr(0)},
 		}
-		defaultEngine(engine, nil)
+		defaultEngine(engine, nil, nil)
 		require.NotNil(t, engine.Worker.Size)
 		assert.Equal(t, 0, *engine.Worker.Size)
 	})
@@ -639,7 +890,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 		// defaulter handles. The validator catches it with
 		// LeaderRequiresWorker.
 		engine := &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}}
-		defaultEngine(engine, nil)
+		defaultEngine(engine, nil, nil)
 		assert.Nil(t, engine.Worker)
 	})
 
@@ -649,7 +900,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 		// WorkerRequiresLeader; the malformed Size remains for the
 		// error message to surface.
 		engine := &v1beta1.EngineSpec{Worker: &v1beta1.WorkerSpec{}}
-		defaultEngine(engine, nil)
+		defaultEngine(engine, nil, nil)
 		assert.Nil(t, engine.Worker.Size)
 	})
 
@@ -661,7 +912,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 			Leader: &v1beta1.LeaderSpec{},
 			Worker: &v1beta1.WorkerSpec{},
 		}
-		defaultDecoder(decoder, nil)
+		defaultDecoder(decoder, nil, nil)
 		require.NotNil(t, decoder.Worker.Size)
 		assert.Equal(t, 1, *decoder.Worker.Size)
 		require.NotNil(t, decoder.Lifecycle)
@@ -673,7 +924,7 @@ func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
 
 	t.Run("single-pod engine — Worker field unset, no panic", func(t *testing.T) {
 		engine := &v1beta1.EngineSpec{}
-		defaultEngine(engine, nil)
+		defaultEngine(engine, nil, nil)
 		assert.Nil(t, engine.Worker)
 		assert.Nil(t, engine.Leader)
 	})


### PR DESCRIPTION
Base-controller layer refresh, ahead of the InferenceService controller overhaul:

- **basemodel**: PVC backend (metadata extraction jobs + scoped RBAC), per-node cache backend, shared helpers; download tracking via labeled ConfigMaps with hash-safe names.
- **controllerconfig**: adds the replica-defaulting policy schema (`deploy.replicas`), lifecycle defaults, and multi-cluster config. The benchmark-job config surface (`BenchmarkJobConfig`/`PodConfig`) is preserved for the benchmark controller.
- **workloadcluster**: connection backoff, watch funnel, status-conflict handling, config-driven probe timeout (per-call value wins; no in-code default).
- **acceleratorclass / servingruntime / runtimerevision** controllers refreshed.
- **workload/types**: the shared typed layer (plan, migration, termination, retry-block primitives) — dependency of controllerconfig; the rest of the workload engine follows with the ISVC controller refresh.
- **ISVC webhook defaulter**: replica-bounds defaulting restored (deferred from #802 pending the controllerconfig schema).
- `IngressConfig.disableIstioVirtualHost` is intentionally kept: the current ISVC controller and manager still consume it; it goes away with the controller refresh.

Models declaring `distribution: Sharded` continue to be handled by the per-node download path, matching current behavior.

Verified locally: build + vet (incl. tests) across the tree; full `pkg/controller/v1beta1/...` and `pkg/webhook/...` suites green; `make manifests`/`make generate` re-run; codespell clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added serving runtime inheritance across cluster and namespace scopes, including status reporting and dependency updates.
  - Added configurable lifecycle, rollout, canary, coordination, monitoring, disruption-budget, and replica settings.
  - Replica defaults for inference components now come from deployment configuration.

- **Bug Fixes**
  - Accelerator matching now selects nodes based on declared GPU resources.
  - Improved reconciliation handling for deleted resources and conflicts.
  - Remote cache operations recover gracefully when caches stop.

- **Security**
  - Strengthened kubeconfig validation and executable command allowlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->