### PR TITLE
[Core] Add bounded CLI observation

### DIFF
--- a/pkg/cli/observation/observation.go
+++ b/pkg/cli/observation/observation.go
@@ -1,0 +1,236 @@
+// Package observation provides bounded, deterministic Kubernetes evidence
+// collection for composite kubectl-ome diagnostics.
+package observation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"sigs.k8s.io/ome/pkg/cli/paging"
+)
+
+// Collection is a bounded immutable-by-value snapshot of one Kubernetes
+// resource kind.
+type Collection[T any] struct {
+	Items     []T
+	Requests  int
+	Truncated bool
+}
+
+// ObjectRef identifies one source whose Warning events should be observed.
+type ObjectRef struct {
+	Namespace string
+	Kind      string
+	Name      string
+	UID       types.UID
+}
+
+// EventLimits bounds target fan-out, concurrent requests, and pagination for
+// each target.
+type EventLimits struct {
+	Paging        paging.Limits
+	MaxTargets    int
+	MaxConcurrent int
+}
+
+// SourceFailure preserves an optional-source error without discarding
+// evidence collected from other targets.
+type SourceFailure struct {
+	Target ObjectRef
+	Err    error
+}
+
+// EventCollection is a deterministic aggregate of per-target Warning events.
+type EventCollection struct {
+	Items          []corev1.Event
+	Requests       int
+	Truncated      bool
+	SkippedTargets int
+	Failures       []SourceFailure
+}
+
+// CollectPods lists a service's pods once, with bounded typed pagination.
+func CollectPods(ctx context.Context, pods coreclient.PodsGetter, namespace, labelSelector string, limits paging.Limits) (Collection[corev1.Pod], error) {
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		return Collection[corev1.Pod]{Items: []corev1.Pod{}}, fmt.Errorf("parse pod label selector: %w", err)
+	}
+	result, err := paging.ListBounded(ctx, metav1.ListOptions{LabelSelector: labelSelector}, limits,
+		func(requestCtx context.Context, opts metav1.ListOptions) (paging.Page[corev1.Pod], error) {
+			list, listErr := pods.Pods(namespace).List(requestCtx, opts)
+			if listErr != nil {
+				return paging.Page[corev1.Pod]{}, listErr
+			}
+			return paging.Page[corev1.Pod]{Items: list.Items, Continue: list.Continue}, nil
+		})
+	items := make([]corev1.Pod, 0, len(result.Items))
+	for _, pod := range result.Items {
+		if selector.Matches(labels.Set(pod.Labels)) {
+			items = append(items, *pod.DeepCopy())
+		}
+	}
+	collection := Collection[corev1.Pod]{
+		Items:     items,
+		Requests:  result.Pages,
+		Truncated: result.Truncated,
+	}
+	sort.SliceStable(collection.Items, func(i, j int) bool {
+		left, right := collection.Items[i], collection.Items[j]
+		if left.Namespace != right.Namespace {
+			return left.Namespace < right.Namespace
+		}
+		return left.Name < right.Name
+	})
+	return collection, err
+}
+
+// CollectWarningEvents observes Warning events for a bounded target set.
+// Individual source failures are returned in the collection; cancellation of
+// the parent context aborts the entire operation.
+func CollectWarningEvents(ctx context.Context, events coreclient.EventsGetter, targets []ObjectRef, limits EventLimits) (EventCollection, error) {
+	result := EventCollection{
+		Items:    []corev1.Event{},
+		Failures: []SourceFailure{},
+	}
+	if limits.MaxTargets <= 0 {
+		return result, fmt.Errorf("event target limit must be positive")
+	}
+	if limits.MaxConcurrent <= 0 {
+		return result, fmt.Errorf("event concurrency limit must be positive")
+	}
+	for index, target := range targets {
+		if target.Namespace == "" {
+			return result, fmt.Errorf("event target %d namespace must not be empty", index)
+		}
+		if target.Kind == "" {
+			return result, fmt.Errorf("event target %d kind must not be empty", index)
+		}
+		if target.Name == "" {
+			return result, fmt.Errorf("event target %d name must not be empty", index)
+		}
+	}
+
+	ordered := append([]ObjectRef(nil), targets...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left, right := ordered[i], ordered[j]
+		if left.Namespace != right.Namespace {
+			return left.Namespace < right.Namespace
+		}
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		return left.UID < right.UID
+	})
+	unique := make([]ObjectRef, 0, len(ordered))
+	for _, target := range ordered {
+		if len(unique) == 0 || unique[len(unique)-1] != target {
+			unique = append(unique, target)
+		}
+	}
+	ordered = unique
+	if len(ordered) > limits.MaxTargets {
+		result.Truncated = true
+		result.SkippedTargets = len(ordered) - limits.MaxTargets
+		ordered = ordered[:limits.MaxTargets]
+	}
+
+	type targetResult struct {
+		collection paging.Result[corev1.Event]
+		err        error
+	}
+	collected := make([]targetResult, len(ordered))
+	jobs := make(chan int)
+	workerCount := limits.MaxConcurrent
+	if workerCount > len(ordered) {
+		workerCount = len(ordered)
+	}
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				collected[index].collection, collected[index].err = collectWarningEventsForTarget(ctx, events, ordered[index], limits.Paging)
+			}
+		}()
+	}
+	for index := range ordered {
+		jobs <- index
+	}
+	close(jobs)
+	workers.Wait()
+
+	seen := make(map[string]struct{})
+	for index, target := range ordered {
+		observed := collected[index]
+		result.Requests += observed.collection.Pages
+		result.Truncated = result.Truncated || observed.collection.Truncated
+		sort.SliceStable(observed.collection.Items, func(i, j int) bool {
+			left, right := observed.collection.Items[i], observed.collection.Items[j]
+			if left.Namespace != right.Namespace {
+				return left.Namespace < right.Namespace
+			}
+			return left.Name < right.Name
+		})
+		for _, event := range observed.collection.Items {
+			if !eventMatchesTarget(event, target) {
+				continue
+			}
+			key := string(event.UID)
+			if key == "" {
+				key = event.Namespace + "/" + event.Name
+			}
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			result.Items = append(result.Items, *event.DeepCopy())
+		}
+		if observed.err != nil {
+			result.Failures = append(result.Failures, SourceFailure{Target: target, Err: observed.err})
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func collectWarningEventsForTarget(ctx context.Context, events coreclient.EventsGetter, target ObjectRef, limits paging.Limits) (paging.Result[corev1.Event], error) {
+	selectorFields := fields.Set{
+		"involvedObject.kind": target.Kind,
+		"involvedObject.name": target.Name,
+		"type":                corev1.EventTypeWarning,
+	}
+	if target.UID != "" {
+		selectorFields["involvedObject.uid"] = string(target.UID)
+	}
+	base := metav1.ListOptions{FieldSelector: selectorFields.AsSelector().String()}
+	return paging.ListBounded(ctx, base, limits,
+		func(requestCtx context.Context, opts metav1.ListOptions) (paging.Page[corev1.Event], error) {
+			list, err := events.Events(target.Namespace).List(requestCtx, opts)
+			if err != nil {
+				return paging.Page[corev1.Event]{}, err
+			}
+			return paging.Page[corev1.Event]{Items: list.Items, Continue: list.Continue}, nil
+		})
+}
+
+func eventMatchesTarget(event corev1.Event, target ObjectRef) bool {
+	if event.Namespace != target.Namespace || event.Type != corev1.EventTypeWarning || event.InvolvedObject.Kind != target.Kind || event.InvolvedObject.Name != target.Name {
+		return false
+	}
+	return target.UID == "" || event.InvolvedObject.UID == target.UID
+}

--- a/pkg/cli/observation/observation_test.go
+++ b/pkg/cli/observation/observation_test.go
@@ -1,0 +1,393 @@
+package observation
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	ktesting "k8s.io/client-go/testing"
+
+	"sigs.k8s.io/ome/pkg/cli/paging"
+)
+
+func TestCollectPodsUsesOneBoundedSelectorAndSortsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const selector = "ome.io/inferenceservice=chat"
+	kube := kubefake.NewSimpleClientset(
+		pod("z", "chat"),
+		pod("a", "chat"),
+		pod("other", "other"),
+	)
+	var restrictions []ktesting.ListRestrictions
+	kube.PrependReactor("list", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		restrictions = append(restrictions, action.(ktesting.ListAction).GetListRestrictions())
+		return false, nil, nil
+	})
+
+	got, err := CollectPods(context.Background(), kube.CoreV1(), "team-a", selector, paging.Limits{
+		PageSize:       10,
+		MaxItems:       10,
+		MaxPages:       1,
+		RequestTimeout: time.Second,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, []string{"a", "z"}, []string{got.Items[0].Name, got.Items[1].Name})
+	assert.Equal(t, 1, got.Requests)
+	assert.False(t, got.Truncated)
+	require.Len(t, restrictions, 1)
+	value, found := restrictions[0].Labels.RequiresExactMatch("ome.io/inferenceservice")
+	require.True(t, found)
+	assert.Equal(t, "chat", value)
+}
+
+func TestCollectPodsDefendsAgainstSelectorBlindSource(t *testing.T) {
+	t.Parallel()
+
+	got, err := CollectPods(context.Background(), blindPodGetter{}, "team-a", "ome.io/inferenceservice=chat", paging.Limits{
+		PageSize:       10,
+		MaxItems:       10,
+		MaxPages:       1,
+		RequestTimeout: time.Second,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, "wanted", got.Items[0].Name)
+}
+
+func TestCollectedSnapshotsDoNotShareNestedSourceData(t *testing.T) {
+	t.Parallel()
+
+	sourcePod := pod("wanted", "chat")
+	sourcePod.Labels["snapshot"] = "original"
+	pods := staticPodGetter{list: &corev1.PodList{Items: []corev1.Pod{*sourcePod}}}
+	podCollection, err := CollectPods(context.Background(), pods, "team-a", "ome.io/inferenceservice=chat", paging.Limits{
+		PageSize:       10,
+		MaxItems:       10,
+		MaxPages:       1,
+		RequestTimeout: time.Second,
+	})
+	require.NoError(t, err)
+	require.Len(t, podCollection.Items, 1)
+
+	sourceEvent := warningEvent("warning", "uid-warning", "pod-a")
+	sourceEvent.Labels = map[string]string{"snapshot": "original"}
+	kube := kubefake.NewSimpleClientset()
+	kube.PrependReactor("list", "events", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &corev1.EventList{Items: []corev1.Event{sourceEvent}}, nil
+	})
+	eventCollection, err := CollectWarningEvents(context.Background(), kube.CoreV1(), []ObjectRef{{
+		Namespace: "team-a", Kind: "Pod", Name: "pod-a",
+	}}, EventLimits{
+		Paging:     paging.Limits{PageSize: 10, MaxItems: 10, MaxPages: 1, RequestTimeout: time.Second},
+		MaxTargets: 1, MaxConcurrent: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, eventCollection.Items, 1)
+
+	sourcePod.Labels["snapshot"] = "mutated"
+	sourceEvent.Labels["snapshot"] = "mutated"
+	assert.Equal(t, "original", podCollection.Items[0].Labels["snapshot"])
+	assert.Equal(t, "original", eventCollection.Items[0].Labels["snapshot"])
+}
+
+func TestCollectWarningEventsCapsTargetsAndConcurrencyDeterministically(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{}, 3)
+	release := make(chan struct{})
+	getter := &blockingEventGetter{started: started, release: release}
+
+	targets := []ObjectRef{
+		{Namespace: "team-a", Kind: "Pod", Name: "z"},
+		{Namespace: "team-a", Kind: "InferenceService", Name: "chat"},
+		{Namespace: "team-a", Kind: "Pod", Name: "a"},
+	}
+	type outcome struct {
+		result EventCollection
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := CollectWarningEvents(context.Background(), getter, targets, EventLimits{
+			Paging: paging.Limits{
+				PageSize:       10,
+				MaxItems:       10,
+				MaxPages:       1,
+				RequestTimeout: time.Second,
+			},
+			MaxTargets:    2,
+			MaxConcurrent: 2,
+		})
+		done <- outcome{result: result, err: err}
+	}()
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("two bounded workers did not start")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatal("started more event queries than the target cap")
+	default:
+	}
+	close(release)
+
+	got := <-done
+	require.NoError(t, got.err)
+	assert.Equal(t, int32(2), getter.maximum.Load())
+	assert.Equal(t, 2, got.result.Requests)
+	assert.True(t, got.result.Truncated)
+	assert.Equal(t, 1, got.result.SkippedTargets)
+	require.Empty(t, got.result.Failures)
+	require.Len(t, got.result.Items, 2)
+	assert.Equal(t, []string{"event-chat", "event-a"}, []string{got.result.Items[0].Name, got.result.Items[1].Name})
+}
+
+func TestCollectWarningEventsPreservesSuccessfulSourcesWhenOneIsForbidden(t *testing.T) {
+	t.Parallel()
+
+	kube := kubefake.NewSimpleClientset()
+	kube.PrependReactor("list", "events", func(action ktesting.Action) (bool, runtime.Object, error) {
+		restrictions := action.(ktesting.ListAction).GetListRestrictions()
+		name, _ := restrictions.Fields.RequiresExactMatch("involvedObject.name")
+		if name == "b" {
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "events"}, name, errors.New("denied"))
+		}
+		return true, &corev1.EventList{Items: []corev1.Event{{
+			ObjectMeta:     metav1.ObjectMeta{Name: "event-a", Namespace: "team-a", UID: "event-a"},
+			Type:           corev1.EventTypeWarning,
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "a"},
+		}}}, nil
+	})
+
+	got, err := CollectWarningEvents(context.Background(), kube.CoreV1(), []ObjectRef{
+		{Namespace: "team-a", Kind: "Pod", Name: "a"},
+		{Namespace: "team-a", Kind: "Pod", Name: "b"},
+	}, EventLimits{
+		Paging:     paging.Limits{PageSize: 10, MaxItems: 10, MaxPages: 1, RequestTimeout: time.Second},
+		MaxTargets: 2, MaxConcurrent: 2,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, "event-a", got.Items[0].Name)
+	require.Len(t, got.Failures, 1)
+	assert.Equal(t, "b", got.Failures[0].Target.Name)
+	assert.True(t, apierrors.IsForbidden(got.Failures[0].Err))
+}
+
+func TestCollectWarningEventsRejectsIncompleteTargetWithoutRequest(t *testing.T) {
+	t.Parallel()
+
+	kube := kubefake.NewSimpleClientset()
+	requested := false
+	kube.PrependReactor("list", "events", func(ktesting.Action) (bool, runtime.Object, error) {
+		requested = true
+		return true, &corev1.EventList{}, nil
+	})
+
+	_, err := CollectWarningEvents(context.Background(), kube.CoreV1(), []ObjectRef{{
+		Kind: "Pod",
+		Name: "pod-a",
+	}}, EventLimits{
+		Paging:     paging.Limits{PageSize: 10, MaxItems: 10, MaxPages: 1, RequestTimeout: time.Second},
+		MaxTargets: 1, MaxConcurrent: 1,
+	})
+
+	require.ErrorContains(t, err, "namespace")
+	assert.False(t, requested)
+}
+
+func TestCollectWarningEventsSortsAndDeduplicatesEachTarget(t *testing.T) {
+	t.Parallel()
+
+	kube := kubefake.NewSimpleClientset()
+	kube.PrependReactor("list", "events", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &corev1.EventList{Items: []corev1.Event{
+			warningEvent("z", "uid-z", "pod-a"),
+			warningEvent("a", "uid-a", "pod-a"),
+			warningEvent("duplicate", "uid-a", "pod-a"),
+		}}, nil
+	})
+
+	got, err := CollectWarningEvents(context.Background(), kube.CoreV1(), []ObjectRef{{
+		Namespace: "team-a", Kind: "Pod", Name: "pod-a",
+	}}, EventLimits{
+		Paging:     paging.Limits{PageSize: 10, MaxItems: 10, MaxPages: 1, RequestTimeout: time.Second},
+		MaxTargets: 1, MaxConcurrent: 1,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, []string{"a", "z"}, []string{got.Items[0].Name, got.Items[1].Name})
+}
+
+func TestCollectWarningEventsRejectsWrongNamespaceFromSelectorBlindSource(t *testing.T) {
+	t.Parallel()
+
+	kube := kubefake.NewSimpleClientset()
+	kube.PrependReactor("list", "events", func(ktesting.Action) (bool, runtime.Object, error) {
+		wrongNamespace := warningEvent("wrong-namespace", "uid-wrong", "pod-a")
+		wrongNamespace.Namespace = "team-b"
+		return true, &corev1.EventList{Items: []corev1.Event{
+			wrongNamespace,
+			warningEvent("wanted", "uid-wanted", "pod-a"),
+		}}, nil
+	})
+
+	got, err := CollectWarningEvents(context.Background(), kube.CoreV1(), []ObjectRef{{
+		Namespace: "team-a", Kind: "Pod", Name: "pod-a",
+	}}, EventLimits{
+		Paging:     paging.Limits{PageSize: 10, MaxItems: 10, MaxPages: 1, RequestTimeout: time.Second},
+		MaxTargets: 1, MaxConcurrent: 1,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, "wanted", got.Items[0].Name)
+}
+
+func TestCollectWarningEventsDeduplicatesTargetsBeforeApplyingCap(t *testing.T) {
+	t.Parallel()
+
+	kube := kubefake.NewSimpleClientset()
+	kube.PrependReactor("list", "events", func(action ktesting.Action) (bool, runtime.Object, error) {
+		restrictions := action.(ktesting.ListAction).GetListRestrictions()
+		name, _ := restrictions.Fields.RequiresExactMatch("involvedObject.name")
+		return true, &corev1.EventList{Items: []corev1.Event{
+			warningEvent("event-"+name, types.UID("uid-"+name), name),
+		}}, nil
+	})
+
+	got, err := CollectWarningEvents(context.Background(), kube.CoreV1(), []ObjectRef{
+		{Namespace: "team-a", Kind: "Pod", Name: "a"},
+		{Namespace: "team-a", Kind: "Pod", Name: "a"},
+		{Namespace: "team-a", Kind: "Pod", Name: "b"},
+	}, EventLimits{
+		Paging:     paging.Limits{PageSize: 10, MaxItems: 10, MaxPages: 1, RequestTimeout: time.Second},
+		MaxTargets: 2, MaxConcurrent: 2,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.Requests)
+	assert.False(t, got.Truncated)
+	assert.Zero(t, got.SkippedTargets)
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, []string{"event-a", "event-b"}, []string{got.Items[0].Name, got.Items[1].Name})
+}
+
+func pod(name, service string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: "team-a",
+		Labels:    map[string]string{"ome.io/inferenceservice": service},
+	}}
+}
+
+func warningEvent(name string, uid types.UID, target string) corev1.Event {
+	return corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: name, Namespace: "team-a", UID: uid},
+		Type:           corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: target},
+	}
+}
+
+type blockingEventGetter struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	active  atomic.Int32
+	maximum atomic.Int32
+}
+
+type blindPodGetter struct{}
+
+type staticPodGetter struct {
+	list *corev1.PodList
+}
+
+func (getter staticPodGetter) Pods(string) coreclient.PodInterface {
+	return &staticPodInterface{PodInterface: nil, list: getter.list}
+}
+
+type staticPodInterface struct {
+	coreclient.PodInterface
+	list *corev1.PodList
+}
+
+func (pods *staticPodInterface) List(context.Context, metav1.ListOptions) (*corev1.PodList, error) {
+	return pods.list, nil
+}
+
+func (blindPodGetter) Pods(namespace string) coreclient.PodInterface {
+	return &blindPodInterface{PodInterface: nil, namespace: namespace}
+}
+
+type blindPodInterface struct {
+	coreclient.PodInterface
+	namespace string
+}
+
+func (pods *blindPodInterface) List(context.Context, metav1.ListOptions) (*corev1.PodList, error) {
+	return &corev1.PodList{Items: []corev1.Pod{
+		*pod("wanted", "chat"),
+		*pod("unrelated", "other"),
+	}}, nil
+}
+
+func (getter *blockingEventGetter) Events(namespace string) coreclient.EventInterface {
+	return &blockingEventInterface{EventInterface: nil, getter: getter, namespace: namespace}
+}
+
+type blockingEventInterface struct {
+	coreclient.EventInterface
+	getter    *blockingEventGetter
+	namespace string
+}
+
+func (events *blockingEventInterface) List(_ context.Context, opts metav1.ListOptions) (*corev1.EventList, error) {
+	current := events.getter.active.Add(1)
+	for {
+		maximum := events.getter.maximum.Load()
+		if current <= maximum || events.getter.maximum.CompareAndSwap(maximum, current) {
+			break
+		}
+	}
+	events.getter.started <- struct{}{}
+	<-events.getter.release
+	events.getter.active.Add(-1)
+
+	selector, err := fields.ParseSelector(opts.FieldSelector)
+	if err != nil {
+		return nil, err
+	}
+	name, _ := selector.RequiresExactMatch("involvedObject.name")
+	kind, _ := selector.RequiresExactMatch("involvedObject.kind")
+	return &corev1.EventList{Items: []corev1.Event{{
+		ObjectMeta: metav1.ObjectMeta{Name: "event-" + name, Namespace: events.namespace, UID: types.UID("uid-" + name)},
+		Type:       corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{
+			Kind: kind,
+			Name: name,
+		},
+	}}}, nil
+}

