### PR TITLE
[Helm] refresh charts; add quota-manager, scheduler

### DIFF
--- a/charts/ome-quota-manager/Chart.yaml
+++ b/charts/ome-quota-manager/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: ome-quota-manager
+description: >-
+  OME fleet quota control plane (OEP-0024). Assembles the AcceleratorQuota tree,
+  reports each node's position and condition, and — once materialization lands —
+  renders the tree into Kueue on a workload cluster or projects per-cluster
+  shares onto members from a management cluster. Installed as its own Deployment
+  so the Kueue write grant it needs is scoped to a ServiceAccount that does not
+  also run the InferenceService reconcilers or the pod mutating webhook.
+  Requires the ome-crd chart (ome.io/AcceleratorQuota).
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/ome-quota-manager/ci/pre-commit-values.yaml
+++ b/charts/ome-quota-manager/ci/pre-commit-values.yaml
@@ -1,0 +1,11 @@
+# Values for the repo-wide pre-commit `helm template` sweep, which renders every
+# chart with defaults. This chart has no default mode on purpose — workload mode
+# writes Kueue objects on the local cluster and management mode projects shares
+# onto others, so guessing either would be a surprise — and the render fails
+# without one. That guard is deliberate; this file keeps it from failing the
+# sweep for every unrelated commit.
+#
+# The negative case (an unset or bogus mode MUST fail to render) is asserted in
+# tests/render_test.sh, so the guard itself stays covered.
+quotaManager:
+  mode: workload

--- a/charts/ome-quota-manager/files/ome.io_acceleratorquotas.yaml
+++ b/charts/ome-quota-manager/files/ome.io_acceleratorquotas.yaml
@@ -1,0 +1,425 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: acceleratorquotas.ome.io
+spec:
+  group: ome.io
+  names:
+    kind: AcceleratorQuota
+    listKind: AcceleratorQuotaList
+    plural: acceleratorquotas
+    shortNames:
+    - aq
+    singular: acceleratorquota
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.role
+      name: Role
+      type: string
+    - jsonPath: .spec.parentRef.name
+      name: Parent
+      type: string
+    - jsonPath: .status.budgets[0].resourceName
+      name: Resource
+      type: string
+    - jsonPath: .status.budgets[0].resourceFlavor
+      name: Flavor
+      type: string
+    - jsonPath: .status.budgets[0].nominal
+      name: Nominal
+      type: string
+    - jsonPath: .status.budgets[0].admitted
+      name: Admitted
+      type: string
+    - jsonPath: .status.budgets[0].borrowed
+      name: Borrowed
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.path
+      name: Path
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              budgets:
+                items:
+                  properties:
+                    borrowingLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    lendingLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    nominal:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    perCluster:
+                      items:
+                        properties:
+                          cluster:
+                            maxLength: 253
+                            type: string
+                          nominal:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - cluster
+                        - nominal
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - cluster
+                      x-kubernetes-list-type: map
+                    policy:
+                      enum:
+                      - Explicit
+                      - Proportional
+                      type: string
+                    resourceFlavor:
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    resourceName:
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?$
+                      type: string
+                  required:
+                  - nominal
+                  - resourceFlavor
+                  - resourceName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-map-keys:
+                - resourceName
+                - resourceFlavor
+                x-kubernetes-list-type: map
+              distribution:
+                properties:
+                  policy:
+                    enum:
+                    - Explicit
+                    - Proportional
+                    type: string
+                type: object
+              namespaces:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              parentRef:
+                properties:
+                  name:
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - name
+                type: object
+              priorityTier:
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+              role:
+                enum:
+                - Cohort
+                - ClusterQueue
+                type: string
+            required:
+            - role
+            type: object
+            x-kubernetes-validations:
+            - message: a ClusterQueue node must set parentRef; only the reserved root
+                node is parent-less
+              rule: self.role != 'ClusterQueue' || has(self.parentRef)
+            - message: a Cohort node must not set namespaces, priorityTier, or distribution;
+                no workload binds to a grouping
+              rule: self.role != 'Cohort' || (!has(self.namespaces) && !has(self.priorityTier)
+                && !has(self.distribution))
+            - message: a Cohort node's budgets carry only resourceName, resourceFlavor,
+                and nominal
+              rule: self.role != 'Cohort' || !has(self.budgets) || self.budgets.all(b,
+                !has(b.policy) && !has(b.borrowingLimit) && !has(b.lendingLimit) &&
+                !has(b.perCluster))
+            - message: a ClusterQueue node must carry at least one budget
+              rule: self.role != 'ClusterQueue' || (has(self.budgets) && size(self.budgets)
+                > 0)
+            - message: a budget whose effective distribution policy is Explicit must
+                set perCluster
+              rule: '!has(self.budgets) || self.budgets.all(b, !(has(b.policy) ? b.policy
+                == ''Explicit'' : (has(self.distribution) && has(self.distribution.policy)
+                && self.distribution.policy == ''Explicit'')) || has(b.perCluster))'
+            - message: a budget whose effective distribution policy is Proportional
+                must not set perCluster; the split is computed
+              rule: '!has(self.budgets) || self.budgets.all(b, !(has(b.policy) ? b.policy
+                == ''Proportional'' : (has(self.distribution) && has(self.distribution.policy)
+                && self.distribution.policy == ''Proportional'')) || !has(b.perCluster))'
+          status:
+            properties:
+              budgets:
+                items:
+                  properties:
+                    admitted:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    borrowed:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    nominal:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    perCluster:
+                      items:
+                        properties:
+                          admitted:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          borrowed:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          cluster:
+                            type: string
+                          nominal:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          reserved:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - cluster
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - cluster
+                      x-kubernetes-list-type: map
+                    reserved:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    resourceFlavor:
+                      type: string
+                    resourceName:
+                      type: string
+                  required:
+                  - resourceFlavor
+                  - resourceName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - resourceName
+                - resourceFlavor
+                x-kubernetes-list-type: map
+              capacity:
+                items:
+                  properties:
+                    allocatable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    highWaterMark:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    observedAt:
+                      format: date-time
+                      type: string
+                    perCluster:
+                      items:
+                        properties:
+                          allocatable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          cluster:
+                            type: string
+                          highWaterMark:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          observedAt:
+                            format: date-time
+                            type: string
+                        required:
+                        - cluster
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - cluster
+                      x-kubernetes-list-type: map
+                    resourceFlavor:
+                      type: string
+                    resourceName:
+                      type: string
+                  required:
+                  - resourceFlavor
+                  - resourceName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - resourceName
+                - resourceFlavor
+                x-kubernetes-list-type: map
+              clusters:
+                items:
+                  properties:
+                    appliedGeneration:
+                      format: int64
+                      type: integer
+                    appliedTime:
+                      format: date-time
+                      type: string
+                    cluster:
+                      type: string
+                    materializedGeneration:
+                      format: int64
+                      type: integer
+                    message:
+                      type: string
+                  required:
+                  - cluster
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - cluster
+                x-kubernetes-list-type: map
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              materialization:
+                properties:
+                  frozen:
+                    type: boolean
+                  frozenAt:
+                    format: date-time
+                    type: string
+                  lastAppliedGeneration:
+                    format: int64
+                    type: integer
+                  lastAppliedTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                type: object
+              observedGeneration:
+                format: int64
+                type: integer
+              parent:
+                type: string
+              path:
+                type: string
+              sourceGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: an AcceleratorQuota name may not exceed 63 characters; it is copied
+            into a label value on every Kueue object the node materializes
+          rule: size(self.metadata.name) <= 63
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/ome-quota-manager/templates/NOTES.txt
+++ b/charts/ome-quota-manager/templates/NOTES.txt
@@ -1,0 +1,51 @@
+ome-quota-manager is installed in namespace {{ .Release.Namespace }}, mode {{ include "ome-quota-manager.mode" . }}.
+
+{{- if not (contains "/" .Values.quotaManager.image.repository) }}
+{{- if not .Values.global.hub }}
+
+The image is {{ include "ome-quota-manager.image" (dict "values" .Values "repository" .Values.quotaManager.image.repository "tag" .Values.quotaManager.image.tag) }} — an unqualified name, which a kubelet resolves against Docker Hub. You are installing straight from the source tree; a chart published by CI has global.hub and the tag stamped to the registry it was built into, so it does not look like this. Side-load the image or set global.hub. If you do neither the pod sits in ImagePullBackOff, and `helm --wait` reports nothing at all until it times out after 5m.
+
+  On kind:  make ome-quota-manager-image QUOTA_MANAGER_IMG={{ .Values.quotaManager.image.repository }}:{{ .Values.quotaManager.image.tag }}
+            kind load docker-image {{ .Values.quotaManager.image.repository }}:{{ .Values.quotaManager.image.tag }} --name <cluster>
+
+  Elsewhere: --set global.hub=<registry>
+{{- end }}
+{{- end }}
+
+{{- if not .Values.quotaManager.crd.install }}
+
+The AcceleratorQuota CRD is not being installed by this release. Without it the manager cannot
+sync its cache and will crash-loop. Either install charts/ome-crd, which owns every OME CRD, or
+— if this chart is the only installer in the cluster — re-run with:
+
+  --set quotaManager.crd.install=true
+
+Do not do both: ome-crd owns the same cluster-scoped object and whichever release claims it
+second fails Helm's ownership check.
+{{- end }}
+
+Check it came up:
+
+  kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ .Values.quotaManager.name }}
+{{- if .Values.quotaManager.webhook.enabled }}
+
+{{- if .Values.quotaManager.webhook.internalCertManagement }}
+
+The webhook serves its own certificate — no cert-manager needed. The pod stays unready until
+the CA is generated and injected, so a Ready pod means admission is live. Confirm the caBundle
+is real rather than the rendered placeholder:
+
+  kubectl get validatingwebhookconfiguration {{ .Values.quotaManager.name }}.ome.io \
+    -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | base64 -d | openssl x509 -noout -subject
+{{- else }}
+
+Internal cert management is off, so cert-manager must be installed and must have issued
+{{ .Values.quotaManager.name }}-serving-cert. Until its cainjector fills in the caBundle, every write to an
+AcceleratorQuota is rejected — the webhook is failurePolicy=Fail.
+{{- end }}
+
+Admission is failurePolicy=Fail and gates CREATE, UPDATE and DELETE of acceleratorquotas.
+Try it without dirtying the tree — sideEffects is None, so a server dry-run still runs the check:
+
+  kubectl apply --dry-run=server -f <a-quota-with-a-bad-parentRef>.yaml
+{{- end }}

