### PR TITLE
[Core] Add CLI namespace options

### DIFF
--- a/pkg/cli/namespace/options.go
+++ b/pkg/cli/namespace/options.go
@@ -1,0 +1,171 @@
+// Package namespace resolves the distinct namespaces used by kubectl-ome.
+package namespace
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	DefaultOMENamespace     = "ome"
+	DefaultAlfredConfigName = "alfred-config"
+	DefaultAlfredConfigKey  = "config.yaml"
+)
+
+// Options holds namespace settings shared by CLI commands.
+type Options struct {
+	OMENamespace     string
+	AlfredNamespace  string
+	AlfredConfigName string
+	AlfredConfigKey  string
+
+	omeNamespaceExplicit     bool
+	alfredNamespaceExplicit  bool
+	alfredConfigNameExplicit bool
+	alfredConfigKeyExplicit  bool
+}
+
+// Resolved identifies the workload and OME control-plane namespaces.
+type Resolved struct {
+	WorkloadNamespace string
+	OMENamespace      string
+	AlfredNamespace   string
+	AlfredConfigName  string
+	AlfredConfigKey   string
+}
+
+// NewOptions returns namespace options with CLI-compatible defaults.
+func NewOptions() *Options {
+	return &Options{
+		OMENamespace:     DefaultOMENamespace,
+		AlfredConfigName: DefaultAlfredConfigName,
+		AlfredConfigKey:  DefaultAlfredConfigKey,
+	}
+}
+
+// AddFlags binds shared namespace settings to flags.
+func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	o.AddOMEFlags(flags)
+	o.AddAlfredFlags(flags)
+}
+
+// AddOMEFlags binds the OME control-plane namespace setting to flags.
+func (o *Options) AddOMEFlags(flags *pflag.FlagSet) {
+	if o.OMENamespace == "" && !o.omeNamespaceExplicit {
+		o.OMENamespace = DefaultOMENamespace
+	}
+	flags.Var(&trackedStringValue{target: &o.OMENamespace, explicit: &o.omeNamespaceExplicit},
+		"ome-namespace", "Namespace where the OME control plane is installed")
+}
+
+// AddAlfredFlags binds Alfred's namespace and configuration settings to flags.
+func (o *Options) AddAlfredFlags(flags *pflag.FlagSet) {
+	if o.AlfredConfigName == "" && !o.alfredConfigNameExplicit {
+		o.AlfredConfigName = DefaultAlfredConfigName
+	}
+	if o.AlfredConfigKey == "" && !o.alfredConfigKeyExplicit {
+		o.AlfredConfigKey = DefaultAlfredConfigKey
+	}
+	flags.Var(&trackedStringValue{target: &o.AlfredNamespace, explicit: &o.alfredNamespaceExplicit},
+		"alfred-namespace", "Namespace where Alfred is installed (defaults to --ome-namespace)")
+	flags.Var(&trackedStringValue{target: &o.AlfredConfigName, explicit: &o.alfredConfigNameExplicit},
+		"alfred-config-name", "Name of Alfred's configuration ConfigMap")
+	flags.Var(&trackedStringValue{target: &o.AlfredConfigKey, explicit: &o.alfredConfigKeyExplicit},
+		"alfred-config-key", "Key inside Alfred's configuration ConfigMap")
+}
+
+// Resolve combines and validates the kubectl workload namespace with
+// control-plane options. It never returns an empty namespace.
+func (o Options) Resolve(workloadNamespace string) (Resolved, error) {
+	omeNamespace, err := effectiveValue(
+		o.OMENamespace, o.omeNamespaceExplicit, DefaultOMENamespace, "OME namespace",
+	)
+	if err != nil {
+		return Resolved{}, err
+	}
+	alfredNamespace, err := effectiveValue(
+		o.AlfredNamespace, o.alfredNamespaceExplicit, omeNamespace, "Alfred namespace",
+	)
+	if err != nil {
+		return Resolved{}, err
+	}
+	alfredConfigName, err := effectiveValue(
+		o.AlfredConfigName, o.alfredConfigNameExplicit, DefaultAlfredConfigName, "Alfred config name",
+	)
+	if err != nil {
+		return Resolved{}, err
+	}
+	alfredConfigKey, err := effectiveValue(
+		o.AlfredConfigKey, o.alfredConfigKeyExplicit, DefaultAlfredConfigKey, "Alfred config key",
+	)
+	if err != nil {
+		return Resolved{}, err
+	}
+
+	if err := validateDNS1123Label("workload namespace", workloadNamespace); err != nil {
+		return Resolved{}, err
+	}
+	if err := validateDNS1123Label("OME namespace", omeNamespace); err != nil {
+		return Resolved{}, err
+	}
+	if err := validateDNS1123Label("Alfred namespace", alfredNamespace); err != nil {
+		return Resolved{}, err
+	}
+	if problems := validation.IsDNS1123Subdomain(alfredConfigName); len(problems) > 0 {
+		return Resolved{}, invalidValue("Alfred config name", alfredConfigName, problems)
+	}
+	if problems := validation.IsConfigMapKey(alfredConfigKey); len(problems) > 0 {
+		return Resolved{}, invalidValue("Alfred config key", alfredConfigKey, problems)
+	}
+
+	return Resolved{
+		WorkloadNamespace: workloadNamespace,
+		OMENamespace:      omeNamespace,
+		AlfredNamespace:   alfredNamespace,
+		AlfredConfigName:  alfredConfigName,
+		AlfredConfigKey:   alfredConfigKey,
+	}, nil
+}
+
+func effectiveValue(value string, explicit bool, fallback, label string) (string, error) {
+	if value != "" {
+		return value, nil
+	}
+	if explicit {
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	return fallback, nil
+}
+
+func validateDNS1123Label(label, value string) error {
+	if problems := validation.IsDNS1123Label(value); len(problems) > 0 {
+		return invalidValue(label, value, problems)
+	}
+	return nil
+}
+
+func invalidValue(label, value string, problems []string) error {
+	return fmt.Errorf("%s %q is invalid: %s", label, value, strings.Join(problems, "; "))
+}
+
+type trackedStringValue struct {
+	target   *string
+	explicit *bool
+}
+
+func (v *trackedStringValue) Set(value string) error {
+	*v.target = value
+	*v.explicit = true
+	return nil
+}
+
+func (v *trackedStringValue) String() string {
+	return *v.target
+}
+
+func (*trackedStringValue) Type() string {
+	return "string"
+}

--- a/pkg/cli/namespace/options_test.go
+++ b/pkg/cli/namespace/options_test.go
@@ -1,0 +1,331 @@
+package namespace
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestResolveSeparatesWorkloadAndOMENamespaces(t *testing.T) {
+	t.Parallel()
+
+	got := mustResolve(t, NewOptions(), "team-a")
+
+	if got.WorkloadNamespace != "team-a" {
+		t.Fatalf("WorkloadNamespace = %q, want %q", got.WorkloadNamespace, "team-a")
+	}
+	if got.OMENamespace != "ome" {
+		t.Fatalf("OMENamespace = %q, want %q", got.OMENamespace, "ome")
+	}
+}
+
+func TestResolveDefaultsAlfredNamespaceToEffectiveOMENamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	options.OMENamespace = "control-plane"
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.AlfredNamespace != "control-plane" {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, "control-plane")
+	}
+}
+
+func TestResolveUsesExplicitAlfredNamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	options.OMENamespace = "control-plane"
+	options.AlfredNamespace = "alfred-system"
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.AlfredNamespace != "alfred-system" {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, "alfred-system")
+	}
+}
+
+func TestResolveDefaultsAlfredConfigLocation(t *testing.T) {
+	t.Parallel()
+
+	got := mustResolve(t, NewOptions(), "team-a")
+
+	if got.AlfredConfigName != "alfred-config" {
+		t.Fatalf("AlfredConfigName = %q, want %q", got.AlfredConfigName, "alfred-config")
+	}
+	if got.AlfredConfigKey != "config.yaml" {
+		t.Fatalf("AlfredConfigKey = %q, want %q", got.AlfredConfigKey, "config.yaml")
+	}
+}
+
+func TestAddFlagsOMEOverrideFlowsToAlfredNamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddFlags(flags)
+	if err := flags.Parse([]string{"--ome-namespace", "control-plane"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.WorkloadNamespace != "team-a" {
+		t.Fatalf("WorkloadNamespace = %q, want %q", got.WorkloadNamespace, "team-a")
+	}
+	if got.OMENamespace != "control-plane" {
+		t.Fatalf("OMENamespace = %q, want %q", got.OMENamespace, "control-plane")
+	}
+	if got.AlfredNamespace != "control-plane" {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, "control-plane")
+	}
+}
+
+func TestAddOMEFlagsBindsOnlyOMENamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddOMEFlags(flags)
+	if got, want := flagNames(flags), []string{"ome-namespace"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("flag names = %v, want %v", got, want)
+	}
+	if err := flags.Parse([]string{"--ome-namespace", "control-plane"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.OMENamespace != "control-plane" {
+		t.Fatalf("OMENamespace = %q, want %q", got.OMENamespace, "control-plane")
+	}
+	if got.AlfredNamespace != "control-plane" {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, "control-plane")
+	}
+}
+
+func TestAddFlagsOverridesAlfredNamespaceIndependently(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddFlags(flags)
+	if err := flags.Parse([]string{"--alfred-namespace", "alfred-system"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.OMENamespace != "ome" {
+		t.Fatalf("OMENamespace = %q, want %q", got.OMENamespace, "ome")
+	}
+	if got.AlfredNamespace != "alfred-system" {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, "alfred-system")
+	}
+}
+
+func TestAddAlfredFlagsBindsOnlyAlfredOptions(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddAlfredFlags(flags)
+	wantNames := []string{"alfred-config-key", "alfred-config-name", "alfred-namespace"}
+	if got := flagNames(flags); !reflect.DeepEqual(got, wantNames) {
+		t.Fatalf("flag names = %v, want %v", got, wantNames)
+	}
+	args := []string{
+		"--alfred-namespace", "alfred-system",
+		"--alfred-config-name", "custom-config",
+		"--alfred-config-key", "settings.yaml",
+	}
+	if err := flags.Parse(args); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.OMENamespace != "ome" {
+		t.Fatalf("OMENamespace = %q, want %q", got.OMENamespace, "ome")
+	}
+	if got.AlfredNamespace != "alfred-system" {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, "alfred-system")
+	}
+	if got.AlfredConfigName != "custom-config" {
+		t.Fatalf("AlfredConfigName = %q, want %q", got.AlfredConfigName, "custom-config")
+	}
+	if got.AlfredConfigKey != "settings.yaml" {
+		t.Fatalf("AlfredConfigKey = %q, want %q", got.AlfredConfigKey, "settings.yaml")
+	}
+}
+
+func TestAddFlagsOverridesAlfredConfigName(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddFlags(flags)
+	if err := flags.Parse([]string{"--alfred-config-name", "custom-config"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.AlfredConfigName != "custom-config" {
+		t.Fatalf("AlfredConfigName = %q, want %q", got.AlfredConfigName, "custom-config")
+	}
+	if got.AlfredConfigKey != "config.yaml" {
+		t.Fatalf("AlfredConfigKey = %q, want %q", got.AlfredConfigKey, "config.yaml")
+	}
+}
+
+func TestAddFlagsOverridesAlfredConfigKey(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions()
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddFlags(flags)
+	if err := flags.Parse([]string{"--alfred-config-key", "settings.yaml"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got := mustResolve(t, options, "team-a")
+
+	if got.AlfredConfigName != "alfred-config" {
+		t.Fatalf("AlfredConfigName = %q, want %q", got.AlfredConfigName, "alfred-config")
+	}
+	if got.AlfredConfigKey != "settings.yaml" {
+		t.Fatalf("AlfredConfigKey = %q, want %q", got.AlfredConfigKey, "settings.yaml")
+	}
+}
+
+func flagNames(flags *pflag.FlagSet) []string {
+	var names []string
+	flags.VisitAll(func(flag *pflag.Flag) {
+		names = append(names, flag.Name)
+	})
+	return names
+}
+
+func TestResolveZeroValueUsesSafeDefaults(t *testing.T) {
+	t.Parallel()
+
+	options := &Options{}
+	got := mustResolve(t, options, "team-a")
+
+	if got.OMENamespace != DefaultOMENamespace {
+		t.Fatalf("OMENamespace = %q, want %q", got.OMENamespace, DefaultOMENamespace)
+	}
+	if got.AlfredNamespace != DefaultOMENamespace {
+		t.Fatalf("AlfredNamespace = %q, want %q", got.AlfredNamespace, DefaultOMENamespace)
+	}
+	if got.AlfredConfigName != DefaultAlfredConfigName {
+		t.Fatalf("AlfredConfigName = %q, want %q", got.AlfredConfigName, DefaultAlfredConfigName)
+	}
+	if got.AlfredConfigKey != DefaultAlfredConfigKey {
+		t.Fatalf("AlfredConfigKey = %q, want %q", got.AlfredConfigKey, DefaultAlfredConfigKey)
+	}
+}
+
+func TestZeroValueAddFlagsPublishesSafeDefaults(t *testing.T) {
+	t.Parallel()
+
+	options := &Options{}
+	flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+	options.AddFlags(flags)
+
+	wantDefaults := map[string]string{
+		"ome-namespace":      DefaultOMENamespace,
+		"alfred-namespace":   "",
+		"alfred-config-name": DefaultAlfredConfigName,
+		"alfred-config-key":  DefaultAlfredConfigKey,
+	}
+	for name, want := range wantDefaults {
+		flag := flags.Lookup(name)
+		if flag == nil {
+			t.Fatalf("flag %q is not registered", name)
+		}
+		if flag.DefValue != want {
+			t.Errorf("flag %q default = %q, want %q", name, flag.DefValue, want)
+		}
+		got, err := flags.GetString(name)
+		if err != nil {
+			t.Fatalf("GetString(%q) error = %v", name, err)
+		}
+		if got != want {
+			t.Errorf("flag %q value = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestAddFlagsRejectsExplicitEmptyValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "OME namespace", arg: "--ome-namespace=", want: "OME namespace"},
+		{name: "Alfred namespace", arg: "--alfred-namespace=", want: "Alfred namespace"},
+		{name: "Alfred config name", arg: "--alfred-config-name=", want: "Alfred config name"},
+		{name: "Alfred config key", arg: "--alfred-config-key=", want: "Alfred config key"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := NewOptions()
+			flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+			options.AddFlags(flags)
+			if err := flags.Parse([]string{test.arg}); err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+
+			_, err := options.Resolve("team-a")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Resolve() error = %v, want error containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsInvalidKubernetesIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workload  string
+		configure func(*Options)
+		want      string
+	}{
+		{name: "workload namespace", workload: "Team_A", want: "workload namespace"},
+		{name: "OME namespace", workload: "team-a", configure: func(o *Options) { o.OMENamespace = "OME_System" }, want: "OME namespace"},
+		{name: "Alfred namespace", workload: "team-a", configure: func(o *Options) { o.AlfredNamespace = "alfred/system" }, want: "Alfred namespace"},
+		{name: "Alfred config name", workload: "team-a", configure: func(o *Options) { o.AlfredConfigName = "Config_Map" }, want: "Alfred config name"},
+		{name: "Alfred config key", workload: "team-a", configure: func(o *Options) { o.AlfredConfigKey = "bad/key" }, want: "Alfred config key"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := NewOptions()
+			if test.configure != nil {
+				test.configure(options)
+			}
+
+			_, err := options.Resolve(test.workload)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Resolve() error = %v, want error containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func mustResolve(t *testing.T, options *Options, workloadNamespace string) Resolved {
+	t.Helper()
+	got, err := options.Resolve(workloadNamespace)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	return got
+}


### PR DESCRIPTION
## What this PR does

### Outcome

This PR adds the shared namespace contract required by runtime, recommendations, doctor, and other operational commands:

| Resource class | Effective namespace |
| --- | --- |
| InferenceService, InferenceReplica, pods, events, autoscalers | kubectl workload namespace |
| Runtime pins and OME control-plane diagnostics | `--ome-namespace`, default `ome` |
| Alfred configuration and recommendations | `--alfred-namespace`, default effective OME namespace |

It also defines granular binders so commands expose only the flags they actually use:

```text
--ome-namespace string       Namespace where the OME control plane is installed (default "ome")
--alfred-namespace string    Namespace where Alfred is installed (defaults to --ome-namespace)
--alfred-config-name string  Name of Alfred's configuration ConfigMap (default "alfred-config")
--alfred-config-key string   Key inside Alfred's configuration ConfigMap (default "config.yaml")
```

Resolution is fail-closed: workload/OME/Alfred namespaces are validated as
Kubernetes namespace names, the ConfigMap name and key use Kubernetes'
validation rules, and an explicitly empty flag is rejected instead of becoming
an all-namespace selector. The exported `Options{}` zero value resolves to the
same safe defaults as `NewOptions()`.

### User-visible CLI output

No command or root flag is registered by this foundation PR, so it intentionally changes no current `kubectl ome` output. Consumer PRs will bind the relevant subset and include their exact help and command output.

The resolved behavior they consume is deterministic:

```text
workload namespace:       team-a
OME namespace:            control-plane
Alfred namespace:         control-plane
Alfred configuration:     alfred-config / config.yaml
```

With an explicit Alfred override:

```text
workload namespace:       team-a
OME namespace:            control-plane
Alfred namespace:         alfred-system
Alfred configuration:     custom-config / settings.yaml
```

### Limits

- No namespace discovery or all-namespace scan.
- Empty workload namespaces and explicit empty namespace/config flags return an
  error; they never flow to a Kubernetes client.
- Invalid DNS-1123 namespace/ConfigMap names and invalid ConfigMap keys return
  an actionable validation error during resolution.
- No Kubernetes client calls.
- No command wiring in this PR.
- Workload, OME, and Alfred namespaces remain distinct in every resolved result.

## Why we need it

The new CLI joins workload resources with control-plane runtime revisions and optional Alfred configuration. Reusing the kubectl workload namespace for all three would silently query the wrong objects on non-default installations. This small contract makes that distinction testable before feature collectors depend on it.

Fixes # — N/A; tracked by OEP-0011.1 foundation item 4.

## How to test

```shell
go test -count=1 ./pkg/cli/namespace
go test -count=1 ./pkg/cli/...
go test -race -count=1 ./pkg/cli/...
go vet ./pkg/cli/...
go build ./cmd/kubectl-ome
```

The namespace package has 100% statement coverage, including constructor and
zero-value defaults, every override, Alfred inheritance, granular flag
exposure, explicit-empty rejection, and malformed Kubernetes identifiers.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (the contract and future CLI flags are documented above; no repository docs are changed in this scoped PR)
- [ ] `make test` passes locally

The final submitted commit passes the scoped CLI suite, race detector, vet, and build. Required repository CI remains the authoritative full-suite gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OME and Alfred namespace settings for CLI commands.
  * Added default namespace and Alfred configuration values.
  * Added command-line flags for independently overriding namespaces and configuration names or keys.
  * Added validation for Kubernetes-compatible names and clear errors for explicitly empty values.

* **Bug Fixes**
  * Ensured Alfred settings safely inherit effective OME namespace values when not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->