--- a/pkg/cli/paging/bounded.go
+++ b/pkg/cli/paging/bounded.go
@@ -1,0 +1,95 @@
+package paging
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Limits bounds both the size of each API request and the total work spent
+// draining a Kubernetes list.
+type Limits struct {
+	PageSize       int64
+	MaxItems       int
+	MaxPages       int
+	RequestTimeout time.Duration
+}
+
+// Page is one typed Kubernetes list response.
+type Page[T any] struct {
+	Items    []T
+	Continue string
+}
+
+// Result contains the bounded prefix returned by ListBounded.
+type Result[T any] struct {
+	Items     []T
+	Pages     int
+	Truncated bool
+}
+
+// ListBounded follows Kubernetes continue tokens without exceeding limits.
+// Base selectors are copied to every request.
+func ListBounded[T any](ctx context.Context, base metav1.ListOptions, limits Limits, fetch func(context.Context, metav1.ListOptions) (Page[T], error)) (Result[T], error) {
+	if err := limits.validate(); err != nil {
+		return Result[T]{}, err
+	}
+	result := Result[T]{Items: make([]T, 0, limits.MaxItems)}
+	continueToken := base.Continue
+
+	for result.Pages < limits.MaxPages && len(result.Items) < limits.MaxItems {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+
+		request := base
+		request.Continue = continueToken
+		request.Limit = limits.PageSize
+		remaining := limits.MaxItems - len(result.Items)
+		if request.Limit > int64(remaining) {
+			request.Limit = int64(remaining)
+		}
+
+		requestCtx, cancel := context.WithTimeout(ctx, limits.RequestTimeout)
+		page, err := fetch(requestCtx, request)
+		cancel()
+		result.Pages++
+		if err != nil {
+			return result, err
+		}
+		if page.Continue != "" && page.Continue == request.Continue {
+			return result, fmt.Errorf("continue token did not advance after page %d", result.Pages)
+		}
+		if len(page.Items) > remaining {
+			result.Items = append(result.Items, page.Items[:remaining]...)
+			result.Truncated = true
+			return result, nil
+		}
+		result.Items = append(result.Items, page.Items...)
+		if page.Continue == "" {
+			return result, nil
+		}
+		continueToken = page.Continue
+	}
+
+	result.Truncated = continueToken != ""
+	return result, nil
+}
+
+func (limits Limits) validate() error {
+	if limits.PageSize <= 0 {
+		return fmt.Errorf("page size must be positive")
+	}
+	if limits.MaxItems <= 0 {
+		return fmt.Errorf("item limit must be positive")
+	}
+	if limits.MaxPages <= 0 {
+		return fmt.Errorf("page limit must be positive")
+	}
+	if limits.RequestTimeout <= 0 {
+		return fmt.Errorf("request timeout must be positive")
+	}
+	return nil
+}

