### PR TITLE
[Core] Enrich CLI inventory

### DIFF
--- a/pkg/cli/cmd/get/columns_test.go
+++ b/pkg/cli/cmd/get/columns_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
@@ -125,6 +127,8 @@ func TestModelAndRuntimeColumnsWrongType(t *testing.T) {
 func TestLongTailColumns(t *testing.T) {
 	mt := "LoRA"
 	base := "llama-3-3-70b"
+	desired := int32(4)
+	encoding := v1beta1.InstanceStatusEncodingColumnarV2
 	cases := []struct {
 		resource string
 		obj      runtime.Object
@@ -145,20 +149,66 @@ func TestLongTailColumns(t *testing.T) {
 				BaseModelRef: v1beta1.ObjectReference{Name: &base},
 			},
 		}, map[string]string{"NAME": "ftw", "TYPE": "LoRA", "BASEMODEL": "llama-3-3-70b"}},
+		{"acceleratorquotas", &v1beta1.AcceleratorQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "team-a", Generation: 7},
+			Spec: v1beta1.AcceleratorQuotaSpec{
+				Role:      v1beta1.AcceleratorQuotaRoleClusterQueue,
+				ParentRef: &v1beta1.AcceleratorQuotaParentRef{Name: "root"},
+			},
+			Status: v1beta1.AcceleratorQuotaStatus{
+				Path:               "/root/team-a",
+				ObservedGeneration: 7,
+				Budgets: []v1beta1.AcceleratorBudgetStatus{{
+					ResourceName: "nvidia.com/gpu", ResourceFlavor: "h100",
+					Nominal: resource.MustParse("8"), Admitted: resource.MustParse("3"),
+				}},
+				Conditions: []metav1.Condition{{Type: v1beta1.AcceleratorQuotaReady, Status: metav1.ConditionTrue}},
+			},
+		}, map[string]string{
+			"NAME": "team-a", "ROLE": "ClusterQueue", "PARENT": "root",
+			"RESOURCE": "nvidia.com/gpu", "FLAVOR": "h100", "NOMINAL": "8",
+			"ADMITTED": "3", "SOURCE": "Reported", "READY": "True", "PATH": "/root/team-a",
+		}},
 		{"inferencereplicas", &v1beta1.InferenceReplica{
 			ObjectMeta: metav1.ObjectMeta{Name: "rep"},
 			Spec: v1beta1.InferenceReplicaSpec{
 				Component: v1beta1.EngineComponent,
 				ParentRef: v1beta1.ParentReference{Name: "llama-70b"},
+				Replicas:  &desired,
+				Paused:    true,
 			},
-			Status: v1beta1.InferenceReplicaStatus{Replicas: 3},
-		}, map[string]string{"NAME": "rep", "COMPONENT": "engine", "PARENT": "llama-70b", "REPLICAS": "3"}},
+			Status: v1beta1.InferenceReplicaStatus{
+				Replicas: 3, ReadyReplicas: 2, AvailableReplicas: 2, ServingReplicas: 1,
+				UpdatedReplicas: 2, CurrentRevision: "rep-a", UpdateRevision: "rep-b",
+				InstanceStatusEncoding: &encoding,
+				Migrations:             []v1beta1.MigrationStatus{{}, {}},
+				Conditions: []metav1.Condition{{
+					Type: "RolloutStalled", Status: metav1.ConditionTrue, Reason: "InstancesFailing",
+				}},
+			},
+		}, map[string]string{
+			"NAME": "rep", "COMPONENT": "engine", "PARENT": "llama-70b",
+			"DESIRED": "4", "CURRENT": "3", "READY": "2", "AVAILABLE": "2",
+			"SERVING": "1", "UPDATED": "2", "CURRENT-REVISION": "rep-a",
+			"UPDATE-REVISION": "rep-b", "MIGRATIONS": "2", "ENCODING": "ColumnarV2",
+			"PAUSED": "true", "LIFECYCLE": "RolloutStalled=True", "REASON": "InstancesFailing",
+			"LIFECYCLE-FRESHNESS": "Current",
+		}},
 		{"workloadclusters", &v1beta1.WorkloadCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "wc"},
+			ObjectMeta: metav1.ObjectMeta{Name: "wc", Generation: 5},
+			Spec: v1beta1.WorkloadClusterSpec{ClusterSource: v1beta1.ClusterConnectionSource{
+				KubeConfig: &v1beta1.KubeConfigSource{
+					SecretRef: corev1.SecretReference{Namespace: "ome", Name: "wc-kubeconfig"},
+					Key:       "west.yaml",
+				},
+			}},
 			Status: v1beta1.WorkloadClusterStatus{Conditions: []metav1.Condition{{
-				Type: "Ready", Status: metav1.ConditionTrue,
+				Type: "Ready", Status: metav1.ConditionTrue, ObservedGeneration: 4, Reason: "Connected",
 			}}},