--- a/charts/ome-quota-manager/templates/_helpers.tpl
+++ b/charts/ome-quota-manager/templates/_helpers.tpl
@@ -1,0 +1,119 @@
+{{/*
+Constructs an image ref with an optional global hub prefix. If the repository
+already contains '/', hub is ignored. Mirrors the ome-scheduler helper.
+Parameters: values, repository, tag.
+*/}}
+{{- define "ome-quota-manager.image" -}}
+{{- $hub := .values.global.hub -}}
+{{- $repo := .repository -}}
+{{- $tag := .tag -}}
+{{- if and $hub (not (contains "/" $repo)) -}}
+{{- printf "%s/%s:%s" $hub $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version, suitable for use as a Kubernetes label value.
+*/}}
+{{- define "ome-quota-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels — minimal and stable across re-renders.
+*/}}
+{{- define "ome-quota-manager.selectorLabels" -}}
+app.kubernetes.io/name: ome-quota-manager
+app.kubernetes.io/component: quota-manager
+{{- end -}}
+
+{{/*
+Full label set stamped on chart resources.
+*/}}
+{{- define "ome-quota-manager.labels" -}}
+{{ include "ome-quota-manager.selectorLabels" . }}
+helm.sh/chart: {{ include "ome-quota-manager.chart" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ome
+{{- end -}}
+
+{{/*
+Where the webhook serving cert lives inside the container. Not a values knob —
+it is a container-local path, not an operator decision — but it is shared
+between the volume mount and the flag, and the two silently disagreeing would
+mean a webhook that never serves.
+*/}}
+{{- define "ome-quota-manager.certDir" -}}
+/tmp/k8s-webhook-server/serving-certs
+{{- end -}}
+
+{{/*
+The accelerator resources capacity derivation is configured with, as a list with
+blanks removed.
+
+Nil-safe and blank-safe on purpose. A GitOps overlay switching the feature off
+naturally writes `capacity:` or `capacity: {resources: null}`, and Helm deletes
+the defaulted map rather than merging it, so an unguarded lookup aborts the whole
+render. Blanks are dropped because the binary drops them too — without that the
+chart would grant cluster-wide Node reads for a list the binary reads as empty.
+*/}}
+{{/*
+Cover resources as name=quantity pairs. Blank names and blank quantities are
+dropped, so a partially-filled overlay disables materialization rather than
+rendering a flag the binary rejects at startup.
+*/}}
+{{- define "ome-quota-manager.coverResources" -}}
+{{- $materialize := .Values.quotaManager.materialize | default dict -}}
+{{- $cover := $materialize.coverResources | default dict -}}
+{{- $out := list -}}
+{{- range $name, $qty := $cover -}}
+{{- if and (trim (toString $name)) (trim (toString $qty)) -}}
+{{- $out = append $out (printf "%s=%s" (trim (toString $name)) (trim (toString $qty))) -}}
+{{- end -}}
+{{- end -}}
+{{- join "," (sortAlpha $out) -}}
+{{- end -}}
+
+{{/*
+The field manager that owns applied Kueue objects. Defaults to the component
+name so a single-manager install needs no configuration, while two managers on
+one cluster can be told apart.
+*/}}
+{{- define "ome-quota-manager.fieldManager" -}}
+{{- $materialize := .Values.quotaManager.materialize | default dict -}}
+{{- $fm := $materialize.fieldManager | default "" -}}
+{{- if trim (toString $fm) -}}
+{{- trim (toString $fm) -}}
+{{- else -}}
+{{- .Values.quotaManager.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ome-quota-manager.acceleratorResources" -}}
+{{- $capacity := .Values.quotaManager.capacity | default dict -}}
+{{- $resources := $capacity.resources | default list -}}
+{{- $out := list -}}
+{{- range $resources -}}
+{{- if trim (toString .) -}}
+{{- $out = append $out (trim (toString .)) -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $out -}}
+{{- end -}}
+
+{{/*
+Fails the render unless mode is one of the two the binary accepts. There is no
+safe default: workload mode writes Kueue objects on this cluster and management
+mode projects shares onto others, so an unset or mistyped value must stop the
+install rather than produce a Deployment that crash-loops on a flag check.
+*/}}
+{{- define "ome-quota-manager.mode" -}}
+{{- $mode := .Values.quotaManager.mode -}}
+{{- if not (has $mode (list "workload" "management")) -}}
+{{- fail (printf "quotaManager.mode must be \"workload\" or \"management\", got %q" $mode) -}}
+{{- end -}}
+{{- $mode -}}
+{{- end -}}

--- a/charts/ome-quota-manager/templates/crd.yaml
+++ b/charts/ome-quota-manager/templates/crd.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.quotaManager.crd.install }}
+{{- /*
+The CRD is copied verbatim from config/crd/full by `make manifests`, then given
+a retention annotation. resource-policy: keep is not optional here: deleting a
+CustomResourceDefinition cascades to every AcceleratorQuota, each of those
+deletions is gated by this chart's own failurePolicy=Fail webhook, and by
+uninstall time the webhook has no endpoints — so an unprotected CRD would wedge
+in Terminating and take the tree down with it.
+*/}}
+{{- $crd := .Files.Get "files/ome.io_acceleratorquotas.yaml" | fromYaml }}
+{{- $meta := $crd.metadata }}
+{{- $_ := set $meta "annotations" (merge (dict "helm.sh/resource-policy" "keep") (default (dict) $meta.annotations)) }}
+{{- $_ := set $meta "labels" (merge (default (dict) $meta.labels) (fromYaml (include "ome-quota-manager.labels" .))) }}
+{{- toYaml $crd }}
+{{- end }}

--- a/charts/ome-quota-manager/templates/deployment.yaml
+++ b/charts/ome-quota-manager/templates/deployment.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.quotaManager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ome-quota-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ome-quota-manager.labels" . | nindent 8 }}
+        {{- with .Values.quotaManager.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.quotaManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.quotaManager.name }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: quota-manager
+        image: {{ include "ome-quota-manager.image" (dict "values" .Values "repository" .Values.quotaManager.image.repository "tag" .Values.quotaManager.image.tag) }}
+        imagePullPolicy: {{ .Values.quotaManager.image.pullPolicy }}
+        args:
+        - "--mode={{ include "ome-quota-manager.mode" . }}"
+        - "--metrics-bind-address=:{{ .Values.quotaManager.metricsPort }}"
+        - "--health-probe-addr=:{{ .Values.quotaManager.probePort }}"
+        - "--leader-elect={{ .Values.quotaManager.leaderElect }}"
+        - "--zap-log-level={{ .Values.quotaManager.logLevel }}"
+        {{- if eq (include "ome-quota-manager.mode" .) "management" }}
+        {{- with .Values.quotaManager.projection.origin }}
+        - "--projection-origin={{ . }}"
+        {{- end }}
+        {{- with .Values.quotaManager.projection.fieldManager }}
+        - "--projection-field-manager={{ . }}"
+        {{- end }}
+        {{- with .Values.quotaManager.projection.defaultDistributionPolicy }}
+        - "--default-distribution-policy={{ . }}"
+        {{- end }}
+        {{- if .Values.quotaManager.projection.execCredentials.enabled }}
+        - "--allow-exec-credentials=true"
+        - "--exec-credential-allowed-commands={{ join "," .Values.quotaManager.projection.execCredentials.allowedCommands }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.quotaManager.maxTreeDepth }}
+        - "--max-tree-depth={{ .Values.quotaManager.maxTreeDepth }}"
+        {{- end }}
+        {{- with .Values.quotaManager.resyncInterval }}
+        - "--resync-interval={{ . }}"
+        {{- end }}
+        {{- if eq (include "ome-quota-manager.mode" .) "workload" }}
+        {{- with (include "ome-quota-manager.acceleratorResources" .) }}
+        - "--accelerator-resources={{ . }}"
+        - "--capacity-hysteresis-percent={{ ($.Values.quotaManager.capacity | default dict).hysteresisPercent | default 0 }}"
+        {{- end }}
+        {{- with (include "ome-quota-manager.coverResources" .) }}
+        - "--cover-resources={{ . }}"
+        - "--field-manager={{ include "ome-quota-manager.fieldManager" $ }}"
+        {{- end }}
+        {{- end }}
+        - "--webhook={{ .Values.quotaManager.webhook.enabled }}"
+        {{- if .Values.quotaManager.webhook.enabled }}
+        - "--webhook-port={{ .Values.quotaManager.webhook.port }}"
+        - "--webhook-cert-dir={{ include "ome-quota-manager.certDir" . }}"
+        - "--internal-cert-management={{ .Values.quotaManager.webhook.internalCertManagement }}"
+        {{- if .Values.quotaManager.webhook.internalCertManagement }}
+        # Derived from quotaManager.name, so the binary carries no default that
+        # could disagree with what this chart rendered.
+        - "--cert-namespace={{ .Release.Namespace }}"
+        - "--cert-secret-name={{ .Values.quotaManager.name }}-webhook-cert"
+        - "--webhook-service-name={{ .Values.quotaManager.name }}-webhook"
+        - "--webhook-config-name={{ .Values.quotaManager.name }}.ome.io"
+        - "--ca-name={{ .Values.quotaManager.name }}-ca"
+        - "--ca-organization=ome"
+        {{- end }}
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.quotaManager.metricsPort }}
+        - name: probe
+          containerPort: {{ .Values.quotaManager.probePort }}
+        {{- if .Values.quotaManager.webhook.enabled }}
+        - name: webhook
+          containerPort: {{ .Values.quotaManager.webhook.port }}
+          protocol: TCP
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: probe
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          {{- toYaml .Values.quotaManager.resources | nindent 10 }}
+        {{- if .Values.quotaManager.webhook.enabled }}
+        volumeMounts:
+        - name: webhook-cert
+          mountPath: {{ include "ome-quota-manager.certDir" . }}
+          readOnly: true
+        {{- end }}
+      {{- if .Values.quotaManager.webhook.enabled }}
+      volumes:
+      # Read-only in both cert modes. With internal management the component
+      # never writes this path: it writes the Secret, and the kubelet projects
+      # the Secret back down here — which is also why a fresh pod stays unready
+      # until that projection lands rather than becoming ready immediately.
+      - name: webhook-cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.quotaManager.name }}-webhook-cert
+      {{- end }}
+      {{- with .Values.quotaManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.quotaManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.quotaManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ome-quota-manager/templates/poddisruptionbudget.yaml
+++ b/charts/ome-quota-manager/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.quotaManager.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.quotaManager.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "ome-quota-manager.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ome-quota-manager/templates/rbac.yaml
+++ b/charts/ome-quota-manager/templates/rbac.yaml
@@ -1,0 +1,235 @@
+# Hand-authored, not generated. controller-gen builds the ome-manager ClusterRole
+# from markers under ./pkg/controller/..., and merging these grants into that role
+# would defeat the point of a separate binary: the quota plane's permissions —
+# today AcceleratorQuota, later cluster-wide write on Kueue's ClusterQueue and
+# Cohort — must belong only to the process that uses them.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.quotaManager.name }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+rules:
+# The tree is assembled from every node on the cluster, so this is a list/watch
+# of the whole kind, not a get of one object.
+- apiGroups: ["ome.io"]
+  resources: ["acceleratorquotas"]
+  verbs: ["get", "list", "watch"]
+# Status only. The controller reports a node's position and condition; it never
+# edits a spec, which is the admin's (or, for a projection, the management
+# plane's) to write.
+- apiGroups: ["ome.io"]
+  resources: ["acceleratorquotas/status"]
+  verbs: ["get", "update", "patch"]
+{{- if eq (include "ome-quota-manager.mode" .) "management" }}
+# Reaching a member starts with the registry: the connector follows each
+# WorkloadCluster's Ready condition to decide what to connect to and what to
+# drop, and the projector reads the same set to know when part of the fleet is
+# missing -- a split computed without an absent member over-grants the fleet.
+#
+# Read-only, deliberately. WorkloadCluster status has exactly one writer, the
+# registry's own reconciler in ome-manager, whose grace and backoff state is
+# in-memory rather than behind a lease. A second writer would flap the condition
+# between two processes and lose the argument silently, since conflicts on that
+# path requeue unreported.
+- apiGroups: ["ome.io"]
+  resources: ["workloadclusters"]
+  verbs: ["get", "list", "watch"]
+# The kubeconfig behind each member. Cluster-wide because a WorkloadCluster's
+# secretRef carries its own namespace, so the Secret can live anywhere an
+# operator puts it.
+#
+# This is the widest grant the quota plane holds, and it is the price of a
+# second binary reaching the fleet: ome-manager already holds the equivalent for
+# placement. Scope it by moving every kubeconfig Secret into one namespace and
+# narrowing this to a Role there, if your layout allows it.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+{{- if and .Values.quotaManager.projection.origin .Values.quotaManager.projection.fieldManager }}
+# The finalizer that gates a node's deletion until its projections are reaped
+# off every member. A projecting plane claims each node before it writes
+# anything, so without this every pass fails on a forbidden patch and no tree is
+# ever projected.
+#
+# patch on the resource itself, not update on acceleratorquotas/finalizers: a
+# finalizer lives in metadata, so adding one is an ordinary patch of the object.
+#
+# Conditioned on the same two values the projector itself requires, so a
+# management plane configured not to project does not carry a write it cannot
+# use.
+- apiGroups: ["ome.io"]
+  resources: ["acceleratorquotas"]
+  verbs: ["patch"]
+{{- end }}
+{{- end }}
+{{- if and (eq (include "ome-quota-manager.mode" .) "workload") (include "ome-quota-manager.acceleratorResources" .) }}
+# Deriving the reserved root's capacity means measuring the cluster's silicon,
+# which is a cluster-wide read of Nodes and of Kueue's ResourceFlavors — the
+# latter because a flavor names a hardware class by node labels and OME does not
+# own node labelling, so the mapping is read rather than authored.
+#
+# Read-only, and only in workload mode: a management-mode manager holds the
+# authored fleet tree and has no local silicon to measure.
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["kueue.x-k8s.io"]
+  resources: ["resourceflavors"]
+  verbs: ["get", "list", "watch"]
+# The one spec write this component makes, and only to bring the reserved root
+# into being. Capacity has to be reportable before any tree is authored, or a
+# management plane sizing a Proportional split has nothing to read from a member
+# that has no budget yet. The root is created bare — the budget on it stays the
+# admin's to write.
+- apiGroups: ["ome.io"]
+  resources: ["acceleratorquotas"]
+  verbs: ["create"]
+{{- end }}
+{{- if and (eq (include "ome-quota-manager.mode" .) "workload") (include "ome-quota-manager.coverResources" .) }}
+# Materializing the tree means writing Kueue's own objects: a Cohort per
+# internal node, a ClusterQueue per leaf, and a LocalQueue in every bound
+# namespace. This is the grant that made the quota plane a separate binary --
+# cluster-wide write on Kueue is not something the ServiceAccount running the
+# InferenceService reconcilers and the fail-closed pod mutator should also hold.
+#
+# delete is needed for the orphan sweep, which is bounded by the managed-by
+# label: objects this manager did not create are never touched. list and watch
+# are what the sweep selects with.
+- apiGroups: ["kueue.x-k8s.io"]
+  resources: ["cohorts", "clusterqueues", "localqueues"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# The finalizer that gates a node's deletion until its Kueue objects are reaped.
+# Without it, deleting the CR leaves a ClusterQueue behind still admitting
+# workloads against a budget nobody can see any more.
+#
+# patch on the resource itself, not update on acceleratorquotas/finalizers: a
+# finalizer lives in metadata, so adding one is an ordinary patch of the object.
+# The finalizers subresource governs something else entirely — setting
+# blockOwnerDeletion in an ownerReference — which this component never does.
+# Granting that instead leaves the controller unable to claim a node, and every
+# pass then fails on a forbidden patch before anything is materialized.
+- apiGroups: ["ome.io"]
+  resources: ["acceleratorquotas"]
+  verbs: ["patch"]
+{{- end }}
+# No events grant: nothing in this component holds an EventRecorder. It is
+# granted back alongside the first emitter rather than kept warm — an unused
+# write verb is indistinguishable from a used one at review time.
+{{- if and .Values.quotaManager.webhook.enabled .Values.quotaManager.webhook.internalCertManagement }}
+# Internal cert management injects the generated caBundle into this component's
+# own ValidatingWebhookConfiguration.
+#
+# update is scoped by name to that one object, so this grant cannot rewrite
+# ome-manager's fail-closed pod mutator or any other component's webhook — the
+# rotator only ever Gets and Updates the configurations it was told to manage.
+# Nothing is granted on mutatingwebhookconfigurations; this component has none.
+#
+# list and watch CANNOT be narrowed the same way: resourceNames does not apply
+# to them, and the rotator builds an unfiltered informer over the kind. Reading
+# webhook configurations is low-sensitivity — caBundles are public — but it is a
+# cluster-wide read and worth knowing about.
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  resourceNames: ["{{ .Values.quotaManager.name }}.ome.io"]
+  verbs: ["get", "update"]
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.quotaManager.name }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.quotaManager.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+{{- if and .Values.quotaManager.webhook.enabled .Values.quotaManager.webhook.internalCertManagement }}
+---
+# The cert Secret is namespaced, so this is a Role rather than another
+# cluster-wide grant. list and watch are unavoidable — the rotator runs a
+# namespace-scoped informer over Secrets — so this does expose every Secret in
+# the release namespace to the component. Keep the namespace to OME's own.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.quotaManager.name }}-webhook-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["{{ .Values.quotaManager.name }}-webhook-cert"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.quotaManager.name }}-webhook-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.quotaManager.name }}-webhook-cert
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.quotaManager.leaderElect }}
+---
+# Leader election is namespaced: the lease lives beside the Deployment, so this
+# is a Role rather than another cluster-wide grant.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.quotaManager.name }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.quotaManager.name }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.quotaManager.name }}-leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ome-quota-manager/templates/remote_access.yaml
+++ b/charts/ome-quota-manager/templates/remote_access.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.quotaManager.remoteAccess.enabled }}
+{{- $name := .Values.quotaManager.remoteAccess.name }}
+{{- $sa := .Values.quotaManager.remoteAccess.serviceAccount }}
+{{- $subjects := .Values.quotaManager.remoteAccess.subjects }}
+{{- if and (not $sa.create) (not $subjects) }}
+{{- fail "quotaManager.remoteAccess is enabled but binds to nobody: set serviceAccount.create=true or list subjects" }}
+{{- end }}
+# Installed on a WORKLOAD cluster, and used by nothing that runs there. This is
+# what a management plane is allowed to do when it projects quota nodes onto
+# this member: the member issues the grant, so the member decides its extent.
+#
+# This template defines PERMISSIONS, not an authentication method. How the
+# management plane proves who it is belongs to the platform rather than to a
+# chart — the transport accepts exec credential plugins, so a cloud workload
+# identity authenticates with nothing stored anywhere. Bind the role to whatever
+# identity that produces through `subjects`.
+#
+# Deliberately NOT a widening of ome-multicluster-access. That role is the
+# placement plane's — InferenceService CRUD plus reads on pods, podgroups and
+# runtimes — and the two planes should not be able to use each other's
+# credentials. Keeping them apart means a leaked quota credential cannot start
+# work, and a leaked placement credential cannot rewrite budgets.
+{{- if $sa.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+    ome.io/component: quota-remote-access
+{{- end }}
+{{- if and $sa.create $sa.staticToken }}
+---
+# A ServiceAccount token that never expires and never rotates, readable by
+# anyone who can read Secrets in this namespace. Opt-in, and the opposite of
+# what a production cluster should carry: prefer `kubectl create token`, which
+# issues a token with a lifetime, or an exec credential plugin, which stores no
+# credential at all.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-token" $name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+    ome.io/component: quota-remote-access
+  annotations:
+    kubernetes.io/service-account.name: {{ $name | quote }}
+type: kubernetes.io/service-account-token
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name | quote }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+    ome.io/component: quota-remote-access
+rules:
+# Projected quota nodes: the management plane creates them, keeps them in step
+# with the fleet tree, and reaps them when a node leaves it or the cluster stops
+# matching. list/watch because a projection is reconciled against the whole set
+# on this cluster, not fetched one at a time.
+#
+# AcceleratorQuota is cluster-scoped, so this cannot be a namespaced Role.
+- apiGroups: ["ome.io"]
+  resources: ["acceleratorquotas"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+# There is no status subresource rule here, and its absence is the design.
+#
+# Status on this cluster is written by the workload-mode manager that runs here:
+# it reports each node's position, what Kueue is holding against it, and the
+# capacity it derived from this cluster's own hardware. A management plane READS
+# all of that — reading needs no separate grant, since status arrives with the
+# object — but writing it would make two processes the author of one field, and
+# the remote one is the one with no way to observe what it is overwriting.
+#
+# Nor is there a grant on nodes, resourceflavors, or anything of Kueue's. The
+# management plane never measures this cluster and never materializes here; it
+# learns capacity from the root node's status, which the local manager derives.
+# Kueue write access on a member belongs to the process running beside Kueue.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name | quote }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+    ome.io/component: quota-remote-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name | quote }}
+subjects:
+{{- if $sa.create }}
+- kind: ServiceAccount
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+{{- range $subjects }}
+- kind: {{ .kind | quote }}
+  name: {{ .name | quote }}
+  {{- if .namespace }}
+  namespace: {{ .namespace | quote }}
+  {{- end }}
+  {{- if ne .kind "ServiceAccount" }}
+  apiGroup: rbac.authorization.k8s.io
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ome-quota-manager/templates/webhook.yaml
+++ b/charts/ome-quota-manager/templates/webhook.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.quotaManager.webhook.enabled }}
+{{- if .Values.quotaManager.webhook.internalCertManagement }}
+# The component generates its own CA and serving cert and injects the caBundle
+# into the ValidatingWebhookConfiguration below, so admission works with no
+# cert-manager in the cluster.
+#
+# This Secret is created EMPTY on purpose. The rotator only ever updates it — it
+# does not create — so a missing Secret is a permanent startup failure rather
+# than something the component recovers from.
+#
+# helm.sh/resource-policy keeps it across an uninstall/reinstall of the chart:
+# without that, a reinstall would leave the ValidatingWebhookConfiguration
+# carrying a caBundle whose key no longer exists anywhere.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.quotaManager.name }}-webhook-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+{{- else }}
+# cert-manager supplies the cert instead. Requires cert-manager and its
+# cainjector to be installed.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.quotaManager.name }}-selfsigned
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.quotaManager.name }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+spec:
+  commonName: {{ .Values.quotaManager.name }}-webhook.{{ .Release.Namespace }}.svc
+  dnsNames:
+  - {{ .Values.quotaManager.name }}-webhook.{{ .Release.Namespace }}.svc
+  - {{ .Values.quotaManager.name }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ .Values.quotaManager.name }}-selfsigned
+  secretName: {{ .Values.quotaManager.name }}-webhook-cert
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.quotaManager.name }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook
+    protocol: TCP
+    name: https
+  selector:
+    {{- include "ome-quota-manager.selectorLabels" . | nindent 4 }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ .Values.quotaManager.name }}.ome.io
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+  {{- if not .Values.quotaManager.webhook.internalCertManagement }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.quotaManager.name }}-serving-cert
+  {{- end }}
+webhooks:
+- name: acceleratorquota.ome-quota-manager.validator
+  clientConfig:
+    # Placeholder. Whoever manages the cert replaces it: the rotator on startup,
+    # or cainjector via the annotation above.
+    caBundle: Cg==
+    service:
+      name: {{ .Values.quotaManager.name }}-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /validate-ome-io-v1beta1-acceleratorquota
+  # Fail closed. A write that breaks the tree is exactly what this exists to
+  # stop, and the blast radius is bounded: it gates one cluster-scoped CRD that
+  # only capacity admins write, never a serving pod.
+  failurePolicy: Fail
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+  timeoutSeconds: {{ .Values.quotaManager.webhook.timeoutSeconds }}
+  # DELETE is included on purpose: removing a grouping orphans everything under
+  # it, and that damage is invisible from the deleted object alone.
+  rules:
+  - apiGroups: ["ome.io"]
+    apiVersions: ["v1beta1"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
+    resources: ["acceleratorquotas"]
+{{- end }}

--- a/charts/ome-quota-manager/tests/render_test.sh
+++ b/charts/ome-quota-manager/tests/render_test.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helm_bin="${HELM_BIN:-helm}"
+
+fail() {
+  echo "ome-quota-manager chart test: $*" >&2
+  exit 1
+}
+
+# Release name deliberately unlike the component name: object names come from
+# quotaManager.name, and a release-derived name would slip through unnoticed if
+# the two matched.
+render() {
+  "${helm_bin}" template rel "${chart_dir}" --namespace ome "$@"
+}
+
+# --- mode is required, and the guard must fire rather than render a bad flag ---
+
+if render >/dev/null 2>&1; then
+  fail "an unset mode rendered instead of failing"
+fi
+for mode in workload management; do
+  render --set quotaManager.mode="${mode}" >/dev/null ||
+    fail "mode ${mode} did not render"
+done
+if render --set quotaManager.mode=both >/dev/null 2>&1; then
+  fail "an invalid mode rendered instead of failing"
+fi
+
+# --- object names track quotaManager.name, never the release ---
+
+default="$(render --set quotaManager.mode=workload)"
+
+grep -Fq 'name: ome-quota-manager' <<<"${default}" ||
+  fail "objects are not named from quotaManager.name"
+if grep -Eq '^\s+name: rel(-|$)' <<<"${default}"; then
+  fail "an object was named from the release instead of quotaManager.name"
+fi
+
+renamed="$(render --set quotaManager.mode=workload --set quotaManager.name=aq-mgr)"
+grep -Fq 'name: aq-mgr' <<<"${renamed}" ||
+  fail "overriding quotaManager.name did not rename objects"
+# The RBAC scopes itself by name, so a rename that misses one grant would leave
+# the component unable to inject its own caBundle.
+grep -Fq 'resourceNames: ["aq-mgr.ome.io"]' <<<"${renamed}" ||
+  fail "the webhook-config grant did not follow the rename"
+grep -Fq 'resourceNames: ["aq-mgr-webhook-cert"]' <<<"${renamed}" ||
+  fail "the secret grant did not follow the rename"
+grep -Fq -- '--webhook-config-name=aq-mgr.ome.io' <<<"${renamed}" ||
+  fail "the binary flag did not follow the rename"
+
+# --- internal cert management: the out-of-the-box default ---
+
+grep -Fq -- '--internal-cert-management=true' <<<"${default}" ||
+  fail "internal cert management is not the default"
+grep -Fq -- '--cert-namespace=ome' <<<"${default}" ||
+  fail "the cert namespace was not passed"
+grep -Fq -- '--cert-secret-name=ome-quota-manager-webhook-cert' <<<"${default}" ||
+  fail "the cert secret name was not passed"
+grep -Fq -- '--webhook-config-name=ome-quota-manager.ome.io' <<<"${default}" ||
+  fail "the webhook config name was not passed"
+
+# The rotator only ever Updates the Secret, so the chart creating it empty is
+# load-bearing: without it the component never becomes ready.
+grep -Fq 'name: ome-quota-manager-webhook-cert' <<<"${default}" ||
+  fail "the placeholder cert Secret was not rendered"
+grep -Fq 'helm.sh/resource-policy: keep' <<<"${default}" ||
+  fail "the cert Secret is not retained across an uninstall"
+
+# The rotator writes the Secret and the kubelet projects it back down, so the
+# mount is the delivery path, not just the cert-manager hand-off.
+grep -Fq 'secretName: ome-quota-manager-webhook-cert' <<<"${default}" ||
+  fail "the cert Secret is not mounted"
+
+if grep -Fq 'cert-manager.io' <<<"${default}"; then
+  fail "the default install still references cert-manager"
+fi
+
+# Self-injection is scoped to this component's own webhook config. A grant that
+# lost its resourceNames could rewrite ome-manager's fail-closed pod mutator.
+grep -Fq 'resourceNames: ["ome-quota-manager.ome.io"]' <<<"${default}" ||
+  fail "webhook-config update is not scoped by name"
+if grep -Fq 'resources: ["mutatingwebhookconfigurations"]' <<<"${default}"; then
+  fail "the quota plane was granted access to mutating webhooks"
+fi
+grep -Fq 'resourceNames: ["ome-quota-manager-webhook-cert"]' <<<"${default}" ||
+  fail "secret update is not scoped by name"
+
+# --- capacity derivation carries its own RBAC, and only in workload mode ---
+
+# The grants and the flags have to appear together: flags without the grants is
+# a crash-looping RBAC error, grants without the flags is a cluster-wide Node
+# read nothing uses.
+grep -Fq 'resources: ["nodes"]' <<<"${default}" ||
+  fail "workload mode did not grant the Node read capacity derivation needs"
+grep -Fq 'resources: ["resourceflavors"]' <<<"${default}" ||
+  fail "workload mode did not grant the ResourceFlavor read"
+grep -Fq -- '--accelerator-resources=google.com/tpu,nvidia.com/gpu' <<<"${default}" ||
+  fail "the accelerator suffixes were not passed"
+grep -Fq -- '--capacity-hysteresis-percent=10' <<<"${default}" ||
+  fail "the hysteresis band was not passed"
+
+# A management-mode install holds the authored fleet tree and has no local
+# silicon, so a cluster-wide Node read there would be unused privilege.
+management="$(render --set quotaManager.mode=management)"
+for unwanted in 'resources: ["nodes"]' 'resources: ["resourceflavors"]' '--accelerator-resources'; do
+  if grep -Fq -- "${unwanted}" <<<"${management}"; then
+    fail "management mode rendered ${unwanted}"
+  fi
+done
+
+# Turning derivation off must drop the grants with it, or the privilege
+# outlives the feature that justified it. Every spelling an operator might
+# reach for, because Helm deletes a defaulted map on a null rather than merging
+# it and an unguarded lookup then aborts the whole render.
+for off in \
+  'quotaManager.capacity.resources=null' \
+  'quotaManager.capacity=null' \
+  'quotaManager.capacity.resources={}' \
+  ; do
+  nocapacity="$(render --set quotaManager.mode=workload --set "${off}")" ||
+    fail "--set ${off} failed to render at all"
+  for unwanted in 'resources: ["nodes"]' 'resources: ["resourceflavors"]' '--accelerator-resources'; do
+    if grep -Fq -- "${unwanted}" <<<"${nocapacity}"; then
+      fail "--set ${off} still rendered ${unwanted}"
+    fi
+  done
+done
+
+# A blank entry is not a resource. The chart must agree with the binary, which
+# trims and drops blanks — otherwise a list of blanks grants cluster-wide Node
+# reads for a feature the binary treats as switched off.
+blanks="$(render --set quotaManager.mode=workload --set 'quotaManager.capacity.resources[0]=')"
+if grep -Fq -- 'resources: ["nodes"]' <<<"${blanks}"; then
+  fail "a list of blank resources still granted the Node read"
+fi
+
+# A flag rendered with no value crash-loops the pod on parse.
+allrendered="$(render --set quotaManager.mode=workload --set quotaManager.capacity.hysteresisPercent=null)"
+if grep -Eq -- '--[a-z-]+=(")?$' <<<"${allrendered}"; then
+  fail "a flag rendered with an empty value"
+fi
+
+# --- materialization carries its own Kueue write RBAC, workload mode only ---
+
+# Flags and grants have to appear together: flags without the grants is a
+# crash-looping RBAC error, grants without the flags is cluster-wide write on
+# Kueue that nothing uses.
+grep -Fq -- '--cover-resources=cpu=16M,memory=16Pi' <<<"${default}" ||
+  fail "the default cover resources were not passed"
+
+# An operator overrides one key and keeps the other: Helm merges the map rather
+# than replacing it, and the whole point of a default is that omitting a key
+# leaves it alone.
+onekey="$(render --set quotaManager.mode=workload \
+  --set quotaManager.materialize.coverResources.cpu=2k)"
+grep -Fq -- '--cover-resources=cpu=2k,memory=16Pi' <<<"${onekey}" ||
+  fail "overriding one cover resource did not leave the other at its default"
+
+# A Cohort's subtree quota sums the cover across its children, and the Kueue this
+# repo compiles against wraps rather than clamps on int64 overflow. Ei-scale
+# defaults leave no room for that sum, and a wrapped ceiling is a wrong admission
+# decision rather than a failure.
+if grep -Eq -- '--cover-resources=[^ ]*[0-9]+(Ei|E)([,"]|$)' <<<"${default}"; then
+  fail "the default cover resources reach Ei/E scale, leaving no room for a cohort subtree sum"
+fi
+grep -Fq -- '--field-manager=ome-quota-manager' <<<"${default}" ||
+  fail "the field manager did not default to the component name"
+grep -Fq 'resources: ["cohorts", "clusterqueues", "localqueues"]' <<<"${default}" ||
+  fail "workload mode did not grant the Kueue write materialization needs"
+# patch on the resource, not update on the finalizers subresource: a finalizer
+# is metadata, so claiming a node is an ordinary patch. Granting the subresource
+# instead leaves every reconcile failing on a forbidden patch, which is invisible
+# to a render test that only checks a grant is present.
+grep -Fq 'verbs: ["patch"]' <<<"${default}" ||
+  fail "the finalizer patch grant is missing, so no node could be claimed or reaped"
+if grep -Fq 'resources: ["acceleratorquotas/finalizers"]' <<<"${default}"; then
+  fail "granted the finalizers subresource, which governs blockOwnerDeletion and is not what a finalizer needs"
+fi
+
+# A rename must carry the field manager with it, or two installs would claim
+# each other's objects.
+grep -Fq -- '--field-manager=aq-mgr' <<<"${renamed}" ||
+  fail "the field manager did not follow the rename"
+
+# A management-mode install writes no Kueue object anywhere, so the write grant
+# there would be pure unused privilege.
+for unwanted in 'resources: ["cohorts", "clusterqueues", "localqueues"]' '--cover-resources' '--field-manager'; do
+  if grep -Fq -- "${unwanted}" <<<"${management}"; then
+    fail "management mode rendered ${unwanted}"
+  fi
+done
+
+# Turning materialization off must drop the write grant with it, in every
+# spelling an operator might reach for.
+for off in \
+  'quotaManager.materialize.coverResources=null' \
+  'quotaManager.materialize=null' \
+  ; do
+  nomat="$(render --set quotaManager.mode=workload --set "${off}")" ||
+    fail "--set ${off} failed to render at all"
+  for unwanted in 'resources: ["cohorts", "clusterqueues", "localqueues"]' '--cover-resources' \
+    'verbs: ["patch"]'; do
+    if grep -Fq -- "${unwanted}" <<<"${nomat}"; then
+      fail "--set ${off} still rendered ${unwanted}"
+    fi
+  done
+done
+
+# A blank quantity is not a cover resource. The chart must agree with the
+# binary, which rejects a valueless pair at startup.
+blankqty="$(render --set quotaManager.mode=workload \
+  --set quotaManager.materialize.coverResources.cpu= \
+  --set quotaManager.materialize.coverResources.memory=)"
+if grep -Fq -- 'resources: ["cohorts", "clusterqueues", "localqueues"]' <<<"${blankqty}"; then
+  fail "blank cover quantities still granted the Kueue write"
+fi
+
+# --- the CRD is opt-in, and retained when it is opted into ---
+
+if grep -Fq 'kind: CustomResourceDefinition' <<<"${default}"; then
+  fail "the CRD rendered by default, which collides with ome-crd"
+fi
+
+withcrd="$(render --set quotaManager.mode=workload --set quotaManager.crd.install=true)"
+grep -Fq 'name: acceleratorquotas.ome.io' <<<"${withcrd}" ||
+  fail "opting in did not render the CRD"
+# Deleting the CRD cascades to every AcceleratorQuota, and each of those deletes
+# is gated by this chart's own fail-closed webhook — which by uninstall time has
+# no endpoints. Without the retention annotation the CRD wedges in Terminating.
+"${helm_bin}" template rel "${chart_dir}" --namespace ome \
+  --set quotaManager.mode=workload --set quotaManager.crd.install=true \
+  --show-only templates/crd.yaml | grep -Fq 'helm.sh/resource-policy: keep' ||
+  fail "the opted-in CRD is not retained on uninstall"
+
+# --- cert-manager remains available as an opt-out ---
+
+certmanager="$(render --set quotaManager.mode=workload \
+  --set quotaManager.webhook.internalCertManagement=false)"
+
+grep -Fq 'kind: Certificate' <<<"${certmanager}" ||
+  fail "opting out did not render a cert-manager Certificate"
+grep -Fq 'cert-manager.io/inject-ca-from: ome/ome-quota-manager-serving-cert' <<<"${certmanager}" ||
+  fail "opting out did not annotate the webhook config for cainjector"
+grep -Fq 'secretName: ome-quota-manager-webhook-cert' <<<"${certmanager}" ||
+  fail "opting out did not mount the cert Secret"
+if grep -Fq 'resources: ["validatingwebhookconfigurations"]' <<<"${certmanager}"; then
+  fail "opting out left the self-injection RBAC in place"
+fi
+
+# --- disabling the webhook drops the whole cert story ---
+
+nowebhook="$(render --set quotaManager.mode=workload \
+  --set quotaManager.webhook.enabled=false)"
+
+for unwanted in ValidatingWebhookConfiguration cert-manager.io ome-quota-manager-webhook-cert; do
+  if grep -Fq "${unwanted}" <<<"${nowebhook}"; then
+    fail "disabling the webhook still rendered ${unwanted}"
+  fi
+done
+
+# --- reaching the fleet is a management-mode grant only ---
+
+mgmt="$(render --set quotaManager.mode=management --show-only templates/rbac.yaml)"
+for wanted in '"workloadclusters"' '"secrets"'; do
+  grep -Fq "${wanted}" <<<"${mgmt}" ||
+    fail "management mode cannot reach the fleet: ${wanted} not granted"
+done
+# The registry has one writer, in ome-manager, and its grace state is in memory.
+# A second writer flaps the condition and loses silently.
+if grep -Fq 'workloadclusters/status' <<<"${mgmt}"; then
+  fail "management mode grants WorkloadCluster status, which belongs to the registry"
+fi
+
+work="$(render --set quotaManager.mode=workload --show-only templates/rbac.yaml)"
+if grep -Fq '"workloadclusters"' <<<"${work}"; then
+  fail "workload mode was granted the registry it never reads"
+fi
+
+# --- a projecting plane can claim the nodes it projects ---
+
+# The projector puts a finalizer on every node it claims, which is an ordinary
+# patch of the object. Without the grant each pass fails forbidden before
+# anything is projected, and the fleet never leaves its authored state.
+mgmtProject="$(render --set quotaManager.mode=management \
+  --set quotaManager.projection.origin=hub-1 \
+  --set quotaManager.projection.fieldManager=proj \
+  --show-only templates/rbac.yaml)"
+
+# One rule spans two lines, and a newline inside a grep pattern makes it two
+# alternative patterns rather than one contiguous match — which would pass on
+# the resource name alone, whatever the verbs beside it. Flatten instead.
+flat() { tr '\n' ' ' | tr -s ' '; }
+claim='resources: ["acceleratorquotas"] verbs: ["patch"]'
+
+grep -Fq "${claim}" <<<"$(flat <<<"${mgmtProject}")" ||
+  fail "a projecting management plane cannot claim a node with a finalizer"
+
+# ...and one that is not projecting carries no write it cannot use.
+if grep -Fq "${claim}" <<<"$(flat <<<"${mgmt}")"; then
+  fail "management mode grants a spec write with no projector to use it"
+fi
+
+# --- projection is off until it is named, and never leaks into workload mode ---
+
+projectOn="$(render --set quotaManager.mode=management \
+  --set quotaManager.projection.origin=hub-1 \
+  --set quotaManager.projection.fieldManager=proj \
+  --set quotaManager.projection.defaultDistributionPolicy=Proportional \
+  --show-only templates/deployment.yaml)"
+# Counted, not merely found. A duplicated template block renders every flag
+# twice, which Go's flag parsing tolerates -- last wins -- so nothing downstream
+# would complain and a `grep -q` would pass while the args list carried each
+# projection flag two times over.
+for wanted in \
+  '--projection-origin=hub-1' \
+  '--projection-field-manager=proj' \
+  '--default-distribution-policy=Proportional'; do
+  seen="$(grep -Fc -- "${wanted}" <<<"${projectOn}" || true)"
+  [ "${seen}" = 1 ] ||
+    fail "management mode rendered ${wanted} ${seen} times, want exactly 1"
+done
+
+# An unmarked copy cannot be told from a node an admin authored on the member,
+# so projection must stay off until an origin is chosen deliberately.
+bare="$(render --set quotaManager.mode=management --show-only templates/deployment.yaml)"
+if grep -Fq -- '--projection-origin' <<<"${bare}"; then
+  fail "projection turned itself on without an origin"
+fi
+
+# A workload-mode manager holds no transport at all; the flags would be inert
+# at best and misleading at worst.
+leak="$(render --set quotaManager.mode=workload \
+  --set quotaManager.projection.origin=hub-1 --show-only templates/deployment.yaml)"
+if grep -Fq -- '--projection-origin' <<<"${leak}"; then
+  fail "projection flags leaked into workload mode"
+fi
+
+# Exec is opt-in, and naming no command still permits none.
+if grep -Fq -- '--allow-exec-credentials' <<<"${projectOn}"; then
+  fail "exec credentials were enabled without being asked for"
+fi
+# --- remote access is off unless asked for, grants narrowly, and mints no
+# --- non-expiring credential unless explicitly told to ---
+
+for unwanted in ome-quota-access quota-remote-access; do
+  if grep -Fq "${unwanted}" <<<"${default}"; then
+    fail "remote access rendered without being enabled (${unwanted})"
+  fi
+done
+
+# Only this template, so the local manager's own grants cannot be mistaken for
+# the remote ones. Comments are stripped: the file explains at length which
+# grants it deliberately omits, and prose about a rule must not read as the rule.
+remote_only() {
+  render --set quotaManager.mode=workload \
+    --set quotaManager.remoteAccess.enabled=true "$@" \
+    --show-only templates/remote_access.yaml | grep -v '^[[:space:]]*#'
+}
+
+remote="$(remote_only)"
+
+for wanted in \
+  'name: "ome-quota-access"' \
+  'resources: ["acceleratorquotas"]'; do
+  grep -Fq "${wanted}" <<<"${remote}" ||
+    fail "enabling remote access did not render ${wanted}"
+done
+
+# A token that never expires is the thing this chart should not hand out by
+# default. It is available for simulators, and only when asked for twice.
+if grep -Fq 'service-account-token' <<<"${remote}"; then
+  fail "enabling remote access minted a non-expiring token without being asked"
+fi
+grep -Fq 'service-account-token' \
+  <<<"$(remote_only --set quotaManager.remoteAccess.serviceAccount.staticToken=true)" ||
+  fail "opting into staticToken did not mint the token Secret"
+
+# The role must be bindable to an identity the platform already rotates, with
+# no in-cluster ServiceAccount at all.
+external="$(remote_only \
+  --set quotaManager.remoteAccess.serviceAccount.create=false \
+  --set 'quotaManager.remoteAccess.subjects[0].kind=User' \
+  --set 'quotaManager.remoteAccess.subjects[0].name=projector@example.com')"
+grep -Fq 'kind: "User"' <<<"${external}" ||
+  fail "an external subject was not bound"
+if grep -Fq 'kind: ServiceAccount' <<<"${external}"; then
+  fail "serviceAccount.create=false still rendered a ServiceAccount"
+fi
+
+# A role bound to nobody is a silent no-op, so it must not render at all.
+if render --set quotaManager.mode=workload \
+  --set quotaManager.remoteAccess.enabled=true \
+  --set quotaManager.remoteAccess.serviceAccount.create=false >/dev/null 2>&1; then
+  fail "remote access bound to nobody rendered instead of failing"
+fi
+
+# The whole point of a separate credential is that it can only write budgets.
+# A grant that let it create workloads, read the fleet's hardware, or touch
+# Kueue would make it interchangeable with ome-multicluster-access, and a leak
+# of either would then cost the same as a leak of both.
+#
+# Status on a member belongs to the workload-mode manager running there; a
+# remote writer cannot see what it would be overwriting.
+for forbidden in \
+  'acceleratorquotas/status' \
+  '"nodes"' \
+  '"pods"' \
+  '"inferenceservices"' \
+  'kueue.x-k8s.io'; do
+  if grep -Fq "${forbidden}" <<<"${remote}"; then
+    fail "the remote role reaches beyond projecting quota: ${forbidden}"
+  fi
+done
+
+echo "ome-quota-manager chart contracts OK"

--- a/charts/ome-quota-manager/values.yaml
+++ b/charts/ome-quota-manager/values.yaml
@@ -1,0 +1,295 @@
+# Default values for ome-quota-manager.
+
+global:
+  # Optional registry prefix applied to image repositories that don't already
+  # contain a '/'. Matches the ome-resources and ome-scheduler convention.
+  hub: ""
+  # Image pull secrets applied to the quota-manager pod.
+  imagePullSecrets: []
+
+quotaManager:
+  # Name every object this chart creates is derived from: the Deployment, the
+  # ServiceAccount, the webhook Service and configuration, the cert Secret, and
+  # the RBAC that scopes itself to those by name. Deliberately not the release
+  # name — a `helm install quota …` should not produce a Deployment called
+  # `quota`, and the ValidatingWebhookConfiguration is cluster-scoped, so a name
+  # that varies per release makes collisions between installs invisible.
+  #
+  # Must be a DNS label of at most 55 characters, so the derived Service and
+  # Secret names stay valid.
+  name: ome-quota-manager
+
+  crd:
+    # Install the AcceleratorQuota CRD from this chart, for a standalone install
+    # with no ome-crd — the manager cannot sync its cache without it, and a
+    # missing CRD shows up only as a crash-looping pod.
+    #
+    # Off by default, and it must stay that way for any cluster that also runs
+    # ome-crd: that chart owns the same cluster-scoped object, and the second
+    # release to claim it fails on Helm's ownership check. Turn this on only
+    # where this chart is the sole installer.
+    install: false
+
+  # Which half of the quota plane this install runs. REQUIRED — the chart fails
+  # to render without it, because there is no safe default: workload mode writes
+  # Kueue objects on this cluster, management mode projects shares onto others,
+  # and guessing either would be a surprise.
+  #   "workload"   - render the local AcceleratorQuota tree into Kueue here.
+  #   "management" - hold the authored fleet tree and project per-cluster shares.
+  # One mode per install: the two write different halves of the reserved root's
+  # status, so running both against one cluster is a last-writer-wins race.
+  mode: ""
+
+  image:
+    repository: ome-quota-manager
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  # Two replicas with leader election: exactly one reconciles and the other is a
+  # warm standby. Leader election must stay on whenever replicaCount > 1 — two
+  # active instances would race each other's status writes on every node.
+  replicaCount: 2
+  leaderElect: true
+
+  # maxTreeDepth bounds a node's distance from the root, in edges (the root is 0,
+  # a top-tier grouping is 1). 0 disables the check rather than assuming a bound;
+  # it is a guardrail against accidental sprawl, not a Kueue limit.
+  maxTreeDepth: 5
+
+  # resyncInterval re-runs the tree checks on an otherwise-idle plane, so a
+  # violation only a clock can clear is noticed without an edit. "" or 0 leaves
+  # reconciles purely event-driven.
+  resyncInterval: 10m
+
+  # The reserved root node is always named "root" and is deliberately not
+  # configurable: every AcceleratorQuota in the fleet writes
+  # parentRef: {name: root}, so a per-cluster name would make those CRs
+  # non-portable between planes.
+
+  # capacity measures this cluster's own silicon and records it on the reserved
+  # root's status, so a budget can be checked against hardware that exists
+  # rather than only against the rest of the tree. Workload mode only — a
+  # management-mode install holds the authored fleet tree and has no local
+  # nodes to measure.
+  capacity:
+    # resources are the extended resource names that count as accelerators,
+    # written in full. Exact names rather than a pattern, because this list
+    # decides what every budget is measured against and a pattern would quietly
+    # widen that.
+    #
+    # A vendor that is not listed contributes no capacity. That is not silent:
+    # a budget written against unmeasured hardware exceeds a capacity of zero
+    # and reports CapacityExceeded. Add the resource here when a new accelerator
+    # arrives in the fleet.
+    #
+    # Empty disables derivation entirely and drops the Node and ResourceFlavor
+    # RBAC with it. There is no default because there is no safe guess: without
+    # this list nothing distinguishes a node's accelerators from its cpu.
+    resources:
+    - google.com/tpu
+    - nvidia.com/gpu
+
+    # hysteresisPercent is how far observed capacity must fall below the
+    # recorded high-water mark before the mark follows it down.
+    #
+    # Budget checks read the mark, not the instantaneous value, because capacity
+    # dips for reasons that say nothing about entitlement — a drain, a rolling
+    # reboot, a device plugin restarting. Without a band those dips would mark
+    # budgets Degraded every time a rack was patched. Growth is always believed
+    # immediately; only shrinkage is damped.
+    #
+    # 0 disables damping, so the mark tracks every dip.
+    hysteresisPercent: 10
+
+  # materialize renders the tree into Kueue: a Cohort per internal node, a
+  # ClusterQueue per leaf, a LocalQueue in every bound namespace.
+  #
+  # Leaving coverResources empty disables it and drops the cluster-wide Kueue
+  # write RBAC with it, so a cluster can observe its quota tree long before it
+  # enforces one.
+  materialize:
+    # coverResources are the non-accelerator resources every rendered
+    # ClusterQueue funds alongside its budget.
+    #
+    # They exist because Kueue refuses to admit a workload whose request names a
+    # resource its queue does not cover, and every serving pod requests cpu and
+    # memory. A queue budgeted only for accelerators therefore admits nothing,
+    # and reports the reason nowhere: the queue exists, its LocalQueues resolve,
+    # and workloads simply stay pending.
+    #
+    # These are not a budget. They are a ceiling set high enough not to be one:
+    # the accelerator entry is what actually limits a tenant. Kueue has no
+    # "unlimited" value for a nominalQuota, and omitting a covered resource is
+    # precisely what makes a queue unable to admit, so a large finite number is
+    # the only idiom available.
+    #
+    # Sizing them is bounded on both sides, and neither bound fails loudly.
+    #
+    #   too low   a real limit on every tenant. Pods stay pending with nothing
+    #             in an error state to say why. Note that cpu suffixes bite:
+    #             9999m is ~10 cores, not 9999.
+    #   too high  Kueue holds these as int64 and a Cohort's subtree quota is the
+    #             SUM over its children, so N leaves each carrying the cover
+    #             must stay inside that. Overflow is not symmetric across
+    #             versions either: newer Kueue clamps, but the version this
+    #             repo compiles against wraps, and a wrapped ceiling means a
+    #             wrong admission decision rather than a failure.
+    #
+    # The units differ, which is easy to miss: cpu is held in MILLI-units, so
+    # its ceiling is a thousand times lower than memory's for the same digits.
+    #
+    # Scale to size against: one 4-chip TPU node is ~224 cpu and ~0.28Ti, so
+    #
+    #     32 nodes    7k cpu     0.01Pi
+    #   7500 nodes  1.68M cpu    2.07Pi
+    #
+    # The defaults are ~9x the 7500-node figure — unreachable in practice, and
+    # far enough from the ceiling that a Cohort can hold ~500 sibling leaves
+    # before the subtree sum is at risk.
+    #
+    # Override either key on its own; Helm merges the map, so setting cpu leaves
+    # memory at its default. Emptying the map disables materialization and drops
+    # the Kueue write RBAC with it.
+    coverResources:
+      cpu: 16M
+      memory: 16Pi
+
+    # fieldManager owns the applied Kueue objects and is the value of the
+    # managed-by label the orphan sweep selects by. Two quota managers pointed
+    # at one cluster MUST NOT share it, or each treats the other's objects as
+    # its own and they will fight. Empty uses the component name.
+    fieldManager: ""
+
+  # webhook serves admission validation for AcceleratorQuota, turning a
+  # tree-breaking write into a rejected kubectl apply instead of a Degraded
+  # condition minutes later.
+  #
+  # The ValidatingWebhookConfiguration is failurePolicy=Fail. That is safe here
+  # in a way it would not be for a pod webhook: it gates one cluster-scoped CRD
+  # that only capacity admins write, so an outage blocks quota edits, never
+  # serving pods.
+  webhook:
+    enabled: true
+    port: 9443
+    # internalCertManagement generates and rotates the serving cert in process
+    # and injects the caBundle itself, so the component works out of the box
+    # with NO cert-manager in the cluster — the same default Kueue ships.
+    #
+    # The cost, stated plainly: self-injection needs write access to this
+    # component's ValidatingWebhookConfiguration. The chart scopes update to
+    # that one object by name, and grants nothing on mutating webhooks, but
+    # list/watch on the kind cannot be narrowed — the rotator builds an
+    # unfiltered informer over it.
+    #
+    # Set false to have cert-manager supply the cert instead: the chart then
+    # renders an Issuer + Certificate and the inject-ca-from annotation, and
+    # drops the webhook-configuration RBAC entirely.
+    internalCertManagement: true
+    # A tree assembly is one uncached LIST plus in-memory work over a handful of
+    # nodes, so the default 10s is generous; it exists so a wedged apiserver
+    # rejects fast rather than hanging every quota write.
+    timeoutSeconds: 10
+
+  logLevel: info
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  podAnnotations: {}
+  podLabels: {}
+
+  # A single-replica install cannot satisfy a PDB, so it is off by default and
+  # only meaningful alongside replicaCount > 1.
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+
+  metricsPort: 8080
+  probePort: 8081
+
+  # Projecting the authored fleet tree onto workload clusters. Management mode
+  # only; a workload-mode manager holds no transport, which is what makes a
+  # projection unable to be re-projected.
+  #
+  # Off until origin and fieldManager are both set. Neither has a default, and
+  # deliberately so: an unmarked copy cannot be told from a node an admin
+  # authored on the member, so nothing could ever sweep it and the member's
+  # webhook would admit edits to it.
+  projection:
+    # Identity stamped on every copy this plane writes, and what its sweep
+    # selects on. Two planes projecting onto one member must not share it, or
+    # each will reap the other's work.
+    origin: ""
+
+    # Field manager owning what this plane applies on a member. Separate from
+    # the workload-mode fieldManager, which owns Kueue objects on a serving
+    # cluster: different objects, different clusters, and a shared name would
+    # make one plane's apply look like the other's.
+    fieldManager: ""
+
+    # Fallback split for a budget whose node declares no distribution:
+    # "Explicit" takes the admin's perCluster shares, "Proportional" divides by
+    # each member's reported capacity. Empty is not a policy -- such a budget is
+    # reported unresolved rather than split by a guess.
+    defaultDistributionPolicy: ""
+
+    # How a member's kubeconfig may authenticate. An exec plugin runs a binary
+    # from this process, so it is opt-in and the binary must be in this image;
+    # the alternative is a bearer token or client certificate inline in the
+    # kubeconfig. The allowlist is a second deliberate step, so enabling exec
+    # without naming a command still permits nothing.
+    execCredentials:
+      enabled: false
+      allowedCommands: []
+
+  # What a MANAGEMENT plane is allowed to do when it projects quota nodes onto
+  # this cluster. Install it on a workload cluster, alongside the workload-mode
+  # manager; a management plane has nothing to project onto itself, and a
+  # single-cluster install never needs it because the tree is authored locally.
+  #
+  # This grants PERMISSIONS. It does not decide how the management plane
+  # authenticates, which belongs to the platform: the transport accepts exec
+  # credential plugins (aws, gke-gcloud-auth-plugin and kubelogin are permitted
+  # by default), so a cloud workload identity needs no credential stored
+  # anywhere. Bind the role to whatever identity that produces via `subjects`.
+  #
+  # Separate from ome-multicluster-access on purpose. That is the placement
+  # plane's credential and can create workloads; this one can only write
+  # budgets. Neither should be able to do the other's job.
+  remoteAccess:
+    enabled: false
+    name: ome-quota-access
+
+    # Identities to bind the role to, beyond the ServiceAccount below. Use this
+    # for an identity your platform already issues and rotates — a cloud IAM
+    # principal, an OIDC subject, a client-certificate user:
+    #
+    #   subjects:
+    #   - kind: User
+    #     name: quota-projector@example.iam.gserviceaccount.com
+    #
+    # kind is User, Group or ServiceAccount; a ServiceAccount subject also needs
+    # a namespace.
+    subjects: []
+
+    serviceAccount:
+      # Create an in-cluster ServiceAccount of `name` and bind the role to it.
+      # Turn this off when `subjects` names an external identity instead.
+      create: true
+
+      # Also mint a ServiceAccount token Secret. It never expires, never
+      # rotates, and is readable by anyone who can read Secrets here, so it is
+      # off: it exists for simulators and for clusters predating TokenRequest.
+      #
+      # Without it, get a token with a lifetime when you need one:
+      #   kubectl -n <ns> create token ome-quota-access --duration=24h
+      staticToken: false

--- a/charts/ome-resources/README.md
+++ b/charts/ome-resources/README.md
@@ -25,26 +25,17 @@ OME Resources and Controller
 | modelAgent.resources.requests.memory | string | `"100Gi"` |  |
 | modelAgent.serviceAccountName | string | `"ome-model-agent"` |  |
 | modelAgent.tolerations | list | `[{"key":"nvidia.com/gpu","operator":"Exists","effect":"NoSchedule"}]` |  |
-| ome.benchmarkJob.cpuLimit | string | `"2"` |  |
-| ome.benchmarkJob.cpuRequest | string | `"2"` |  |
-| ome.benchmarkJob.image | string | `"genai-bench"` |  |
-| ome.benchmarkJob.memoryLimit | string | `"2Gi"` |  |
-| ome.benchmarkJob.memoryRequest | string | `"2Gi"` |  |
-| ome.benchmarkJob.tag | string | `"0.1.113"` |  |
 | ome.controller.affinity | object | `{}` |  |
 | ome.controller.deploymentMode | string | `"RawDeployment"` |  |
 | ome.controller.image | string | `"ome-manager"` |  |
 | ome.controller.ingressGateway.additionalIngressDomains | string | `nil` |  |
 | ome.controller.ingressGateway.disableIngressCreation | bool | `true` |  |
-| ome.controller.ingressGateway.disableIstioVirtualHost | bool | `false` |  |
 | ome.controller.ingressGateway.domain | string | `"svc.cluster.local"` |  |
 | ome.controller.ingressGateway.domainTemplate | string | `"{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"` |  |
 | ome.controller.ingressGateway.enableGatewayAPI | bool | `false` |  |
 | ome.controller.ingressGateway.ingressGateway.className | string | `"istio"` |  |
-| ome.controller.ingressGateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |
+| ome.controller.ingressGateway.ingressGateway.gateway | string | `"istio-system/ingress-gateway"` |  |
 | ome.controller.ingressGateway.ingressGateway.gatewayService | string | `"istio-ingressgateway.istio-system.svc.cluster.local"` |  |
-| ome.controller.ingressGateway.localGateway.gateway | string | `"knative-serving/knative-local-gateway"` |  |
-| ome.controller.ingressGateway.localGateway.gatewayService | string | `"knative-local-gateway.istio-system.svc.cluster.local"` |  |
 | ome.controller.ingressGateway.omeIngressGateway | string | `""` |  |
 | ome.controller.ingressGateway.pathTemplate | string | `""` |  |
 | ome.controller.ingressGateway.urlScheme | string | `"http"` |  |
@@ -64,6 +55,7 @@ OME Resources and Controller
 | ome.kedaConfig.scalingThreshold | string | `"10"` |  |
 | ome.metricsaggregator.enableMetricAggregation | string | `"false"` |  |
 | ome.metricsaggregator.enablePrometheusScraping | string | `"false"` |  |
+| ome.multiclusterAccess.enabled | bool | `true` | Install ServiceAccount, token Secret, and scoped RBAC for InferenceDeploymentOperator. |
 | ome.omeAgent.authType | string | `"InstancePrincipal"` |  |
 | ome.omeAgent.compartmentId | string | `"ocid1.compartment.oc1..dummy-compartment"` |  |
 | ome.omeAgent.fineTunedAdapter.cpuLimit | int | `15` |  |
@@ -79,3 +71,172 @@ OME Resources and Controller
 | ome.omeAgent.tag | string | `"v0.1.2"` |  |
 | ome.omeAgent.vaultId | string | `"ocid1.vault.oc1.ap-osaka-1.dummy.dummy-vault"` |  |
 | ome.version | string | `"v0.1.2"` |  |
+| prometheus.enabled | bool | `true` | Bundle a single-replica Prometheus for KEDA autoscaling input. See [Bundled Prometheus](#bundled-prometheus). |
+| prometheus.externalLabels | object | `{"cluster":"ome"}` | Labels identifying this Prometheus to remote-write, federation, and alerting consumers. |
+| prometheus.goMemLimit | string | `""` | Optional Go soft memory limit, for example `9GiB`; leave headroom below the container limit for mmap and other non-heap memory. |
+| prometheus.listenPort | int | `9090` | Internal Prometheus HTTP listen port. |
+| prometheus.metricRelabelConfigs | list | `[]` | Prometheus `metric_relabel_configs` for the InferenceService scrape job. |
+| prometheus.persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes for a chart-managed Prometheus PVC. |
+| prometheus.persistence.annotations | object | `{}` | Annotations for a chart-managed Prometheus PVC. |
+| prometheus.persistence.enabled | bool | `false` | Use a PVC instead of `emptyDir` for the TSDB. |
+| prometheus.persistence.existingClaim | string | `""` | Existing PVC to mount when persistence is enabled; empty creates `ome-prometheus`. |
+| prometheus.persistence.size | string | `"16Gi"` | Requested size for a chart-managed Prometheus PVC. |
+| prometheus.persistence.storageClassName | string | `""` | StorageClass for a chart-managed PVC; empty uses the cluster default. |
+| prometheus.query.maxConcurrency | int | `0` | Maximum concurrent PromQL queries; zero uses the Prometheus default. |
+| prometheus.query.maxSamples | int | `0` | Maximum samples a single query may load; zero uses the Prometheus default. |
+| prometheus.query.timeout | string | `""` | PromQL query timeout; empty uses the Prometheus default. |
+| prometheus.requireScrapeAnnotation | bool | `false` | Require an explicit scrape opt-in through `prometheus.io/scrape` or `ome.io/enable-prometheus-scraping`. |
+| prometheus.retention | string | `"30m"` | Persisted-block retention window. It does not bound the mutable head/WAL. |
+| prometheus.retentionSize | string | `"6GB"` | TSDB size-retention guard. Keep below 80-85% of the selected volume capacity; empty disables it. |
+| prometheus.scrapeInterval | string | `"15s"` |  |
+| prometheus.scrapeLimits.bodySizeLimit | string | `""` | Maximum uncompressed response body accepted per InferenceService scrape; empty disables it. |
+| prometheus.scrapeLimits.keepDroppedTargets | int | `0` | Maximum dropped InferenceService targets retained in memory; zero uses the Prometheus default. |
+| prometheus.scrapeLimits.labelLimit | int | `0` | Maximum labels accepted per scraped sample; zero disables it. |
+| prometheus.scrapeLimits.labelNameLengthLimit | int | `0` | Maximum scraped label-name length; zero disables it. |
+| prometheus.scrapeLimits.labelValueLengthLimit | int | `0` | Maximum scraped label-value length; zero disables it. |
+| prometheus.scrapeLimits.sampleLimit | int | `0` | Maximum samples accepted from one InferenceService target per scrape; zero disables it. |
+| prometheus.scrapeLimits.targetLimit | int | `0` | Maximum active targets allowed in the InferenceService scrape pool; zero disables it. |
+| prometheus.scrapeNamespaces | list | `[]` | Namespaces in which to discover InferenceService pods; empty discovers them cluster-wide. |
+| prometheus.scrapeTimeout | string | `"10s"` | Per-target scrape timeout. |
+| prometheus.selfScrape.enabled | bool | `true` | Scrape Prometheus process and TSDB metrics for capacity planning. |
+| prometheus.image.repository | string | `"prom/prometheus"` |  |
+| prometheus.image.tag | string | `"v3.0.1"` |  |
+| prometheus.resources.limits.cpu | string | `"500m"` |  |
+| prometheus.resources.limits.memory | string | `"3Gi"` | Sized for a moderate fleet (~500 ISVC pods); larger fleets should scope `scrapeNamespaces` and/or trim scraped metrics. |
+| prometheus.resources.requests.cpu | string | `"100m"` |  |
+| prometheus.resources.requests.memory | string | `"512Mi"` |  |
+| prometheus.service.port | int | `9090` |  |
+| prometheus.service.type | string | `"ClusterIP"` |  |
+| prometheus.storage.sizeLimit | string | `"8Gi"` | emptyDir size cap. Covers active head, WAL, and compaction overlap for a moderate high-cardinality inference fleet. |
+
+## Bundled Prometheus
+
+The chart enables a single-replica Prometheus alongside the controller by
+default. It exists for one purpose: to be the metrics source that KEDA
+`prometheus` triggers point at when an InferenceService's
+[OEP-0013][oep-0013] autoscaler asks for one.
+
+Keep it enabled when your cluster does not already run a Prometheus that
+scrapes OME pods. Operators with an existing cluster Prometheus should disable
+the bundled instance and configure their KEDA triggers' `serverAddress` to
+point at the existing instance.
+
+```sh
+helm upgrade ome-resources ./charts/ome-resources \
+  --set prometheus.enabled=false
+```
+
+KEDA triggers then address it via the cluster-local Service DNS:
+
+```yaml
+trigger:
+  type: prometheus
+  metadata:
+    serverAddress: http://ome-prometheus.<release-namespace>.svc:9090
+    query: <your-promql>
+```
+
+**What it is NOT**: this bundled Prometheus is not a long-term
+observability install. Defaults reflect that explicitly:
+
+- Single replica, no HA.
+- Non-durable `emptyDir` storage by default; replacement pods start with an
+  empty TSDB. Set `prometheus.persistence.enabled=true` and optionally provide
+  `prometheus.persistence.existingClaim` when history must survive replacement.
+- 8 GiB default `emptyDir` cap (`prometheus.storage.sizeLimit`) to accommodate
+  active head, WAL, and compaction overlap; override it for the fleet's actual
+  series count and ingestion rate.
+- 30 minute time retention (`prometheus.retention`) for persisted blocks,
+  sized to KEDA query windows rather than dashboards or alerts. Prometheus's
+  mutable head and WAL can span its two-hour production block duration, so
+  time retention alone is not a disk bound.
+- 6 GB size retention (`prometheus.retentionSize`) below the 8 GiB
+  `emptyDir` cap. Prometheus counts the head/WAL toward this policy but cannot
+  delete them; large fleets must also increase `prometheus.storage.sizeLimit`
+  or reduce scrape cardinality/rate.
+- No Alertmanager, no recording rules, no `remote_write`.
+- Discovers OME-owned pods through the `ome.io/inferenceservice` label. Set
+  `prometheus.requireScrapeAnnotation=true` on large or shared clusters to
+  require `prometheus.io/scrape: "true"` or
+  `ome.io/enable-prometheus-scraping: "true"`. An explicit
+  `prometheus.io/scrape: "false"` takes precedence.
+- Exposes optional limits for each InferenceService scrape, the target pool,
+  and PromQL query execution.
+
+Large clusters should enable the guards explicitly:
+
+```yaml
+prometheus:
+  requireScrapeAnnotation: true
+  scrapeLimits:
+    sampleLimit: 10000
+    targetLimit: 5000
+    labelLimit: 100
+    labelNameLengthLimit: 128
+    labelValueLengthLimit: 2048
+    bodySizeLimit: 50MB
+    keepDroppedTargets: 100
+  query:
+    maxConcurrency: 8
+    maxSamples: 10000000
+    timeout: 30s
+```
+
+Prometheus fails the scrape pool when `targetLimit` is exceeded, so choose it
+above the observed post-relabel target count and alert before that threshold.
+
+Use `prometheus.metricRelabelConfigs` to retain only metrics referenced by
+autoscaling and canary PromQL. For example:
+
+```yaml
+prometheus:
+  metricRelabelConfigs:
+    - source_labels: [__name__]
+      regex: "http_requests_total|request_queue_size"
+      action: keep
+```
+
+Size memory from active series rather than retention:
+
+```text
+projected series = expected targets × measured series per target
+memory limit     = 1.3 × (1 GiB + projected series × 4 KiB) + query headroom
+```
+
+After deployment, replace the planning estimate with observed peaks from
+`prometheus_tsdb_head_series` and container working-set memory. Size the
+request above the normal P95 and the limit above both the P99 and WAL-replay
+peak. Time retention below Prometheus's roughly two-hour mutable head window
+primarily changes persisted-block disk, not steady-state head memory.
+
+Estimate retained block storage as `samples/sec × retention seconds × 1.5–2
+bytes/sample`, then add the measured head and WAL footprint plus 30–50%
+compaction headroom. Keep `retentionSize` below 80–85% of the volume size.
+
+Enabling persistence replaces `emptyDir` with a fresh claim; it does not migrate
+existing data. A chart-managed claim follows the Helm release lifecycle. Use an
+existing claim when storage must remain independently managed, and fix memory
+and cardinality limits before preserving a WAL that cannot be replayed.
+
+For long-term observability, deploy a separate full Prometheus stack
+(kube-prometheus-stack, etc.) and leave `prometheus.enabled=false`.
+
+[oep-0013]: ../../oeps/0013-autoscaling/README.md
+
+## Multicluster Access
+
+`ome.multiclusterAccess.enabled=true` installs a ServiceAccount and long-lived
+token Secret that a control-plane InferenceDeploymentOperator can use to manage
+OME resources in this workload cluster. The RBAC is scoped to writing derived
+`InferenceService` resources, plus read-only access to the `InferenceReplica`,
+`ClusterServingRuntime`, `Pod` and `PodGroup` resources the control plane reads
+to observe admission. Placement stalls in `Racing` without the
+`InferenceReplica` read: the per-component IR status is the admission signal
+that selects a winner.
+
+## Default Runtime
+
+The chart always installs `ClusterServingRuntime/default-runtime`.
+InferenceDeploymentOperator-generated `InferenceService` resources reference
+this runtime and supply only per-deployment overrides such as image, checkpoint,
+resources, env, args, and replica envelopes.

--- a/charts/ome-resources/templates/_helpers.tpl
+++ b/charts/ome-resources/templates/_helpers.tpl
@@ -18,6 +18,47 @@ Parameters:
 {{- end }}
 
 {{/*
+Chart name and version, suitable for use as a Kubernetes label value.
+*/}}
+{{- define "ome.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common chart provenance labels. Keep these out of selectors so a chart or app
+version change does not make an existing workload selector immutable.
+*/}}
+{{- define "ome.labels" -}}
+helm.sh/chart: {{ include "ome.chart" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ome
+{{- end -}}
+
+{{/*
+Selector labels for the bundled Prometheus (Deployment + Service
+selector). Kept minimal so they stay stable across re-renders.
+*/}}
+{{- define "ome-prometheus.selectorLabels" -}}
+app.kubernetes.io/name: ome-prometheus
+app.kubernetes.io/component: ome-prometheus
+{{- end }}
+
+{{/*
+Full label set stamped on bundled Prometheus resources. Mirrors the
+selector labels and folds in operator-supplied
+.Values.prometheus.additionalLabels.
+*/}}
+{{- define "ome-prometheus.labels" -}}
+{{ include "ome-prometheus.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ome
+{{- with .Values.prometheus.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Instance-type -> short-name map as a compact JSON string.
 Single source of truth (.Values.modelAgent.instanceTypeMap) rendered into both
 the model-agent ConfigMap (instance-type-map key) and the enigma init

--- a/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
@@ -5,7 +5,33 @@ metadata:
   name: model-agent-config-map
   namespace: {{ .Release.Namespace }}
 data:
-  # Instance-type -> short-name map. Source of truth: values.yaml
-  # modelAgent.instanceTypeMap (rendered via the ome.instanceTypeMap helper).
-  instance-type-map: {{ include "ome.instanceTypeMap" . | quote }}
+  # Instance type mappings for various cloud providers:
+  # - Oracle Cloud (OCI) shapes
+  # - AWS instance types
+  # - Azure instance types
+  # - Google Cloud instance types
+  # - CoreWeave instance types
+  # - Nebius instance types
+  instance-type-map: |-
+    {
+      "BM.GPU.A10.4": "A10",
+      "BM.GPU.A100-v2.8": "A100-80G",
+      "BM.GPU4.8": "A100-40G",
+      "BM.GPU.B4.8": "A100-40G",
+      "BM.GPU.H100.8": "H100",
+      "BM.GPU.H100-NC.8": "H100",
+      "BM.GPU.H200.8": "H200",
+      "BM.GPU.H200-NC.8": "H200",
+      "BM.GPU.B200.8": "B200",
+      "p5.48xlarge": "H100",
+      "Standard_ND96isr_H100_v5": "H100",
+      "a3-highgpu-8g": "H100",
+      "gd-8xh100ib-i128": "H100",
+      "gd-8xh200ib-i128": "H200",
+      "gd-8xl40-i128": "L40",
+      "gpu-h100-sxm": "H100",
+      "gpu-h200-sxm": "H200",
+      "gpu-b200-sxm": "B200",
+      "gpu-l40s": "L40S"
+    }
 {{- end }}

--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -4,6 +4,9 @@ kind: DaemonSet
 metadata:
   name: ome-model-agent-daemonset
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "ome-model-agent-daemonset"
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -19,6 +22,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.modelAgent.health.port }}"
         prometheus.io/path: "/metrics"
+        {{- with .Values.modelAgent.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: {{ .Values.modelAgent.priorityClassName }}
       serviceAccountName: {{ .Values.modelAgent.serviceAccountName }}

--- a/charts/ome-resources/templates/model-agent-daemonset/podmonitor.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/podmonitor.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.podMonitor.enabled }}
+# model-agent runs as a DaemonSet with no fronting Service (it's a
+# node-local daemon, not addressed via cluster DNS), so PodMonitor is
+# the right scrape primitive — ServiceMonitor would need a synthetic
+# Service that serves no other purpose.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ome-model-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: ome-model-agent-daemonset
+    {{- with .Values.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ome-model-agent-daemonset
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.podMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout | default "10s" }}
+      {{- with .Values.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ome-resources/templates/ome-controller/configmap.yaml
+++ b/charts/ome-resources/templates/ome-controller/configmap.yaml
@@ -8,16 +8,17 @@ metadata:
 data:
   ingress: |-
     {
+        "disableIstioVirtualHost": {{ .Values.ome.controller.ingressGateway.disableIstioVirtualHost }},
         "ingressGateway" : "{{ .Values.ome.controller.ingressGateway.ingressGateway.gateway }}",
         "ingressService" : "{{ .Values.ome.controller.ingressGateway.ingressGateway.gatewayService }}",
         "omeIngressGateway" : "{{ .Values.ome.controller.ingressGateway.omeIngressGateway | default "" }}",
         "omeIngressGatewayClass" : "{{ .Values.ome.controller.ingressGateway.omeIngressGatewayClass | default "" }}",
+        "consistentHashHeaders": {{ .Values.ome.controller.ingressGateway.consistentHashHeaders | default list | toJson }},
         "ingressDomain"  : "{{ .Values.ome.controller.ingressGateway.domain }}",
         "ingressClassName" : "{{ .Values.ome.controller.ingressGateway.ingressGateway.className }}",
         "additionalIngressDomains" : {{ .Values.ome.controller.ingressGateway.additionalIngressDomains | default "null" }},
         "domainTemplate": "{{ .Values.ome.controller.ingressGateway.domainTemplate }}",
         "urlScheme": "{{ .Values.ome.controller.ingressGateway.urlScheme }}",
-        "disableIstioVirtualHost": {{ .Values.ome.controller.ingressGateway.disableIstioVirtualHost }},
         "pathTemplate": "{{ .Values.ome.controller.ingressGateway.pathTemplate | default "" }}",
         "disableIngressCreation": {{ .Values.ome.controller.ingressGateway.disableIngressCreation | default false }},
         "enableGatewayAPI": {{ .Values.ome.controller.ingressGateway.enableGatewayAPI | default false }},
@@ -31,23 +32,113 @@ data:
     }
   deploy: |-
     {
-      "defaultDeploymentMode": "{{ .Values.ome.controller.deploymentMode }}"
+      "defaultDeploymentMode": "{{ .Values.ome.controller.deploymentMode }}"{{- with .Values.ome.controller.replicas }},
+      "replicas": {{ toJson . }}{{- end }}
+    }
+{{- with .Values.ome.controller.podDisruptionBudget }}
+  podDisruptionBudget: |-
+    {{- toJson . | nindent 4 }}
+{{- end }}
+
+  canaryAnalysis: |-
+    {
+      "bundledPrometheusAddress": "{{ .Values.ome.controller.canaryAnalysis.bundledPrometheusAddress | default (printf "http://ome-prometheus.%s.svc:%v" .Release.Namespace .Values.prometheus.service.port) }}",
+      "queryTimeout": "{{ .Values.ome.controller.canaryAnalysis.queryTimeout | default "5s" }}",
+      "maxConcurrency": {{ .Values.ome.controller.canaryAnalysis.maxConcurrency | default 8 }},
+      "cacheTTL": "{{ .Values.ome.controller.canaryAnalysis.cacheTTL | default "2m" }}"
     }
 
-  modelInit: |-
+  coordination: |-
     {
-        "image":  "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",
-        "memoryRequest": "{{ .Values.ome.omeAgent.modelInit.memoryRequest }}",
-        "memoryLimit": "{{ .Values.ome.omeAgent.modelInit.memoryLimit }}",
-        "cpuRequest": "{{ .Values.ome.omeAgent.modelInit.cpuRequest }}",
-        "cpuLimit": "{{ .Values.ome.omeAgent.modelInit.cpuLimit }}",
-        "compartmentId": "{{ .Values.ome.omeAgent.compartmentId }}",
-        "authType" : "{{ .Values.ome.omeAgent.authType }}",
-        "vaultId": "{{ .Values.ome.omeAgent.vaultId }}",
-        "region": "{{ .Values.ome.omeAgent.region }}",
-        "extraEnvVars": {{ concat (.Values.ome.omeAgent.modelInit.extraEnvVars | default list) (list (dict "name" "INSTANCE_TYPE_MAP" "value" $instanceTypeMap)) | toJson }},
-        "extraVolumeMounts": {{ toJson .Values.ome.omeAgent.modelInit.extraVolumeMounts }}
+      "trafficWeightDeadbandPercent": {{ .Values.ome.controller.coordination.trafficWeightDeadbandPercent | default 0 }}{{- if hasKey .Values.ome.controller.coordination "defaultRatioTolerancePercent" }},
+      "defaultRatioTolerancePercent": {{ .Values.ome.controller.coordination.defaultRatioTolerancePercent }}{{- end }}
     }
+
+  {{- with .Values.ome.controller.lifecycle }}
+  {{- $fields := list }}
+  {{- if hasKey . "scaleUpPodBatchSize" }}
+  {{- $fields = append $fields (dict "scaleUpPodBatchSize" .scaleUpPodBatchSize) }}
+  {{- end }}
+  {{- if hasKey . "scaleDownPodBatchSize" }}
+  {{- $fields = append $fields (dict "scaleDownPodBatchSize" .scaleDownPodBatchSize) }}
+  {{- end }}
+  {{- if hasKey . "scaleDownRequeueInterval" }}
+  {{- $fields = append $fields (dict "scaleDownRequeueInterval" .scaleDownRequeueInterval) }}
+  {{- end }}
+  {{- if hasKey . "revisionHistoryLimit" }}
+  {{- $fields = append $fields (dict "revisionHistoryLimit" .revisionHistoryLimit) }}
+  {{- end }}
+  {{- with .updateRetry }}
+  {{- $fields = append $fields (dict "updateRetry" (dict "maxAttempts" .maxAttempts "initialDelay" .initialDelay "maxDelay" .maxDelay "multiplier" .multiplier)) }}
+  {{- end }}
+  {{- with .stuckPodGracePeriod }}
+  {{- $fields = append $fields (dict "stuckPodGracePeriod" .) }}
+  {{- end }}
+  {{- with .autoMigrate }}
+  {{- $fields = append $fields (dict "autoMigrate" (dict "maxAttempts" .maxAttempts)) }}
+  {{- end }}
+  {{- with .forceDelete }}
+  {{- $fields = append $fields (dict "forceDelete" (dict "overdueSlack" .overdueSlack "nodeUnreachableThreshold" .nodeUnreachableThreshold)) }}
+  {{- end }}
+  {{- with .teardown }}
+  {{- $fields = append $fields (dict "teardown" (dict "deadline" .deadline)) }}
+  {{- end }}
+  {{- if $fields }}
+  lifecycle: |-
+    {{- $merged := dict }}
+    {{- range $fields }}
+    {{- $merged = merge $merged . }}
+    {{- end }}
+    {{ $merged | toJson | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
+  multicluster: |-
+    {
+      "workloadCluster": {
+        "clientQPS": {{ .Values.ome.multicluster.config.workloadCluster.clientQPS | default 0 }},
+        "clientBurst": {{ .Values.ome.multicluster.config.workloadCluster.clientBurst | default 0 }},
+        "perCallTimeout": "{{ .Values.ome.multicluster.config.workloadCluster.perCallTimeout | default "" }}",
+        "cacheEnabled": {{ .Values.ome.multicluster.config.workloadCluster.cacheEnabled | default false }},
+        "healthInterval": "{{ .Values.ome.multicluster.config.workloadCluster.healthInterval | default "" }}",
+        "connectionGrace": "{{ .Values.ome.multicluster.config.workloadCluster.connectionGrace | default "" }}",
+        "eventsBatchPeriod": "{{ .Values.ome.multicluster.config.workloadCluster.eventsBatchPeriod | default "" }}",
+        "establishInitial": "{{ .Values.ome.multicluster.config.workloadCluster.establishInitial | default "" }}",
+        "establishMax": "{{ .Values.ome.multicluster.config.workloadCluster.establishMax | default "" }}",
+        "reconnectRetryMax": "{{ .Values.ome.multicluster.config.workloadCluster.reconnectRetryMax | default "" }}",
+        "funnelResyncInterval": "{{ .Values.ome.multicluster.config.workloadCluster.funnelResyncInterval | default "" }}",
+        "funnelBufferSize": {{ .Values.ome.multicluster.config.workloadCluster.funnelBufferSize | default 0 }}
+      },
+      "placement": {
+        "requeueInterval": "{{ .Values.ome.multicluster.config.placement.requeueInterval | default "" }}",
+        "gcInterval": "{{ .Values.ome.multicluster.config.placement.gcInterval | default "" }}",
+        "maxConcurrentReconciles": {{ .Values.ome.multicluster.config.placement.maxConcurrentReconciles | default 0 }},
+        "fanoutTimeout": "{{ .Values.ome.multicluster.config.placement.fanoutTimeout | default "" }}",
+        "winnerLostGrace": "{{ .Values.ome.multicluster.config.placement.winnerLostGrace | default "" }}",
+        "statusBatchPeriod": "{{ .Values.ome.multicluster.config.placement.statusBatchPeriod | default "" }}",
+        "statusSafetyRequeue": "{{ .Values.ome.multicluster.config.placement.statusSafetyRequeue | default "" }}",
+        "dispatcherMode": "{{ .Values.ome.multicluster.config.placement.dispatcherMode | default "" }}",
+        "dispatcherStepSize": {{ .Values.ome.multicluster.config.placement.dispatcherStepSize | default 0 }},
+        "dispatcherRoundTimeout": "{{ .Values.ome.multicluster.config.placement.dispatcherRoundTimeout | default "" }}",
+        "localQueue": "{{ .Values.ome.multicluster.config.placement.localQueue | default "" }}"
+      },
+      "endpoint": {
+        "globalHostTemplate": "{{ .Values.ome.multicluster.config.endpoint.globalHostTemplate | default "" }}",
+        "globalGateway": "{{ .Values.ome.multicluster.config.endpoint.globalGateway | default "" }}",
+        "routeNamespace": "{{ .Values.ome.multicluster.config.endpoint.routeNamespace | default "" }}",
+        "backendPort": {{ .Values.ome.multicluster.config.endpoint.backendPort | default 0 }}
+      }
+    }
+
+  metricsAggregator: |-
+    {
+      "enableMetricAggregation": "{{ .Values.ome.metricsaggregator.enableMetricAggregation }}",
+      "enablePrometheusScraping" : "{{ .Values.ome.metricsaggregator.enablePrometheusScraping }}"
+    }
+{{- if .Values.ome.podMonitor }}
+  podMonitor: |-
+    {{- toJson .Values.ome.podMonitor | nindent 4 }}
+{{- end }}
   servingSidecar: |-
     {
         "image": "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",
@@ -81,6 +172,46 @@ data:
       "customPromQuery": "{{ .Values.ome.kedaConfig.customPromQuery | default "" }}",
       "scalingThreshold": "{{ .Values.ome.kedaConfig.scalingThreshold | default "10" }}",
       "scalingOperator": "{{ .Values.ome.kedaConfig.scalingOperator | default "GreaterThanOrEqual" }}"
+    }
+  modelInit: |-
+    {
+        "image":  "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",
+        "memoryRequest": "{{ .Values.ome.omeAgent.modelInit.memoryRequest }}",
+        "memoryLimit": "{{ .Values.ome.omeAgent.modelInit.memoryLimit }}",
+        "cpuRequest": "{{ .Values.ome.omeAgent.modelInit.cpuRequest }}",
+        "cpuLimit": "{{ .Values.ome.omeAgent.modelInit.cpuLimit }}",
+        "compartmentId": "{{ .Values.ome.omeAgent.compartmentId }}",
+        "authType" : "{{ .Values.ome.omeAgent.authType }}",
+        "vaultId": "{{ .Values.ome.omeAgent.vaultId }}",
+        "region": "{{ .Values.ome.omeAgent.region }}",
+        "extraEnvVars": {{ concat (.Values.ome.omeAgent.modelInit.extraEnvVars | default list) (list (dict "name" "INSTANCE_TYPE_MAP" "value" $instanceTypeMap)) | toJson }},
+        "extraVolumeMounts": {{ toJson .Values.ome.omeAgent.modelInit.extraVolumeMounts }}
+    }
+  omeAgent: |-
+    {
+        "image": "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",
+        "serviceAccount": "{{ .Values.ome.omeAgent.metadataJob.serviceAccount }}",
+        "memoryRequest": "{{ .Values.ome.omeAgent.metadataJob.memoryRequest }}",
+        "memoryLimit": "{{ .Values.ome.omeAgent.metadataJob.memoryLimit }}",
+        "cpuRequest": "{{ .Values.ome.omeAgent.metadataJob.cpuRequest }}",
+        "cpuLimit": "{{ .Values.ome.omeAgent.metadataJob.cpuLimit }}",
+        "backoffLimit": {{ .Values.ome.omeAgent.metadataJob.backoffLimit | default 2 }},
+        "ttlSecondsAfterFinished": {{ .Values.ome.omeAgent.metadataJob.ttlSecondsAfterFinished | default 3600 }},
+        "nodeSelector": {{ .Values.ome.omeAgent.metadataJob.nodeSelector | default dict | toJson }},
+        "tolerations": {{ .Values.ome.omeAgent.metadataJob.tolerations | default list | toJson }},
+        "affinity": {{ .Values.ome.omeAgent.metadataJob.affinity | default dict | toJson }},
+        "priorityClassName": "{{ .Values.ome.omeAgent.metadataJob.priorityClassName | default "" }}"
+    }
+  servingSidecar: |-
+    {
+        "image": "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",
+        "memoryRequest": "2Gi",
+        "memoryLimit": "4Gi",
+        "cpuRequest": "1",
+        "cpuLimit": "2",
+        "compartmentId": "{{ .Values.ome.omeAgent.compartmentId }}",
+        "authType" : "{{ .Values.ome.omeAgent.authType }}",
+        "region": "{{ .Values.ome.omeAgent.region }}"
     }
 ---
 apiVersion: v1

--- a/charts/ome-resources/templates/ome-controller/default-runtime.yaml
+++ b/charts/ome-resources/templates/ome-controller/default-runtime.yaml
@@ -1,0 +1,178 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: default-runtime
+  labels:
+    app.kubernetes.io/name: default-runtime
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/part-of: ome
+    ome.io/component: default-runtime
+spec:
+  disabled: false
+  decoderConfig:
+    annotations:
+      fb.metric.schema: sglang_metrics
+      k8s.v1.cni.cncf.io/networks: '[{"name":"ibs0p0-macvlan","namespace":"cw-multus"},{"name":"ibs0p1-macvlan","namespace":"cw-multus"},{"name":"ibs0p2-macvlan","namespace":"cw-multus"},{"name":"ibs0p3-macvlan","namespace":"cw-multus"},{"name":"ibs1p0-macvlan","namespace":"cw-multus"},{"name":"ibs1p1-macvlan","namespace":"cw-multus"},{"name":"ibs1p2-macvlan","namespace":"cw-multus"},{"name":"ibs1p3-macvlan","namespace":"cw-multus"},{"name":"ibs2p0-macvlan","namespace":"cw-multus"},{"name":"ibs2p1-macvlan","namespace":"cw-multus"},{"name":"ibs2p2-macvlan","namespace":"cw-multus"},{"name":"ibs2p3-macvlan","namespace":"cw-multus"},{"name":"ibs3p0-macvlan","namespace":"cw-multus"},{"name":"ibs3p1-macvlan","namespace":"cw-multus"},{"name":"ibs3p2-macvlan","namespace":"cw-multus"},{"name":"ibs3p3-macvlan","namespace":"cw-multus"}]'
+    nodeSelector:
+      kubernetes.io/arch: arm64
+    runner:
+      name: worker
+      ports:
+        - containerPort: 30000
+          name: http
+          protocol: TCP
+        - containerPort: 8998
+          name: bootstrap
+          protocol: TCP
+      securityContext:
+        capabilities:
+          add:
+            - IPC_LOCK
+            - SYS_PTRACE
+        privileged: true
+      readinessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /health
+          port: 30000
+        initialDelaySeconds: 120
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 30000
+        periodSeconds: 30
+        timeoutSeconds: 30
+      livenessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /health
+          port: 30000
+        periodSeconds: 60
+        timeoutSeconds: 30
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /tmp
+          name: tmp-storage
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 940Gi
+        name: dshm
+      - emptyDir: {}
+        name: tmp-storage
+  engineConfig:
+    annotations:
+      fb.metric.schema: sglang_metrics
+      k8s.v1.cni.cncf.io/networks: '[{"name":"ibs0p0-macvlan","namespace":"cw-multus"},{"name":"ibs0p1-macvlan","namespace":"cw-multus"},{"name":"ibs0p2-macvlan","namespace":"cw-multus"},{"name":"ibs0p3-macvlan","namespace":"cw-multus"},{"name":"ibs1p0-macvlan","namespace":"cw-multus"},{"name":"ibs1p1-macvlan","namespace":"cw-multus"},{"name":"ibs1p2-macvlan","namespace":"cw-multus"},{"name":"ibs1p3-macvlan","namespace":"cw-multus"},{"name":"ibs2p0-macvlan","namespace":"cw-multus"},{"name":"ibs2p1-macvlan","namespace":"cw-multus"},{"name":"ibs2p2-macvlan","namespace":"cw-multus"},{"name":"ibs2p3-macvlan","namespace":"cw-multus"},{"name":"ibs3p0-macvlan","namespace":"cw-multus"},{"name":"ibs3p1-macvlan","namespace":"cw-multus"},{"name":"ibs3p2-macvlan","namespace":"cw-multus"},{"name":"ibs3p3-macvlan","namespace":"cw-multus"}]'
+    nodeSelector:
+      kubernetes.io/arch: arm64
+    runner:
+      name: worker
+      ports:
+        - containerPort: 30000
+          name: http
+          protocol: TCP
+        - containerPort: 8998
+          name: bootstrap
+          protocol: TCP
+      securityContext:
+        capabilities:
+          add:
+            - IPC_LOCK
+            - SYS_PTRACE
+        privileged: true
+      readinessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /health
+          port: 30000
+        initialDelaySeconds: 120
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 30000
+        periodSeconds: 30
+        timeoutSeconds: 30
+      livenessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /health
+          port: 30000
+        periodSeconds: 60
+        timeoutSeconds: 30
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /tmp
+          name: tmp-storage
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 940Gi
+        name: dshm
+      - emptyDir: {}
+        name: tmp-storage
+  routerConfig:
+    annotations:
+      fb.metric.schema: sglang_metrics
+    runner:
+      name: router
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      livenessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /liveness
+          port: 30080
+        periodSeconds: 30
+        timeoutSeconds: 10
+      ports:
+        - containerPort: 30080
+          name: http
+          protocol: TCP
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+      readinessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /readiness
+          port: 30080
+        periodSeconds: 30
+        timeoutSeconds: 10
+      resources:
+        limits:
+          cpu: "32"
+          memory: 32Gi
+        requests:
+          cpu: "16"
+          memory: 16Gi
+      startupProbe:
+        failureThreshold: 30
+        httpGet:
+          path: /readiness
+          port: 30080
+        periodSeconds: 20
+        timeoutSeconds: 10

--- a/charts/ome-resources/templates/ome-controller/deployment.yaml
+++ b/charts/ome-resources/templates/ome-controller/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: ome-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "ome.labels" . | nindent 4 }}
     control-plane: ome-controller-manager
     controller-tools.k8s.io: "1.0"
   annotations:
@@ -22,10 +23,14 @@ spec:
         controller-tools.k8s.io: "1.0"
         logging-forward: enabled
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ome-controller/configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: manager
         prometheus.io/scrape: 'true'
         prometheus.io/path: '/metrics'
         prometheus.io/port: '8080'
+        {{- with .Values.ome.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: ome-controller-manager
       {{- with .Values.ome.controller.nodeSelector }}
@@ -60,6 +65,34 @@ spec:
         - "--leader-elect"
         - "--webhook"
         - "--zap-encoder=console"
+        {{- if .Values.ome.controller.inferenceServiceMaxConcurrentReconciles }}
+        - "--inferenceservice-max-concurrent-reconciles={{ .Values.ome.controller.inferenceServiceMaxConcurrentReconciles }}"
+        {{- end }}
+        {{- if .Values.ome.controller.inferenceReplicaMaxConcurrentReconciles }}
+        - "--inferencereplica-max-concurrent-reconciles={{ .Values.ome.controller.inferenceReplicaMaxConcurrentReconciles }}"
+        {{- end }}
+        {{- if .Values.ome.controller.configCacheTTL }}
+        - "--config-cache-ttl={{ .Values.ome.controller.configCacheTTL }}"
+        {{- end }}
+        {{- if .Values.ome.controller.kubeAPIQPS }}
+        - "--kube-api-qps={{ .Values.ome.controller.kubeAPIQPS }}"
+        {{- end }}
+        {{- if .Values.ome.controller.kubeAPIBurst }}
+        - "--kube-api-burst={{ .Values.ome.controller.kubeAPIBurst }}"
+        {{- end }}
+        {{- if .Values.ome.multicluster.enabled }}
+        - "--enable-multicluster"
+        {{- if .Values.ome.multicluster.role }}
+        - "--multicluster-role={{ .Values.ome.multicluster.role }}"
+        {{- end }}
+        {{- if .Values.ome.multicluster.execCredentials.enabled }}
+        - "--allow-exec-credentials"
+        - "--exec-credential-allowed-commands={{ .Values.ome.multicluster.execCredentials.allowedCommands }}"
+        {{- end }}
+        {{- with .Values.ome.multicluster.placementControlPlaneID }}
+        - "--placement-control-plane-id={{ . }}"
+        {{- end }}
+        {{- end }}
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/charts/ome-resources/templates/ome-controller/rbac/multicluster_access.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/multicluster_access.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.ome.multiclusterAccess.enabled }}
+{{- $serviceAccountName := "ome-multicluster-access" }}
+{{- $tokenSecretName := "ome-multicluster-access-token" }}
+{{- $clusterRoleName := "ome-multicluster-access" }}
+{{- $clusterRoleBindingName := "ome-multicluster-access" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $serviceAccountName | quote }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceAccountName | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/part-of: ome
+    ome.io/component: multicluster-access
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $tokenSecretName | quote }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceAccountName | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/part-of: ome
+    ome.io/component: multicluster-access
+  annotations:
+    kubernetes.io/service-account.name: {{ $serviceAccountName | quote }}
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $clusterRoleName | quote }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceAccountName | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/part-of: ome
+    ome.io/component: multicluster-access
+rules:
+# Derived InferenceServices: the control plane fans these out onto the
+# workload cluster, observes their admission status, and reaps losers.
+- apiGroups:
+  - ome.io
+  resources:
+  - inferenceservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# InferenceReplicas: read-only. The per-component IR status on the workload
+# cluster is the authoritative admission signal the placement controller reads
+# to select a winner and to count admitted replicas per home; the derived
+# ISVC's status does not carry it. IRs are projected by the workload cluster's
+# own reconciler, so the control plane never writes them.
+- apiGroups:
+  - ome.io
+  resources:
+  - inferencereplicas
+  verbs:
+  - get
+  - list
+  - watch
+# ClusterServingRuntimes: read-only. The control plane never writes runtimes
+# on workload clusters (those are managed per-cluster via GitOps); it only
+# reads them for runtime context. Write verbs were over-broad blast radius.
+- apiGroups:
+  - ome.io
+  resources:
+  - clusterservingruntimes
+  verbs:
+  - get
+  - list
+  - watch
+# Pods: read-only, needed so the placement controller can observe admission
+# on the workload cluster directly (pods released from / held by a scheduling
+# gate) instead of only trusting the mirrored derived-ISVC status.
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+# PodGroups (scheduler-plugins coscheduling): read-only, for gang-admission
+# observation. Optional CRD — absent on clusters without scheduler-plugins,
+# where this rule is simply inert.
+- apiGroups:
+  - scheduling.x-k8s.io
+  resources:
+  - podgroups
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $clusterRoleBindingName | quote }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceAccountName | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/part-of: ome
+    ome.io/component: multicluster-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $clusterRoleName | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $serviceAccountName | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/ome-resources/templates/ome-controller/rbac/supplemental_view_role.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/supplemental_view_role.yaml
@@ -1,0 +1,31 @@
+---
+# Supplemental read-only access aggregated into the built-in `view` ClusterRole,
+# covering the resources `view` misses but the read-plane needs:
+#
+#   * all ome.io CRDs (InferenceService, BaseModel, ServingRuntime, InferenceReplica, …)
+#   * cluster nodes
+#
+# Kubernetes' built-in `view` is aggregation-based: it does not cover custom
+# resources (their roles carry no aggregate-to-view label) and deliberately
+# excludes nodes (cluster-scoped infra). So a principal holding `view` — e.g. MUSE
+# authenticating to a GKE cluster via its K8S_CLUSTER ACL `ClusterRole:view` grant
+# — can read pods but is DENIED on ome.io resources and nodes. The result: empty
+# OME views and a capacity rollup (which needs node topology/allocatable) that
+# never syncs. This role closes both gaps the idiomatic way.
+#
+# Only `aggregate-to-view` is set: MUSE (and every read principal on these
+# clusters) comes in through `view`, so edit/admin aggregation would only widen
+# the grant with no consumer.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ome-supplemental-viewer
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["ome.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]

--- a/charts/ome-resources/templates/ome-controller/service.yaml
+++ b/charts/ome-resources/templates/ome-controller/service.yaml
@@ -25,6 +25,11 @@ spec:
     control-plane: ome-controller-manager
     controller-tools.k8s.io: "1.0"
   ports:
-  - port: 8443
+  - name: https
+    port: 8443
     targetPort: https
+    protocol: TCP
+  - name: metrics
+    port: 8080
+    targetPort: metrics
     protocol: TCP

--- a/charts/ome-resources/templates/ome-controller/servicemonitor.yaml
+++ b/charts/ome-resources/templates/ome-controller/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceMonitor.enabled }}
+# Scrape OME controller-manager metrics via prometheus-operator's
+# ServiceMonitor CRD. Targets the named "metrics" port on
+# ome-controller-manager-service. Pod-annotation-based scraping
+# (prometheus.io/scrape) still works for clusters running vanilla
+# Prometheus and is left in place for back-compat.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ome-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: ome-controller-manager
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: ome-controller-manager
+      controller-tools.k8s.io: "1.0"
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ome-resources/templates/ome-controller/webhooks/basemodelvalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/basemodelvalidator.yaml
@@ -15,7 +15,12 @@ webhooks:
     failurePolicy: Fail
     name: basemodel.ome-webhook-server.validator
     sideEffects: None
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1"]
+    # Skip on objects already being deleted: finalizer-only patches
+    # shouldn't trigger spec-invariant checks (would deadlock GC).
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
     rules:
       - apiGroups:
           - ome.io
@@ -44,7 +49,12 @@ webhooks:
     failurePolicy: Fail
     name: clusterbasemodel.ome-webhook-server.validator
     sideEffects: None
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1"]
+    # Skip on objects already being deleted: finalizer-only patches
+    # shouldn't trigger spec-invariant checks (would deadlock GC).
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
     rules:
       - apiGroups:
           - ome.io

--- a/charts/ome-resources/templates/ome-controller/webhooks/controllerrevision-immutability.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/controllerrevision-immutability.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -6,31 +7,26 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: ome/serving-cert
 webhooks:
+  # Scoped to the OME release namespace so StatefulSet/DaemonSet-owned
+  # ControllerRevisions elsewhere in the cluster are not gated. Inside
+  # the OME ns, the handler additionally checks the ome.io/created-by
+  # annotation before rejecting Update.
   - clientConfig:
       caBundle: Cg==
       service:
         name: ome-webhook-server-service
         namespace: {{ .Release.Namespace }}
         path: /validate-apps-v1-controllerrevision
-    failurePolicy: Ignore
+    failurePolicy: Fail
     name: controllerrevision-immutability.ome-webhook-server.validator
-    # Scope to OME's own namespace: every OME-written runtime-revision lives
-    # here, so this covers 100% of them while leaving StatefulSet/DaemonSet
-    # ControllerRevisions in every other namespace untouched (the apiserver
-    # filters them out before ever calling the webhook).
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: {{ .Release.Namespace }}
-    sideEffects: None
-    # Fail-open (Ignore) + a short timeout: a wedged webhook server adds at
-    # most 5s to an in-namespace ControllerRevision UPDATE, then admits it.
-    # The webhook is defense-in-depth (K8s already enforces .data/.revision
-    # immutability natively), so a brief gap only skips the .labels check.
-    timeoutSeconds: 5
-    admissionReviewVersions: ["v1"]
     rules:
       - apiGroups:
-          - apps
+          - "apps"
         apiVersions:
           - v1
         operations:

--- a/charts/ome-resources/templates/ome-controller/webhooks/isvcmutator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/isvcmutator.yaml
@@ -7,6 +7,14 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: ome/serving-cert
 webhooks:
+{{- /*
+  OEP-0018: the ISVC defaulter runtime-selects against the local catalog, which
+  is empty on the control plane, so the manager skips this handler there.
+  Installing the config (failurePolicy: Fail) would 404 and reject every user
+  ISVC, so skip the defaulter entry under the control-plane role. The pod
+  mutator entry below stays so the webhook list is never empty.
+*/ -}}
+{{- if ne .Values.ome.multicluster.role "control-plane" }}
   - clientConfig:
       caBundle: Cg==
       service:
@@ -17,6 +25,11 @@ webhooks:
     name: inferenceservice.ome-webhook-server.defaulter
     sideEffects: None
     admissionReviewVersions: ["v1beta1"]
+    # Skip on objects already being deleted: finalizer-only patches
+    # shouldn't trigger spec-invariant checks (would deadlock GC).
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
     rules:
       - apiGroups:
           - ome.io
@@ -27,6 +40,7 @@ webhooks:
           - UPDATE
         resources:
           - inferenceservices
+{{- end }}
   - clientConfig:
       caBundle: Cg==
       service:

--- a/charts/ome-resources/templates/ome-controller/webhooks/isvcvalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/isvcvalidator.yaml
@@ -1,3 +1,11 @@
+{{- /*
+  OEP-0018: the InferenceService validator runtime-selects against the local
+  cluster's runtime/model catalog. On the control plane that catalog is empty,
+  so the manager does not register this webhook handler there. Installing the
+  config (failurePolicy: Fail) would then 404 and reject every user ISVC, so
+  skip the config entirely under the control-plane role.
+*/ -}}
+{{- if ne .Values.ome.multicluster.role "control-plane" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -16,6 +24,11 @@ webhooks:
     name: inferenceservice.ome-webhook-server.validator
     sideEffects: None
     admissionReviewVersions: ["v1beta1"]
+    # Skip on objects already being deleted: finalizer-only patches
+    # shouldn't trigger spec-invariant checks (would deadlock GC).
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
     rules:
       - apiGroups:
           - ome.io
@@ -26,3 +39,4 @@ webhooks:
           - UPDATE
         resources:
           - inferenceservices
+{{- end }}

--- a/charts/ome-resources/templates/ome-controller/webhooks/runtimepreset.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/runtimepreset.yaml
@@ -1,42 +1,9 @@
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  creationTimestamp: null
-  name: clusterservingruntime.ome.io
-  annotations:
-    cert-manager.io/inject-ca-from: ome/serving-cert
-webhooks:
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: ome-webhook-server-service
-        namespace: {{ .Release.Namespace }}
-        path: /validate-ome-io-v1beta1-clusterservingruntime
-    failurePolicy: Fail
-    name: clusterservingruntime.ome-webhook-server.validator
-    sideEffects: None
-    admissionReviewVersions: ["v1beta1"]
-    # Skip on objects already being deleted: finalizer-only patches
-    # shouldn't trigger spec-invariant checks (would deadlock GC).
-    matchConditions:
-      - name: skip-deletion
-        expression: "!has(object.metadata.deletionTimestamp)"
-    rules:
-      - apiGroups:
-          - ome.io
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - clusterservingruntimes
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
+kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: servingruntime.ome.io
+  name: servingruntime-preset.ome.io
   annotations:
     cert-manager.io/inject-ca-from: ome/serving-cert
 webhooks:
@@ -45,13 +12,11 @@ webhooks:
       service:
         name: ome-webhook-server-service
         namespace: {{ .Release.Namespace }}
-        path: /validate-ome-io-v1beta1-servingruntime
+        path: /mutate-ome-io-v1beta1-servingruntime-preset
     failurePolicy: Fail
-    name: servingruntime.ome-webhook-server.validator
+    name: servingruntime.ome-webhook-server.preset
     sideEffects: None
-    admissionReviewVersions: ["v1beta1"]
-    # Skip on objects already being deleted: finalizer-only patches
-    # shouldn't trigger spec-invariant checks (would deadlock GC).
+    admissionReviewVersions: ["v1"]
     matchConditions:
       - name: skip-deletion
         expression: "!has(object.metadata.deletionTimestamp)"
@@ -65,3 +30,26 @@ webhooks:
           - UPDATE
         resources:
           - servingruntimes
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-ome-io-v1beta1-clusterservingruntime-preset
+    failurePolicy: Fail
+    name: clusterservingruntime.ome-webhook-server.preset
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterservingruntimes

--- a/charts/ome-resources/templates/prometheus/configmap.yaml
+++ b/charts/ome-resources/templates/prometheus/configmap.yaml
@@ -1,0 +1,173 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ome-prometheus-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+data:
+  # Scrape config covers two pod populations:
+  #   1. InferenceService-owned pods (every deployment mode stamps
+  #      the `ome.io/inferenceservice` label on its pods — that's
+  #      the canonical OME-wide pod selector, not the OMENative-only
+  #      `ome.io/managed-by`).
+  #   2. OME control-plane pods (controller-manager, model-agent)
+  #      that opt in via the standard Prometheus annotation.
+  # Port + path resolve from the standard `prometheus.io/port` and
+  # `prometheus.io/path` annotations when set; otherwise Prometheus
+  # falls back to its discovery defaults.
+  prometheus.yml: |
+    global:
+      scrape_interval: {{ .Values.prometheus.scrapeInterval }}
+      scrape_timeout: {{ .Values.prometheus.scrapeTimeout }}
+      {{- with .Values.prometheus.externalLabels }}
+      external_labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    scrape_configs:
+      - job_name: ome-inferenceservice-pods
+        {{- with .Values.prometheus.scrapeLimits.sampleLimit }}
+        sample_limit: {{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.scrapeLimits.targetLimit }}
+        target_limit: {{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.scrapeLimits.labelLimit }}
+        label_limit: {{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.scrapeLimits.labelNameLengthLimit }}
+        label_name_length_limit: {{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.scrapeLimits.labelValueLengthLimit }}
+        label_value_length_limit: {{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.scrapeLimits.bodySizeLimit }}
+        body_size_limit: {{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.scrapeLimits.keepDroppedTargets }}
+        keep_dropped_targets: {{ . }}
+        {{- end }}
+        kubernetes_sd_configs:
+          - role: pod
+            # Server-side informer filter: discover ONLY InferenceService pods.
+            # The keep-relabel below runs AFTER discovery, so without this filter
+            # the pod informer would cache every pod in the cluster and OOM the
+            # bundled Prometheus on large multi-tenant clusters.
+            selectors:
+              - role: pod
+                label: "ome.io/inferenceservice"
+            {{- with .Values.prometheus.scrapeNamespaces }}
+            # Optionally hard-scope discovery to specific namespaces.
+            namespaces:
+              names:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+        relabel_configs:
+          # Only pods owned by an InferenceService.
+          - source_labels: [__meta_kubernetes_pod_label_ome_io_inferenceservice]
+            regex: .+
+            action: keep
+          # Only Running and Ready pods (KEDA reads instantaneous values).
+          # Phase alone still admits a pod that is loading model weights: its
+          # metrics endpoint is not listening yet, so it reports a scrape
+          # failure for the whole load window.
+          - source_labels: [__meta_kubernetes_pod_phase]
+            regex: Running
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_ready]
+            regex: "true"
+            action: keep
+          {{- if .Values.prometheus.requireScrapeAnnotation }}
+          # An explicit standard opt-out wins over the OME-level opt-in.
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            regex: "false"
+            action: drop
+          # Scraping is opt-in through either the standard annotation or OME's
+          # controller-level scrape setting.
+          - source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+              - __meta_kubernetes_pod_annotation_ome_io_enable_prometheus_scraping
+            regex: "true;.*|.*;true"
+            action: keep
+          {{- else }}
+          # Compatibility mode scrapes every ISVC pod unless it explicitly
+          # opts out with the standard annotation.
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            regex: "false"
+            action: drop
+          {{- end }}
+          # Address: replace the discovered port with prometheus.io/port
+          # when set on the pod.
+          - source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+            action: replace
+          # Metrics path: replace /metrics with prometheus.io/path
+          # when set on the pod.
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            regex: (.+)
+            target_label: __metrics_path__
+            action: replace
+          # Convenience labels for KEDA / dashboards.
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_label_ome_io_inferenceservice]
+            target_label: inferenceservice
+          # OME stamps the PLAIN `component` pod label
+          # (constants.OMEComponentLabel = "component"), not an
+          # ome.io/-prefixed one -- so source the unprefixed label.
+          - source_labels: [__meta_kubernetes_pod_label_component]
+            target_label: component
+        {{- with .Values.prometheus.metricRelabelConfigs }}
+        metric_relabel_configs:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+      - job_name: ome-control-plane
+        kubernetes_sd_configs:
+          - role: pod
+            # Control-plane pods are matched by annotation (which SD can't filter
+            # on), so scope discovery to this release's namespace -- where the
+            # controller-manager/model-agent run -- instead of all cluster pods.
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+          # Opt-in via the standard prometheus.io/scrape annotation.
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            regex: "true"
+            action: keep
+          # Restrict to this release's namespace so we don't pick up
+          # unrelated annotated pods cluster-wide.
+          - source_labels: [__meta_kubernetes_namespace]
+            regex: {{ .Release.Namespace }}
+            action: keep
+          - source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+            action: replace
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            regex: (.+)
+            target_label: __metrics_path__
+            action: replace
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+
+      {{- if .Values.prometheus.selfScrape.enabled }}
+      - job_name: ome-prometheus
+        static_configs:
+          - targets:
+              - {{ printf "127.0.0.1:%v" .Values.prometheus.listenPort | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/ome-resources/templates/prometheus/deployment.yaml
+++ b/charts/ome-resources/templates/prometheus/deployment.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.prometheus.enabled }}
+# Single-replica Prometheus bundled for KEDA autoscaling input only. It is not
+# a general-purpose observability install: storage defaults to emptyDir,
+# retention is short, and there is no Alertmanager, recording rules, or
+# remote_write. Disable it when your cluster
+# already runs a Prometheus that scrapes OME pods.
+#
+# A ConfigMap change triggers a rollout via the checksum annotation
+# below; the `--web.enable-lifecycle` flag also allows an in-pod
+# `POST /-/reload` for operators who want zero-downtime reloads.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ome-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "ome-prometheus.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ome-prometheus.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/prometheus/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: ome-prometheus
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      {{- with .Values.prometheus.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: prometheus
+          image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
+          imagePullPolicy: {{ .Values.prometheus.image.pullPolicy }}
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time={{ .Values.prometheus.retention }}
+            {{- with .Values.prometheus.retentionSize }}
+            - --storage.tsdb.retention.size={{ . }}
+            {{- end }}
+            {{- with .Values.prometheus.query.maxConcurrency }}
+            - --query.max-concurrency={{ . }}
+            {{- end }}
+            {{- with .Values.prometheus.query.maxSamples }}
+            - --query.max-samples={{ . | int64 }}
+            {{- end }}
+            {{- with .Values.prometheus.query.timeout }}
+            - --query.timeout={{ . }}
+            {{- end }}
+            - --web.enable-lifecycle
+            - --web.listen-address=:{{ .Values.prometheus.listenPort }}
+          {{- with .Values.prometheus.goMemLimit }}
+          env:
+            - name: GOMEMLIMIT
+              value: {{ . | quote }}
+          {{- end }}
+          ports:
+            - name: http-web
+              containerPort: {{ .Values.prometheus.listenPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http-web
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http-web
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.prometheus.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: storage
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: ome-prometheus-config
+        - name: storage
+          {{- if .Values.prometheus.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default "ome-prometheus" .Values.prometheus.persistence.existingClaim | quote }}
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.prometheus.storage.sizeLimit }}
+          {{- end }}
+{{- end }}

--- a/charts/ome-resources/templates/prometheus/prometheusrule.yaml
+++ b/charts/ome-resources/templates/prometheus/prometheusrule.yaml
@@ -1,0 +1,189 @@
+{{- if .Values.prometheusRule.enabled }}
+{{- $r := .Values.prometheusRule }}
+{{- $cp := $r.selectors.controlPlane }}
+{{- $router := $r.selectors.router }}
+{{- $book := $r.runbookUrlBase }}
+# OME P0 alerts — the page-immediately tier.
+#
+# Each rule states a symptom, names a runbook section, and takes every
+# threshold and duration from values.yaml. Nothing here is tuned in the
+# template: an operator changing a threshold should never have to edit a
+# rendered rule.
+#
+# Control-plane series are selected by pod name, not by `job`. The job label
+# depends on which scrape path is in use (ServiceMonitor vs the
+# prometheus.io/scrape annotation), so it is not portable across installs.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ome-p0-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome.labels" . | nindent 4 }}
+    {{- with $r.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: ome.p0
+      interval: {{ $r.interval }}
+      rules:
+        {{- if $r.rules.controllerDown.enabled }}
+        # Three distinct ways to have no reconciliation, deliberately in one
+        # alert because the response is the same and the on-call does not
+        # benefit from three pages for one outage.
+        #
+        # absent() is load-bearing: if every controller pod disappears, `up`
+        # stops being reported and a plain `up == 0` matches nothing, so the
+        # most severe case would be the one that never pages.
+        #
+        # The leader clause has no absent() guard on purpose. It degrades to
+        # "no series, no alert" if leader election is ever turned off, which
+        # is correct; an absent() there would page on a supported config.
+        - alert: OMEControllerDown
+          expr: >-
+            absent(up{ {{- $cp -}} }) == 1
+            or max(up{ {{- $cp -}} }) == 0
+            or max(leader_election_master_status{ {{- $cp -}} }) == 0
+          for: {{ $r.rules.controllerDown.duration }}
+          labels:
+            severity: {{ $r.severity }}
+            tier: p0
+            component: control-plane
+          annotations:
+            summary: "OME control plane is not reconciling"
+            description: >-
+              No OME controller-manager replica is both scraping and holding the
+              leader lease. Nothing in the cluster is being reconciled: no
+              InferenceService will converge, scale, or roll out until this
+              recovers.
+            runbook_url: "{{ $book }}#omecontrollerdown"
+        {{- end }}
+        {{- if $r.rules.webhookFailing.enabled }}
+        # Server errors only. An admission *rejection* is a 200 carrying
+        # allowed=false, so a spike in rejected specs is not this alert --
+        # that is the webhook doing its job.
+        - alert: OMEWebhookFailing
+          expr: >-
+            sum(rate(controller_runtime_webhook_requests_total{ {{- $cp }},code=~"5.." }[5m]))
+            /
+            sum(rate(controller_runtime_webhook_requests_total{ {{- $cp -}} }[5m]))
+            > {{ $r.rules.webhookFailing.ratioThreshold }}
+          for: {{ $r.rules.webhookFailing.duration }}
+          labels:
+            severity: {{ $r.severity }}
+            tier: p0
+            component: webhook
+          annotations:
+            summary: "OME admission webhook is returning server errors"
+            description: >-
+              {{ "{{" }} $value | humanizePercentage {{ "}}" }} of admission requests are
+              failing with 5xx. OME serves its webhooks from the
+              controller-manager, so this blocks every InferenceService create
+              and update in the cluster, including the ones that would fix it.
+            runbook_url: "{{ $book }}#omewebhookfailing"
+        {{- end }}
+        {{- if $r.rules.serviceUnavailable.enabled }}
+        # max() across router pods, not min(): the service is only down when
+        # NO router can see a healthy backend. One router with an empty pool
+        # while its peers are serving is a router problem, not an outage, and
+        # belongs in a lower tier.
+        #
+        # router_pool_total_count > 0 stands in for "desired > 0" because OME
+        # exports no desired-replica series today. It reads as "backends are
+        # registered but none of them are healthy", which is the condition
+        # worth paging on -- and it will not fire for a workload that is
+        # intentionally scaled to zero.
+        - alert: OMEServiceUnavailable
+          expr: >-
+            (max by (namespace, inferenceservice) (router_pool_healthy_count{ {{- $router -}} }) == 0)
+            and
+            (max by (namespace, inferenceservice) (router_pool_total_count{ {{- $router -}} }) > 0)
+          for: {{ $r.rules.serviceUnavailable.duration }}
+          labels:
+            severity: {{ $r.severity }}
+            tier: p0
+            component: router
+          annotations:
+            summary: "InferenceService {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.inferenceservice {{ "}}" }} has no healthy backend"
+            description: >-
+              Backends are registered for this InferenceService but no router
+              considers any of them healthy, so requests to it are failing.
+              Check the engine pods before the router: an ejected backend is
+              usually an engine that stopped passing its health check.
+            runbook_url: "{{ $book }}#omeserviceunavailable"
+        {{- end }}
+        {{- if $r.rules.massRolloutFailure.enabled }}
+        # Built on the transition counter, NOT on
+        # ome_omenative_rollout_group_failure_total: that one is incremented
+        # on every reconcile while a group sits in Failed, so a single stuck
+        # workload would drive any ratio built on it without bound. The
+        # transition counter only moves on an actual phase change.
+        #
+        # Both a rate and a spread are required. A ratio alone fires when one
+        # busy workload fails repeatedly; the InferenceService count is what
+        # makes this "the control plane broke rollouts" rather than "a
+        # workload is broken", which is a lower tier.
+        - alert: OMEMassRolloutFailure
+          expr: >-
+            (
+              sum(rate(ome_omenative_rollout_group_transition_total{ {{- $cp }},to="Failed" }[15m]))
+              /
+              sum(rate(ome_omenative_rollout_group_transition_total{ {{- $cp }},to=~"Idle|Staged|Failed" }[15m]))
+              > {{ $r.rules.massRolloutFailure.ratioThreshold }}
+            )
+            and
+            (
+              count(
+                sum by (namespace, isvc) (
+                  rate(ome_omenative_rollout_group_transition_total{ {{- $cp }},to="Failed" }[15m])
+                ) > 0
+              ) >= {{ $r.rules.massRolloutFailure.minInferenceServices }}
+            )
+          for: {{ $r.rules.massRolloutFailure.duration }}
+          labels:
+            severity: {{ $r.severity }}
+            tier: p0
+            component: coordination
+          annotations:
+            summary: "OME rollouts are failing across multiple InferenceServices"
+            description: >-
+              {{ "{{" }} $value | humanizePercentage {{ "}}" }} of coordination groups
+              reaching a terminal phase are landing in Failed, across at least
+              {{ $r.rules.massRolloutFailure.minInferenceServices }} InferenceServices.
+              A blast radius this wide points at the control plane or a shared
+              dependency rather than at any one workload.
+            runbook_url: "{{ $book }}#omemassrolloutfailure"
+        {{- end }}
+        {{- if $r.rules.reconcileStalled.enabled }}
+        # Wedged, not down: the process is healthy enough to be scraped, which
+        # is exactly why this needs its own alert -- every liveness signal
+        # looks fine.
+        #
+        # All three clauses are needed. Depth alone is a busy controller; a
+        # zero reconcile rate alone is an idle one; only a growing backlog
+        # that nothing is draining is a stall. deriv() over a subquery
+        # supplies the "rising" half.
+        - alert: OMEReconcileStalled
+          expr: >-
+            (sum(workqueue_depth{ {{- $cp -}} }) > {{ $r.rules.reconcileStalled.minQueueDepth }})
+            and
+            (sum(rate(controller_runtime_reconcile_total{ {{- $cp -}} }[10m])) <= {{ $r.rules.reconcileStalled.maxReconcileRate }})
+            and
+            (deriv(sum(workqueue_depth{ {{- $cp -}} })[10m:]) > 0)
+          for: {{ $r.rules.reconcileStalled.duration }}
+          labels:
+            severity: {{ $r.severity }}
+            tier: p0
+            component: control-plane
+          annotations:
+            summary: "OME controller is up but not draining its work queue"
+            description: >-
+              The controller-manager is being scraped and holds the lease, but
+              its work queue is growing while the reconcile rate is
+              effectively zero. Every liveness signal will look healthy; the
+              controller is stuck. Check for a blocked apiserver call or a
+              deadlocked reconcile before restarting.
+            runbook_url: "{{ $book }}#omereconcilestalled"
+        {{- end }}
+{{- end }}

--- a/charts/ome-resources/templates/prometheus/pvc.yaml
+++ b/charts/ome-resources/templates/prometheus/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.persistence.enabled (not .Values.prometheus.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ome-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+  {{- with .Values.prometheus.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.prometheus.persistence.accessModes | nindent 4 }}
+  {{- with .Values.prometheus.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.prometheus.persistence.size }}
+{{- end }}

--- a/charts/ome-resources/templates/prometheus/rbac.yaml
+++ b/charts/ome-resources/templates/prometheus/rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.prometheus.enabled }}
+# Cluster-wide pod / service / endpoints read access so Prometheus
+# can discover OME-managed pods across all namespaces via
+# kubernetes_sd_configs. No write verbs — this Prometheus only
+# scrapes; it does not run an Alertmanager or remote-write.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ome-prometheus
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ome-prometheus
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ome-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: ome-prometheus
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ome-resources/templates/prometheus/service.yaml
+++ b/charts/ome-resources/templates/prometheus/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheus.enabled }}
+# Fronts the bundled Prometheus Deployment for in-cluster KEDA and canary
+# queries. The Service port may differ from the container's listen port.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ome-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.prometheus.service.type }}
+  ports:
+    - name: http-web
+      port: {{ .Values.prometheus.service.port }}
+      targetPort: http-web
+      protocol: TCP
+  selector:
+    {{- include "ome-prometheus.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/ome-resources/templates/prometheus/serviceaccount.yaml
+++ b/charts/ome-resources/templates/prometheus/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ome-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-prometheus.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/ome-resources/tests/render_test.sh
+++ b/charts/ome-resources/tests/render_test.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helm_bin="${HELM_BIN:-helm}"
+
+fail() {
+  echo "ome-resources chart test: $*" >&2
+  exit 1
+}
+
+rendered="$("${helm_bin}" template ome-resources "${chart_dir}" --namespace ome)"
+controller="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --show-only templates/ome-controller/deployment.yaml)"
+controller_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq 'helm.sh/chart: ome-resources-0.1.0' <<<"${controller}" ||
+  fail "controller chart version label was not rendered"
+grep -Fq 'app.kubernetes.io/version: "1.16.0"' <<<"${controller}" ||
+  fail "controller app version label was not rendered"
+grep -Fq '"scaleUpPodBatchSize":100' <<<"${controller_config}" ||
+  fail "default OMENative scale-up Pod batch size was not rendered"
+grep -Fq '"scaleDownPodBatchSize":100' <<<"${controller_config}" ||
+  fail "default OMENative scale-down Pod batch size was not rendered"
+grep -Fq '"scaleDownRequeueInterval":"5s"' <<<"${controller_config}" ||
+  fail "default OMENative scale-down requeue interval was not rendered"
+grep -Fq '"rawDeployment":{"maxUnavailable":1}' <<<"${controller_config}" ||
+  fail "default RawDeployment disruption budget was not rendered"
+if grep -Fq '"omeNative"' <<<"${controller_config}"; then
+  fail "an OMENative disruption budget default was rendered"
+fi
+
+scale_up_batch_overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleUpPodBatchSize=37 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"scaleUpPodBatchSize":37' <<<"${scale_up_batch_overridden}" ||
+  fail "OMENative scale-up Pod batch size override was not rendered"
+grep -Fq '"scaleDownPodBatchSize":100' <<<"${scale_up_batch_overridden}" ||
+  fail "scale-up override unexpectedly changed the scale-down Pod batch size"
+
+scale_up_batch_zero="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleUpPodBatchSize=0 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"scaleUpPodBatchSize":0' <<<"${scale_up_batch_zero}" ||
+  fail "explicit zero OMENative scale-up Pod batch size was not rendered"
+
+scale_down_batch_overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleDownPodBatchSize=41 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"scaleDownPodBatchSize":41' <<<"${scale_down_batch_overridden}" ||
+  fail "OMENative scale-down Pod batch size override was not rendered"
+grep -Fq '"scaleUpPodBatchSize":100' <<<"${scale_down_batch_overridden}" ||
+  fail "scale-down override unexpectedly changed the scale-up Pod batch size"
+
+scale_down_batch_zero="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleDownPodBatchSize=0 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"scaleDownPodBatchSize":0' <<<"${scale_down_batch_zero}" ||
+  fail "explicit zero OMENative scale-down Pod batch size was not rendered"
+
+scale_down_batch_omitted="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleDownPodBatchSize=null \
+  --show-only templates/ome-controller/configmap.yaml)"
+if grep -Fq 'scaleDownPodBatchSize' <<<"${scale_down_batch_omitted}"; then
+  fail "OMENative scale-down Pod batch size was rendered when omitted"
+fi
+grep -Fq '"scaleUpPodBatchSize":100' <<<"${scale_down_batch_omitted}" ||
+  fail "omitting scale-down unexpectedly removed the scale-up Pod batch size"
+
+scale_down_interval_overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-string ome.controller.lifecycle.scaleDownRequeueInterval=37s \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"scaleDownRequeueInterval":"37s"' <<<"${scale_down_interval_overridden}" ||
+  fail "OMENative scale-down requeue interval override was not rendered"
+grep -Fq '"scaleDownPodBatchSize":100' <<<"${scale_down_interval_overridden}" ||
+  fail "requeue interval override unexpectedly changed the scale-down Pod batch size"
+
+scale_down_interval_zero="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-string ome.controller.lifecycle.scaleDownRequeueInterval=0s \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"scaleDownRequeueInterval":"0s"' <<<"${scale_down_interval_zero}" ||
+  fail "explicit zero OMENative scale-down requeue interval was not rendered"
+
+scale_down_interval_omitted="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleDownRequeueInterval=null \
+  --show-only templates/ome-controller/configmap.yaml)"
+if grep -Fq 'scaleDownRequeueInterval' <<<"${scale_down_interval_omitted}"; then
+  fail "OMENative scale-down requeue interval was rendered when omitted"
+fi
+grep -Fq '"scaleDownPodBatchSize":100' <<<"${scale_down_interval_omitted}" ||
+  fail "omitting the requeue interval unexpectedly removed the scale-down Pod batch size"
+
+default_controller_checksum="$(grep -m1 'checksum/config:' <<<"${controller}" | awk '{print $2}')"
+scale_down_controller="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.lifecycle.scaleDownPodBatchSize=41 \
+  --show-only templates/ome-controller/deployment.yaml)"
+scale_down_controller_checksum="$(grep -m1 'checksum/config:' <<<"${scale_down_controller}" | awk '{print $2}')"
+[[ -n "${default_controller_checksum}" && -n "${scale_down_controller_checksum}" ]] ||
+  fail "controller ConfigMap checksum was not rendered"
+[[ "${default_controller_checksum}" != "${scale_down_controller_checksum}" ]] ||
+  fail "changing scale-down Pod batch size did not roll the controller checksum"
+
+scale_down_interval_controller="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-string ome.controller.lifecycle.scaleDownRequeueInterval=37s \
+  --show-only templates/ome-controller/deployment.yaml)"
+scale_down_interval_checksum="$(grep -m1 'checksum/config:' <<<"${scale_down_interval_controller}" | awk '{print $2}')"
+[[ -n "${scale_down_interval_checksum}" ]] ||
+  fail "scale-down requeue interval controller checksum was not rendered"
+[[ "${default_controller_checksum}" != "${scale_down_interval_checksum}" ]] ||
+  fail "changing scale-down requeue interval did not roll the controller checksum"
+
+model_agent="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set modelAgent.enabled=true \
+  --show-only templates/model-agent-daemonset/daemonset.yaml)"
+grep -Fq 'helm.sh/chart: ome-resources-0.1.0' <<<"${model_agent}" ||
+  fail "model agent chart version label was not rendered"
+
+prometheus_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --show-only templates/prometheus/configmap.yaml)"
+prometheus_deployment="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --show-only templates/prometheus/deployment.yaml)"
+
+grep -Fq 'scrape_timeout: 10s' <<<"${prometheus_config}" ||
+  fail "default Prometheus scrape timeout was not rendered"
+grep -Fq 'cluster: ome' <<<"${prometheus_config}" ||
+  fail "default Prometheus external label was not rendered"
+if grep -Fq 'sample_limit:' <<<"${prometheus_config}" ||
+  grep -Fq 'target_limit:' <<<"${prometheus_config}" ||
+  grep -Fq 'body_size_limit:' <<<"${prometheus_config}"; then
+  fail "optional Prometheus scrape limits were rendered by default"
+fi
+grep -Fq 'regex: "false"' <<<"${prometheus_config}" ||
+  fail "default Prometheus scrape annotation compatibility mode was not rendered"
+if grep -Fq 'regex: "true;.*|.*;true"' <<<"${prometheus_config}"; then
+  fail "Prometheus scrape opt-in was rendered by default"
+fi
+grep -Fq 'job_name: ome-prometheus' <<<"${prometheus_config}" ||
+  fail "Prometheus self-scrape job was not rendered"
+grep -Fq '127.0.0.1:9090' <<<"${prometheus_config}" ||
+  fail "Prometheus self-scrape target was not rendered"
+if grep -Fq -- '--query.' <<<"${prometheus_deployment}"; then
+  fail "optional Prometheus query limits were rendered by default"
+fi
+if grep -Fq 'name: GOMEMLIMIT' <<<"${prometheus_deployment}"; then
+  fail "Prometheus GOMEMLIMIT was rendered when unset"
+fi
+if grep -Fq 'templates/prometheus/pvc.yaml' <<<"${rendered}"; then
+  fail "Prometheus PVC was rendered when persistence is disabled"
+fi
+
+prometheus_without_self_scrape="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.selfScrape.enabled=false \
+  --show-only templates/prometheus/configmap.yaml)"
+if grep -Fq -- '- job_name: ome-prometheus' <<<"${prometheus_without_self_scrape}"; then
+  fail "Prometheus self-scrape job was rendered when disabled"
+fi
+
+opt_in_scrape_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.requireScrapeAnnotation=true \
+  --show-only templates/prometheus/configmap.yaml)"
+grep -Fq 'regex: "true;.*|.*;true"' <<<"${opt_in_scrape_config}" ||
+  fail "Prometheus scrape annotation opt-in was not rendered"
+grep -Fq '__meta_kubernetes_pod_annotation_ome_io_enable_prometheus_scraping' <<<"${opt_in_scrape_config}" ||
+  fail "OME Prometheus scrape opt-in annotation was not rendered"
+
+metric_relabel_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set 'prometheus.metricRelabelConfigs[0].source_labels[0]=__name__' \
+  --set-string 'prometheus.metricRelabelConfigs[0].regex=up|cd_probe_up' \
+  --set 'prometheus.metricRelabelConfigs[0].action=keep' \
+  --show-only templates/prometheus/configmap.yaml)"
+grep -Fq 'metric_relabel_configs:' <<<"${metric_relabel_config}" ||
+  fail "Prometheus metric relabel configuration was not rendered"
+grep -Fq 'regex: up|cd_probe_up' <<<"${metric_relabel_config}" ||
+  fail "Prometheus metric relabel regex override was not rendered"
+default_prometheus_checksum="$(grep -m1 'checksum/config:' <<<"${prometheus_deployment}" | awk '{print $2}')"
+metric_relabel_deployment="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set 'prometheus.metricRelabelConfigs[0].source_labels[0]=__name__' \
+  --set-string 'prometheus.metricRelabelConfigs[0].regex=up|cd_probe_up' \
+  --set 'prometheus.metricRelabelConfigs[0].action=keep' \
+  --show-only templates/prometheus/deployment.yaml)"
+metric_relabel_checksum="$(grep -m1 'checksum/config:' <<<"${metric_relabel_deployment}" | awk '{print $2}')"
+[[ -n "${default_prometheus_checksum}" && -n "${metric_relabel_checksum}" ]] ||
+  fail "Prometheus ConfigMap checksum was not rendered"
+[[ "${default_prometheus_checksum}" != "${metric_relabel_checksum}" ]] ||
+  fail "changing Prometheus metric relabeling did not roll the config checksum"
+
+prometheus_runtime_overrides="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.listenPort=9191 \
+  --set prometheus.service.port=80 \
+  --set-string prometheus.goMemLimit=9GiB \
+  --show-only templates/prometheus/deployment.yaml)"
+prometheus_port_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.listenPort=9191 \
+  --set prometheus.service.port=80 \
+  --show-only templates/prometheus/configmap.yaml)"
+prometheus_port_service="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.listenPort=9191 \
+  --set prometheus.service.port=80 \
+  --show-only templates/prometheus/service.yaml)"
+prometheus_port_controller_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.listenPort=9191 \
+  --set prometheus.service.port=80 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq -- '--web.listen-address=:9191' <<<"${prometheus_runtime_overrides}" ||
+  fail "Prometheus listen port override was not rendered"
+grep -Fq 'containerPort: 9191' <<<"${prometheus_runtime_overrides}" ||
+  fail "Prometheus container port override was not rendered"
+grep -Fq '127.0.0.1:9191' <<<"${prometheus_port_config}" ||
+  fail "Prometheus self-scrape did not use the listen port"
+grep -Fq 'port: 80' <<<"${prometheus_port_service}" ||
+  fail "Prometheus Service port override was not rendered"
+grep -Fq 'http://ome-prometheus.ome.svc:80' <<<"${prometheus_port_controller_config}" ||
+  fail "canary Prometheus address did not use the Service port"
+grep -Fq 'name: GOMEMLIMIT' <<<"${prometheus_runtime_overrides}" ||
+  fail "Prometheus GOMEMLIMIT name was not rendered"
+grep -Fq 'value: "9GiB"' <<<"${prometheus_runtime_overrides}" ||
+  fail "Prometheus GOMEMLIMIT value was not rendered"
+
+prometheus_persistent="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.persistence.enabled=true \
+  --set prometheus.persistence.size=32Gi \
+  --set prometheus.persistence.storageClassName=fast-rwo)"
+prometheus_persistent_deployment="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.persistence.enabled=true \
+  --show-only templates/prometheus/deployment.yaml)"
+grep -Fq 'templates/prometheus/pvc.yaml' <<<"${prometheus_persistent}" ||
+  fail "Prometheus PVC was not rendered when persistence is enabled"
+grep -Fq 'claimName: "ome-prometheus"' <<<"${prometheus_persistent_deployment}" ||
+  fail "Prometheus chart-managed PVC was not mounted"
+grep -Fq 'storage: 32Gi' <<<"${prometheus_persistent}" ||
+  fail "Prometheus chart-managed PVC size was not rendered"
+grep -Fq 'storageClassName: "fast-rwo"' <<<"${prometheus_persistent}" ||
+  fail "Prometheus chart-managed PVC storage class was not rendered"
+grep -Fq -- '- ReadWriteOnce' <<<"${prometheus_persistent}" ||
+  fail "Prometheus chart-managed PVC access mode was not rendered"
+if grep -Fq 'emptyDir:' <<<"${prometheus_persistent_deployment}"; then
+  fail "Prometheus emptyDir was rendered with persistence enabled"
+fi
+
+prometheus_existing_claim="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.persistence.enabled=true \
+  --set prometheus.persistence.existingClaim=shared-prometheus)"
+prometheus_existing_claim_deployment="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.persistence.enabled=true \
+  --set prometheus.persistence.existingClaim=shared-prometheus \
+  --show-only templates/prometheus/deployment.yaml)"
+grep -Fq 'claimName: "shared-prometheus"' <<<"${prometheus_existing_claim_deployment}" ||
+  fail "Prometheus existing PVC was not mounted"
+if grep -Fq 'templates/prometheus/pvc.yaml' <<<"${prometheus_existing_claim}"; then
+  fail "Prometheus PVC was created when an existing claim was configured"
+fi
+
+overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set prometheus.storage.sizeLimit=16Gi)"
+grep -Fq 'sizeLimit: 16Gi' <<<"${overridden}" ||
+  fail "Prometheus storage sizeLimit override was not rendered"
+
+without_size_retention="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-string prometheus.retentionSize=)"
+if grep -Fq -- '--storage.tsdb.retention.size=' <<<"${without_size_retention}"; then
+  fail "Prometheus size retention was rendered when disabled"
+fi
+
+# The fleet-quota controller lives under pkg/controller/v1beta1/acceleratorquota,
+# inside the tree controller-gen scans, but it runs in ome-quota-manager with its
+# own ServiceAccount. A +kubebuilder:rbac marker added there would regenerate
+# role.yaml, pass the manifests-drift gate once committed, and silently hand
+# ome-manager the quota plane's permissions — eventually cluster-wide write on
+# Kueue's ClusterQueue and Cohort, on the ServiceAccount that also runs the
+# fail-closed pod mutating webhook.
+if grep -Fq 'acceleratorquotas' <<<"${rendered}"; then
+  fail "quota RBAC leaked into the ome-manager role; it belongs to charts/ome-quota-manager"
+fi
+
+# The control plane selects a placement winner from the per-component
+# InferenceReplica status it reads on each workload cluster, so the
+# multicluster-access ClusterRole must grant it. Without the grant every read is
+# forbidden, fan-out still succeeds, and placement never leaves Racing — a
+# failure mode no lane in the test matrix reproduces, because they all
+# authenticate as cluster-admin rather than as this ServiceAccount.
+multicluster_access="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --show-only templates/ome-controller/rbac/multicluster_access.yaml)"
+grep -Fqx '  - inferencereplicas' <<<"${multicluster_access}" ||
+  fail "multicluster-access ClusterRole does not grant inferencereplicas"

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -9,6 +9,103 @@ global:
 
 ome:
   version: &defaultVersion v1.2.2
+  metricsaggregator:
+    enableMetricAggregation: "false"
+    enablePrometheusScraping: "false"
+  # podMonitor configures cluster-scope defaults for every PodMonitor OME
+  # generates per InferenceService Component. Omit (or leave empty) to keep the
+  # legacy behavior: PodMonitors carry only OME's own labels, so a
+  # label-selecting metrics collector will not scrape them and metrics flow only
+  # via the pod-annotation scrape path.
+  #
+  # Set `labels` to opt the generated PodMonitors into an external scrape
+  # pipeline that selects monitors by label — e.g. an OpenTelemetry target
+  # allocator whose podMonitorSelector requires {monitoring.example.com/scrape-tier: cluster}.
+  # These labels land on metadata.labels only (never spec.selector).
+  #
+  # Set `relabelings` to map Kubernetes SD meta labels onto the stable metric
+  # labels dashboards key on, so PodMonitor-scraped series match the legacy
+  # pod-annotation ("kubernetes-pods") label schema. Appended to every endpoint.
+  #
+  # podMonitor:
+  #   labels:
+  #     monitoring.example.com/scrape-tier: cluster
+  #   relabelings:
+  #     - sourceLabels: ["__meta_kubernetes_pod_label_ome_io_inferenceservice"]
+  #       targetLabel: inferenceservice
+  #     - sourceLabels: ["__meta_kubernetes_pod_label_component"]
+  #       targetLabel: component
+  #     - sourceLabels: ["__meta_kubernetes_pod_label_serving_runtime"]
+  #       targetLabel: serving_runtime
+  #     - sourceLabels: ["__meta_kubernetes_namespace"]
+  #       targetLabel: k8s_namespace_name
+  podMonitor: {}
+  # multiclusterAccess installs the long-lived ServiceAccount token used by
+  # InferenceDeploymentOperator to manage OME resources from a control-plane
+  # cluster.
+  multiclusterAccess:
+    enabled: true
+  # multicluster enables the OEP-0018 control-plane fan-out placement controllers.
+  # Alpha; default off. On the CONTROL-PLANE cluster set enabled: true and
+  # role: control-plane (this disables the local InferenceService->pods reconciler
+  # and runs the placement + WorkloadCluster controllers). Leave default on
+  # workload clusters.
+  multicluster:
+    enabled: false
+    role: ""
+    # execCredentials lets WorkloadCluster kubeconfigs authenticate with an exec
+    # credential plugin (short-lived cloud tokens, e.g. EKS/GKE). REQUIRES the
+    # plugin binary baked into the manager image (BYO image) AND pod identity
+    # (IRSA / Workload Identity). SECURITY: an exec block runs a command in the
+    # controller pod — keep WorkloadCluster kubeconfig Secrets admin-only.
+    execCredentials:
+      enabled: false
+      allowedCommands: "aws,gke-gcloud-auth-plugin,kubelogin"
+    # placementControlPlaneID: this control plane's identity, stamped on every
+    # derived InferenceService it creates so its GC only reaps its OWN deriveds.
+    # REQUIRED (set to a unique value per control plane) when multiple control
+    # planes share a workload cluster; otherwise one control plane's GC would
+    # delete another's deriveds. Leave empty for a single control plane.
+    placementControlPlaneID: ""
+    # config holds the multi-cluster TUNABLES, rendered into the
+    # inferenceservice-config ConfigMap's "multicluster" block (NOT manager
+    # flags, so an edit applies on the next config load, not a restart). Every
+    # field is optional: leave a duration "" or a number 0 to use the manager's
+    # built-in default. Durations are Go duration strings ("1m", "30s", "250ms").
+    config:
+      # workloadCluster: remote-cluster connection/transport + the status funnel.
+      workloadCluster:
+        clientQPS: 0             # steady-state QPS to each remote apiserver (0 => client-go default)
+        clientBurst: 0           # burst over clientQPS (0 => client-go default)
+        perCallTimeout: ""       # per-request timeout ("" => none)
+        cacheEnabled: false      # serve cross-cluster reads from an informer cache; prerequisite for the funnel
+        healthInterval: ""       # re-probe cadence for an otherwise-idle WorkloadCluster
+        connectionGrace: ""      # transient-failure grace before a reachable cluster is disconnected
+        eventsBatchPeriod: ""    # debounce for a rotated-kubeconfig Secret's key-update burst
+        establishInitial: ""     # initial remote watch-establish timeout
+        establishMax: ""         # cap on the watch-establish timeout
+        reconnectRetryMax: ""    # cap on the reconnect backoff for an unreachable cluster
+        funnelResyncInterval: "" # how fast a newly-connected cluster is noticed by the status funnel
+        funnelBufferSize: 0      # depth of the funnel's buffered event channel
+      # placement: the fan-out placement controller, its status convergence + GC.
+      placement:
+        requeueInterval: ""         # status-refresh poll cadence
+        gcInterval: ""              # orphan-sweep cadence
+        maxConcurrentReconciles: 0  # parallel placement reconciles (0 => single worker)
+        fanoutTimeout: ""           # per-cluster fan-out apply deadline
+        winnerLostGrace: ""         # grace before re-placing when the sticky winner's derived is missing
+        statusBatchPeriod: ""       # debounce for a burst of cross-cluster status events
+        statusSafetyRequeue: ""     # steady-state re-read backstop when the funnel is on
+        dispatcherMode: ""          # "AllAtOnce" (default) or "Incremental"
+        dispatcherStepSize: 0       # candidates Incremental adds per round (0 => one)
+        dispatcherRoundTimeout: ""  # Incremental round dwell ("" => no dwell)
+        localQueue: "default"       # Kueue LocalQueue for derived workloads ("" => no queue label, so Kueue does not gate them)
+      # endpoint: the global endpoint publisher (Gateway API HTTPRoute to the winner).
+      endpoint:
+        globalHostTemplate: ""  # text/template for the global host ("" => only annotated ISVCs publish)
+        globalGateway: ""       # "namespace/name" of the global Gateway ("" => publisher is a no-op)
+        routeNamespace: ""      # namespace for the published HTTPRoute + Service ("" => the ISVC's namespace)
+        backendPort: 0          # port on the winner's ingress the global host forwards to
   benchmarkJob:
     image: genai-bench
     tag: 0.1.113
@@ -16,16 +113,175 @@ ome:
     memoryRequest: "2Gi"
     cpuLimit: "2"
     memoryLimit: "2Gi"
+  kedaConfig:
+    enableKeda: true
+    promServerAddress: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
+    customPromQuery: ""
+    scalingThreshold: "10"
+    scalingOperator: "GreaterThanOrEqual"
+
   controller:
     replicaCount: 3
+    # Additional annotations applied to the controller pod template.
+    # Merged after the chart's default annotations (prometheus.io/scrape, etc.).
+    # Typical use: metric-pipeline schema tagging, e.g.
+    #   podAnnotations:
+    #     metrics-schema: ome-controller
+    podAnnotations: {}
     deploymentMode: "RawDeployment"
+    # Admission-time component replica defaults stamped by the ISVC mutating
+    # webhook on unset minReplicas/maxReplicas. Source of truth for these
+    # values (the OME binary has NO built-in defaults; an omitted field means
+    # the defaulter leaves that field as authored). A filled maxReplicas is
+    # raised to an authored minReplicas so admission never manufactures a
+    # min>max conflict.
+    replicas:
+      defaultMinReplicas: 1
+      defaultMaxReplicas:
+        engine: 3
+        decoder: 3
+        router: 2
+    # Max reconciles each controller runs in parallel (distinct objects only —
+    # controller-runtime serializes per object key, so independent objects
+    # reconcile concurrently). Source of truth for these values (the OME binary
+    # has NO built-in default; 0/unset falls back to controller-runtime's
+    # single-worker default). Raise on large clusters (thousands of ISVCs) where
+    # a single worker can't keep up with the reconcile backlog.
+    inferenceServiceMaxConcurrentReconciles: 4
+    inferenceReplicaMaxConcurrentReconciles: 4
+    # Client-side rate limit toward the local apiserver, shared by the manager
+    # cache/client, the direct clientset, and the webhook handlers. Source of
+    # truth for these values (the OME binary has NO built-in default; 0/unset
+    # falls back to controller-runtime's 20 QPS / 30 burst). The floor scales
+    # with the concurrent-reconcile counts above: each worker issues several
+    # reads and writes per pass, so leaving the default in place throttles the
+    # reconcile loop long before the apiserver is the bottleneck. Client-side
+    # throttling surfaces as "Waited for ... due to client-side throttling" in
+    # the controller log.
+    kubeAPIQPS: 100
+    kubeAPIBurst: 200
+    # TTL for the in-memory cache of the inferenceservice-config ConfigMap on the
+    # InferenceService reconcile path. Collapses the per-reconcile config loads
+    # (deploy/inferenceservice/ingress/canaryAnalysis) onto one apiserver GET per
+    # window; kept short so ConfigMap edits apply without a restart. Set to "0" to
+    # disable caching (read the apiserver on every load).
+    configCacheTTL: "30s"
+    # canaryAnalysis tunes metric-gated canary promotion (spec.rollout.canary).
+    canaryAnalysis:
+      # Default Prometheus the analysis queries when a canary does not set its own
+      # spec.rollout.canary.prometheus.serverAddress. Empty -> the bundled
+      # ome-prometheus Service at prometheus.service.port. Set to your own
+      # Prometheus/Thanos for production.
+      bundledPrometheusAddress: ""
+      # Per-sample query timeout, max background query concurrency, and how long a
+      # sampled result stays usable in the controller's cache.
+      queryTimeout: "5s"
+      maxConcurrency: 8
+      cacheTTL: "2m"
+    # coordination tunes the OMENative cross-Component coordination layer.
+    coordination:
+      # Per-revision hysteresis band (percent) for the pod-proportional traffic
+      # writer. A recomputed weight set whose every per-revision percent moves by
+      # strictly less than this from what is already in status is treated as
+      # pod-count jitter (a pod momentarily Pending between reconciles) and the
+      # status write + HTTPRoute re-enqueue is suppressed. 0 disables the band
+      # (write on any diff — the prior behavior). A small value (e.g. 5) damps the
+      # continuous churn at large pod counts; a sustained ratio change still
+      # exceeds the band and converges.
+      trafficWeightDeadbandPercent: 0
+      # Default maintainRatio.tolerance (percent) applied when a rollout group
+      # sets maintainRatio but omits the tolerance. An explicit per-group value
+      # (including 0) always wins. Remove the key to leave the default
+      # unconfigured — a group that omits tolerance then rolls with no drift
+      # bound.
+      defaultRatioTolerancePercent: 5
+    # podDisruptionBudget configures pod-level availability policies by mode.
+    # Omitting rawDeployment keeps the chart default; set rawDeployment: null
+    # to disable it.
+    podDisruptionBudget:
+      rawDeployment:
+        maxUnavailable: 1
+    # lifecycle tunes the OMENative per-Instance lifecycle state machine.
+    lifecycle:
+      # Missing-Pod budget for one OMENative scale-up pass. Instance and
+      # leader/worker gang boundaries remain atomic: all missing Pods for a
+      # selected Instance are handled together. Creating intents are committed
+      # in one status update before the corresponding Pods are created. A first
+      # eligible Instance larger than this value proceeds alone. Omit only to
+      # preserve this field's unbounded compatibility behavior. The manager
+      # reads this once at startup and rejects non-positive values; Helm rolls
+      # the manager automatically when the rendered ConfigMap changes.
+      scaleUpPodBatchSize: 100
+      # Active scale-down budget in Pod-equivalent units: live and Terminating
+      # Pods, with a cost-1 floor for Podless status work. Instance and
+      # leader/worker gang boundaries remain atomic, and the first eligible
+      # Instance larger than this value proceeds alone. Existing Delete-owned
+      # work is resumed before newly extra Instances are admitted. Omit only to
+      # preserve this field's unbounded compatibility behavior. The manager
+      # reads this once at startup and rejects non-positive values; Helm rolls
+      # every manager replica when the rendered ConfigMap changes.
+      scaleDownPodBatchSize: 100
+      # Periodic wake-up cadence while scale-down drain, Pod deletion, or
+      # per-Instance cleanup remains in flight. Pod, EndpointSlice, PodGroup,
+      # and owner watches also drive progress. Omit to disable cadence polling;
+      # configured force-delete and teardown deadlines still wake exactly when
+      # due. Malformed or non-positive durations prevent manager startup. Helm
+      # rolls the manager when this value changes.
+      scaleDownRequeueInterval: 5s
+      # revisionHistoryLimit caps how many non-live ControllerRevisions the
+      # InferenceReplica controller retains per (InferenceService, Component)
+      # when the ISVC does not set the ome.io/revision-history-limit
+      # annotation (the annotation, a positive integer, always wins). Live
+      # revisions — current, target, and every per-Instance running/target
+      # revision — are never deleted regardless of the limit. The OME binary
+      # has NO built-in default: removing this field disables pruning
+      # entirely for ISVCs without the annotation (revisions accumulate).
+      revisionHistoryLimit: 10
+      # updateRetry bounds automatic same-target update retries (RetryBlock).
+      # A rollout that fails toward an UNCHANGED target revision backs off
+      # exponentially (initialDelay * multiplier^(attempt-1), capped at
+      # maxDelay) and Holds after maxAttempts; only a new target revision
+      # releases the hold. The OME binary has NO built-in defaults: removing
+      # this block fails safe (the first same-target failure Holds
+      # immediately with a RetryHeld warning event).
+      updateRetry:
+        maxAttempts: 3
+        initialDelay: 1m
+        maxDelay: 30m
+        multiplier: 2.0
+      # stuckPodGracePeriod is the wait window after pod creation before a
+      # terminal kubelet waiting state escalates to Phase=Failed. Removing
+      # this field disables fast escalation (the InstanceReadyTimeout backstop
+      # still fires).
+      stuckPodGracePeriod: 60s
+      # autoMigrate configures the deadline-disposition relocation budget.
+      # Removing this block disables the relocation branch.
+      autoMigrate:
+        maxAttempts: 3
+      # forceDelete enables automated force-deletion (grace 0) of pods stuck
+      # Terminating on unreachable/gone nodes — opt-in; leave commented out
+      # (the default) to disable the escalation entirely. Both fields are
+      # required when the block is present: overdueSlack is how long past a
+      # pod's own deletionTimestamp before it counts as wedged;
+      # nodeUnreachableThreshold is the minimum age of the node's
+      # unreachable evidence before acting.
+      # forceDelete:
+      #   overdueSlack: 2m
+      #   nodeUnreachableThreshold: 5m
+      # teardown bounds how long a deleting InferenceReplica may hold its
+      # finalizer while draining pods. Past the deadline, the controller
+      # warns and lifts the finalizer (degrading to plain GC). Absence (of
+      # the entire block) is the fully supported default: the finalizer
+      # holds strictly until clean, NO deadline.
+      teardown:
+        deadline: 30m
     ingressGateway:
+      disableIstioVirtualHost: false
       domain: svc.cluster.local
       domainTemplate: "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"
       urlScheme: http
-      disableIstioVirtualHost: false
       ingressGateway:
-        gateway: knative-serving/knative-ingress-gateway
+        gateway: istio-system/ingress-gateway
         gatewayService: istio-ingressgateway.istio-system.svc.cluster.local
         className: istio
       omeIngressGateway: ""
@@ -34,6 +290,11 @@ ome:
       # built-in default. Must be an RFC-1123 label (invalid values are rejected
       # at config-load). Empty => the primary endpoint carries no class.
       omeIngressGatewayClass: ""
+      # Request headers forming the consistent-hash key for generated backend
+      # traffic policies. Config-driven: the binary's built-in fallback is
+      # ["x-routing-key"] only; this chart value is the deployment's source
+      # of truth for any additional routing headers.
+      consistentHashHeaders: ["x-routing-key", "X-SMG-Routing-Key"]
       additionalIngressDomains: null
       pathTemplate: ""
       disableIngressCreation: true
@@ -43,9 +304,9 @@ ome:
       perISVCSubdomain: false
       # Shared-host scheme (perISVCSubdomain=false) host label:
       # "<sharedHostPrefix>.<domain>". The OME binary has NO built-in default —
-      # this chart value is the source of truth. Empty string => bare <domain>
-      # (no prefix).
-      sharedHostPrefix: ""
+      # this chart value is the source of truth. Override per-cluster (e.g. via
+      # GitOps) as needed; empty string => bare <domain> (no prefix).
+      sharedHostPrefix: "llm"
       # Attach each generated HTTPRoute to extra gateways beyond the primary one
       # (e.g. an external gateway alongside the internal). Each entry adds a
       # parentRef + a hostname rendered from its own domain. Empty => single gateway.
@@ -53,16 +314,37 @@ ome:
       #   additionalIngressGateways:
       #     - omeIngressGateway: "envoy-gateway-system/external-gateway"
       #       ingressDomain: "external.example.com"
-      #       class: "external"
       additionalIngressGateways: []
-      # Per-namespace gateway overrides: map an ISVC namespace to the gateway(s)
-      # its routes attach to, replacing the cluster-default primary/additional
-      # gateways for that namespace. Empty => cluster defaults everywhere.
+      # Per-namespace gateway override: map an ISVC namespace to the gateway(s) its
+      # HTTPRoutes attach to, replacing the primary (omeIngressGateway/domain) and
+      # additionalIngressGateways above for ISVCs in that namespace. The route host
+      # is unchanged — it is still "<isvc>.<namespace>.<domain>" from domainTemplate —
+      # so this lets one controller serve per-namespace Gateways that each own their
+      # namespace's TLS cert + DNS (e.g. a "prod" Gateway for *.prod.<domain>).
+      # Namespaces absent here fall back to the cluster defaults; a per-ISVC
+      # "ome.io/ingress-gateway" annotation still overrides this. Empty => disabled.
+      # Example:
+      #   namespaceIngressGateways:
+      #     prod:
+      #       primary:
+      #         omeIngressGateway: "envoy-gateway-system/prod-int-gw-https"
+      #         ingressDomain: "int-gw-https.example.com"
+      #       additional:
+      #         - omeIngressGateway: "envoy-gateway-system/prod-ext-gw-https"
+      #           ingressDomain: "ext-gw-https.example.com"
       namespaceIngressGateways: {}
-      # Cluster-default Gateway API request timeout (seconds) for generated
-      # routes; unset => no route timeout is imposed and the gateway's own
-      # default applies.
-      # defaultRouteTimeoutSeconds: 60
+      # Cluster-default Gateway API request timeout (seconds) applied to every
+      # generated HTTPRoute whose ISVC doesn't set spec.<component>.timeoutSeconds.
+      # The OME binary has NO built-in default — this chart value is the source of
+      # truth (override per-cluster via GitOps).
+      #   0    => emit "0s" = explicitly DISABLE the overall request timeout
+      #           (recommended for inference: generations/streams run long; the
+      #           gateway's idle timeout still reaps dead streams).
+      #   >0   => that many seconds.
+      #   null => field omitted, which falls back to Envoy's built-in 15s route
+      #           default (truncates long requests) — avoid; prefer 0 or a value.
+      # A per-ISVC spec.<component>.timeoutSeconds still overrides this.
+      defaultRouteTimeoutSeconds: 0
     nodeSelector: {}
     tolerations: []
     topologySpreadConstraints: []
@@ -95,9 +377,6 @@ ome:
       memoryLimit: 320Gi
       cpuRequest: 15
       cpuLimit: 15
-    # metadataJob configures the metadata-extraction Job the BaseModel
-    # controller spawns on demand for PVC-backed models. It runs
-    # `ome-agent model-metadata` against the PVC-mounted model directory.
     metadataJob:
       serviceAccount: ome-model-metadata
       memoryRequest: 256Mi
@@ -113,29 +392,7 @@ ome:
       tolerations: []
       affinity: {}
       priorityClassName: ""
-  kedaConfig:
-    enableKeda: true
-    promServerAddress: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
-    customPromQuery: ""
-    scalingThreshold: "10"
-    scalingOperator: "GreaterThanOrEqual"
 modelAgent:
-  # Deploy the model-agent DaemonSet (node-local model download/cache).
-  # Required for BaseModel/ClusterBaseModel-backed model resolution.
-  # Installs whose runtimes fetch models themselves can leave this off.
-  enabled: false
-  hostPath: /mnt/data/models
-  priorityClassName: system-node-critical
-  serviceAccountName: ome-model-agent
-  image:
-    # Docker registry hub. If set, overrides global.hub for model-agent.
-    # If repository contains '/', hub is ignored.
-    # Leave empty to use global.hub
-    hub: ""
-    repository: model-agent
-    pullPolicy: Always
-    tag: *defaultVersion
-
   # Instance-type -> short-name mappings, by cloud provider. Single source of
   # truth: rendered into the model-agent ConfigMap (instance-type-map) and the
   # enigma init container's INSTANCE_TYPE_MAP env var via the
@@ -167,6 +424,24 @@ modelAgent:
     gpu-h200-sxm: H200
     gpu-b200-sxm: B200
     gpu-l40s: L40S
+  # Deploy the model-agent DaemonSet (node-local model download/cache).
+  # Required for BaseModel/ClusterBaseModel-backed model resolution.
+  # Installs whose runtimes fetch models themselves can leave this off.
+  enabled: true
+  # Additional annotations applied to the model-agent pod template.
+  # Same shape and intent as ome.controller.podAnnotations above.
+  podAnnotations: {}
+  hostPath: /mnt/data/models
+  priorityClassName: system-node-critical
+  serviceAccountName: ome-model-agent
+  image:
+    # Docker registry hub. If set, overrides global.hub for model-agent.
+    # If repository contains '/', hub is ignored.
+    # Leave empty to use global.hub
+    hub: ""
+    repository: model-agent
+    pullPolicy: Always
+    tag: *defaultVersion
 
   # When enabled, the model agent will only run on nodes with GPU
   gpuNodesOnly: false
@@ -224,3 +499,213 @@ modelAgent:
     requests:
       cpu: '10'
       memory: 100Gi
+
+# ServiceMonitor for the controller-manager metrics endpoint.
+# Requires prometheus-operator (monitoring.coreos.com/v1) installed
+# in the cluster. Leave disabled for clusters that use vanilla
+# Prometheus pod-annotation discovery (the prometheus.io/scrape
+# annotations on the controller pod continue to work).
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  # Extra labels merged onto the ServiceMonitor (e.g., to match the
+  # operator's ruleSelector / serviceMonitorSelector).
+  additionalLabels: {}
+  # Prometheus relabel rules applied before scraping.
+  relabelings: []
+  # Prometheus relabel rules applied after scraping (drop/keep series).
+  metricRelabelings: []
+
+# P0 alert rules — the tier that pages immediately. Every rule here is a
+# symptom a user can feel; causes belong in the lower tiers, because paging on
+# a cause that has not yet hurt anyone teaches the on-call to close pages
+# without reading them.
+#
+# Shipped as a prometheus-operator PrometheusRule, so it needs the
+# monitoring.coreos.com/v1 CRD and a Prometheus whose ruleSelector matches
+# (see additionalLabels). The Prometheus this chart bundles is a plain
+# Deployment reading a ConfigMap and does NOT consume PrometheusRule objects —
+# point these at the same Prometheus that backs your alerting.
+#
+# Disabled by default: an alert rule that fires into a routing tree nobody has
+# configured is worse than no rule at all.
+prometheusRule:
+  enabled: false
+  # Extra labels merged onto the PrometheusRule, to match the operator's
+  # ruleSelector.
+  additionalLabels: {}
+  # How often Prometheus evaluates this group.
+  interval: 30s
+  # Routing label stamped on every rule below.
+  severity: critical
+  # Runbook base URL. Each alert appends its own "#anchor", so a reader lands
+  # on the section for the alert that woke them. Empty emits the bare anchor —
+  # every alert still names its section, it just is not clickable.
+  runbookUrlBase: ""
+  # Series selectors, as PromQL label matchers without the enclosing braces.
+  #
+  # OME control-plane series are matched by pod name rather than by `job`: the
+  # job label differs between the ServiceMonitor scrape path and the
+  # prometheus.io/scrape annotation path, so it is not portable. Override if
+  # your store relabels differently, or to scope alerts to one cluster.
+  selectors:
+    controlPlane: pod=~"ome-controller-manager.*"
+    # Router series come from the router image, which is built outside this
+    # repo. Leave empty to match all routers the store knows about.
+    router: ""
+  rules:
+    # No reconciliation is happening at all: the pods are gone, every replica
+    # is failing its scrape, or the replicas are up but none holds the lease.
+    controllerDown:
+      enabled: true
+      duration: 5m
+    # The admission webhook is returning server errors, which blocks every
+    # InferenceService write cluster-wide. Counts 5xx only: a *rejected*
+    # admission is a 200 carrying allowed=false, and rejecting a bad spec is
+    # the webhook working.
+    webhookFailing:
+      enabled: true
+      duration: 5m
+      ratioThreshold: 0.1
+    # An InferenceService has registered backends but the routers see none of
+    # them as healthy — a customer-visible outage for that workload.
+    serviceUnavailable:
+      enabled: true
+      duration: 5m
+    # Rollouts are failing broadly enough to implicate the control plane
+    # rather than any one workload, so both a rate and a spread are required.
+    massRolloutFailure:
+      enabled: true
+      duration: 15m
+      ratioThreshold: 0.5
+      minInferenceServices: 3
+    # The controller is up and scraping, but wedged: work is queued, the
+    # backlog is growing, and nothing is being reconciled.
+    reconcileStalled:
+      enabled: true
+      duration: 10m
+      # Depth below this is normal churn, not a backlog.
+      minQueueDepth: 1
+      # Reconciles/sec at or below this counts as no progress.
+      maxReconcileRate: 0.01
+
+# PodMonitor for the model-agent DaemonSet. The DaemonSet has no
+# fronting Service (it's addressed via node-local hostPath, not
+# cluster DNS), so PodMonitor is the right scrape primitive.
+podMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels: {}
+  relabelings: []
+  metricRelabelings: []
+
+# Single-replica Prometheus bundled by this chart for KEDA autoscaling and
+# canary metric analysis. It is the default source for canary queries. Disable
+# it when your cluster already runs a Prometheus that scrapes OME pods, and
+# point analysis and KEDA at that instance instead. It is not intended for
+# long-term observability or alerting; retention is deliberately short and
+# storage defaults to emptyDir.
+prometheus:
+  enabled: true
+  # Retention window for persisted TSDB blocks. Short by design — this
+  # Prometheus exists for autoscaling input, not long-term observability.
+  # This does not bound the mutable head/WAL, which can span Prometheus's
+  # two-hour production block duration.
+  retention: 30m
+  # Size-based TSDB retention guard. Prometheus counts the head/WAL when
+  # evaluating this limit but can delete only persisted blocks. 6GB is about
+  # 70% of the default 8Gi emptyDir cap, leaving space for the mutable head,
+  # WAL checkpoints, and compaction. Set empty to disable; when overriding,
+  # keep this below 80-85% of the selected volume capacity.
+  retentionSize: 6GB
+  scrapeInterval: 15s
+  scrapeTimeout: 10s
+  # Internal Prometheus HTTP port. service.port remains the Service-facing
+  # port and may differ from this value.
+  listenPort: 9090
+  # Require an explicit scrape opt-in on InferenceService pods through either
+  # prometheus.io/scrape="true" or ome.io/enable-prometheus-scraping="true".
+  # The compatibility default keeps the existing opt-out behavior; enable this
+  # on large or shared clusters to bound the discovered scrape population.
+  requireScrapeAnnotation: false
+  # Prometheus metric_relabel_configs applied to the InferenceService scrape
+  # job. Use this to keep only the series needed by autoscaling and canary
+  # queries. Empty keeps every metric exposed by scraped pods.
+  metricRelabelConfigs: []
+  # Optional per-scrape guardrails. Set an individual value to 0 or empty to
+  # leave the corresponding Prometheus limit unset.
+  scrapeLimits:
+    sampleLimit: 0
+    targetLimit: 0
+    labelLimit: 0
+    labelNameLengthLimit: 0
+    labelValueLengthLimit: 0
+    bodySizeLimit: ""
+    keepDroppedTargets: 0
+  # Retain Prometheus's own process and TSDB metrics for capacity planning.
+  selfScrape:
+    enabled: true
+  externalLabels:
+    cluster: ome
+  # Optional query guards. Zero or empty values retain Prometheus's upstream
+  # defaults.
+  query:
+    maxConcurrency: 0
+    maxSamples: 0
+    timeout: ""
+  # Optional Go soft memory limit. Leave empty to use Prometheus's runtime
+  # behavior; set below the container limit to reserve non-heap headroom.
+  goMemLimit: ""
+  # Namespaces to discover InferenceService pods in. Empty = all namespaces
+  # (discovery is server-side filtered to ome.io/inferenceservice pods, which
+  # bounds the Kubernetes informer but not scrape cardinality). Set a list to
+  # hard-scope discovery on large multi-tenant clusters.
+  scrapeNamespaces: []
+  image:
+    repository: prom/prometheus
+    tag: "v3.0.1"
+    pullPolicy: IfNotPresent
+  # Memory scales with active series = (scrape targets) x (series per pod).
+  # LLM-serving pods expose high cardinality (per-request histograms, KV-cache,
+  # per-model labels), so a few hundred ISVC pods can push the head block past
+  # 1Gi and OOM-crashloop (the WAL replays the oversized head on every restart).
+  # 3Gi covers a moderate fleet (~500 ISVC pods). LARGER fleets: scope
+  # `scrapeNamespaces` to the namespaces you autoscale, and/or drop the metric
+  # firehose to the KEDA-needed series — this Prometheus is autoscaling input,
+  # not observability. Memory-by-count won't scale forever; cut cardinality.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 3Gi
+  service:
+    type: ClusterIP
+    port: 9090
+  storage:
+    # emptyDir size cap. Prometheus keeps the active head and WAL beyond the
+    # configured retention window, and compaction temporarily needs space for
+    # both source and output blocks. 8Gi covers a moderate high-cardinality
+    # inference fleet while still protecting the node from runaway disk use;
+    # retentionSize cannot delete the mutable head or WAL.
+    sizeLimit: 8Gi
+  # Optional durable TSDB storage. When disabled, the Deployment uses the
+  # emptyDir volume configured above. existingClaim takes precedence over a
+  # chart-managed claim when persistence is enabled.
+  persistence:
+    enabled: false
+    existingClaim: ""
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 16Gi
+    annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Extra labels merged onto every Prometheus-related resource.
+  # Useful for fleet labels or cost-attribution tags.
+  additionalLabels: {}

--- a/charts/ome-scheduler/Chart.yaml
+++ b/charts/ome-scheduler/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: ome-scheduler
+description: >-
+  OME accelerator scheduler — the upstream kube-scheduler built as a library with
+  the OME placement plugin (OMEGangPack, OEP-0022) registered. Installed as a
+  SECOND scheduler; workloads opt in via spec.schedulerName. Requires the
+  scheduler-plugins PodGroup CRD (scheduling.x-k8s.io) to be present in the
+  cluster.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.35.0-0 <1.36.0-0"

--- a/charts/ome-scheduler/README.md
+++ b/charts/ome-scheduler/README.md
@@ -1,0 +1,160 @@
+# ome-scheduler Helm chart
+
+Installs [ome-scheduler](../../scheduler) — the upstream kube-scheduler built as a
+library with the OME placement plugin (`OMEGangPack`, OEP-0022) — as a **second
+scheduler**. It does not replace the cluster's default scheduler; workloads opt
+in per-pod via `spec.schedulerName`.
+
+> **Alpha version pin:** the scheduler module and image are built against
+> Kubernetes **1.35.4**, and the chart accepts only Kubernetes 1.35. The matching
+> scheduler-plugins dependency is currently published only as the
+> `v0.35.4-devel` tag. Keep this chart opt-in until a stable v0.35 tag replaces
+> that development dependency.
+
+## Why a separate chart
+
+ome-scheduler is optional, opt-in, and pinned to the fleet's Kubernetes version
+on its own cadence (it's a separate Go module). Keeping it out of the operator
+chart (`ome-resources`) means its broad, sensitive scheduler RBAC isn't forced
+onto every OME install, and it can be upgraded/rolled back independently.
+
+## Prerequisite: the PodGroup CRD
+
+The plugin reads the scheduler-plugins `PodGroup` CR
+(`scheduling.x-k8s.io/v1alpha1`) for gang size and the topology annotation. That
+CRD must be installed in the cluster first (it is **not** bundled here — it's an
+external, shared dependency):
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.35.4-devel/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+```
+
+## Install
+
+```sh
+helm install ome-scheduler charts/ome-scheduler -n ome --create-namespace
+```
+
+## Using it
+
+A workload opts in by setting the scheduler name and declaring its gang via a
+PodGroup:
+
+```yaml
+# pod template
+spec:
+  schedulerName: ome-scheduler
+  # + the standard gang label:
+  #   metadata.labels["scheduling.x-k8s.io/pod-group"]: my-gang
+```
+
+```yaml
+apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: my-gang
+  annotations:
+    ome.io/topology-key: <node-label-that-defines-a-domain>   # e.g. an NVLink clique / TPU slice / rack label
+spec:
+  minMember: <gang size>
+  scheduleTimeoutSeconds: 600
+```
+
+The scheduler plugin bakes in no OME metadata names: this chart configures
+`scheduler.plugin.podGroupTopologyKeyAnnotation` as `ome.io/topology-key`.
+Gang size comes from `minMember`, the annotation value names the domain label,
+and node free-ness comes from each pod's own resource requests.
+
+The chart validates that annotation name while
+`scheduler.omeControllerIntegration.enabled` is true, because the OME
+controller publishes the fixed `ome.io/topology-key` contract. Generic
+PodGroup producers may disable the integration guard and configure another
+annotation name.
+
+Add the fleet's accelerator resource to
+`scheduler.nodeResourcesFit.resources` if the built-in `MostAllocated` score
+should pack at node level. Choosing production weights requires fleet-specific
+fragmentation measurements and is outside this chart's contract:
+
+```yaml
+scheduler:
+  nodeResourcesFit:
+    resources:
+      - name: example.com/accelerator
+        weight: 10
+      - name: cpu
+        weight: 1
+      - name: memory
+        weight: 1
+```
+
+The chart disables only built-in `PodTopologySpread` scoring because soft
+spreading contradicts packing. Explicit `DoNotSchedule` topology constraints
+remain enforced by its filter path.
+
+## Availability and metrics
+
+The default deployment runs two replicas with leader election and creates a
+PodDisruptionBudget. Rendering fails when `replicaCount > 1` and leader election
+is disabled. Required hostname anti-affinity keeps the leader and standby off the
+same node. Updates replace one standby at a time with no surge, so a two-node
+control pool can roll while one scheduler remains available. The PDB protects
+the same floor during voluntary disruptions, and rendering rejects a
+`minAvailable` value greater than or equal to `replicaCount`, which would block
+maintenance. On a one-node development cluster, set `replicaCount: 1` and
+either disable the PDB or set `minAvailable: 0`. The optional
+`*-metrics` Service exposes the scheduler's
+authenticated HTTPS `/metrics` endpoint; configure your monitor with Kubernetes
+service-account authentication and any required RBAC.
+
+## Permissions and version alignment
+
+The chart binds the scheduler ServiceAccount to the API server's auto-reconciled
+`system:kube-scheduler` and `system:volume-scheduler` ClusterRoles. This avoids a
+copied permission list drifting from the Kubernetes minor in the cluster. The
+chart-owned `*-extras` role adds only the scheduler-specific leader Lease and
+read-only PodGroup access.
+
+This role arrangement also means Kubernetes supplies the DRA permissions that
+belong to that release when DRA is enabled. It does **not** make a scheduler
+binary portable across Kubernetes minors; the chart's `kubeVersion` guard must
+move together with the binary, dependency set, and envtest pin.
+
+## Test boundary
+
+`make helm-lint` renders this chart and checks the scheduler configuration, HA
+guard, RBAC bindings, probes, metrics Service, PDB, and replica separation. The
+scheduler module's envtest suite exercises the plugin inside kube-scheduler.
+`make test-kind-scheduler` builds the scheduler locally and runs the focused
+OME-controller-to-scheduler contract on its own Kubernetes 1.35 KIND cluster:
+the generated scheduler name and PodGroup annotation must result in the whole
+gang landing in one synthetic topology domain. The broader controller KIND
+suite still uses the default scheduler and does not duplicate that coverage.
+
+## Key values
+
+| Value | Default | Meaning |
+|---|---|---|
+| `scheduler.name` | `ome-scheduler` | Profile / opt-in name (also the leader-election lock). |
+| `scheduler.image.repository` / `.tag` | `ome-scheduler` / `latest` | Image (prefixed by `global.hub` if set). |
+| `scheduler.replicaCount` | `2` | Leader plus warm standby for HA. |
+| `scheduler.leaderElect` | `true` | Only the leader schedules. |
+| `scheduler.omeControllerIntegration.enabled` | `true` | Enforce OME's fixed PodGroup topology annotation contract. |
+| `scheduler.deploymentStrategy` | one unavailable, no surge | Roll on two eligible nodes without violating required anti-affinity. |
+| `scheduler.verbosity` | `2` | klog `-v` level. |
+| `scheduler.plugin.topologyKey` | `""` | Fallback domain label for unannotated PodGroups. |
+| `scheduler.plugin.podGroupTopologyKeyAnnotation` | `ome.io/topology-key` | PodGroup annotation whose value names the per-gang domain label. |
+| `scheduler.plugin.unsupportedPlacementGroupLabel` | `ome.io/placement-group` | Label that fails closed until partner-gang reservations are implemented. |
+| `scheduler.plugin.defaultPermitTimeoutSeconds` | `600` | Configured fallback for PodGroups without a timeout. |
+| `scheduler.plugin.podGroupSyncTimeoutSeconds` | `30` | Maximum initial PodGroup cache-sync wait. |
+| `scheduler.plugin.gcIntervalSeconds` | `60` | Pin and reservation reconciliation cadence. |
+| `scheduler.plugin.standaloneDomainPacking` | `true` | Pack standalone whole-node pods into partly-filled domains; inert until `topologyKey` is set. |
+| `scheduler.percentageOfNodesToScore` | unset | Profile-scoped feasibility-scan breadth. Unset keeps upstream's adaptive 5-50% sample; set `100` wherever `standaloneDomainPacking` is active so the domain score sees every free node. |
+| `scheduler.omeGangPack.scoreWeight` | `10` | Weight of the domain-packing score; keep at or above `nodeResourcesFit.scoreWeight`. |
+| `scheduler.nodeResourcesFit.*` | see values | `MostAllocated` score weight and resource weights. |
+| `scheduler.metrics.service.enabled` | `true` | Create the authenticated HTTPS metrics Service. |
+| `scheduler.podDisruptionBudget.*` | enabled / `1` | Keep one scheduler available; `minAvailable` must be lower than replicas. |
+| `scheduler.resources.requests.memory` / `.limits.memory` | `4Gi` / `12Gi` | Accommodate cluster-wide informer caches and startup LIST peaks; override for constrained clusters. |
+| `scheduler.affinity` | required hostname anti-affinity | Keep the active scheduler and standby on different nodes. |
+
+See [`values.yaml`](values.yaml) for the full set.

--- a/charts/ome-scheduler/templates/_helpers.tpl
+++ b/charts/ome-scheduler/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Constructs an image ref with an optional global hub prefix. If the repository
+already contains '/', hub is ignored. Mirrors the ome-resources helper.
+Parameters: values, repository, tag.
+*/}}
+{{- define "ome-scheduler.image" -}}
+{{- $hub := .values.global.hub -}}
+{{- $repo := .repository -}}
+{{- $tag := .tag -}}
+{{- if and $hub (not (contains "/" $repo)) -}}
+{{- printf "%s/%s:%s" $hub $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version, suitable for use as a Kubernetes label value.
+*/}}
+{{- define "ome-scheduler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels — minimal and stable across re-renders.
+*/}}
+{{- define "ome-scheduler.selectorLabels" -}}
+app.kubernetes.io/name: ome-scheduler
+app.kubernetes.io/component: scheduler
+{{- end -}}
+
+{{/*
+Full label set stamped on chart resources.
+*/}}
+{{- define "ome-scheduler.labels" -}}
+{{ include "ome-scheduler.selectorLabels" . }}
+helm.sh/chart: {{ include "ome-scheduler.chart" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ome
+{{- end -}}

--- a/charts/ome-scheduler/templates/configmap.yaml
+++ b/charts/ome-scheduler/templates/configmap.yaml
@@ -1,0 +1,79 @@
+# The scheduler's KubeSchedulerConfiguration. One profile whose schedulerName is
+# the opt-in name; OMEGangPack is enabled via multiPoint, which wires it into
+# every extension point it implements (PreFilter, Filter, PostFilter, Reserve,
+# Permit, PostBind, and EnqueueExtensions) — no per-hook
+# enumeration to drift.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.scheduler.name }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: {{ .Values.scheduler.leaderElect }}
+      resourceName: {{ .Values.scheduler.name }}
+      resourceNamespace: {{ .Release.Namespace }}
+    profiles:
+      - schedulerName: {{ .Values.scheduler.name }}
+        {{- with .Values.scheduler.percentageOfNodesToScore }}
+        # Profile-scoped: only workloads that opt into this scheduler pay for the
+        # exhaustive feasibility scan that OMEGangPack's domain score needs.
+        percentageOfNodesToScore: {{ . }}
+        {{- end }}
+        plugins:
+          multiPoint:
+            enabled:
+              - name: OMEGangPack
+            {{- if .Values.scheduler.disablePreemption }}
+            disabled:
+              # Until OEP-0022 Phase C adds topology-aware preemption, the default
+              # preemptor is domain-blind for gangs: a no-fit gang carries no pin
+              # for Filter to enforce during preemption simulation, so it can evict
+              # victims scattered across domains that never assemble one whole free
+              # domain — churning pods for nothing. Disabling it here means
+              # ome-scheduler simply waits for capacity (the default scheduler still
+              # preempts for everything it schedules). Set disablePreemption: false
+              # to restore the built-in behavior.
+              - name: DefaultPreemption
+            {{- end }}
+          score:
+            enabled:
+              - name: NodeResourcesFit
+                weight: {{ .Values.scheduler.nodeResourcesFit.scoreWeight }}
+              # Domain-level bin-packing for standalone pods. OMEGangPack is
+              # already wired via multiPoint; this explicit entry only sets its
+              # Score weight (multiPoint does not re-add it).
+              - name: OMEGangPack
+                weight: {{ .Values.scheduler.omeGangPack.scoreWeight }}
+            {{- if .Values.scheduler.disablePodTopologySpreadScore }}
+            disabled:
+              # Soft topology spreading directly conflicts with OEP-0022's
+              # packing policy. Hard DoNotSchedule constraints still run via
+              # PodTopologySpread's PreFilter and Filter extension points.
+              - name: PodTopologySpread
+            {{- end }}
+        pluginConfig:
+          - name: OMEGangPack
+            args:
+              {{- with .Values.scheduler.plugin.topologyKey }}
+              topologyKey: {{ . | quote }}
+              {{- end }}
+              podGroupTopologyKeyAnnotation: {{ .Values.scheduler.plugin.podGroupTopologyKeyAnnotation | quote }}
+              unsupportedPlacementGroupLabel: {{ .Values.scheduler.plugin.unsupportedPlacementGroupLabel | quote }}
+              defaultPermitTimeoutSeconds: {{ .Values.scheduler.plugin.defaultPermitTimeoutSeconds }}
+              podGroupSyncTimeoutSeconds: {{ .Values.scheduler.plugin.podGroupSyncTimeoutSeconds }}
+              gcIntervalSeconds: {{ .Values.scheduler.plugin.gcIntervalSeconds }}
+              standaloneDomainPacking: {{ .Values.scheduler.plugin.standaloneDomainPacking }}
+          - name: NodeResourcesFit
+            args:
+              scoringStrategy:
+                type: MostAllocated
+                {{- with .Values.scheduler.nodeResourcesFit.resources }}
+                resources:
+                  {{- toYaml . | nindent 18 }}
+                {{- end }}

--- a/charts/ome-scheduler/templates/deployment.yaml
+++ b/charts/ome-scheduler/templates/deployment.yaml
@@ -1,0 +1,100 @@
+{{- if and (gt (int .Values.scheduler.replicaCount) 1) (not .Values.scheduler.leaderElect) -}}
+{{- fail "scheduler.leaderElect must be true when scheduler.replicaCount is greater than 1" -}}
+{{- end }}
+{{- if and .Values.scheduler.omeControllerIntegration.enabled (ne .Values.scheduler.plugin.podGroupTopologyKeyAnnotation "ome.io/topology-key") -}}
+{{- fail "scheduler.plugin.podGroupTopologyKeyAnnotation must be ome.io/topology-key when scheduler.omeControllerIntegration.enabled is true; disable OME controller integration for generic producers" -}}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.scheduler.replicaCount }}
+  strategy:
+    {{- toYaml .Values.scheduler.deploymentStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "ome-scheduler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ome-scheduler.labels" . | nindent 8 }}
+      annotations:
+        # Re-roll the pods when the scheduler config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.scheduler.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.scheduler.name }}
+      {{- $pullSecrets := .Values.scheduler.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: scheduler
+        image: {{ include "ome-scheduler.image" (dict "values" .Values "repository" .Values.scheduler.image.repository "tag" .Values.scheduler.image.tag) }}
+        imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
+        command:
+        - /ome-scheduler
+        args:
+        - --config=/etc/kubernetes/ome-scheduler/config.yaml
+        - --v={{ .Values.scheduler.verbosity }}
+        - --bind-address={{ .Values.scheduler.metrics.bindAddress }}
+        - --secure-port={{ .Values.scheduler.metrics.securePort }}
+        ports:
+        - name: https-metrics
+          containerPort: {{ .Values.scheduler.metrics.securePort }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.scheduler.probes.liveness.path }}
+            port: https-metrics
+            scheme: HTTPS
+          initialDelaySeconds: {{ .Values.scheduler.probes.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.scheduler.probes.liveness.periodSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.scheduler.probes.readiness.path }}
+            port: https-metrics
+            scheme: HTTPS
+          initialDelaySeconds: {{ .Values.scheduler.probes.readiness.initialDelaySeconds }}
+        resources:
+          {{- toYaml .Values.scheduler.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes/ome-scheduler
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Values.scheduler.name }}-config

--- a/charts/ome-scheduler/templates/poddisruptionbudget.yaml
+++ b/charts/ome-scheduler/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.scheduler.podDisruptionBudget.enabled (ge (int .Values.scheduler.podDisruptionBudget.minAvailable) (int .Values.scheduler.replicaCount)) -}}
+{{- fail "scheduler.podDisruptionBudget.minAvailable must be less than scheduler.replicaCount so voluntary maintenance can make progress" -}}
+{{- end }}
+{{- if .Values.scheduler.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.scheduler.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "ome-scheduler.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ome-scheduler/templates/rbac.yaml
+++ b/charts/ome-scheduler/templates/rbac.yaml
@@ -1,0 +1,150 @@
+# Reuse the API server's auto-reconciled scheduler roles instead of copying
+# version-sensitive kube-scheduler permissions into this chart. This keeps core,
+# volume, and DRA permissions aligned with the Kubernetes minor installed in the
+# cluster. The chart-owned role below contains only ome-scheduler's distinct
+# leader lock and PodGroup read contract.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.scheduler.name }}-system-scheduler
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+---
+# Kubernetes binds its in-tree scheduler to this separate role for dynamic
+# volume binding. A second scheduler needs the same version-managed permissions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.scheduler.name }}-system-volume-scheduler
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:volume-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.scheduler.name }}-extras
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+rules:
+# Leader election uses a scheduler-specific Lease rather than kube-scheduler's
+# built-in lock. RBAC cannot restrict create by resourceName, so create remains
+# lease-wide; reads and updates are restricted to this scheduler's lock.
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resourceNames: ["{{ .Values.scheduler.name }}"]
+  resources: ["leases"]
+  verbs: ["get", "update"]
+# OMEGangPack reads gang size, timeout, and topology metadata from PodGroup.
+- apiGroups: ["scheduling.x-k8s.io"]
+  resources: ["podgroups"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.scheduler.name }}-extras
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.scheduler.name }}-extras
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+---
+# The scheduler reads extension-apiserver-authentication in kube-system for its
+# delegated secure-serving authentication configuration.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.scheduler.name }}-extension-apiserver-authentication-reader
+  namespace: kube-system
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.scheduler.metrics.authDelegation.enabled }}
+---
+# The metrics endpoint is served on a secure port with delegated authn/authz, so
+# the scheduler must be able to issue TokenReviews and SubjectAccessReviews to
+# decide whether a caller may scrape it. Without this binding every scrape of
+# /metrics is rejected 401/403 no matter how the scraper is configured — the
+# reader RoleBinding above only covers reading the client-CA config, not
+# authorizing callers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.scheduler.name }}-auth-delegator
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.scheduler.metrics.reader.create }}
+---
+# Grants permission to read the scheduler's /metrics endpoint. `/metrics` is a
+# non-resource URL, so it cannot be expressed as a normal resource rule. Bind
+# this to whichever identity scrapes the scheduler.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.scheduler.name }}-metrics-reader
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+{{- with .Values.scheduler.metrics.reader.serviceAccounts }}
+---
+# Bind the reader role to the configured scraper identities. Left empty, the role
+# is created but bound to nothing — the chart does not guess who scrapes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $.Values.scheduler.name }}-metrics-reader
+  labels:
+    {{- include "ome-scheduler.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $.Values.scheduler.name }}-metrics-reader
+subjects:
+{{- range . }}
+- kind: ServiceAccount
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ome-scheduler/templates/service.yaml
+++ b/charts/ome-scheduler/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.scheduler.metrics.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.scheduler.name }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+  {{- with .Values.scheduler.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.scheduler.metrics.service.type }}
+  selector:
+    {{- include "ome-scheduler.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https-metrics
+      port: {{ .Values.scheduler.metrics.service.port }}
+      targetPort: https-metrics
+      protocol: TCP
+{{- end }}

--- a/charts/ome-scheduler/templates/serviceaccount.yaml
+++ b/charts/ome-scheduler/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}

--- a/charts/ome-scheduler/templates/servicemonitor.yaml
+++ b/charts/ome-scheduler/templates/servicemonitor.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.scheduler.metrics.serviceMonitor.enabled }}
+{{- if not .Values.scheduler.metrics.service.enabled }}
+{{- fail "scheduler.metrics.serviceMonitor.enabled requires scheduler.metrics.service.enabled — the ServiceMonitor selects the metrics Service" -}}
+{{- end }}
+# Scrape the scheduler's metrics via prometheus-operator's ServiceMonitor CRD,
+# targeting the named `https-metrics` port on the metrics Service.
+#
+# Unlike the controller-manager's ServiceMonitor, this endpoint is HTTPS with
+# delegated authn/authz (the kube-scheduler contract), so the scrape must present
+# a bearer token and trust the serving certificate. The scheduler serves a
+# self-signed cert by default, hence insecureSkipVerify; point `tlsConfig` at a CA
+# instead if you front it with a known issuer.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-scheduler.labels" . | nindent 4 }}
+    {{- with .Values.scheduler.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ome-scheduler.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: https-metrics
+      path: /metrics
+      scheme: https
+      interval: {{ .Values.scheduler.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.scheduler.metrics.serviceMonitor.scrapeTimeout }}
+      # The scraping pod's own projected token. Its ServiceAccount must hold the
+      # /metrics grant — see scheduler.metrics.reader.serviceAccounts.
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        {{- with .Values.scheduler.metrics.serviceMonitor.tlsConfig }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+        insecureSkipVerify: true
+        {{- end }}
+      {{- with .Values.scheduler.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ome-scheduler/tests/render_test.sh
+++ b/charts/ome-scheduler/tests/render_test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helm_bin="${HELM_BIN:-helm}"
+kube_version="1.35.0"
+
+fail() {
+  echo "ome-scheduler chart test: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local needle="$1"
+  grep -Fq -- "${needle}" <<<"${rendered}" || fail "render missing: ${needle}"
+}
+
+assert_absent() {
+  local needle="$1"
+  if grep -Fq -- "${needle}" <<<"${rendered}"; then
+    fail "render unexpectedly contains: ${needle}"
+  fi
+}
+
+"${helm_bin}" lint --strict --kube-version "${kube_version}" "${chart_dir}" >/dev/null
+rendered="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --namespace ome-system)"
+
+assert_contains 'helm.sh/chart: ome-scheduler-0.1.0'
+assert_contains 'app.kubernetes.io/version: "0.1.0"'
+
+# Embedded KubeSchedulerConfiguration contract. Helm cannot schema-check the
+# opaque ConfigMap string, so keep indentation-sensitive assertions for its
+# extension-point and plugin-argument structure.
+assert_contains '          multiPoint:'
+assert_contains '              - name: OMEGangPack'
+assert_contains '          score:'
+assert_contains '              - name: NodeResourcesFit'
+assert_contains '                type: MostAllocated'
+assert_contains '              - name: PodTopologySpread'
+assert_contains '              defaultPermitTimeoutSeconds: 600'
+assert_contains '              podGroupTopologyKeyAnnotation: "ome.io/topology-key"'
+assert_contains '              unsupportedPlacementGroupLabel: "ome.io/placement-group"'
+assert_contains '              podGroupSyncTimeoutSeconds: 30'
+assert_contains '              gcIntervalSeconds: 60'
+assert_contains '              standaloneDomainPacking: true'
+
+# Node sampling is profile-scoped and opt-in: absent by default (upstream's
+# adaptive band), rendered as a sibling of schedulerName when configured.
+assert_absent 'percentageOfNodesToScore'
+exhaustive="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.percentageOfNodesToScore=100)"
+grep -Fq '        percentageOfNodesToScore: 100' <<<"${exhaustive}" \
+  || fail "configured percentageOfNodesToScore was not rendered into the profile"
+for invalid in 0 101; do
+  if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+    --kube-version "${kube_version}" \
+    --set "scheduler.percentageOfNodesToScore=${invalid}" >/dev/null 2>&1; then
+    fail "out-of-range percentageOfNodesToScore ${invalid} unexpectedly passed values schema validation"
+  fi
+done
+
+# Production deployment surface.
+assert_contains 'kind: PodDisruptionBudget'
+assert_contains 'name: ome-scheduler-metrics'
+assert_contains 'path: /healthz'
+assert_contains 'path: /readyz'
+assert_contains 'requiredDuringSchedulingIgnoredDuringExecution:'
+assert_contains 'topologyKey: kubernetes.io/hostname'
+assert_contains 'whenUnsatisfiable: ScheduleAnyway'
+assert_contains 'maxUnavailable: 1'
+assert_contains 'maxSurge: 0'
+assert_contains $'        resources:\n          limits:\n            cpu: "2"\n            memory: 12Gi\n          requests:\n            cpu: 200m\n            memory: 4Gi'
+
+# Resource sizing remains configurable for constrained clusters.
+custom_resources="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.resources.requests.memory=1Gi \
+  --set scheduler.resources.limits.memory=2Gi)"
+grep -Fq $'        resources:\n          limits:\n            cpu: "2"\n            memory: 2Gi\n          requests:\n            cpu: 200m\n            memory: 1Gi' \
+  <<<"${custom_resources}" || fail "custom scheduler memory resources were not rendered"
+
+# Core and volume permissions come from the cluster's version-managed roles;
+# the chart-owned role is restricted to the distinct Lease/PodGroup contract.
+assert_contains 'name: system:kube-scheduler'
+assert_contains 'name: system:volume-scheduler'
+assert_contains 'name: ome-scheduler-extras'
+assert_contains 'resources: ["podgroups"]'
+assert_absent 'resources: ["nodes"]'
+assert_absent 'resources: ["pods"]'
+assert_absent 'resources: ["persistentvolumeclaims", "persistentvolumes"]'
+
+# Cross-field safety: replicated schedulers must use leader election.
+if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.replicaCount=2 \
+  --set scheduler.leaderElect=false >/dev/null 2>&1; then
+  fail "unsafe HA configuration unexpectedly rendered"
+fi
+
+# The values schema must reject invalid behavioral timeouts.
+if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.plugin.gcIntervalSeconds=0 >/dev/null 2>&1; then
+  fail "zero GC interval unexpectedly passed values schema validation"
+fi
+if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.name=Invalid_Name >/dev/null 2>&1; then
+  fail "invalid scheduler resource/profile name unexpectedly passed values schema validation"
+fi
+too_long_name="$(printf '%056d' 0 | tr '0' 'a')"
+if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set "scheduler.name=${too_long_name}" >/dev/null 2>&1; then
+  fail "overlong scheduler resource/profile name unexpectedly passed values schema validation"
+fi
+
+# The image contains kube-scheduler 1.35 APIs and is not a cross-minor binary.
+for unsupported_version in 1.34.99 1.36.0; do
+  if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+    --kube-version "${unsupported_version}" >/dev/null 2>&1; then
+    fail "unsupported Kubernetes ${unsupported_version} unexpectedly rendered"
+  fi
+done
+
+# OME's controller publishes a fixed topology annotation. Generic producers
+# must explicitly disable that integration guard before selecting another key.
+if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.plugin.podGroupTopologyKeyAnnotation=example.com/topology-key \
+  >/dev/null 2>&1; then
+  fail "OME integration accepted a mismatched PodGroup topology annotation"
+fi
+generic="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.omeControllerIntegration.enabled=false \
+  --set scheduler.plugin.podGroupTopologyKeyAnnotation=example.com/topology-key)"
+if ! grep -Fq 'podGroupTopologyKeyAnnotation: "example.com/topology-key"' <<<"${generic}"; then
+  fail "generic producer annotation was not rendered after disabling OME integration"
+fi
+
+# A PDB cannot require every replica without blocking voluntary maintenance.
+if "${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.replicaCount=1 \
+  --set scheduler.podDisruptionBudget.minAvailable=1 >/dev/null 2>&1; then
+  fail "blocking singleton PodDisruptionBudget unexpectedly rendered"
+fi
+"${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --set scheduler.replicaCount=1 \
+  --set scheduler.podDisruptionBudget.minAvailable=0 >/dev/null
+
+# Optional resources must be removable without leaving malformed YAML.
+minimal="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --namespace ome-system \
+  --set scheduler.replicaCount=1 \
+  --set scheduler.metrics.service.enabled=false \
+  --set scheduler.podDisruptionBudget.enabled=false)"
+if grep -Fq 'kind: PodDisruptionBudget' <<<"${minimal}"; then
+  fail "disabled PodDisruptionBudget was rendered"
+fi
+# Anchored: the Service is named exactly `ome-scheduler-metrics`, and other
+# metrics resources share that prefix (e.g. the `-metrics-reader` ClusterRole),
+# so a substring match would report them as the disabled Service.
+if grep -Eq '^  name: ome-scheduler-metrics$' <<<"${minimal}"; then
+  fail "disabled metrics Service was rendered"
+fi
+
+# Scraping the secure metrics port needs delegated authn/authz on the scheduler
+# side and a /metrics grant on the scraper side. Both ship by default; both must
+# be removable.
+assert_contains "name: system:auth-delegator"
+assert_contains "name: ome-scheduler-metrics-reader"
+assert_contains 'nonResourceURLs: ["/metrics"]'
+
+no_scrape_rbac="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --namespace ome-system \
+  --set scheduler.metrics.authDelegation.enabled=false \
+  --set scheduler.metrics.reader.create=false)"
+if grep -Fq 'name: system:auth-delegator' <<<"${no_scrape_rbac}"; then
+  fail "disabled auth-delegator binding was rendered"
+fi
+if grep -Fq 'name: ome-scheduler-metrics-reader' <<<"${no_scrape_rbac}"; then
+  fail "disabled metrics-reader ClusterRole was rendered"
+fi
+
+# The reader role binds only to explicitly configured scrapers; the chart never
+# guesses an identity. With none configured exactly one object carries the name
+# (the ClusterRole); a binding would add a second.
+reader_objects="$(grep -cE '^  name: ome-scheduler-metrics-reader$' <<<"${rendered}" || true)"
+if [[ "${reader_objects}" != "1" ]]; then
+  fail "expected only the metrics-reader ClusterRole with no scraper configured, found ${reader_objects} objects"
+fi
+bound="$("${helm_bin}" template ome-scheduler "${chart_dir}" \
+  --kube-version "${kube_version}" \
+  --namespace ome-system \
+  --set-json 'scheduler.metrics.reader.serviceAccounts=[{"name":"collector","namespace":"telemetry"}]')"
+grep -Fq 'name: collector' <<<"${bound}" || fail "configured scraper was not bound"
+grep -Fq 'namespace: telemetry' <<<"${bound}" || fail "configured scraper namespace missing"

--- a/charts/ome-scheduler/values.schema.json
+++ b/charts/ome-scheduler/values.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["scheduler"],
+  "properties": {
+    "scheduler": {
+      "type": "object",
+      "required": ["name", "replicaCount", "leaderElect", "omeControllerIntegration", "deploymentStrategy", "plugin", "omeGangPack", "nodeResourcesFit", "metrics", "probes", "podDisruptionBudget"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 55,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+        },
+        "replicaCount": {"type": "integer", "minimum": 1},
+        "leaderElect": {"type": "boolean"},
+        "omeControllerIntegration": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {"type": "boolean"}
+          }
+        },
+        "deploymentStrategy": {
+          "type": "object",
+          "required": ["type", "rollingUpdate"],
+          "properties": {
+            "type": {"type": "string", "enum": ["RollingUpdate"]},
+            "rollingUpdate": {
+              "type": "object",
+              "required": ["maxUnavailable", "maxSurge"],
+              "properties": {
+                "maxUnavailable": {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "string"}]},
+                "maxSurge": {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "string"}]}
+              }
+            }
+          }
+        },
+        "plugin": {
+          "type": "object",
+          "required": ["topologyKey", "podGroupTopologyKeyAnnotation", "unsupportedPlacementGroupLabel", "defaultPermitTimeoutSeconds", "podGroupSyncTimeoutSeconds", "gcIntervalSeconds", "standaloneDomainPacking"],
+          "properties": {
+            "topologyKey": {"type": "string"},
+            "podGroupTopologyKeyAnnotation": {"type": "string", "minLength": 1},
+            "unsupportedPlacementGroupLabel": {"type": "string"},
+            "defaultPermitTimeoutSeconds": {"type": "integer", "minimum": 1},
+            "podGroupSyncTimeoutSeconds": {"type": "integer", "minimum": 1},
+            "gcIntervalSeconds": {"type": "integer", "minimum": 1},
+            "standaloneDomainPacking": {"type": "boolean"}
+          }
+        },
+        "percentageOfNodesToScore": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "omeGangPack": {
+          "type": "object",
+          "required": ["scoreWeight"],
+          "properties": {
+            "scoreWeight": {"type": "integer", "minimum": 1, "maximum": 1000000}
+          }
+        },
+        "nodeResourcesFit": {
+          "type": "object",
+          "required": ["scoreWeight", "resources"],
+          "properties": {
+            "scoreWeight": {"type": "integer", "minimum": 1, "maximum": 1000000},
+            "resources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "weight"],
+                "properties": {
+                  "name": {"type": "string", "minLength": 1},
+                  "weight": {"type": "integer", "minimum": 1}
+                }
+              }
+            }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "required": ["bindAddress", "securePort", "service"],
+          "properties": {
+            "bindAddress": {"type": "string", "minLength": 1},
+            "securePort": {"type": "integer", "minimum": 1, "maximum": 65535},
+            "service": {
+              "type": "object",
+              "required": ["enabled", "type", "port"],
+              "properties": {
+                "enabled": {"type": "boolean"},
+                "type": {"type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"]},
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535}
+              }
+            }
+          }
+        },
+        "probes": {
+          "type": "object",
+          "required": ["liveness", "readiness"],
+          "properties": {
+            "liveness": {
+              "type": "object",
+              "required": ["path", "initialDelaySeconds", "periodSeconds"],
+              "properties": {
+                "path": {"type": "string", "pattern": "^/"},
+                "initialDelaySeconds": {"type": "integer", "minimum": 0},
+                "periodSeconds": {"type": "integer", "minimum": 1}
+              }
+            },
+            "readiness": {
+              "type": "object",
+              "required": ["path", "initialDelaySeconds"],
+              "properties": {
+                "path": {"type": "string", "pattern": "^/"},
+                "initialDelaySeconds": {"type": "integer", "minimum": 0}
+              }
+            }
+          }
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "required": ["enabled", "minAvailable"],
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "minAvailable": {"type": "integer", "minimum": 0}
+          }
+        },
+        "affinity": {"type": "object"},
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {"type": "object"}
+        }
+      }
+    }
+  }
+}

--- a/charts/ome-scheduler/values.yaml
+++ b/charts/ome-scheduler/values.yaml
@@ -1,0 +1,221 @@
+# Default values for ome-scheduler.
+
+global:
+  # Optional registry prefix applied to image repositories that don't already
+  # contain a '/'. Matches the ome-resources chart's convention.
+  hub: ""
+  # Image pull secrets applied to the scheduler pod (overridable per-component).
+  imagePullSecrets: []
+
+scheduler:
+  # The scheduler's profile name. This is the value workloads put in
+  # spec.schedulerName to be scheduled by ome-scheduler; it is also the
+  # leader-election lock name. No workload convention is baked into the binary —
+  # this name is the entire opt-in surface. It must be a DNS label of at most
+  # 55 characters so chart-generated Service names remain valid.
+  name: ome-scheduler
+
+  image:
+    repository: ome-scheduler
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  # HA by default: multiple replicas with leader election, so exactly one instance
+  # schedules and the rest are warm standbys for fast failover. A scheduler is a
+  # single-writer decision loop — you can never run more than one ACTIVE instance
+  # (two would double-bind pods), so leaderElect must stay true whenever
+  # replicaCount > 1. Scale down to 1 for constrained/dev clusters.
+  replicaCount: 2
+  leaderElect: true
+  # The OME controller publishes its topology contract with a fixed annotation
+  # name. Keep this enabled for OME workloads. Generic/non-OME PodGroup
+  # producers may disable it and configure their own annotation name below.
+  omeControllerIntegration:
+    enabled: true
+  # Required anti-affinity prevents a surge replica from sharing either
+  # scheduler node. Replace the standby in place so a two-node control pool can
+  # roll without deadlocking; maxUnavailable keeps one scheduler available.
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+
+  # klog verbosity. 2 is a reasonable production default. The gang pin/Filter
+  # decision trace lives at V(4) — raise to 4 to debug placement (which domain a
+  # gang pinned, pinStale inputs, per-domain free counts, Filter rejects).
+  verbosity: 2
+
+  # Disable the built-in DefaultPreemption plugin for this scheduler. Until
+  # topology-aware preemption lands (OEP-0022 Phase C), default preemption is
+  # domain-blind for gangs and can evict victims that never form a whole domain.
+  # Leave true so ome-scheduler waits for capacity instead; the default scheduler
+  # still preempts for its own workloads. Set false to restore built-in behavior.
+  disablePreemption: true
+
+  plugin:
+    # Node label that identifies an accelerator domain as a fallback for
+    # PodGroups without a per-gang annotation. Leave empty when every gang
+    # declares its key.
+    topologyKey: ""
+    # Metadata names are configuration so the scheduler plugin itself is not
+    # coupled to the OME controller API. This chart wires OME's PodGroup contract.
+    podGroupTopologyKeyAnnotation: ome.io/topology-key
+    # Partner-gang placement is not implemented yet. When this configured label
+    # is present, fail closed instead of silently placing partner gangs apart.
+    unsupportedPlacementGroupLabel: ome.io/placement-group
+    # Fallback when a PodGroup omits spec.scheduleTimeoutSeconds. This lives in
+    # chart configuration rather than being compiled into the scheduler.
+    defaultPermitTimeoutSeconds: 600
+    # Bound the optional initial PodGroup informer sync. The informer continues
+    # retrying after startup if the CRD is temporarily unavailable.
+    podGroupSyncTimeoutSeconds: 30
+    # Pin/reservation reconciliation cadence.
+    gcIntervalSeconds: 60
+    # Steer standalone (non-gang) whole-node pods toward already-busy domains, so
+    # partly-filled slices fill before empty ones open and whole slices stay free
+    # for multi-host gangs. Only takes effect when topologyKey above is set (e.g.
+    # cloud.google.com/gke-tpu-partition-2x2x2-id on a TPU pool), and its domain
+    # counts are only as complete as the node sample Score receives — see
+    # percentageOfNodesToScore below.
+    standaloneDomainPacking: true
+
+  # Domain-level packing score for standalone pods (OMEGangPack.Score). Weight it
+  # at/above nodeResourcesFit so the partition-level signal wins the tie that
+  # node-level MostAllocated cannot break (all empty whole-node candidates tie).
+  omeGangPack:
+    scoreWeight: 10
+
+  nodeResourcesFit:
+    # Node-level packing complements OMEGangPack's domain-level packing.
+    scoreWeight: 10
+    # Set fleet accelerator resources here as needed. CPU and memory retain
+    # sensible packing behavior on mixed nodes without assuming a GPU vendor.
+    resources:
+      - name: cpu
+        weight: 1
+      - name: memory
+        weight: 1
+
+  # Disable only PodTopologySpread's preference score, which contradicts
+  # packing. Its PreFilter/Filter path remains enabled for explicit hard
+  # DoNotSchedule constraints.
+  disablePodTopologySpreadScore: true
+
+  # How many of the cluster's nodes must pass Filter before the scheduler stops
+  # looking for more candidates. Unset leaves upstream's adaptive 5-50% band,
+  # which hands Score a sample of the feasible nodes; OMEGangPack derives its
+  # per-domain free-node counts from exactly that sample, so a partial view can
+  # rank an empty domain above a partly-filled one. Set to 100 wherever
+  # standaloneDomainPacking is active. Gang pods never rely on this — PreFilter
+  # already narrows them to a single domain.
+  percentageOfNodesToScore:
+
+  # The scheduler serves /metrics on a secure port (HTTPS + delegated authn/authz),
+  # the same contract as kube-scheduler. Scraping it therefore needs three things,
+  # not just a port: the scheduler authorized to verify callers (authDelegation),
+  # the scraper authorized to read /metrics (reader), and the scraper pointed at
+  # the endpoint (podAnnotations below, or a PodMonitor/ServiceMonitor).
+  metrics:
+    bindAddress: 0.0.0.0
+    securePort: 10259
+    # Lets the scheduler issue TokenReview/SubjectAccessReview to authorize
+    # scrape callers. Without it every /metrics request is rejected 401/403.
+    authDelegation:
+      enabled: true
+    reader:
+      # Create a ClusterRole granting `get` on the /metrics non-resource URL.
+      create: true
+      # Identities to bind that role to — the ServiceAccounts that scrape. Empty
+      # means the role is created but bound to nothing; the chart does not guess
+      # who scrapes in your environment.
+      serviceAccounts: []
+      #  - name: prometheus
+      #    namespace: monitoring
+    service:
+      enabled: true
+      type: ClusterIP
+      port: 10259
+      annotations: {}
+    # Scrape via prometheus-operator's ServiceMonitor CRD, the mechanism the
+    # ome-resources chart already uses for the controller-manager. On a
+    # Prometheus-Operator stack this — not the pod annotations below — is what
+    # creates the scrape target. Off by default: it requires the CRD.
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: 10s
+      # Extra labels merged onto the ServiceMonitor, e.g. to match the operator's
+      # serviceMonitorSelector.
+      additionalLabels: {}
+      # TLS for the HTTPS metrics port. The scheduler serves a self-signed cert by
+      # default, so verification is skipped unless a CA is supplied here.
+      tlsConfig: {}
+      #  ca:
+      #    secret:
+      #      name: scrape-ca
+      #      key: ca.crt
+      #  serverName: ome-scheduler-metrics.ome.svc
+      relabelings: []
+      metricRelabelings: []
+
+  probes:
+    liveness:
+      path: /healthz
+      initialDelaySeconds: 15
+      periodSeconds: 20
+    readiness:
+      path: /readyz
+      initialDelaySeconds: 5
+
+  podDisruptionBudget:
+    enabled: true
+    # Must be lower than replicaCount. For a one-replica development install,
+    # disable the PDB or set this to 0 so upgrades and drains can proceed.
+    minAvailable: 1
+
+  resources:
+    # kube-scheduler informers cache cluster-wide Pods, Nodes, and PodGroups.
+    # Startup LIST processing temporarily uses more memory than steady state,
+    # so size the default for large production clusters; constrained/dev
+    # clusters can override these values.
+    requests:
+      cpu: 200m
+      memory: 4Gi
+    limits:
+      cpu: "2"
+      memory: 12Gi
+
+  nodeSelector: {}
+  # Keep the active scheduler and its standby off the same node. Required
+  # anti-affinity makes the HA claim concrete: a single node loss cannot remove
+  # both replicas. On a one-node development cluster, set replicaCount: 1.
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: ome-scheduler
+              app.kubernetes.io/component: scheduler
+          topologyKey: kubernetes.io/hostname
+  tolerations: []
+  # Prefer an even hostname distribution as a second line of defense if an
+  # operator replaces the affinity block with a less restrictive policy.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ome-scheduler
+          app.kubernetes.io/component: scheduler
+  # Annotations on the scheduler pods. For annotation-based Prometheus discovery,
+  # the scheme must be https — the metrics port is TLS, so a plain-HTTP scrape
+  # fails. Left empty by default because discovery is environment-specific: many
+  # clusters use a PodMonitor/ServiceMonitor against the metrics Service instead.
+  podAnnotations: {}
+  #  prometheus.io/scrape: "true"
+  #  prometheus.io/scheme: "https"
+  #  prometheus.io/port: "10259"
+  #  prometheus.io/path: "/metrics"
+  imagePullSecrets: []

--- a/charts/ome-serving/README.md
+++ b/charts/ome-serving/README.md
@@ -90,6 +90,7 @@ models:
       # image: custom-image:tag
       # routerImage: custom-router:tag
       # memFrac: "0.85"
+      # modelCacheProviders: ["model_cache"]  # opt in only for capable images
       # extraArgs: ["--flag", "value"]
 ```
 

--- a/charts/ome-serving/templates/_helpers.tpl
+++ b/charts/ome-serving/templates/_helpers.tpl
@@ -23,7 +23,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Model Registry - Maps model names to their supportedModelFormats configuration.
 This hides architecture details from users - they only need to specify model name.
-Extracted from 180 runtime files in config/runtimes/srt/
+The catalog below was historically extracted from the in-tree SGLang
+runtime YAMLs; those files now live in operators' own GitOps repos and
+this template is the canonical reference here.
 */}}
 {{- define "ome-serving.modelRegistry" -}}
 # Qwen3 models