--- a/pkg/cli/paging/bounded_test.go
+++ b/pkg/cli/paging/bounded_test.go
@@ -1,0 +1,117 @@
+package paging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestListBoundedPreservesSelectorsAndStopsAtItemLimit(t *testing.T) {
+	t.Parallel()
+
+	base := metav1.ListOptions{
+		LabelSelector: "ome.io/inferenceservice=chat",
+		FieldSelector: "status.phase=Running",
+	}
+	var requests []metav1.ListOptions
+	pages := []Page[string]{
+		{Items: []string{"a", "b"}, Continue: "next"},
+		{Items: []string{"c"}, Continue: "more"},
+	}
+
+	got, err := ListBounded(context.Background(), base, Limits{
+		PageSize:       2,
+		MaxItems:       3,
+		MaxPages:       5,
+		RequestTimeout: time.Second,
+	}, func(_ context.Context, opts metav1.ListOptions) (Page[string], error) {
+		requests = append(requests, opts)
+		return pages[len(requests)-1], nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, got.Items)
+	assert.True(t, got.Truncated)
+	assert.Equal(t, 2, got.Pages)
+	require.Len(t, requests, 2)
+	assert.Equal(t, int64(2), requests[0].Limit)
+	assert.Empty(t, requests[0].Continue)
+	assert.Equal(t, int64(1), requests[1].Limit)
+	assert.Equal(t, "next", requests[1].Continue)
+	for _, request := range requests {
+		assert.Equal(t, base.LabelSelector, request.LabelSelector)
+		assert.Equal(t, base.FieldSelector, request.FieldSelector)
+	}
+}
+
+func TestListBoundedRejectsInvalidLimitsWithoutFetching(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		limits Limits
+	}{
+		{name: "page size", limits: Limits{MaxItems: 1, MaxPages: 1, RequestTimeout: time.Second}},
+		{name: "item limit", limits: Limits{PageSize: 1, MaxPages: 1, RequestTimeout: time.Second}},
+		{name: "page limit", limits: Limits{PageSize: 1, MaxItems: 1, RequestTimeout: time.Second}},
+		{name: "request timeout", limits: Limits{PageSize: 1, MaxItems: 1, MaxPages: 1}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			_, err := ListBounded(context.Background(), metav1.ListOptions{}, test.limits,
+				func(context.Context, metav1.ListOptions) (Page[string], error) {
+					called = true
+					return Page[string]{}, nil
+				})
+
+			require.Error(t, err)
+			assert.False(t, called)
+		})
+	}
+}
+
+func TestListBoundedRejectsNonAdvancingContinueToken(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	got, err := ListBounded(context.Background(), metav1.ListOptions{}, Limits{
+		PageSize:       1,
+		MaxItems:       5,
+		MaxPages:       5,
+		RequestTimeout: time.Second,
+	}, func(context.Context, metav1.ListOptions) (Page[string], error) {
+		calls++
+		return Page[string]{Items: []string{"item"}, Continue: "stuck"}, nil
+	})
+
+	require.ErrorContains(t, err, "continue token did not advance")
+	assert.Equal(t, []string{"item"}, got.Items)
+	assert.Equal(t, 2, calls)
+}
+
+func TestListBoundedGivesEveryRequestItsOwnTimeout(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 5 * time.Second
+	_, err := ListBounded(context.Background(), metav1.ListOptions{}, Limits{
+		PageSize:       1,
+		MaxItems:       1,
+		MaxPages:       1,
+		RequestTimeout: timeout,
+	}, func(ctx context.Context, _ metav1.ListOptions) (Page[string], error) {
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok, "fetch context must have a deadline")
+		remaining := time.Until(deadline)
+		assert.Positive(t, remaining)
+		assert.LessOrEqual(t, remaining, timeout)
+		return Page[string]{Items: []string{"item"}}, nil
+	})
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What this PR does

