### PR TITLE
[Core] Add CLI root exit-code seam

### DIFF
--- a/cmd/kubectl-ome/main.go
+++ b/cmd/kubectl-ome/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -11,8 +10,9 @@ import (
 
 func main() {
 	streams := genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	if err := cli.NewRootCmd(streams).Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+	os.Exit(run(os.Args[1:], streams))
+}
+
+func run(args []string, streams genericiooptions.IOStreams) int {
+	return cli.Run(args, streams)
 }

--- a/cmd/kubectl-ome/main_test.go
+++ b/cmd/kubectl-ome/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+func TestRunIsTestableWithoutProcessExit(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     strings.NewReader(""),
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	if code := run([]string{"--help"}, streams); code != 0 {
+		t.Fatalf("run(--help) = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "kubectl ome <command>") {
+		t.Fatalf("stdout = %q, want root help", stdout.String())
+	}
+}
+
+func TestRunReturnsErrorCodeWithoutExiting(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     strings.NewReader(""),
+		Out:    &bytes.Buffer{},
+		ErrOut: &stderr,
+	}
+	if code := run([]string{"not-a-command"}, streams); code != 1 {
+		t.Fatalf("run(bad command) = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "error: unknown command") {
+		t.Fatalf("stderr = %q, want unknown-command diagnostic", stderr.String())
+	}
+}

--- a/pkg/cli/execute.go
+++ b/pkg/cli/execute.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/exitcode"
+)
+
+// ExecuteCommand executes cmd, writes one user-facing error, and returns the
+// stable process exit code without terminating the process.
+func ExecuteCommand(cmd *cobra.Command, stderr io.Writer) int {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetErr(stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		return exitcode.Success
+	}
+	if stderr != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+	}
+	return exitcode.FromError(err)
+}
+
+// Run constructs and executes the production command tree for args.
+func Run(args []string, streams genericiooptions.IOStreams) int {
+	cmd := NewRootCmd(streams)
+	cmd.SetArgs(args)
+	return ExecuteCommand(cmd, streams.ErrOut)
+}