--- a/charts/ome-serving/templates/clusterservingruntime.yaml
+++ b/charts/ome-serving/templates/clusterservingruntime.yaml
@@ -14,6 +14,7 @@
 {{- $isPdMode := $model.pdMode | default false }}
 {{- $ibDevice := $model.runtime.ibDevice | default $.Values.defaults.ibDevice | default "mlx5_0" }}
 {{- $rdmaProfile := $model.runtime.rdmaProfile | default $.Values.defaults.rdmaProfile | default "oci-roce" }}
+{{- $modelCacheProviders := $model.runtime.modelCacheProviders }}
 ---
 apiVersion: ome.io/v1beta1
 kind: ClusterServingRuntime
@@ -33,6 +34,10 @@ spec:
       modelArchitecture: {{ $modelInfo.architecture }}
       autoSelect: {{ $modelInfo.autoSelect }}
       priority: {{ $modelInfo.priority }}
+{{- with $modelCacheProviders }}
+      modelCacheProviders:
+{{ toYaml . | nindent 8 }}
+{{- end }}
   protocolVersions:
     - openAI
   modelSizeRange:

--- a/charts/ome-serving/values.yaml
+++ b/charts/ome-serving/values.yaml
@@ -41,6 +41,10 @@ models:
     hfModelId: arcee-ai/AFM-4.5B-Base
     runtime:
       gpus: 1