Implements OEP-0011.1 roadmap item 10:

- adds typed, capped Kubernetes pagination with per-request timeouts and truncation metadata
- adds deterministic pod collection with selector defense and deep-copied snapshots
- adds bounded concurrent Warning Event collection with target caps, optional-source failures, deduplication, and deterministic ordering
- rejects non-advancing continuation tokens without duplicating evidence

## Why we need it

Composite status, instance, rollout, and migration commands need a shared observation layer that cannot issue unbounded requests or discard useful primary evidence when an optional Event source fails.

Fixes # — N/A; tracked by OEP-0011.1.

## How to test

- `go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...`
- `go test -race -count=1 ./pkg/cli/...`
- `go vet ./cmd/kubectl-ome ./pkg/cli/...`
- `go build -o /tmp/ome-cli-bounded-kubectl-ome ./cmd/kubectl-ome`
- combined CLI coverage: 84.5%; new observation and paging packages: 88.5% each

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (not applicable; the merged OEP-0011.1 defines this contract)
- [ ] `make test` passes locally (full repository validation is delegated to required CI; scoped test, race, vet, and build pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded Kubernetes diagnostics for collecting pods and warning events.
  * Added pagination controls for page size, item limits, request limits, and timeouts.
  * Added deterministic sorting, filtering, deduplication, and snapshot isolation.
  * Added concurrent event collection with configurable target and worker limits.
  * Added truncation details and per-target failure reporting.

* **Bug Fixes**
  * Improved handling of invalid selectors, incomplete targets, cancellation, timeouts, and non-advancing pagination tokens.

* **Tests**
  * Added comprehensive coverage for collection, pagination, limits, sorting, deduplication, concurrency, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->