### PR TITLE
[Bugfix] Ignore derived instance counters

### DIFF
--- a/pkg/cli/instancestatus/normalize.go
+++ b/pkg/cli/instancestatus/normalize.go
@@ -68,9 +68,8 @@ func normalizeDense(source []v1beta1.OMENativeInstanceStatus, maxRows int) (Resu
 		}
 		seen[row.Index] = struct{}{}
 		if !validPhase(row.Phase) || row.Incarnation < 0 ||
-			row.PodCount < 0 || row.ReadyPodCount < 0 ||
-			row.ServingPodCount < 0 || row.AvailablePodCount < 0 ||
-			row.ScheduledPodCount < 0 ||
+			row.PodCount < 0 || row.ServingPodCount < 0 ||
+			row.AvailablePodCount < 0 ||
 			(row.ActiveOrdinal != 0 && row.ActiveOrdinal != 1) {
 			return Result{}, newDecodeError(ErrorReasonValueDomain)
 		}

--- a/pkg/cli/instancestatus/normalize_test.go
+++ b/pkg/cli/instancestatus/normalize_test.go
@@ -57,6 +57,27 @@ func TestNormalizeDenseV1(t *testing.T) {
 	}
 }
 
+func TestNormalizeDenseV1PreservesCompatibilityFields(t *testing.T) {
+	t.Parallel()
+
+	status := &v1beta1.InferenceReplicaStatus{
+		InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{
+			Index:             0,
+			Phase:             v1beta1.OMENativeInstanceReady,
+			ReadyPodCount:     -1,
+			ScheduledPodCount: -2,
+		}},
+	}
+
+	got, err := Normalize(status)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Rows, status.InstanceStatuses) {
+		t.Fatalf("Rows = %#v, want compatibility fields preserved from %#v", got.Rows, status.InstanceStatuses)
+	}
+}
+
 func TestNormalizeColumnarV2(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What this PR does

Stops the CLI instance-status decoder from interpreting the legacy
`ReadyPodCount` and `ScheduledPodCount` compatibility fields. Dense status
rows still preserve those values through the existing deep copy.

Adds a regression test proving compatibility values are accepted and
preserved.

## Why we need it

PR #806 was merged after its `Test and Build` job found that these removable
observation fields had new direct production reads. The fields are derived
from Pods and must not be used as persisted status authority.

Follow-up to #806.

## How to test

- `go test ./pkg/controller/v1beta1/workload -run ^TestRemovableObservationFieldsHaveNoUnauditedDirectProductionAccess$ -count=1`
- `go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...`
- `go test -race ./pkg/cli/...`
- `go vet ./cmd/kubectl-ome ./pkg/cli/...`
- `go build ./cmd/kubectl-ome`

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (not applicable; behavior correction only)
- [ ] `make test` passes locally (covered by CI; focused CLI, race, vet, and build checks pass locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance-status normalization by allowing negative ready-pod counts where applicable.
  * Continued validating the primary pod-count fields for consistency.

* **Tests**
  * Added coverage confirming compatibility pod-count fields are preserved during normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->