+      # modelCacheProviders is intentionally opt-in. Set this only for
+      # runtime images that can load sharded models through the provider.
+      # modelCacheProviders:
+      #   - model_cache
 
   baichuan2-13b-chat:
     enabled: false


### PR DESCRIPTION
Chart refresh following the controller/quota/scheduler code waves:

- **ome-resources**: controller deployment and `inferenceservice-config` brought current — multi-cluster access RBAC, supplemental view role, runtime-preset and controller-revision webhooks, optional default runtime, PodMonitor/ServiceMonitor wiring, an optional bundled Prometheus, and a `tests/render_test.sh` covering the render matrix. The benchmark and InferenceReplica webhook configurations this repo already ships are retained.
- **ome-quota-manager** (new): deploys `cmd/ome-quota-manager` (#807) with `quotaManager.mode` = `workload` | `management`, RBAC, and webhook certificate handling.
- **ome-scheduler** (new): deploys the ome-scheduler (#807) with its plugin configuration.
- **ome-serving**: catalog refresh; the model-cache provider example uses the `model_cache` provider value.
- `ome-crd` untouched (generated from `make manifests`).

Verified locally: `helm lint` on all five charts (0 failed), `helm template` renders for every chart including both quota-manager modes, `tests/render_test.sh` passes, codespell clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm charts for quota management and accelerator-aware scheduling.
  * Added optional bundled Prometheus monitoring, alerting, persistence, and service discovery.
  * Added multicluster access, metrics integrations, runtime configuration, and a default serving runtime.
  * Added configurable webhooks, certificate management, remote access, RBAC, disruption budgets, and scheduling controls.
* **Bug Fixes**
  * Improved webhook handling by excluding deletion-related updates and enforcing validation failures.
* **Documentation**
  * Expanded chart configuration and installation guidance, including model cache provider settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->