### PR TITLE
[Helm] drop dead kedaConfig; model-agent opt-in

### DIFF
--- a/charts/ome-resources/README.md
+++ b/charts/ome-resources/README.md
@@ -48,11 +48,6 @@ OME Resources and Controller
 | ome.controller.tag | string | `"v0.1.2"` |  |
 | ome.controller.tolerations | list | `[]` |  |
 | ome.controller.topologySpreadConstraints | list | `[]` |  |
-| ome.kedaConfig.customPromQuery | string | `""` |  |
-| ome.kedaConfig.enableKeda | bool | `true` |  |
-| ome.kedaConfig.promServerAddress | string | `"http://prometheus-operated.monitoring.svc.cluster.local:9090"` |  |
-| ome.kedaConfig.scalingOperator | string | `"GreaterThanOrEqual"` |  |
-| ome.kedaConfig.scalingThreshold | string | `"10"` |  |
 | ome.metricsaggregator.enableMetricAggregation | string | `"false"` |  |
 | ome.metricsaggregator.enablePrometheusScraping | string | `"false"` |  |
 | ome.multiclusterAccess.enabled | bool | `true` | Install ServiceAccount, token Secret, and scoped RBAC for InferenceDeploymentOperator. |

--- a/charts/ome-resources/templates/ome-controller/configmap.yaml
+++ b/charts/ome-resources/templates/ome-controller/configmap.yaml
@@ -165,14 +165,6 @@ data:
         "affinity": {{ .Values.ome.omeAgent.metadataJob.affinity | default dict | toJson }},
         "priorityClassName": "{{ .Values.ome.omeAgent.metadataJob.priorityClassName | default "" }}"
     }
-  kedaConfig: |-
-    {
-      "enableKeda" : {{ .Values.ome.kedaConfig.enableKeda | default true }},
-      "promServerAddress": "{{ .Values.ome.kedaConfig.promServerAddress | default "http://prometheus-operated.monitoring.svc.cluster.local:9090" }}",
-      "customPromQuery": "{{ .Values.ome.kedaConfig.customPromQuery | default "" }}",
-      "scalingThreshold": "{{ .Values.ome.kedaConfig.scalingThreshold | default "10" }}",
-      "scalingOperator": "{{ .Values.ome.kedaConfig.scalingOperator | default "GreaterThanOrEqual" }}"
-    }
   modelInit: |-
     {
         "image":  "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -113,12 +113,6 @@ ome:
     memoryRequest: "2Gi"
     cpuLimit: "2"
     memoryLimit: "2Gi"
-  kedaConfig:
-    enableKeda: true
-    promServerAddress: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
-    customPromQuery: ""
-    scalingThreshold: "10"
-    scalingOperator: "GreaterThanOrEqual"
 
   controller:
     replicaCount: 3
@@ -425,9 +419,9 @@ modelAgent:
     gpu-b200-sxm: B200
     gpu-l40s: L40S
   # Deploy the model-agent DaemonSet (node-local model download/cache).
-  # Required for BaseModel/ClusterBaseModel-backed model resolution.
-  # Installs whose runtimes fetch models themselves can leave this off.
-  enabled: true
+  # Required for BaseModel/ClusterBaseModel-backed model resolution;
+  # enable it unless your runtimes fetch models themselves.
+  enabled: false
   # Additional annotations applied to the model-agent pod template.
   # Same shape and intent as ome.controller.podAnnotations above.
   podAnnotations: {}


### PR DESCRIPTION
Two follow-ups to #809 from review:

- **Remove the `kedaConfig` block** from `inferenceservice-config` (plus its values and README rows): nothing in the codebase reads that configmap key anymore — KEDA autoscaling is driven by the per-Component autoscaler settings and annotations. Verified by search: zero consumers.
- **`modelAgent.enabled` defaults to `false`**: the model-agent DaemonSet is opt-in; installs whose runtimes fetch models themselves shouldn't get a fleet-wide DaemonSet by default.

`helm lint` clean, all templates render, `tests/render_test.sh` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed Helm settings for KEDA integration and autoscaling configuration.
  * Model Agent is now disabled by default in new deployments.
* **Documentation**
  * Updated chart documentation to remove references to the retired KEDA settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->