### PR TITLE
[Core] Normalize CLI instance status

### DIFF
--- a/pkg/cli/instancestatus/errors.go
+++ b/pkg/cli/instancestatus/errors.go
@@ -1,0 +1,77 @@
+package instancestatus
+
+import "errors"
+
+// ErrorReason is a stable, payload-free classification for normalization
+// failures. Callers can turn it into unavailable evidence without parsing an
+// error string or exposing status contents.
+type ErrorReason string
+
+const (
+	ErrorReasonUnknownEncoding ErrorReason = "unknown_encoding"
+	ErrorReasonRepresentation  ErrorReason = "invalid_representation"
+	ErrorReasonIndexSyntax     ErrorReason = "invalid_index_syntax"
+	ErrorReasonIndexCanonical  ErrorReason = "noncanonical_index_set"
+	ErrorReasonCardinality     ErrorReason = "cardinality_limit"
+	ErrorReasonCoverage        ErrorReason = "invalid_coverage"
+	ErrorReasonRowOrder        ErrorReason = "invalid_row_order"
+	ErrorReasonValueDomain     ErrorReason = "invalid_value"
+)
+
+// DecodeError deliberately carries only a bounded reason. Source payloads can
+// include revision names and operation data that must not leak through an
+// error assembled for logs or machine-readable evidence.
+type DecodeError struct {
+	reason ErrorReason
+}
+
+func (e *DecodeError) Error() string {
+	if e == nil {
+		return "instance status normalization failed"
+	}
+	switch e.reason {
+	case ErrorReasonUnknownEncoding:
+		return "instance status encoding is unknown"
+	case ErrorReasonRepresentation:
+		return "instance status representation is invalid"
+	case ErrorReasonIndexSyntax:
+		return "instance index set syntax is invalid"
+	case ErrorReasonIndexCanonical:
+		return "instance index set is not canonical"
+	case ErrorReasonCardinality:
+		return "instance status exceeds the normalization limit"
+	case ErrorReasonCoverage:
+		return "instance status column coverage is invalid"
+	case ErrorReasonRowOrder:
+		return "instance status row order is invalid"
+	case ErrorReasonValueDomain:
+		return "instance status value is outside its supported domain"
+	default:
+		return "instance status normalization failed"
+	}
+}
+
+// ErrorReasonOf extracts a normalization error reason through wrapping.
+func ErrorReasonOf(err error) (ErrorReason, bool) {
+	var decodeErr *DecodeError
+	if !errors.As(err, &decodeErr) || decodeErr == nil {
+		return "", false
+	}
+	switch decodeErr.reason {
+	case ErrorReasonUnknownEncoding,
+		ErrorReasonRepresentation,
+		ErrorReasonIndexSyntax,
+		ErrorReasonIndexCanonical,
+		ErrorReasonCardinality,
+		ErrorReasonCoverage,
+		ErrorReasonRowOrder,
+		ErrorReasonValueDomain:
+		return decodeErr.reason, true
+	default:
+		return "", false
+	}
+}
+
+func newDecodeError(reason ErrorReason) error {
+	return &DecodeError{reason: reason}
+}