-		}, map[string]string{"NAME": "wc", "READY": "True"}},
+		}, map[string]string{
+			"NAME": "wc", "CONNECTION": "KubeConfig", "REFERENCE": "ome/wc-kubeconfig",
+			"KEY": "west.yaml", "READY": "True", "GENERATION": "5", "OBSERVED-GENERATION": "4", "REASON": "Connected",
+		}},
 	}
 	for _, tc := range cases {
 		e, err := resolve(tc.resource)
@@ -183,7 +233,7 @@ func TestLongTailColumns(t *testing.T) {
 func TestLongTailColumnsWrongType(t *testing.T) {
 	wrong := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "not-a-long-tail-resource"}}
 	for _, resource := range []string{
-		"acceleratorclasses", "benchmarkjobs", "finetunedweights",
+		"acceleratorclasses", "acceleratorquotas", "benchmarkjobs", "finetunedweights",
 		"inferencereplicas", "workloadclusters",
 	} {
 		e, err := resolve(resource)
@@ -193,6 +243,107 @@ func TestLongTailColumnsWrongType(t *testing.T) {
 			assert.NotPanics(t, func() { got = c.Extract(wrong) }, "%s/%s", resource, c.Name)
 			assert.Equal(t, "?", got, "%s/%s", resource, c.Name)
 		}
+	}
+}
+
+func TestInferenceReplicaInventoryFallbacks(t *testing.T) {
+	entry, err := resolve("ir")
+	require.NoError(t, err)
+	replica := &v1beta1.InferenceReplica{}
+	got := map[string]string{}
+	for _, column := range entry.Columns {
+		got[column.Name] = column.Extract(replica)
+	}
+	assert.Equal(t, "-", got["DESIRED"])
+	assert.Equal(t, "DenseV1", got["ENCODING"])
+	assert.Equal(t, "-", got["CURRENT-REVISION"])
+	assert.Equal(t, "-", got["UPDATE-REVISION"])
+	assert.Equal(t, "-", got["COORDINATION"])
+	assert.Equal(t, "Unavailable", got["LIFECYCLE"])
+	assert.Equal(t, "-", got["REASON"])
+}
+
+func TestInferenceReplicaLifecycleConditionPriorityAndFreshness(t *testing.T) {
+	replica := &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Status: v1beta1.InferenceReplicaStatus{Conditions: []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "MinimumAvailable", ObservedGeneration: 2},
+			{Type: "RolloutStalled", Status: metav1.ConditionTrue, Reason: "InstancesFailing", ObservedGeneration: 1},
+		}},
+	}
+
+	got := inferenceReplicaLifecycle(replica)
+	assert.Equal(t, "RolloutStalled=True", got.state, "an active stall must not be hidden by Ready=True")
+	assert.Equal(t, "InstancesFailing", got.reason)
+	assert.Equal(t, "Stale", got.freshness)
+
+	replica.Status.Conditions[1].Status = metav1.ConditionFalse
+	got = inferenceReplicaLifecycle(replica)
+	assert.Equal(t, "Ready=True", got.state)
+	assert.Equal(t, "MinimumAvailable", got.reason)
+	assert.Equal(t, "Current", got.freshness)
+}
+
+func TestWorkloadClusterConnectionModes(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    v1beta1.ClusterConnectionSource
+		wantKind  string
+		wantValue string
+		wantKey   string
+	}{
+		{
+			name: "cluster profile",
+			source: v1beta1.ClusterConnectionSource{
+				ClusterProfileRef: &v1beta1.ClusterProfileRef{Name: "gpu-west"},
+			},
+			wantKind: "ClusterProfile", wantValue: "gpu-west", wantKey: "-",
+		},
+		{
+			name: "kubeconfig default key",
+			source: v1beta1.ClusterConnectionSource{
+				KubeConfig: &v1beta1.KubeConfigSource{SecretRef: corev1.SecretReference{Name: "config"}},
+			},
+			wantKind: "KubeConfig", wantValue: "config", wantKey: "kubeconfig",
+		},
+		{
+			name: "kubeconfig custom key",
+			source: v1beta1.ClusterConnectionSource{
+				KubeConfig: &v1beta1.KubeConfigSource{
+					SecretRef: corev1.SecretReference{Name: "config"}, Key: "west.yaml",
+				},
+			},
+			wantKind: "KubeConfig", wantValue: "config", wantKey: "west.yaml",
+		},
+		{
+			name: "kubeconfig missing secret name",
+			source: v1beta1.ClusterConnectionSource{
+				KubeConfig: &v1beta1.KubeConfigSource{SecretRef: corev1.SecretReference{Namespace: "ome"}},
+			},
+			wantKind: "KubeConfig", wantValue: "-", wantKey: "kubeconfig",
+		},
+		{
+			name:     "invalid empty source",
+			wantKind: "Invalid", wantValue: "-", wantKey: "-",
+		},
+		{
+			name: "invalid ambiguous source",
+			source: v1beta1.ClusterConnectionSource{
+				KubeConfig:        &v1beta1.KubeConfigSource{SecretRef: corev1.SecretReference{Name: "config"}},
+				ClusterProfileRef: &v1beta1.ClusterProfileRef{Name: "profile"},
+			},
+			wantKind: "Invalid", wantValue: "-", wantKey: "-",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := workloadClusterConnection(&v1beta1.WorkloadCluster{
+				Spec: v1beta1.WorkloadClusterSpec{ClusterSource: test.source},
+			})
+			assert.Equal(t, test.wantKind, got.kind)
+			assert.Equal(t, test.wantValue, got.reference)
+			assert.Equal(t, test.wantKey, got.key)
+		})
 	}
 }
 