--- a/pkg/cli/execute_test.go
+++ b/pkg/cli/execute_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/exitcode"
+)
+
+func TestExecuteCommandMapsErrorsAndPrintsOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "success", want: exitcode.Success},
+		{name: "ordinary", err: errors.New("ordinary failure"), want: exitcode.GeneralError},
+		{name: "assertion", err: &exitcode.UnmetAssertionError{Err: errors.New("not ready")}, want: exitcode.AssertionUnmet},
+		{name: "conflict", err: &exitcode.PreconditionError{Err: errors.New("stale target")}, want: exitcode.MutationConflict},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var stderr bytes.Buffer
+			cmd := &cobra.Command{
+				Use: "test",
+				RunE: func(*cobra.Command, []string) error {
+					return test.err
+				},
+			}
+			cmd.SetErr(&stderr)
+
+			if got := ExecuteCommand(cmd, &stderr); got != test.want {
+				t.Fatalf("ExecuteCommand() = %d, want %d", got, test.want)
+			}
+			if test.err == nil {
+				if stderr.Len() != 0 {
+					t.Fatalf("stderr = %q, want empty", stderr.String())
+				}
+				return
+			}
+			want := "error: " + test.err.Error() + "\n"
+			if stderr.String() != want {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+			}
+		})
+	}
+}
+
+func TestRunUsesRootAndProvidedStreams(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     strings.NewReader(""),
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	if got := Run([]string{"--help"}, streams); got != exitcode.Success {
+		t.Fatalf("Run(--help) = %d, want %d; stderr=%q", got, exitcode.Success, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "kubectl ome <command>") || stderr.Len() != 0 {
+		t.Fatalf("Run(--help) stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunReturnsGeneralErrorForBadInvocation(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     strings.NewReader(""),
+		Out:    &bytes.Buffer{},
+		ErrOut: &stderr,
+	}
+	if got := Run([]string{"not-a-command"}, streams); got != exitcode.GeneralError {
+		t.Fatalf("Run(bad command) = %d, want %d", got, exitcode.GeneralError)
+	}
+	if !strings.Contains(stderr.String(), "error: unknown command") {
+		t.Fatalf("stderr = %q, want unknown-command diagnostic", stderr.String())
+	}
+}

--- a/pkg/cli/exitcode/exitcode.go
+++ b/pkg/cli/exitcode/exitcode.go
@@ -1,0 +1,67 @@
+// Package exitcode maps typed CLI failures to stable process exit codes.
+package exitcode
+
+import "errors"
+
+const (
+	Success          = 0
+	GeneralError     = 1
+	AssertionUnmet   = 2
+	MutationConflict = 3
+)
+
+// UnmetAssertionError reports a completed observation whose explicit
+// assertion or wait predicate was not satisfied.
+type UnmetAssertionError struct {
+	Err error
+}
+
+func (e *UnmetAssertionError) Error() string {
+	if e == nil || e.Err == nil {
+		return "assertion unmet"
+	}
+	return e.Err.Error()
+}
+
+func (e *UnmetAssertionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// PreconditionError reports that a guarded mutation was rejected because its
+// live target no longer satisfies the verified precondition.
+type PreconditionError struct {
+	Err error
+}
+
+func (e *PreconditionError) Error() string {
+	if e == nil || e.Err == nil {
+		return "mutation precondition failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *PreconditionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// FromError returns the stable process exit code for err.
+func FromError(err error) int {
+	if err == nil {
+		return Success
+	}
+	var assertion *UnmetAssertionError
+	if errors.As(err, &assertion) {
+		return AssertionUnmet
+	}
+	var precondition *PreconditionError
+	if errors.As(err, &precondition) {
+		return MutationConflict
+	}
+	return GeneralError
+}

--- a/pkg/cli/exitcode/exitcode_test.go
+++ b/pkg/cli/exitcode/exitcode_test.go
@@ -1,0 +1,58 @@
+package exitcode
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestFromError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "success", want: Success},
+		{name: "ordinary error", err: errors.New("boom"), want: GeneralError},
+		{name: "unmet assertion", err: &UnmetAssertionError{Err: errors.New("not ready")}, want: AssertionUnmet},
+		{name: "wrapped assertion", err: fmt.Errorf("wait failed: %w", &UnmetAssertionError{Err: errors.New("not ready")}), want: AssertionUnmet},
+		{name: "stale mutation", err: &PreconditionError{Err: errors.New("resource changed")}, want: MutationConflict},
+		{name: "wrapped stale mutation", err: fmt.Errorf("apply failed: %w", &PreconditionError{Err: errors.New("resource changed")}), want: MutationConflict},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := FromError(test.err); got != test.want {
+				t.Fatalf("FromError(%v) = %d, want %d", test.err, got, test.want)
+			}
+		})
+	}
+}
+
+func TestTypedErrorsPreserveCause(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("predicate not met")
+	assertion := &UnmetAssertionError{Err: cause}
+	if assertion.Error() != cause.Error() || !errors.Is(assertion, cause) {
+		t.Fatalf("UnmetAssertionError does not preserve cause: %v", assertion)
+	}
+
+	stale := &PreconditionError{Err: cause}
+	if stale.Error() != cause.Error() || !errors.Is(stale, cause) {
+		t.Fatalf("PreconditionError does not preserve cause: %v", stale)
+	}
+}
+
+func TestTypedErrorsHandleNilCause(t *testing.T) {
+	t.Parallel()
+
+	if got := (&UnmetAssertionError{}).Error(); got != "assertion unmet" {
+		t.Fatalf("nil UnmetAssertionError = %q", got)
+	}
+	if got := (&PreconditionError{}).Error(); got != "mutation precondition failed" {
+		t.Fatalf("nil PreconditionError = %q", got)
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -18,8 +18,17 @@ import (
 // AddCommand line.
 func NewRootCmd(streams genericiooptions.IOStreams) *cobra.Command {
 	configFlags := genericclioptions.NewConfigFlags(true)
-	f := factory.New(configFlags)
+	return newRootCmd(factory.New(configFlags), configFlags, streams)
+}
 
+// NewRootCmdWithFactory builds the root command with an injected client
+// factory while preserving the production kubectl configuration flags.
+func NewRootCmdWithFactory(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	configFlags := genericclioptions.NewConfigFlags(true)
+	return newRootCmd(f, configFlags, streams)
+}
+
+func newRootCmd(f factory.Factory, configFlags *genericclioptions.ConfigFlags, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ome",
 		Short: "Inspect OME models, runtimes and inference services",
@@ -33,6 +42,9 @@ component-aware log streaming.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	cmd.SetIn(streams.In)
+	cmd.SetOut(streams.Out)
+	cmd.SetErr(streams.ErrOut)
 	configFlags.AddFlags(cmd.PersistentFlags())
 
 	// Command families. Keep alphabetical.

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+)
+
+func TestRootCommandTree(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmdWithFactory(factory.Static{NS: "default"}, genericiooptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &bytes.Buffer{},
+		ErrOut: &bytes.Buffer{},
+	})
+	got := commandPaths(root)
+	want := []string{
+		"ome get",
+		"ome logs",
+		"ome runtime",
+		"ome runtime explain",
+		"ome status",
+		"ome version",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command tree = %v, want %v", got, want)
+	}
+	if !root.SilenceErrors || !root.SilenceUsage {
+		t.Fatalf("root error policy = (SilenceErrors=%t, SilenceUsage=%t), want both true", root.SilenceErrors, root.SilenceUsage)
+	}
+}
+
+func TestInjectedRootCarriesAllKubectlConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmdWithFactory(factory.Static{NS: "default"}, genericiooptions.IOStreams{})
+	wantCmd := &cobra.Command{Use: "expected"}
+	genericclioptions.NewConfigFlags(true).AddFlags(wantCmd.PersistentFlags())
+
+	got := flagNames(root.PersistentFlags())
+	want := flagNames(wantCmd.PersistentFlags())
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("persistent kube flags = %v, want %v", got, want)
+	}
+	if flag := root.PersistentFlags().Lookup("namespace"); flag == nil || flag.Shorthand != "n" {
+		t.Fatalf("namespace flag = %#v, want -n shorthand", flag)
+	}
+}
+
+func commandPaths(root *cobra.Command) []string {
+	var paths []string
+	var walk func(*cobra.Command)
+	walk = func(parent *cobra.Command) {
+		for _, child := range parent.Commands() {
+			paths = append(paths, child.CommandPath())
+			walk(child)
+		}
+	}
+	walk(root)
+	sort.Strings(paths)
+	return paths
+}
+
+func flagNames(flags *pflag.FlagSet) []string {
+	var names []string
+	flags.VisitAll(func(flag *pflag.Flag) {
+		names = append(names, flag.Name)
+	})
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## What this PR does

Adds a stable process boundary for kubectl-ome: injectable root command construction, centralized typed exit-code mapping, exact-once error rendering, and a testable main entry point.

## Why we need it

The OEP 11.1 CLI roadmap needs one consistent execution seam before adding operational command families. This keeps Cobra wiring, streams, client injection, and automation-safe exit behavior uniform across subsequent focused PRs.

Fixes # N/A

## How to test

- `go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...`
- `go test -race -count=1 ./pkg/cli/...`
- `go vet ./cmd/kubectl-ome ./pkg/cli/...`
- `go build -o /tmp/kubectl-ome ./cmd/kubectl-ome`

All scoped commands pass locally. The repository-wide unit suite currently inherits an unrelated main-branch failure from #807: a stale approval in `pkg/controller/v1beta1/workload/removable_fields_audit_test.go` for CLI compatibility-counter reads removed by #808.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable; no documentation change needed)
- [ ] `make test` passes locally (blocked by the documented unrelated main-branch audit failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent command-line exit codes for successful execution and different error conditions.
  * Improved CLI error handling to display a single clear diagnostic without redundant usage output.
  * Help and command execution now honor the configured input, output, and error streams.
  * Added support for constructing commands with injected configuration.

* **Bug Fixes**
  * Unknown commands now return a stable failure status without terminating unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->