--- a/pkg/cli/instancestatus/indexset.go
+++ b/pkg/cli/instancestatus/indexset.go
@@ -1,0 +1,140 @@
+package instancestatus
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+type indexSet struct {
+	ordered []int32
+	lookup  map[int32]struct{}
+}
+
+func parseIndexSet(raw string, maxCardinality int) (indexSet, error) {
+	if maxCardinality <= 0 || maxCardinality > DefaultMaxRows {
+		return indexSet{}, newDecodeError(ErrorReasonCardinality)
+	}
+	if raw == "" {
+		return indexSet{}, newDecodeError(ErrorReasonIndexSyntax)
+	}
+	// A canonical set needs at most ten digits plus one separator per member.
+	// Reject a larger raw field before token scanning so adversarial comma-heavy
+	// input cannot allocate in proportion to untrusted bytes.
+	if len(raw) > maxCardinality*11 {
+		return indexSet{}, newDecodeError(ErrorReasonCardinality)
+	}
+
+	cardinality, err := scanIndexSet(raw, maxCardinality, nil)
+	if err != nil {
+		return indexSet{}, err
+	}
+
+	set := indexSet{
+		ordered: make([]int32, 0, int(cardinality)),
+		lookup:  make(map[int32]struct{}, int(cardinality)),
+	}
+	_, err = scanIndexSet(raw, maxCardinality, func(first, last int32) {
+		for value := first; ; value++ {
+			set.ordered = append(set.ordered, value)
+			set.lookup[value] = struct{}{}
+			if value == last {
+				break
+			}
+		}
+	})
+	if err != nil {
+		return indexSet{}, err
+	}
+	return set, nil
+}
+
+func scanIndexSet(raw string, maxCardinality int, visit func(first, last int32)) (uint64, error) {
+	var cardinality uint64
+	previousLast := int32(-2)
+	for termStart := 0; termStart < len(raw); {
+		relativeEnd := strings.IndexByte(raw[termStart:], ',')
+		termEnd := len(raw)
+		if relativeEnd >= 0 {
+			termEnd = termStart + relativeEnd
+		}
+		if termEnd == termStart {
+			return 0, newDecodeError(ErrorReasonIndexSyntax)
+		}
+		first, last, err := parseInterval(raw[termStart:termEnd])
+		if err != nil {
+			return 0, err
+		}
+		if first <= previousLast ||
+			(previousLast != math.MaxInt32 && first == previousLast+1) {
+			return 0, newDecodeError(ErrorReasonIndexCanonical)
+		}
+		cardinality += uint64(last) - uint64(first) + 1
+		if cardinality > uint64(maxCardinality) {
+			return 0, newDecodeError(ErrorReasonCardinality)
+		}
+		if visit != nil {
+			visit(first, last)
+		}
+		previousLast = last
+		if termEnd == len(raw) {
+			break
+		}
+		termStart = termEnd + 1
+		if termStart == len(raw) {
+			return 0, newDecodeError(ErrorReasonIndexSyntax)
+		}
+	}
+	return cardinality, nil
+}
+
+func parseInterval(term string) (int32, int32, error) {
+	if term == "" {
+		return 0, 0, newDecodeError(ErrorReasonIndexSyntax)
+	}
+	dash := strings.IndexByte(term, '-')
+	if dash < 0 {
+		value, err := parseIndex(term)
+		return value, value, err
+	}
+	if dash == 0 || dash == len(term)-1 || strings.IndexByte(term[dash+1:], '-') >= 0 {
+		return 0, 0, newDecodeError(ErrorReasonIndexSyntax)
+	}
+	first, err := parseIndex(term[:dash])
+	if err != nil {
+		return 0, 0, err
+	}
+	last, err := parseIndex(term[dash+1:])
+	if err != nil {
+		return 0, 0, err
+	}
+	if first >= last {
+		return 0, 0, newDecodeError(ErrorReasonIndexCanonical)
+	}
+	return first, last, nil
+}
+
+func parseIndex(raw string) (int32, error) {
+	if raw == "" || (len(raw) > 1 && raw[0] == '0') {
+		return 0, newDecodeError(ErrorReasonIndexSyntax)
+	}
+	for _, char := range raw {
+		if char < '0' || char > '9' {
+			return 0, newDecodeError(ErrorReasonIndexSyntax)
+		}
+	}
+	value, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || value < 0 {
+		return 0, newDecodeError(ErrorReasonIndexSyntax)
+	}
+	return int32(value), nil
+}
+
+func subsetOf(candidate, members indexSet) bool {
+	for _, index := range candidate.ordered {
+		if _, ok := members.lookup[index]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cli/instancestatus/normalize.go
+++ b/pkg/cli/instancestatus/normalize.go
@@ -1,0 +1,332 @@
+// Package instancestatus normalizes InferenceReplica per-instance status
+// encodings into checked, bounded rows for CLI collectors and renderers.
+package instancestatus
+
+import "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+
+// DefaultMaxRows bounds expansion of a compact ColumnarV2 payload. The limit
+// is deliberately much larger than a normal serving fleet while preventing a
+// malformed range from causing unbounded CLI memory use.
+const DefaultMaxRows = 10_000
+
+// Encoding identifies the source representation used for normalized rows.
+type Encoding string
+
+const (
+	EncodingDenseV1    Encoding = "DenseV1"
+	EncodingColumnarV2 Encoding = "ColumnarV2"
+)
+
+// Result contains independent, normalized rows and their source encoding.
+// Rows preserve DenseV1 order or ColumnarV2 RowOrder; ColumnarV2 without an
+// explicit RowOrder is ascending by instance index.
+type Result struct {
+	Encoding Encoding
+	Rows     []v1beta1.OMENativeInstanceStatus
+}
+
+// Normalize decodes status with DefaultMaxRows as the expansion bound.
+func Normalize(status *v1beta1.InferenceReplicaStatus) (Result, error) {
+	return normalizeWithLimit(status, DefaultMaxRows)
+}
+
+func normalizeWithLimit(status *v1beta1.InferenceReplicaStatus, maxRows int) (Result, error) {
+	if maxRows <= 0 || maxRows > DefaultMaxRows {
+		return Result{}, newDecodeError(ErrorReasonCardinality)
+	}
+	if status == nil {
+		return Result{}, newDecodeError(ErrorReasonRepresentation)
+	}
+	if status.InstanceStatusEncoding == nil {
+		if status.InstanceStatusColumns != nil {
+			return Result{}, newDecodeError(ErrorReasonRepresentation)
+		}
+		return normalizeDense(status.InstanceStatuses, maxRows)
+	}
+	if *status.InstanceStatusEncoding != v1beta1.InstanceStatusEncodingColumnarV2 {
+		return Result{}, newDecodeError(ErrorReasonUnknownEncoding)
+	}
+	if status.InstanceStatusColumns == nil || len(status.InstanceStatuses) != 0 {
+		return Result{}, newDecodeError(ErrorReasonRepresentation)
+	}
+	return normalizeColumnar(status.InstanceStatusColumns, maxRows)
+}
+
+func normalizeDense(source []v1beta1.OMENativeInstanceStatus, maxRows int) (Result, error) {
+	if len(source) > maxRows {
+		return Result{}, newDecodeError(ErrorReasonCardinality)
+	}
+	rows := make([]v1beta1.OMENativeInstanceStatus, len(source))
+	seen := make(map[int32]struct{}, len(source))
+	for i := range source {
+		row := &source[i]
+		if row.Index < 0 {
+			return Result{}, newDecodeError(ErrorReasonValueDomain)
+		}
+		if _, duplicate := seen[row.Index]; duplicate {
+			return Result{}, newDecodeError(ErrorReasonCoverage)
+		}
+		seen[row.Index] = struct{}{}
+		if !validPhase(row.Phase) || row.Incarnation < 0 ||
+			row.PodCount < 0 || row.ReadyPodCount < 0 ||
+			row.ServingPodCount < 0 || row.AvailablePodCount < 0 ||
+			row.ScheduledPodCount < 0 ||
+			(row.ActiveOrdinal != 0 && row.ActiveOrdinal != 1) {
+			return Result{}, newDecodeError(ErrorReasonValueDomain)
+		}
+		rows[i] = *row.DeepCopy()
+	}
+	return Result{Encoding: EncodingDenseV1, Rows: rows}, nil
+}
+
+func normalizeColumnar(columns *v1beta1.InstanceStatusColumns, maxRows int) (Result, error) {
+	members, err := parseIndexSet(columns.Members, maxRows)
+	if err != nil {
+		return Result{}, err
+	}
+	rowsByIndex := make(map[int32]*v1beta1.OMENativeInstanceStatus, len(members.ordered))
+	for _, index := range members.ordered {
+		rowsByIndex[index] = &v1beta1.OMENativeInstanceStatus{Index: index}
+	}
+
+	phaseSeen := make(map[int32]struct{}, len(members.ordered))
+	for _, group := range columns.Phases {
+		if !validPhase(group.Value) {
+			return Result{}, newDecodeError(ErrorReasonValueDomain)
+		}
+		set, err := checkedSubset(group.Indexes, members, maxRows)
+		if err != nil {
+			return Result{}, err
+		}
+		for _, index := range set.ordered {
+			if _, duplicate := phaseSeen[index]; duplicate {
+				return Result{}, newDecodeError(ErrorReasonCoverage)
+			}
+			phaseSeen[index] = struct{}{}
+			rowsByIndex[index].Phase = group.Value
+		}
+	}
+	if len(phaseSeen) != len(members.ordered) {
+		return Result{}, newDecodeError(ErrorReasonCoverage)
+	}
+
+	if err := applyStringGroups(columns.RunningRevisions, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus, value string) {
+		row.RunningRevision = value
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := applyStringGroups(columns.TargetRevisions, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus, value string) {
+		row.TargetRevision = value
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := applyInt64Groups(columns.Incarnations, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus, value int64) {
+		row.Incarnation = value
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := applyCountGroups(columns.PodCounts, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus, value int32) {
+		row.PodCount = value
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := applyCountGroups(columns.ServingPodCounts, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus, value int32) {
+		row.ServingPodCount = value
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := applyCountGroups(columns.AvailablePodCounts, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus, value int32) {
+		row.AvailablePodCount = value
+	}); err != nil {
+		return Result{}, err
+	}
+
+	if err := applyBooleanSet(columns.Admitted, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus) {
+		row.Admitted = true
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := applyBooleanSet(columns.ActiveOrdinalOne, members, maxRows, rowsByIndex, func(row *v1beta1.OMENativeInstanceStatus) {
+		row.ActiveOrdinal = 1
+	}); err != nil {
+		return Result{}, err
+	}
+
+	entrySeen := make(map[int32]struct{}, len(columns.Entries))
+	for i := range columns.Entries {
+		entry := &columns.Entries[i]
+		row, member := rowsByIndex[entry.Index]
+		if !member {
+			return Result{}, newDecodeError(ErrorReasonCoverage)
+		}
+		if _, duplicate := entrySeen[entry.Index]; duplicate {
+			return Result{}, newDecodeError(ErrorReasonCoverage)
+		}
+		entrySeen[entry.Index] = struct{}{}
+		if len(entry.Conditions) == 0 && entry.Operation == nil && entry.LastFailure == nil {
+			return Result{}, newDecodeError(ErrorReasonValueDomain)
+		}
+		copy := entry.DeepCopy()
+		row.Conditions = copy.Conditions
+		row.Operation = copy.Operation
+		row.LastFailure = copy.LastFailure
+	}
+
+	order, err := checkedRowOrder(columns.RowOrder, members)
+	if err != nil {
+		return Result{}, err
+	}
+	rows := make([]v1beta1.OMENativeInstanceStatus, len(order))
+	for i, index := range order {
+		rows[i] = *rowsByIndex[index]
+	}
+	return Result{Encoding: EncodingColumnarV2, Rows: rows}, nil
+}
+
+func checkedSubset(raw string, members indexSet, maxRows int) (indexSet, error) {
+	set, err := parseIndexSet(raw, maxRows)
+	if err != nil {
+		return indexSet{}, err
+	}
+	if !subsetOf(set, members) {
+		return indexSet{}, newDecodeError(ErrorReasonCoverage)
+	}
+	return set, nil
+}
+
+func applyStringGroups(
+	groups []v1beta1.InstanceStatusStringGroup,
+	members indexSet,
+	maxRows int,
+	rows map[int32]*v1beta1.OMENativeInstanceStatus,
+	assign func(*v1beta1.OMENativeInstanceStatus, string),
+) error {
+	seen := make(map[int32]struct{})
+	for _, group := range groups {
+		if group.Value == "" {
+			return newDecodeError(ErrorReasonValueDomain)
+		}
+		set, err := checkedSubset(group.Indexes, members, maxRows)
+		if err != nil {
+			return err
+		}
+		for _, index := range set.ordered {
+			if _, duplicate := seen[index]; duplicate {
+				return newDecodeError(ErrorReasonCoverage)
+			}
+			seen[index] = struct{}{}
+			assign(rows[index], group.Value)
+		}
+	}
+	return nil
+}
+
+func applyInt64Groups(
+	groups []v1beta1.InstanceStatusInt64Group,
+	members indexSet,
+	maxRows int,
+	rows map[int32]*v1beta1.OMENativeInstanceStatus,
+	assign func(*v1beta1.OMENativeInstanceStatus, int64),
+) error {
+	return applyGroups(members, maxRows, rows, len(groups), func(i int) (string, bool, func(*v1beta1.OMENativeInstanceStatus)) {
+		group := groups[i]
+		return group.Indexes, group.Value > 0, func(row *v1beta1.OMENativeInstanceStatus) { assign(row, group.Value) }
+	})
+}
+
+func applyCountGroups(
+	groups []v1beta1.InstanceStatusCountGroup,
+	members indexSet,
+	maxRows int,
+	rows map[int32]*v1beta1.OMENativeInstanceStatus,
+	assign func(*v1beta1.OMENativeInstanceStatus, int32),
+) error {
+	return applyGroups(members, maxRows, rows, len(groups), func(i int) (string, bool, func(*v1beta1.OMENativeInstanceStatus)) {
+		group := groups[i]
+		return group.Indexes, group.Value > 0, func(row *v1beta1.OMENativeInstanceStatus) { assign(row, group.Value) }
+	})
+}
+
+func applyGroups(
+	members indexSet,
+	maxRows int,
+	rows map[int32]*v1beta1.OMENativeInstanceStatus,
+	count int,
+	group func(int) (string, bool, func(*v1beta1.OMENativeInstanceStatus)),
+) error {
+	seen := make(map[int32]struct{})
+	for i := 0; i < count; i++ {
+		indexes, valid, assign := group(i)
+		if !valid {
+			return newDecodeError(ErrorReasonValueDomain)
+		}
+		set, err := checkedSubset(indexes, members, maxRows)
+		if err != nil {
+			return err
+		}
+		for _, index := range set.ordered {
+			if _, duplicate := seen[index]; duplicate {
+				return newDecodeError(ErrorReasonCoverage)
+			}
+			seen[index] = struct{}{}
+			assign(rows[index])
+		}
+	}
+	return nil
+}
+
+func applyBooleanSet(
+	raw *string,
+	members indexSet,
+	maxRows int,
+	rows map[int32]*v1beta1.OMENativeInstanceStatus,
+	assign func(*v1beta1.OMENativeInstanceStatus),
+) error {
+	if raw == nil {
+		return nil
+	}
+	set, err := checkedSubset(*raw, members, maxRows)
+	if err != nil {
+		return err
+	}
+	for _, index := range set.ordered {
+		assign(rows[index])
+	}
+	return nil
+}
+
+func checkedRowOrder(rowOrder []int32, members indexSet) ([]int32, error) {
+	if len(rowOrder) == 0 {
+		return append([]int32(nil), members.ordered...), nil
+	}
+	if len(rowOrder) != len(members.ordered) {
+		return nil, newDecodeError(ErrorReasonRowOrder)
+	}
+	seen := make(map[int32]struct{}, len(rowOrder))
+	for _, index := range rowOrder {
+		if _, member := members.lookup[index]; !member {
+			return nil, newDecodeError(ErrorReasonRowOrder)
+		}
+		if _, duplicate := seen[index]; duplicate {
+			return nil, newDecodeError(ErrorReasonRowOrder)
+		}
+		seen[index] = struct{}{}
+	}
+	return append([]int32(nil), rowOrder...), nil
+}
+
+func validPhase(phase v1beta1.OMENativeInstancePhase) bool {
+	switch phase {
+	case v1beta1.OMENativeInstancePending,
+		v1beta1.OMENativeInstanceCreating,
+		v1beta1.OMENativeInstanceReady,
+		v1beta1.OMENativeInstanceUpdating,
+		v1beta1.OMENativeInstanceRestarting,
+		v1beta1.OMENativeInstanceMigrating,
+		v1beta1.OMENativeInstanceFailed,
+		v1beta1.OMENativeInstanceDeleting:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/cli/instancestatus/normalize_test.go
+++ b/pkg/cli/instancestatus/normalize_test.go
@@ -1,0 +1,416 @@
+package instancestatus
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestNormalizeDenseV1(t *testing.T) {
+	t.Parallel()
+
+	exitCode := int32(137)
+	status := &v1beta1.InferenceReplicaStatus{
+		InstanceStatuses: []v1beta1.OMENativeInstanceStatus{
+			{
+				Index:             2,
+				Incarnation:       3,
+				Phase:             v1beta1.OMENativeInstanceMigrating,
+				RunningRevision:   "engine-old",
+				TargetRevision:    "engine-new",
+				PodCount:          2,
+				ServingPodCount:   1,
+				AvailablePodCount: 1,
+				Admitted:          true,
+				ActiveOrdinal:     1,
+				Conditions:        []metav1.Condition{{Type: "Ready", Status: metav1.ConditionFalse}},
+				Operation:         &v1beta1.InstanceOperation{ID: "migration-1"},
+				LastFailure:       &v1beta1.InstanceTermination{PodName: "engine-2", ExitCode: &exitCode},
+			},
+			{Index: 0, Phase: v1beta1.OMENativeInstanceReady},
+		},
+	}
+
+	got, err := Normalize(status)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if got.Encoding != EncodingDenseV1 {
+		t.Fatalf("Encoding = %q, want %q", got.Encoding, EncodingDenseV1)
+	}
+	if !reflect.DeepEqual(got.Rows, status.InstanceStatuses) {
+		t.Fatalf("Rows = %#v, want %#v", got.Rows, status.InstanceStatuses)
+	}
+
+	got.Rows[0].Conditions[0].Type = "mutated"
+	got.Rows[0].Operation.ID = "mutated"
+	*got.Rows[0].LastFailure.ExitCode = 1
+	if status.InstanceStatuses[0].Conditions[0].Type != "Ready" ||
+		status.InstanceStatuses[0].Operation.ID != "migration-1" ||
+		*status.InstanceStatuses[0].LastFailure.ExitCode != 137 {
+		t.Fatal("Normalize() result aliases the source DenseV1 status")
+	}
+}
+
+func TestNormalizeColumnarV2(t *testing.T) {
+	t.Parallel()
+
+	encoding := v1beta1.InstanceStatusEncodingColumnarV2
+	admitted := "0-1,5"
+	activeOrdinalOne := "2,5"
+	status := &v1beta1.InferenceReplicaStatus{
+		InstanceStatusEncoding: &encoding,
+		InstanceStatusColumns: &v1beta1.InstanceStatusColumns{
+			Members:  "0-2,5",
+			RowOrder: []int32{5, 2, 0, 1},
+			Phases: []v1beta1.InstanceStatusPhaseGroup{
+				{Value: v1beta1.OMENativeInstanceReady, Indexes: "0-1,5"},
+				{Value: v1beta1.OMENativeInstanceMigrating, Indexes: "2"},
+			},
+			RunningRevisions: []v1beta1.InstanceStatusStringGroup{{Value: "engine-old", Indexes: "0-2,5"}},
+			TargetRevisions:  []v1beta1.InstanceStatusStringGroup{{Value: "engine-new", Indexes: "2,5"}},
+			Incarnations:     []v1beta1.InstanceStatusInt64Group{{Value: 3, Indexes: "2,5"}},
+			PodCounts:        []v1beta1.InstanceStatusCountGroup{{Value: 2, Indexes: "0-2,5"}},
+			ServingPodCounts: []v1beta1.InstanceStatusCountGroup{
+				{Value: 2, Indexes: "0-1"},
+				{Value: 1, Indexes: "2,5"},
+			},
+			AvailablePodCounts: []v1beta1.InstanceStatusCountGroup{{Value: 2, Indexes: "0-1"}},
+			Admitted:           &admitted,
+			ActiveOrdinalOne:   &activeOrdinalOne,
+			Entries: []v1beta1.InstanceStatusColumnEntry{{
+				Index:      2,
+				Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionFalse}},
+				Operation:  &v1beta1.InstanceOperation{ID: "migration-2"},
+			}},
+		},
+	}
+
+	got, err := Normalize(status)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	want := Result{
+		Encoding: EncodingColumnarV2,
+		Rows: []v1beta1.OMENativeInstanceStatus{
+			{Index: 5, Incarnation: 3, Phase: v1beta1.OMENativeInstanceReady, RunningRevision: "engine-old", TargetRevision: "engine-new", PodCount: 2, ServingPodCount: 1, Admitted: true, ActiveOrdinal: 1},
+			{Index: 2, Incarnation: 3, Phase: v1beta1.OMENativeInstanceMigrating, RunningRevision: "engine-old", TargetRevision: "engine-new", PodCount: 2, ServingPodCount: 1, ActiveOrdinal: 1, Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionFalse}}, Operation: &v1beta1.InstanceOperation{ID: "migration-2"}},
+			{Index: 0, Phase: v1beta1.OMENativeInstanceReady, RunningRevision: "engine-old", PodCount: 2, ServingPodCount: 2, AvailablePodCount: 2, Admitted: true},
+			{Index: 1, Phase: v1beta1.OMENativeInstanceReady, RunningRevision: "engine-old", PodCount: 2, ServingPodCount: 2, AvailablePodCount: 2, Admitted: true},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Normalize() = %#v, want %#v", got, want)
+	}
+
+	got.Rows[1].Conditions[0].Type = "mutated"
+	got.Rows[1].Operation.ID = "mutated"
+	entry := status.InstanceStatusColumns.Entries[0]
+	if entry.Conditions[0].Type != "Ready" || entry.Operation.ID != "migration-2" {
+		t.Fatal("Normalize() result aliases the source ColumnarV2 status")
+	}
+}
+
+func TestNormalizeColumnarV2DefaultsToAscendingMemberOrder(t *testing.T) {
+	t.Parallel()
+
+	status := columnarStatus("1,3-4", []v1beta1.InstanceStatusPhaseGroup{{
+		Value:   v1beta1.OMENativeInstanceReady,
+		Indexes: "1,3-4",
+	}})
+	got, err := Normalize(status)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	want := []int32{1, 3, 4}
+	for i, row := range got.Rows {
+		if row.Index != want[i] {
+			t.Fatalf("Rows[%d].Index = %d, want %d", i, row.Index, want[i])
+		}
+	}
+}
+
+func TestNormalizeDenseAndColumnarParity(t *testing.T) {
+	t.Parallel()
+
+	condition := metav1.Condition{Type: "Ready", Status: metav1.ConditionFalse}
+	dense := &v1beta1.InferenceReplicaStatus{InstanceStatuses: []v1beta1.OMENativeInstanceStatus{
+		{Index: 3, Incarnation: 2, Phase: v1beta1.OMENativeInstanceMigrating, RunningRevision: "old", TargetRevision: "new", PodCount: 2, ServingPodCount: 1, AvailablePodCount: 1, Admitted: true, ActiveOrdinal: 1, Conditions: []metav1.Condition{condition}, Operation: &v1beta1.InstanceOperation{ID: "op-3"}},
+		{Index: 0, Phase: v1beta1.OMENativeInstanceReady, RunningRevision: "old", PodCount: 2, ServingPodCount: 2, AvailablePodCount: 2, Admitted: true},
+		{Index: 2, Phase: v1beta1.OMENativeInstanceReady, RunningRevision: "old", PodCount: 2, ServingPodCount: 2},
+	}}
+	columnar := columnarStatus("0,2-3", []v1beta1.InstanceStatusPhaseGroup{
+		{Value: v1beta1.OMENativeInstanceReady, Indexes: "0,2"},
+		{Value: v1beta1.OMENativeInstanceMigrating, Indexes: "3"},
+	})
+	columns := columnar.InstanceStatusColumns
+	columns.RowOrder = []int32{3, 0, 2}
+	columns.RunningRevisions = []v1beta1.InstanceStatusStringGroup{{Value: "old", Indexes: "0,2-3"}}
+	columns.TargetRevisions = []v1beta1.InstanceStatusStringGroup{{Value: "new", Indexes: "3"}}
+	columns.Incarnations = []v1beta1.InstanceStatusInt64Group{{Value: 2, Indexes: "3"}}
+	columns.PodCounts = []v1beta1.InstanceStatusCountGroup{{Value: 2, Indexes: "0,2-3"}}
+	columns.ServingPodCounts = []v1beta1.InstanceStatusCountGroup{{Value: 2, Indexes: "0,2"}, {Value: 1, Indexes: "3"}}
+	columns.AvailablePodCounts = []v1beta1.InstanceStatusCountGroup{{Value: 2, Indexes: "0"}, {Value: 1, Indexes: "3"}}
+	admitted := "0,3"
+	active := "3"
+	columns.Admitted = &admitted
+	columns.ActiveOrdinalOne = &active
+	columns.Entries = []v1beta1.InstanceStatusColumnEntry{{Index: 3, Conditions: []metav1.Condition{condition}, Operation: &v1beta1.InstanceOperation{ID: "op-3"}}}
+
+	denseResult, err := Normalize(dense)
+	if err != nil {
+		t.Fatalf("Normalize(DenseV1) error = %v", err)
+	}
+	columnarResult, err := Normalize(columnar)
+	if err != nil {
+		t.Fatalf("Normalize(ColumnarV2) error = %v", err)
+	}
+	if !reflect.DeepEqual(denseResult.Rows, columnarResult.Rows) {
+		t.Fatalf("normalized rows differ:\nDenseV1: %#v\nColumnarV2: %#v", denseResult.Rows, columnarResult.Rows)
+	}
+}
+
+func TestNormalizeEmptyDenseV1(t *testing.T) {
+	t.Parallel()
+
+	got, err := Normalize(&v1beta1.InferenceReplicaStatus{})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if got.Encoding != EncodingDenseV1 || got.Rows == nil || len(got.Rows) != 0 {
+		t.Fatalf("Normalize() = %#v, want DenseV1 with non-nil empty rows", got)
+	}
+}
+
+func TestNormalizeRejectsRepresentationContradictions(t *testing.T) {
+	t.Parallel()
+
+	columnar := v1beta1.InstanceStatusEncodingColumnarV2
+	unknown := v1beta1.InstanceStatusEncoding("FutureV3")
+	tests := []struct {
+		name   string
+		status *v1beta1.InferenceReplicaStatus
+		reason ErrorReason
+	}{
+		{name: "nil status", reason: ErrorReasonRepresentation},
+		{name: "columns without encoding", status: &v1beta1.InferenceReplicaStatus{InstanceStatusColumns: &v1beta1.InstanceStatusColumns{}}, reason: ErrorReasonRepresentation},
+		{name: "columnar without columns", status: &v1beta1.InferenceReplicaStatus{InstanceStatusEncoding: &columnar}, reason: ErrorReasonRepresentation},
+		{name: "columnar with dense rows", status: &v1beta1.InferenceReplicaStatus{InstanceStatusEncoding: &columnar, InstanceStatusColumns: &v1beta1.InstanceStatusColumns{}, InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{Index: 0}}}, reason: ErrorReasonRepresentation},
+		{name: "unknown encoding", status: &v1beta1.InferenceReplicaStatus{InstanceStatusEncoding: &unknown}, reason: ErrorReasonUnknownEncoding},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Normalize(test.status)
+			assertReason(t, err, test.reason)
+		})
+	}
+}
+
+func TestNormalizeRejectsMalformedColumnarV2(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*v1beta1.InstanceStatusColumns)
+		reason ErrorReason
+	}{
+		{name: "empty members", mutate: func(c *v1beta1.InstanceStatusColumns) { c.Members = "" }, reason: ErrorReasonIndexSyntax},
+		{name: "noncanonical members", mutate: func(c *v1beta1.InstanceStatusColumns) { c.Members = "0,1" }, reason: ErrorReasonIndexCanonical},
+		{name: "phase coverage gap", mutate: func(c *v1beta1.InstanceStatusColumns) { c.Phases[0].Indexes = "0" }, reason: ErrorReasonCoverage},
+		{name: "missing phases", mutate: func(c *v1beta1.InstanceStatusColumns) { c.Phases = nil }, reason: ErrorReasonCoverage},
+		{name: "phase overlap", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.Phases = append(c.Phases, v1beta1.InstanceStatusPhaseGroup{Value: v1beta1.OMENativeInstanceFailed, Indexes: "1"})
+		}, reason: ErrorReasonCoverage},
+		{name: "invalid phase", mutate: func(c *v1beta1.InstanceStatusColumns) { c.Phases[0].Value = "Unknown" }, reason: ErrorReasonValueDomain},
+		{name: "row order missing member", mutate: func(c *v1beta1.InstanceStatusColumns) { c.RowOrder = []int32{0} }, reason: ErrorReasonRowOrder},
+		{name: "row order duplicate", mutate: func(c *v1beta1.InstanceStatusColumns) { c.RowOrder = []int32{0, 0} }, reason: ErrorReasonRowOrder},
+		{name: "row order outsider", mutate: func(c *v1beta1.InstanceStatusColumns) { c.RowOrder = []int32{0, 2} }, reason: ErrorReasonRowOrder},
+		{name: "empty revision value", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.RunningRevisions = []v1beta1.InstanceStatusStringGroup{{Indexes: "0"}}
+		}, reason: ErrorReasonValueDomain},
+		{name: "overlapping revision groups", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.RunningRevisions = []v1beta1.InstanceStatusStringGroup{{Value: "a", Indexes: "0-1"}, {Value: "b", Indexes: "1"}}
+		}, reason: ErrorReasonCoverage},
+		{name: "zero incarnation", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.Incarnations = []v1beta1.InstanceStatusInt64Group{{Indexes: "0"}}
+		}, reason: ErrorReasonValueDomain},
+		{name: "negative incarnation", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.Incarnations = []v1beta1.InstanceStatusInt64Group{{Value: -1, Indexes: "0"}}
+		}, reason: ErrorReasonValueDomain},
+		{name: "negative pod count", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.PodCounts = []v1beta1.InstanceStatusCountGroup{{Value: -1, Indexes: "0"}}
+		}, reason: ErrorReasonValueDomain},
+		{name: "boolean outsider", mutate: func(c *v1beta1.InstanceStatusColumns) { outsider := "2"; c.Admitted = &outsider }, reason: ErrorReasonCoverage},
+		{name: "entry outsider", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.Entries = []v1beta1.InstanceStatusColumnEntry{{Index: 2, Operation: &v1beta1.InstanceOperation{ID: "a"}}}
+		}, reason: ErrorReasonCoverage},
+		{name: "duplicate entries", mutate: func(c *v1beta1.InstanceStatusColumns) {
+			c.Entries = []v1beta1.InstanceStatusColumnEntry{{Index: 0, Operation: &v1beta1.InstanceOperation{ID: "a"}}, {Index: 0, Operation: &v1beta1.InstanceOperation{ID: "b"}}}
+		}, reason: ErrorReasonCoverage},
+		{name: "empty entry", mutate: func(c *v1beta1.InstanceStatusColumns) { c.Entries = []v1beta1.InstanceStatusColumnEntry{{Index: 0}} }, reason: ErrorReasonValueDomain},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			status := columnarStatus("0-1", []v1beta1.InstanceStatusPhaseGroup{{Value: v1beta1.OMENativeInstanceReady, Indexes: "0-1"}})
+			test.mutate(status.InstanceStatusColumns)
+			_, err := Normalize(status)
+			assertReason(t, err, test.reason)
+		})
+	}
+}
+
+func TestNormalizeRejectsAmplification(t *testing.T) {
+	t.Parallel()
+
+	status := columnarStatus("0-3", []v1beta1.InstanceStatusPhaseGroup{{Value: v1beta1.OMENativeInstanceReady, Indexes: "0-3"}})
+	_, err := normalizeWithLimit(status, 3)
+	assertReason(t, err, ErrorReasonCardinality)
+	_, err = normalizeWithLimit(status, 0)
+	assertReason(t, err, ErrorReasonCardinality)
+	_, err = normalizeWithLimit(columnarStatus("0", []v1beta1.InstanceStatusPhaseGroup{{Value: v1beta1.OMENativeInstanceReady, Indexes: "0"}}), DefaultMaxRows+1)
+	assertReason(t, err, ErrorReasonCardinality)
+}
+
+func TestNormalizeRejectsOversizedRawIndexSetBeforeTokenizing(t *testing.T) {
+	t.Parallel()
+
+	oversized := "0" + strings.Repeat(",0", DefaultMaxRows*6)
+	status := columnarStatus(oversized, []v1beta1.InstanceStatusPhaseGroup{{
+		Value:   v1beta1.OMENativeInstanceReady,
+		Indexes: oversized,
+	}})
+	_, err := Normalize(status)
+	assertReason(t, err, ErrorReasonCardinality)
+}
+
+func TestNormalizeRejectsMalformedDenseV1(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		rows []v1beta1.OMENativeInstanceStatus
+	}{
+		{name: "negative index", rows: []v1beta1.OMENativeInstanceStatus{{Index: -1, Phase: v1beta1.OMENativeInstanceReady}}},
+		{name: "duplicate index", rows: []v1beta1.OMENativeInstanceStatus{{Index: 1, Phase: v1beta1.OMENativeInstanceReady}, {Index: 1, Phase: v1beta1.OMENativeInstanceReady}}},
+		{name: "invalid phase", rows: []v1beta1.OMENativeInstanceStatus{{Index: 1, Phase: "Unknown"}}},
+		{name: "negative count", rows: []v1beta1.OMENativeInstanceStatus{{Index: 1, Phase: v1beta1.OMENativeInstanceReady, PodCount: -1}}},
+		{name: "negative incarnation", rows: []v1beta1.OMENativeInstanceStatus{{Index: 1, Incarnation: -1, Phase: v1beta1.OMENativeInstanceReady}}},
+		{name: "invalid active ordinal", rows: []v1beta1.OMENativeInstanceStatus{{Index: 1, Phase: v1beta1.OMENativeInstanceReady, ActiveOrdinal: 2}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Normalize(&v1beta1.InferenceReplicaStatus{InstanceStatuses: test.rows})
+			if err == nil {
+				t.Fatal("Normalize() error = nil, want malformed DenseV1 rejection")
+			}
+		})
+	}
+}
+
+func FuzzNormalizeColumnarFieldsNeverPanic(f *testing.F) {
+	for _, seed := range []struct {
+		members  string
+		phases   string
+		optional string
+		boolean  string
+		orderA   int32
+		orderB   int32
+	}{
+		{members: "0", phases: "0", optional: "0", boolean: "0", orderA: 0, orderB: 0},
+		{members: "0-1", phases: "0-1", optional: "0", boolean: "1", orderA: 1, orderB: 0},
+		{members: "0-3", phases: "0-3", optional: "1-2", boolean: "3", orderA: 3, orderB: 0},
+		{members: "0,2-4", phases: "0,2-4", optional: "4", boolean: "2", orderA: 4, orderB: 2},
+		{members: "", phases: "00", optional: "3-1", boolean: "2147483648", orderA: -1, orderB: 5},
+		{members: "sensitive", phases: "0,1", optional: "", boolean: "sensitive", orderA: 1, orderB: 1},
+	} {
+		f.Add(seed.members, seed.phases, seed.optional, seed.boolean, seed.orderA, seed.orderB)
+	}
+	f.Fuzz(func(t *testing.T, members, phases, optional, boolean string, orderA, orderB int32) {
+		status := columnarStatus(members, []v1beta1.InstanceStatusPhaseGroup{{
+			Value:   v1beta1.OMENativeInstanceReady,
+			Indexes: phases,
+		}})
+		status.InstanceStatusColumns.RunningRevisions = []v1beta1.InstanceStatusStringGroup{{Value: "revision", Indexes: optional}}
+		status.InstanceStatusColumns.Admitted = &boolean
+		status.InstanceStatusColumns.RowOrder = []int32{orderA, orderB}
+		result, err := normalizeWithLimit(status, 64)
+		if err != nil {
+			if _, ok := ErrorReasonOf(err); !ok {
+				t.Fatalf("unclassified error: %T: %v", err, err)
+			}
+			if result.Encoding != "" || result.Rows != nil {
+				t.Fatalf("failed normalization returned partial result %#v", result)
+			}
+			return
+		}
+		if len(result.Rows) > 64 {
+			t.Fatalf("normalizeWithLimit() returned %d rows, limit 64", len(result.Rows))
+		}
+		seen := make(map[int32]struct{}, len(result.Rows))
+		for _, row := range result.Rows {
+			if row.Index < 0 {
+				t.Fatalf("negative normalized index %d", row.Index)
+			}
+			if _, duplicate := seen[row.Index]; duplicate {
+				t.Fatalf("duplicate normalized index %d", row.Index)
+			}
+			seen[row.Index] = struct{}{}
+		}
+	})
+}
+
+func TestDecodeErrorDoesNotExposePayload(t *testing.T) {
+	t.Parallel()
+
+	secret := "sensitive-revision-token"
+	status := columnarStatus(secret, []v1beta1.InstanceStatusPhaseGroup{{Value: v1beta1.OMENativeInstanceReady, Indexes: secret}})
+	_, err := Normalize(status)
+	if err == nil {
+		t.Fatal("Normalize() error = nil, want syntax error")
+	}
+	if got := err.Error(); got == "" || contains(got, secret) {
+		t.Fatalf("error %q exposes status payload", got)
+	}
+	var decodeErr *DecodeError
+	if !errors.As(err, &decodeErr) {
+		t.Fatalf("error type = %T, want *DecodeError", err)
+	}
+}
+
+func columnarStatus(members string, phases []v1beta1.InstanceStatusPhaseGroup) *v1beta1.InferenceReplicaStatus {
+	encoding := v1beta1.InstanceStatusEncodingColumnarV2
+	return &v1beta1.InferenceReplicaStatus{
+		InstanceStatusEncoding: &encoding,
+		InstanceStatusColumns: &v1beta1.InstanceStatusColumns{
+			Members: members,
+			Phases:  phases,
+		},
+	}
+}
+
+func assertReason(t *testing.T, err error, want ErrorReason) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want reason %q", want)
+	}
+	if got, ok := ErrorReasonOf(err); !ok || got != want {
+		t.Fatalf("ErrorReasonOf(%v) = (%q, %t), want (%q, true)", err, got, ok, want)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this PR does

Adds the OEP-0011.1 instance-status normalization foundation for the OME CLI.
It decodes both DenseV1 and ColumnarV2 InferenceReplica status into one
deep-copied row model while preserving source encoding and row order.

The decoder rejects contradictory representations, malformed/noncanonical
index sets, invalid value domains, incomplete or overlapping column coverage,
and invalid row order. Column expansion and raw index-set scanning are bounded,
and failures use stable payload-free reason codes.

## Why we need it

InferenceReplica status can use either dense rows or compact column groups.
Upcoming instance, migration, rollout, autoscaling, and service-status commands
need one authoritative decoder so they do not omit ColumnarV2 instances or
invent partial rows from malformed status.

Related to OEP-0011.1 roadmap item 8.

<!-- Fixes # -->

## How to test

```sh
go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...
go test -race ./pkg/cli/...
go vet ./cmd/kubectl-ome ./pkg/cli/...
go build -o /tmp/kubectl-ome ./cmd/kubectl-ome
go test ./pkg/cli/instancestatus -cover
go test ./pkg/cli/instancestatus -run='^$' \
  -fuzz=FuzzNormalizeColumnarFieldsNeverPanic -fuzztime=3s
```

Focused package coverage is 87.7%. The live fuzz pass completed 46,604
executions without a failure.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (package/API documentation; no user-facing command yet)
- [ ] `make test` passes locally (focused CLI tests, race, vet, and build pass;
      full repository `make test` runs in PR CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting Dense and Columnar instance-status formats into consistent instance-status rows.
  * Added validation for malformed data, ordering, coverage, duplicates, and excessive input sizes.
  * Added support for parsing index ranges and grouped status assignments.
* **Bug Fixes**
  * Improved handling of invalid status data with stable, categorized errors.
  * Error messages now avoid exposing raw input payloads.
* **Tests**
  * Added comprehensive coverage for supported formats, validation failures, limits, parity, and fuzz safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->