--- a/pkg/cli/cmd/get/get.go
+++ b/pkg/cli/cmd/get/get.go
@@ -133,6 +133,10 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 		table.Headers = append(table.Headers, c.Name)
 	}
 	for _, obj := range objs {
+		if o.entry.TableRows != nil {
+			table.Rows = append(table.Rows, o.entry.TableRows(obj, o.Output == "wide")...)
+			continue
+		}
 		var row []string
 		for _, c := range o.entry.Columns {
 			if c.Wide && o.Output != "wide" {

--- a/pkg/cli/cmd/get/get_test.go
+++ b/pkg/cli/cmd/get/get_test.go
@@ -6,10 +6,12 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"sigs.k8s.io/yaml"
@@ -219,4 +221,107 @@ func TestGetSelectorSurvivesPaging(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out, "gpu-isvc")
 	assert.NotContains(t, out, "cpu-isvc")
+}
+
+func TestGetAcceleratorQuotaFlattensBudgetRows(t *testing.T) {
+	quota := &v1beta1.AcceleratorQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a"},
+		Spec: v1beta1.AcceleratorQuotaSpec{
+			Role:      v1beta1.AcceleratorQuotaRoleClusterQueue,
+			ParentRef: &v1beta1.AcceleratorQuotaParentRef{Name: "root"},
+		},
+		Status: v1beta1.AcceleratorQuotaStatus{
+			Budgets: []v1beta1.AcceleratorBudgetStatus{
+				{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h200", Nominal: resource.MustParse("4"), Admitted: resource.MustParse("1")},
+				{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h100", Nominal: resource.MustParse("8"), Admitted: resource.MustParse("3")},
+			},
+			Conditions: []metav1.Condition{{Type: v1beta1.AcceleratorQuotaReady, Status: metav1.ConditionTrue}},
+		},
+	}
+	f := factory.Static{OME: omefake.NewSimpleClientset(quota), NS: "team-a"}
+
+	out, err := execute(t, f, "aq")
+	require.NoError(t, err)
+	assert.Equal(t, 2, strings.Count(out, "team-a"), out)
+	assert.Contains(t, out, "h100")
+	assert.Contains(t, out, "h200")
+	assert.Equal(t, 2, strings.Count(out, "Reported"), "each status-backed row must label its evidence")
+	assert.Less(t, strings.Index(out, "h100"), strings.Index(out, "h200"), "budget rows must be deterministic")
+}
+
+func TestGetAcceleratorQuotaRawJSONRemainsUnflattened(t *testing.T) {
+	quota := &v1beta1.AcceleratorQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a"},
+		Status: v1beta1.AcceleratorQuotaStatus{Budgets: []v1beta1.AcceleratorBudgetStatus{
+			{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h100"},
+			{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h200"},
+		}},
+	}
+	f := factory.Static{OME: omefake.NewSimpleClientset(quota), NS: "team-a"}
+
+	out, err := execute(t, f, "acceleratorquotas", "-o", "json")
+	require.NoError(t, err)
+	var list struct {
+		Items []struct {
+			Status struct {
+				Budgets []json.RawMessage `json:"budgets"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &list))
+	require.Len(t, list.Items, 1)
+	assert.Len(t, list.Items[0].Status.Budgets, 2, "machine output must preserve one API object")
+}
+
+func TestGetAcceleratorQuotaFallsBackToDeclaredBudget(t *testing.T) {
+	quota := &v1beta1.AcceleratorQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "unreported"},
+		Spec: v1beta1.AcceleratorQuotaSpec{
+			Role: v1beta1.AcceleratorQuotaRoleClusterQueue,
+			Budgets: []v1beta1.AcceleratorBudget{{
+				ResourceName: "nvidia.com/gpu", ResourceFlavor: "b200", Nominal: resource.MustParse("16"),
+			}},
+		},
+	}
+	f := factory.Static{OME: omefake.NewSimpleClientset(quota), NS: "team-a"}
+
+	out, err := execute(t, f, "aq")
+	require.NoError(t, err)
+	assert.Contains(t, out, "b200")
+	assert.Contains(t, out, "16")
+	assert.Contains(t, out, "Declared")
+	assert.Contains(t, out, "Unknown", "missing status must not be presented as healthy")
+}
+
+func TestGetAcceleratorQuotaPreservesStaleAndCurrentBudgets(t *testing.T) {
+	quota := &v1beta1.AcceleratorQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a", Generation: 2},
+		Spec: v1beta1.AcceleratorQuotaSpec{
+			Role: v1beta1.AcceleratorQuotaRoleClusterQueue,
+			Budgets: []v1beta1.AcceleratorBudget{
+				{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h100", Nominal: resource.MustParse("8")},
+				{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h200", Nominal: resource.MustParse("4")},
+			},
+		},
+		Status: v1beta1.AcceleratorQuotaStatus{
+			ObservedGeneration: 1,
+			Budgets: []v1beta1.AcceleratorBudgetStatus{{
+				ResourceName: "nvidia.com/gpu", ResourceFlavor: "h100",
+				Nominal: resource.MustParse("2"), Admitted: resource.MustParse("2"),
+			}},
+			Conditions: []metav1.Condition{{
+				Type: v1beta1.AcceleratorQuotaReady, Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+	f := factory.Static{OME: omefake.NewSimpleClientset(quota), NS: "team-a"}
+
+	out, err := execute(t, f, "aq")
+	require.NoError(t, err)
+	assert.Equal(t, 3, strings.Count(out, "team-a"), out)
+	assert.Equal(t, 2, strings.Count(out, "Declared"), out)
+	assert.Equal(t, 1, strings.Count(out, "Reported"), out)
+	assert.Equal(t, 3, strings.Count(out, "Stale"), out)
+	assert.Contains(t, out, "h200", "a current declaration absent from stale status must remain visible")
+	assert.Less(t, strings.Index(out, "Declared"), strings.Index(out, "Reported"), "current declaration must precede stale reported data for the same budget")
 }

--- a/pkg/cli/cmd/get/registry.go
+++ b/pkg/cli/cmd/get/registry.go
@@ -36,6 +36,7 @@ type entry struct {
 	Aliases    []string
 	Namespaced bool
 	Columns    []column
+	TableRows  func(runtime.Object, bool) [][]string
 	List       listFunc
 	GetOne     getFunc
 }
@@ -697,7 +698,21 @@ var inferenceReplicasEntry = &entry{
 		{Name: "NAME", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return r.Name })},
 		{Name: "COMPONENT", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(string(r.Spec.Component)) })},
 		{Name: "PARENT", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(r.Spec.ParentRef.Name) })},
-		{Name: "REPLICAS", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.Replicas) })},
+		{Name: "DESIRED", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return int32OrDash(r.Spec.Replicas) })},
+		{Name: "CURRENT", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.Replicas) })},
+		{Name: "READY", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.ReadyReplicas) })},
+		{Name: "AVAILABLE", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.AvailableReplicas) })},
+		{Name: "LIFECYCLE", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return inferenceReplicaLifecycle(r).state })},
+		{Name: "REASON", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return inferenceReplicaLifecycle(r).reason })},
+		{Name: "SERVING", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.ServingReplicas) })},
+		{Name: "UPDATED", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.UpdatedReplicas) })},
+		{Name: "CURRENT-REVISION", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(r.Status.CurrentRevision) })},
+		{Name: "UPDATE-REVISION", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(r.Status.UpdateRevision) })},
+		{Name: "MIGRATIONS", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", len(r.Status.Migrations)) })},
+		{Name: "ENCODING", Wide: true, Extract: safeCol(instanceStatusEncoding)},
+		{Name: "PAUSED", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%t", r.Spec.Paused) })},
+		{Name: "COORDINATION", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(r.Status.CoordinationGroupRef) })},
+		{Name: "LIFECYCLE-FRESHNESS", Wide: true, Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return inferenceReplicaLifecycle(r).freshness })},
 		{Name: "AGE", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.Age(r.CreationTimestamp) })},
 	},
 	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
@@ -727,18 +742,78 @@ var inferenceReplicasEntry = &entry{
 	},
 }
 
+func int32OrDash(value *int32) string {
+	if value == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *value)
+}
+
+func instanceStatusEncoding(replica *v1beta1.InferenceReplica) string {
+	if replica.Status.InstanceStatusEncoding == nil {
+		return "DenseV1"
+	}
+	return printers.OrDash(string(*replica.Status.InstanceStatusEncoding))
+}
+
+type inferenceReplicaLifecycleValue struct {
+	state     string
+	reason    string
+	freshness string
+}
+
+func inferenceReplicaLifecycle(replica *v1beta1.InferenceReplica) inferenceReplicaLifecycleValue {
+	// RolloutStalled is advisory and may coexist with Ready=True. Prefer an
+	// active stall so inventory cannot make a serving-but-wedged rollout look
+	// healthy. Otherwise Ready is the primary lifecycle condition.
+	stalled := meta.FindStatusCondition(replica.Status.Conditions, "RolloutStalled")
+	if stalled != nil && stalled.Status == metav1.ConditionTrue {
+		return inferenceReplicaLifecycleFromCondition(stalled, replica.Generation)
+	}
+	ready := meta.FindStatusCondition(replica.Status.Conditions, "Ready")
+	if ready != nil {
+		return inferenceReplicaLifecycleFromCondition(ready, replica.Generation)
+	}
+	if stalled != nil {
+		return inferenceReplicaLifecycleFromCondition(stalled, replica.Generation)
+	}
+	return inferenceReplicaLifecycleValue{state: "Unavailable", reason: "-", freshness: "Unavailable"}
+}
+
+func inferenceReplicaLifecycleFromCondition(condition *metav1.Condition, generation int64) inferenceReplicaLifecycleValue {
+	return inferenceReplicaLifecycleValue{
+		state:     fmt.Sprintf("%s=%s", condition.Type, condition.Status),
+		reason:    printers.OrDash(condition.Reason),
+		freshness: generationFreshness(generation, condition.ObservedGeneration),
+	}
+}
+
 var workloadClustersEntry = &entry{
 	Canonical:  "workloadclusters",
 	Aliases:    []string{"workloadcluster", "wc"},
 	Namespaced: false,
 	Columns: []column{
 		{Name: "NAME", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return w.Name })},
+		{Name: "CONNECTION", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return workloadClusterConnection(w).kind })},
+		{Name: "REFERENCE", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return workloadClusterConnection(w).reference })},
+		{Name: "KEY", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return workloadClusterConnection(w).key })},
 		{Name: "READY", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string {
-			c := meta.FindStatusCondition(w.Status.Conditions, v1beta1.WorkloadClusterReady)
-			if c == nil {
-				return "Unknown"
+			return conditionStatus(w.Status.Conditions, v1beta1.WorkloadClusterReady)
+		})},
+		{Name: "GENERATION", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return fmt.Sprintf("%d", w.Generation) })},
+		{Name: "OBSERVED-GENERATION", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string {
+			condition := meta.FindStatusCondition(w.Status.Conditions, v1beta1.WorkloadClusterReady)
+			if condition == nil || condition.ObservedGeneration == 0 {
+				return "-"
 			}
-			return string(c.Status)
+			return fmt.Sprintf("%d", condition.ObservedGeneration)
+		})},
+		{Name: "REASON", Wide: true, Extract: safeCol(func(w *v1beta1.WorkloadCluster) string {
+			condition := meta.FindStatusCondition(w.Status.Conditions, v1beta1.WorkloadClusterReady)
+			if condition == nil {
+				return "-"
+			}
+			return printers.OrDash(condition.Reason)
 		})},
 		{Name: "AGE", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return printers.Age(w.CreationTimestamp) })},
 	},
@@ -769,6 +844,257 @@ var workloadClustersEntry = &entry{
 	},
 }
 
+type workloadClusterConnectionValue struct {
+	kind      string
+	reference string
+	key       string
+}
+
+func workloadClusterConnection(cluster *v1beta1.WorkloadCluster) workloadClusterConnectionValue {
+	source := cluster.Spec.ClusterSource
+	switch {
+	case source.KubeConfig != nil && source.ClusterProfileRef == nil:
+		key := source.KubeConfig.Key
+		if key == "" {
+			key = "kubeconfig"
+		}
+		name := source.KubeConfig.SecretRef.Name
+		if name == "" {
+			return workloadClusterConnectionValue{kind: "KubeConfig", reference: "-", key: key}
+		}
+		if source.KubeConfig.SecretRef.Namespace != "" {
+			name = source.KubeConfig.SecretRef.Namespace + "/" + name
+		}
+		return workloadClusterConnectionValue{kind: "KubeConfig", reference: printers.OrDash(name), key: key}
+	case source.ClusterProfileRef != nil && source.KubeConfig == nil:
+		return workloadClusterConnectionValue{kind: "ClusterProfile", reference: printers.OrDash(source.ClusterProfileRef.Name), key: "-"}
+	default:
+		return workloadClusterConnectionValue{kind: "Invalid", reference: "-", key: "-"}
+	}
+}
+
+type acceleratorQuotaBudgetRow struct {
+	resource        string
+	flavor          string
+	nominal         string
+	admitted        string
+	source          string
+	statusFreshness string
+	borrowed        string
+	reserved        string
+}
+
+func acceleratorQuotaBudgetRows(quota *v1beta1.AcceleratorQuota) []acceleratorQuotaBudgetRow {
+	statusFreshness := acceleratorQuotaStatusFreshness(quota)
+	rows := make([]acceleratorQuotaBudgetRow, 0, len(quota.Status.Budgets)+len(quota.Spec.Budgets))
+	if len(quota.Status.Budgets) > 0 {
+		for _, budget := range quota.Status.Budgets {
+			rows = append(rows, acceleratorQuotaBudgetRow{
+				resource:        budget.ResourceName,
+				flavor:          budget.ResourceFlavor,
+				nominal:         budget.Nominal.String(),
+				admitted:        budget.Admitted.String(),
+				source:          "Reported",
+				statusFreshness: statusFreshness,
+				borrowed:        budget.Borrowed.String(),
+				reserved:        budget.Reserved.String(),
+			})
+		}
+	}
+	// Current status is authoritative for the flattened budget view. When it
+	// has not observed metadata.generation, retain the current declaration as
+	// separate evidence instead of hiding it behind stale reported rows.
+	if len(quota.Spec.Budgets) > 0 && (len(quota.Status.Budgets) == 0 || statusFreshness != "Current") {
+		for _, budget := range quota.Spec.Budgets {
+			rows = append(rows, acceleratorQuotaBudgetRow{
+				resource:        budget.ResourceName,
+				flavor:          budget.ResourceFlavor,
+				nominal:         budget.Nominal.String(),
+				admitted:        "-",
+				source:          "Declared",
+				statusFreshness: statusFreshness,
+				borrowed:        "-",
+				reserved:        "-",
+			})
+		}
+	}
+	if len(rows) == 0 {
+		rows = append(rows, acceleratorQuotaBudgetRow{
+			resource: "-", flavor: "-", nominal: "-", admitted: "-", source: "Unavailable",
+			statusFreshness: statusFreshness, borrowed: "-", reserved: "-",
+		})
+	}
+	return sortAcceleratorQuotaBudgetRows(rows)
+}
+
+func sortAcceleratorQuotaBudgetRows(rows []acceleratorQuotaBudgetRow) []acceleratorQuotaBudgetRow {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].resource != rows[j].resource {
+			return rows[i].resource < rows[j].resource
+		}
+		if rows[i].flavor != rows[j].flavor {
+			return rows[i].flavor < rows[j].flavor
+		}
+		if rows[i].source != rows[j].source {
+			return rows[i].source == "Declared"
+		}
+		return false
+	})
+	return rows
+}
+
+func acceleratorQuotaStatusFreshness(quota *v1beta1.AcceleratorQuota) string {
+	if quota.Status.ObservedGeneration == 0 {
+		// Zero generations occur only in synthetic objects. Preserve the useful
+		// convention that populated synthetic status is current in unit tests.
+		if quota.Generation == 0 && (len(quota.Status.Budgets) > 0 || len(quota.Status.Conditions) > 0) {
+			return "Current"
+		}
+		return "Unobserved"
+	}
+	return generationFreshness(quota.Generation, quota.Status.ObservedGeneration)
+}
+
+func generationFreshness(generation, observedGeneration int64) string {
+	if generation == observedGeneration {
+		return "Current"
+	}
+	if observedGeneration == 0 {
+		return "Unobserved"
+	}
+	return "Stale"
+}
+
+func acceleratorQuotaParent(quota *v1beta1.AcceleratorQuota) string {
+	if quota.Spec.ParentRef == nil {
+		return "-"
+	}
+	return printers.OrDash(quota.Spec.ParentRef.Name)
+}
+
+func conditionStatus(conditions []metav1.Condition, conditionType string) string {
+	condition := meta.FindStatusCondition(conditions, conditionType)
+	if condition == nil {
+		return "Unknown"
+	}
+	return string(condition.Status)
+}
+
+func firstAcceleratorQuotaBudget(quota *v1beta1.AcceleratorQuota) acceleratorQuotaBudgetRow {
+	return acceleratorQuotaBudgetRows(quota)[0]
+}
+
+var acceleratorQuotasEntry = &entry{
+	Canonical:  "acceleratorquotas",
+	Aliases:    []string{"acceleratorquota", "aq"},
+	Namespaced: false,
+	Columns: []column{
+		{Name: "NAME", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string { return q.Name })},
+		{Name: "ROLE", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string { return printers.OrDash(string(q.Spec.Role)) })},
+		{Name: "PARENT", Extract: safeCol(acceleratorQuotaParent)},
+		{Name: "RESOURCE", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return printers.OrDash(firstAcceleratorQuotaBudget(q).resource)
+		})},
+		{Name: "FLAVOR", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return printers.OrDash(firstAcceleratorQuotaBudget(q).flavor)
+		})},
+		{Name: "NOMINAL", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return printers.OrDash(firstAcceleratorQuotaBudget(q).nominal)
+		})},
+		{Name: "ADMITTED", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return printers.OrDash(firstAcceleratorQuotaBudget(q).admitted)
+		})},
+		{Name: "SOURCE", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return firstAcceleratorQuotaBudget(q).source
+		})},
+		{Name: "STATUS-FRESHNESS", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return firstAcceleratorQuotaBudget(q).statusFreshness
+		})},
+		{Name: "READY", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return conditionStatus(q.Status.Conditions, v1beta1.AcceleratorQuotaReady)
+		})},
+		{Name: "DEGRADED", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return conditionStatus(q.Status.Conditions, v1beta1.AcceleratorQuotaDegraded)
+		})},
+		{Name: "AGE", Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string { return printers.Age(q.CreationTimestamp) })},
+		{Name: "BORROWED", Wide: true, Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return printers.OrDash(firstAcceleratorQuotaBudget(q).borrowed)
+		})},
+		{Name: "RESERVED", Wide: true, Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string {
+			return printers.OrDash(firstAcceleratorQuotaBudget(q).reserved)
+		})},
+		{Name: "PATH", Wide: true, Extract: safeCol(func(q *v1beta1.AcceleratorQuota) string { return printers.OrDash(q.Status.Path) })},
+	},
+	TableRows: acceleratorQuotaTableRows,
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		client, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			list, err := client.OmeV1beta1().AcceleratorQuotas().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(list.Items))
+			for index := range list.Items {
+				items = append(items, &list.Items[index])
+			}
+			return items, list.Continue, nil
+		})
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		client, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return client.OmeV1beta1().AcceleratorQuotas().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+const (
+	acceleratorQuotaColumns     = 12
+	acceleratorQuotaWideColumns = 15
+)
+
+func acceleratorQuotaTableRows(obj runtime.Object, wide bool) [][]string {
+	quota, ok := obj.(*v1beta1.AcceleratorQuota)
+	if !ok {
+		width := acceleratorQuotaColumns
+		if wide {
+			width = acceleratorQuotaWideColumns
+		}
+		row := make([]string, width)
+		for index := range row {
+			row[index] = "?"
+		}
+		return [][]string{row}
+	}
+	rows := make([][]string, 0, len(acceleratorQuotaBudgetRows(quota)))
+	for _, budget := range acceleratorQuotaBudgetRows(quota) {
+		row := []string{
+			quota.Name,
+			printers.OrDash(string(quota.Spec.Role)),
+			acceleratorQuotaParent(quota),
+			printers.OrDash(budget.resource),
+			printers.OrDash(budget.flavor),
+			printers.OrDash(budget.nominal),
+			printers.OrDash(budget.admitted),
+			budget.source,
+			budget.statusFreshness,
+			conditionStatus(quota.Status.Conditions, v1beta1.AcceleratorQuotaReady),
+			conditionStatus(quota.Status.Conditions, v1beta1.AcceleratorQuotaDegraded),
+			printers.Age(quota.CreationTimestamp),
+		}
+		if wide {
+			row = append(row, printers.OrDash(budget.borrowed), printers.OrDash(budget.reserved), printers.OrDash(quota.Status.Path))
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
 // registry lists every resource `kubectl ome get` knows how to render. Adding
 // a resource means adding an entry here, never a new command.
 var registry = []*entry{
@@ -776,6 +1102,6 @@ var registry = []*entry{
 	modelsEntry,
 	baseModelsEntry, clusterBaseModelsEntry,
 	runtimesEntry, servingRuntimesEntry, clusterServingRuntimesEntry,
-	acceleratorClassesEntry, benchmarkJobsEntry,
+	acceleratorClassesEntry, acceleratorQuotasEntry, benchmarkJobsEntry,
 	fineTunedWeightsEntry, inferenceReplicasEntry, workloadClustersEntry,
 }

--- a/pkg/cli/cmd/get/registry_test.go
+++ b/pkg/cli/cmd/get/registry_test.go
@@ -5,6 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 )
 
 func TestResolveCanonicalAndAlias(t *testing.T) {
@@ -12,6 +16,14 @@ func TestResolveCanonicalAndAlias(t *testing.T) {
 		e, err := resolve(name)
 		require.NoError(t, err, name)
 		assert.Equal(t, "inferenceservices", e.Canonical, name)
+	}
+}
+
+func TestResolveAcceleratorQuotaCanonicalAndAlias(t *testing.T) {
+	for _, name := range []string{"acceleratorquotas", "acceleratorquota", "aq", "AQ"} {
+		e, err := resolve(name)
+		require.NoError(t, err, name)
+		assert.Equal(t, "acceleratorquotas", e.Canonical, name)
 	}
 }
 
@@ -26,7 +38,7 @@ func TestRegistryHasAllResources(t *testing.T) {
 	want := []string{
 		"inferenceservices", "basemodels", "clusterbasemodels",
 		"servingruntimes", "clusterservingruntimes", "acceleratorclasses",
-		"benchmarkjobs", "finetunedweights", "inferencereplicas",
+		"acceleratorquotas", "benchmarkjobs", "finetunedweights", "inferencereplicas",
 		"workloadclusters", "models", "runtimes",
 	}
 	var got []string
@@ -34,4 +46,31 @@ func TestRegistryHasAllResources(t *testing.T) {
 		got = append(got, e.Canonical)
 	}
 	assert.ElementsMatch(t, want, got)
+}
+
+func TestAcceleratorQuotaTableRowsMatchVisibleColumns(t *testing.T) {
+	quota := &v1beta1.AcceleratorQuota{
+		Status: v1beta1.AcceleratorQuotaStatus{Budgets: []v1beta1.AcceleratorBudgetStatus{
+			{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h100"},
+			{ResourceName: "nvidia.com/gpu", ResourceFlavor: "h200"},
+		}},
+	}
+	for _, wide := range []bool{false, true} {
+		visible := 0
+		for _, column := range acceleratorQuotasEntry.Columns {
+			if !column.Wide || wide {
+				visible++
+			}
+		}
+		for _, object := range []runtime.Object{
+			quota,
+			&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "wrong-kind"}},
+		} {
+			rows := acceleratorQuotasEntry.TableRows(object, wide)
+			require.NotEmpty(t, rows)
+			for _, row := range rows {
+				assert.Len(t, row, visible)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## What this PR does

### Operator outcome

This PR makes the existing inventory command useful for three current operational resources:

- AcceleratorQuota is now discoverable as `acceleratorquotas`, `acceleratorquota`, or `aq`.
- InferenceReplica shows desired versus observed replica state and, in wide mode, rollout and migration state.
- WorkloadCluster shows connection-reference metadata and readiness/generation state without reading the referenced Secret.

### Representative CLI output

Accelerator quota budgets are flattened into one deterministic table row per resource/flavor pair:

```text
$ kubectl ome get aq
NAME    ROLE          PARENT  RESOURCE        FLAVOR  NOMINAL  ADMITTED  SOURCE    STATUS-FRESHNESS  READY  DEGRADED  AGE
team-a  ClusterQueue  root    nvidia.com/gpu  h100    8        3         Reported  Current           True   Unknown   12m
team-a  ClusterQueue  root    nvidia.com/gpu  h200    4        1         Reported  Current           True   Unknown   12m
```

If status is stale, current declarations remain visible beside the old reported evidence instead of being hidden by it:

```text
$ kubectl ome get aq
NAME    ROLE          PARENT  RESOURCE        FLAVOR  NOMINAL  ADMITTED  SOURCE    STATUS-FRESHNESS  READY  DEGRADED  AGE
team-a  ClusterQueue  root    nvidia.com/gpu  h100    8        -         Declared  Stale             True   Unknown   12m
team-a  ClusterQueue  root    nvidia.com/gpu  h100    4        3         Reported  Stale             True   Unknown   12m
team-a  ClusterQueue  root    nvidia.com/gpu  h200    4        -         Declared  Stale             True   Unknown   12m
```

InferenceReplica output exposes lifecycle state and reason; wide output adds rollout counters and condition freshness:

```text
$ kubectl ome get ir -o wide
NAME  COMPONENT  PARENT     DESIRED  CURRENT  READY  AVAILABLE  LIFECYCLE           REASON            SERVING  UPDATED  CURRENT-REVISION  UPDATE-REVISION  MIGRATIONS  ENCODING   PAUSED  COORDINATION  LIFECYCLE-FRESHNESS  AGE
rep   engine     llama-70b  4        3        2      2          RolloutStalled=True  InstancesFailing  1        2        rep-a             rep-b            2           ColumnarV2  true    -             Current              5m
```

WorkloadCluster wide output shows the reference only; it never fetches kubeconfig data:

```text
$ kubectl ome get workloadclusters -o wide
NAME  CONNECTION  REFERENCE          KEY        READY  GENERATION  OBSERVED-GENERATION  REASON     AGE
wc    KubeConfig  ome/wc-kubeconfig  west.yaml  True   5           4                    Connected  1h
```

### Output contract and limits

- Table output alone is flattened for AcceleratorQuota.
- JSON and YAML continue to return the original Kubernetes API object or list envelope; one quota with two budgets remains one object with two `status.budgets` entries.
- Rows are sorted by resource name and flavor.
- `SOURCE` is `Reported`, `Declared`, or `Unavailable`; `STATUS-FRESHNESS` is `Current`, `Stale`, or `Unobserved`.
- Stale/unobserved quota status keeps both current declared rows and reported rows, with deterministic declared-before-reported ordering for the same resource/flavor.
- Missing conditions remain `Unknown`.
- An active `RolloutStalled=True` condition takes precedence over `Ready` so a serving-but-stuck rollout cannot look healthy; wide output labels the selected condition `Current`, `Stale`, or `Unobserved`.
- WorkloadCluster output displays only Secret reference namespace/name and effective key metadata (`kubeconfig` when omitted). It never reads Secret data or contacts a remote cluster.

## Why we need it

The current `get` command omitted AcceleratorQuota and hid the replica, revision, migration, encoding, and placement evidence operators need during incidents. This PR closes that inventory gap without turning table formatting into a new machine-readable API.

Fixes # — N/A; tracked by OEP-0011.1 inventory items 11–13.

## How to test

```shell
go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...
go test -race -count=1 ./pkg/cli/...
go vet ./cmd/kubectl-ome ./pkg/cli/...
go build ./cmd/kubectl-ome
```

Focused assertions cover aliases, cluster-scoped list/get, selector propagation, deterministic multi-budget ordering, stale-generation declaration retention, lifecycle precedence and freshness, missing conditions, wide columns, default/custom kubeconfig keys, malformed WorkloadCluster connection sources, wrong object types, and lossless JSON output.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (operator-facing behavior is documented above; no repository docs are changed in this scoped PR)
- [ ] `make test` passes locally

The final submitted commit passes the scoped CLI suite, race detector, vet, and build. Required repository CI remains the authoritative full-suite gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accelerator quota support to get and list commands, including budget details, sorting, freshness, and fallback values.
  * Expanded inference replica output with lifecycle, serving, revision, migration, encoding, pause, and coordination details.
  * Added workload-cluster connection and status metadata to command output.
  * Improved table rendering across narrow and wide views, with JSON output preserving complete resource data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->