### PR TITLE
[Core] Add typed CLI report contracts

### DIFF
--- a/pkg/cli/report/format.go
+++ b/pkg/cli/report/format.go
@@ -1,0 +1,29 @@
+// Package report defines deterministic, versioned diagnostic output helpers.
+// Raw Kubernetes API object output remains owned by pkg/cli/printers.
+package report
+
+import "fmt"
+
+// Format selects the representation used for a diagnostic report.
+type Format string
+
+const (
+	FormatTable Format = "table"
+	FormatJSON  Format = "json"
+	FormatYAML  Format = "yaml"
+)
+
+// ParseFormat validates a diagnostic output format. An empty value selects
+// the human-readable table format used by diagnostic commands by default.
+func ParseFormat(value string) (Format, error) {
+	switch Format(value) {
+	case "", FormatTable:
+		return FormatTable, nil
+	case FormatJSON:
+		return FormatJSON, nil
+	case FormatYAML:
+		return FormatYAML, nil
+	default:
+		return "", fmt.Errorf("unsupported output format %q (supported: table, json, yaml)", value)
+	}
+}

--- a/pkg/cli/report/format_test.go
+++ b/pkg/cli/report/format_test.go
@@ -1,0 +1,83 @@
+package report_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+func TestParseFormatAcceptsSupportedValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  report.Format
+	}{
+		{name: "default", value: "", want: report.FormatTable},
+		{name: "table", value: "table", want: report.FormatTable},
+		{name: "json", value: "json", want: report.FormatJSON},
+		{name: "yaml", value: "yaml", want: report.FormatYAML},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := report.ParseFormat(tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseFormatRejectsUnsupportedValues(t *testing.T) {
+	_, err := report.ParseFormat("wide")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "table, json, yaml")
+}
+
+func TestTableWriteProducesStableColumns(t *testing.T) {
+	var output bytes.Buffer
+	table := report.Table{
+		Headers: []string{"NAME", "STATE"},
+		Rows: [][]string{
+			{"short", "Ready"},
+			{"a-longer-name", "Unavailable"},
+		},
+	}
+
+	require.NoError(t, table.Write(&output))
+	assert.Equal(t, "NAME            STATE\nshort           Ready\n"+
+		"a-longer-name   Unavailable\n", output.String())
+}
+
+func TestTableWriteReturnsOutputErrors(t *testing.T) {
+	wantErr := errors.New("write failed")
+	err := (report.Table{Headers: []string{"NAME"}}).Write(errorWriter{err: wantErr})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestTableWriteEscapesStructureControlCharactersWithoutMutation(t *testing.T) {
+	var output bytes.Buffer
+	table := report.Table{
+		Headers: []string{"NA\tME"},
+		Rows:    [][]string{{"chat\nprod\r\x01"}},
+	}
+
+	require.NoError(t, table.Write(&output))
+	assert.Equal(t, "NA\\tME\nchat\\nprod\\r\\u0001\n", output.String())
+	assert.Equal(t, "NA\tME", table.Headers[0])
+	assert.Equal(t, "chat\nprod\r\x01", table.Rows[0][0])
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}

--- a/pkg/cli/report/render.go
+++ b/pkg/cli/report/render.go
@@ -1,0 +1,67 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Document is implemented by typed reports that can return a deterministic
+// copy and derive a human table from that same typed value.
+type Document[T any] interface {
+	Canonical() T
+	Table() Table
+}
+
+// Write renders a typed report in table, JSON, or YAML form. Serialization
+// and destination writer errors are returned to the command layer.
+func Write[T Document[T]](w io.Writer, format Format, document T) error {
+	parsedFormat, err := ParseFormat(string(format))
+	if err != nil {
+		return err
+	}
+	format = parsedFormat
+
+	canonical := document.Canonical()
+	switch format {
+	case FormatTable:
+		if err := canonical.Table().Write(w); err != nil {
+			return fmt.Errorf("write report table: %w", err)
+		}
+		return nil
+	case FormatJSON:
+		data, err := json.MarshalIndent(canonical, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal report json: %w", err)
+		}
+		data = append(data, '\n')
+		if err := writeBytes(w, data); err != nil {
+			return fmt.Errorf("write report json: %w", err)
+		}
+		return nil
+	case FormatYAML:
+		data, err := yaml.Marshal(canonical)
+		if err != nil {
+			return fmt.Errorf("marshal report yaml: %w", err)
+		}
+		if err := writeBytes(w, data); err != nil {
+			return fmt.Errorf("write report yaml: %w", err)
+		}
+		return nil
+	default:
+		panic("unreachable output format")
+	}
+}
+
+func writeBytes(w io.Writer, data []byte) error {
+	written, err := w.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/pkg/cli/report/render_test.go
+++ b/pkg/cli/report/render_test.go
@@ -1,0 +1,161 @@
+package report_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestWriteTableUsesCanonicalTypedContent(t *testing.T) {
+	document := reportEnvelope([]string{"z", "a"})
+	var output bytes.Buffer
+
+	require.NoError(t, report.Write(&output, report.FormatTable, document))
+	assert.Equal(t, "NAME\na\nz\n", output.String())
+	assert.Equal(t, []string{"z", "a"}, document.Content.Rows)
+}
+
+func TestWriteEmptyFormatUsesDefaultTable(t *testing.T) {
+	var output bytes.Buffer
+
+	require.NotPanics(t, func() {
+		require.NoError(t, report.Write(&output, report.Format(""), reportEnvelope([]string{"a"})))
+	})
+	assert.Equal(t, "NAME\na\n", output.String())
+}
+
+func TestWriteJSONIsDeterministicAndKeepsEmptySlices(t *testing.T) {
+	document := reportEnvelope([]string{})
+	document.Sources = []v1alpha1.SourceReference{
+		{Kind: "Pod", Namespace: "prod", Name: "z", Evidence: v1alpha1.EvidenceObserved},
+		{Kind: "Pod", Namespace: "prod", Name: "a", Evidence: v1alpha1.EvidenceObserved},
+	}
+	document.Warnings = nil
+	var first bytes.Buffer
+	var second bytes.Buffer
+
+	require.NoError(t, report.Write(&first, report.FormatJSON, document))
+	require.NoError(t, report.Write(&second, report.FormatJSON, document))
+
+	assert.Equal(t, first.String(), second.String())
+	assert.Contains(t, first.String(), `"apiVersion": "cli.ome.io/v1alpha1"`)
+	assert.Contains(t, first.String(), `"sources": [`)
+	assert.Contains(t, first.String(), `"rows": []`)
+	assert.Contains(t, first.String(), `"warnings": []`)
+	assert.Less(t, strings.Index(first.String(), `"name": "a"`), strings.Index(first.String(), `"name": "z"`))
+	assert.Equal(t, "z", document.Sources[0].Name)
+}
+
+func TestWriteYAMLIsDeterministicAndKeepsEmptySlices(t *testing.T) {
+	document := reportEnvelope(nil)
+	document.Sources = nil
+	document.Warnings = nil
+	var first bytes.Buffer
+	var second bytes.Buffer
+
+	require.NoError(t, report.Write(&first, report.FormatYAML, document))
+	require.NoError(t, report.Write(&second, report.FormatYAML, document))
+
+	assert.Equal(t, first.String(), second.String())
+	assert.Contains(t, first.String(), "apiVersion: cli.ome.io/v1alpha1\n")
+	assert.Contains(t, first.String(), "sources: []\n")
+	assert.Contains(t, first.String(), "rows: []\n")
+	assert.Contains(t, first.String(), "warnings: []\n")
+}
+
+func TestWriteRejectsUnsupportedFormat(t *testing.T) {
+	err := report.Write(&bytes.Buffer{}, report.Format("wide"), reportEnvelope(nil))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "table, json, yaml")
+}
+
+func TestWriteReturnsSerializationErrors(t *testing.T) {
+	for _, format := range []report.Format{report.FormatJSON, report.FormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			err := report.Write(&bytes.Buffer{}, format, unsupportedDocument{Value: make(chan int)})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), string(format))
+		})
+	}
+}
+
+func TestWriteReturnsOutputErrors(t *testing.T) {
+	wantErr := errors.New("destination closed")
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			err := report.Write(errorWriter{err: wantErr}, format, reportEnvelope(nil))
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, wantErr)
+		})
+	}
+}
+
+func TestWriteReturnsShortWriteErrors(t *testing.T) {
+	for _, format := range []report.Format{report.FormatJSON, report.FormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			err := report.Write(shortWriter{}, format, reportEnvelope(nil))
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, io.ErrShortWrite)
+		})
+	}
+}
+
+type rowsContent struct {
+	Rows []string `json:"rows"`
+}
+
+func (c rowsContent) Canonical() rowsContent {
+	result := c
+	result.Rows = append([]string{}, c.Rows...)
+	sort.Strings(result.Rows)
+	return result
+}
+
+func (c rowsContent) Table() report.Table {
+	table := report.Table{Headers: []string{"NAME"}, Rows: make([][]string, 0, len(c.Rows))}
+	for _, row := range c.Rows {
+		table.Rows = append(table.Rows, []string{row})
+	}
+	return table
+}
+
+func reportEnvelope(rows []string) v1alpha1.Envelope[rowsContent] {
+	return v1alpha1.Envelope[rowsContent]{
+		Kind:        "InstanceReport",
+		Metadata:    v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		CollectedAt: time.Date(2026, time.August, 31, 18, 0, 0, 0, time.UTC),
+		Content:     rowsContent{Rows: rows},
+	}
+}
+
+type unsupportedDocument struct {
+	Value chan int `json:"value"`
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(value []byte) (int, error) {
+	return len(value) - 1, nil
+}
+
+func (d unsupportedDocument) Canonical() unsupportedDocument {
+	return d
+}
+
+func (unsupportedDocument) Table() report.Table {
+	return report.Table{}
+}

--- a/pkg/cli/report/table.go
+++ b/pkg/cli/report/table.go
@@ -1,0 +1,58 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"unicode"
+)
+
+// Table is the deterministic human-readable view of a typed report.
+type Table struct {
+	Headers []string
+	Rows    [][]string
+}
+
+// Write renders the table and returns all underlying writer errors.
+func (t Table) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 8, 3, ' ', 0)
+	if _, err := fmt.Fprintln(tw, joinCells(t.Headers)); err != nil {
+		return err
+	}
+	for _, row := range t.Rows {
+		if _, err := fmt.Fprintln(tw, joinCells(row)); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func joinCells(cells []string) string {
+	normalized := make([]string, len(cells))
+	for i, cell := range cells {
+		normalized[i] = sanitizeCell(cell)
+	}
+	return strings.Join(normalized, "\t")
+}
+
+func sanitizeCell(value string) string {
+	var result strings.Builder
+	for _, char := range value {
+		switch char {
+		case '\t':
+			result.WriteString(`\t`)
+		case '\n':
+			result.WriteString(`\n`)
+		case '\r':
+			result.WriteString(`\r`)
+		default:
+			if unicode.IsControl(char) {
+				fmt.Fprintf(&result, `\u%04x`, char)
+				continue
+			}
+			result.WriteRune(char)
+		}
+	}
+	return result.String()
+}

--- a/pkg/cli/report/v1alpha1/action_result.go
+++ b/pkg/cli/report/v1alpha1/action_result.go
@@ -1,0 +1,121 @@
+package v1alpha1
+
+import (
+	"strings"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+const ActionResultKind = "ActionResult"
+
+// DryRunMode identifies whether an action was submitted to the API server.
+type DryRunMode string
+
+const (
+	DryRunNone   DryRunMode = "none"
+	DryRunClient DryRunMode = "client"
+	DryRunServer DryRunMode = "server"
+)
+
+// ActionTarget is the exact Kubernetes object identity used by an action.
+type ActionTarget struct {
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace,omitempty"`
+	Name            string `json:"name"`
+	UID             string `json:"uid,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+
+// ActionResult is the separate, versioned stdout contract shared by guarded
+// mutating commands. Preview, confirmation, and warnings remain on stderr.
+type ActionResult struct {
+	APIVersion   string       `json:"apiVersion"`
+	Kind         string       `json:"kind"`
+	CollectedAt  time.Time    `json:"collectedAt"`
+	Action       string       `json:"action"`
+	Target       ActionTarget `json:"target"`
+	DryRun       DryRunMode   `json:"dryRun"`
+	RequestID    string       `json:"requestID,omitempty"`
+	RevisionHash string       `json:"revisionHash,omitempty"`
+	Accepted     bool         `json:"accepted"`
+	Applied      bool         `json:"applied"`
+	Message      string       `json:"message,omitempty"`
+	FollowUp     string       `json:"followUp,omitempty"`
+}
+
+// NewActionResult creates an unapplied result using an injectable clock.
+func NewActionResult(action string, target ActionTarget, dryRun DryRunMode, clock Clock) ActionResult {
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	return (ActionResult{
+		APIVersion:  APIVersion,
+		Kind:        ActionResultKind,
+		CollectedAt: clock.Now().UTC(),
+		Action:      action,
+		Target:      target,
+		DryRun:      dryRun,
+	}).Canonical()
+}
+
+// Canonical returns a deterministic copy and enforces dry-run invariants:
+// neither dry-run mode may claim application, and client dry-run cannot claim
+// API acceptance because it submits no request.
+func (r ActionResult) Canonical() ActionResult {
+	result := r
+	result.APIVersion = APIVersion
+	result.Kind = ActionResultKind
+	result.CollectedAt = r.CollectedAt.UTC()
+	if result.DryRun != DryRunNone {
+		result.Applied = false
+	}
+	if result.DryRun == DryRunClient {
+		result.Accepted = false
+	}
+	return result
+}
+
+// Table derives the concise human view from the typed action result.
+func (r ActionResult) Table() report.Table {
+	return report.Table{
+		Headers: []string{
+			"ACTION", "TARGET", "DRY-RUN", "ACCEPTED", "APPLIED",
+			"REQUEST-ID", "REVISION-HASH", "MESSAGE", "FOLLOW-UP",
+		},
+		Rows: [][]string{{
+			r.Action,
+			r.Target.displayName(),
+			string(r.DryRun),
+			yesNo(r.Accepted),
+			yesNo(r.Applied),
+			orDash(r.RequestID),
+			orDash(r.RevisionHash),
+			orDash(r.Message),
+			orDash(r.FollowUp),
+		}},
+	}
+}
+
+func (t ActionTarget) displayName() string {
+	parts := []string{t.Kind}
+	if t.Namespace != "" {
+		parts = append(parts, t.Namespace)
+	}
+	parts = append(parts, t.Name)
+	return strings.Join(parts, "/")
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "Yes"
+	}
+	return "No"
+}
+
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}

--- a/pkg/cli/report/v1alpha1/action_result_test.go
+++ b/pkg/cli/report/v1alpha1/action_result_test.go
@@ -1,0 +1,230 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestNewActionResultUsesVersionedTypedDefaultsAndInjectedTime(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)
+	target := v1alpha1.ActionTarget{
+		Kind:            "InferenceService",
+		Namespace:       "prod",
+		Name:            "chat",
+		UID:             "uid-1",
+		ResourceVersion: "42",
+	}
+
+	got := v1alpha1.NewActionResult("pause", target, v1alpha1.DryRunServer, fixedClock{now: now})
+
+	assert.Equal(t, v1alpha1.APIVersion, got.APIVersion)
+	assert.Equal(t, v1alpha1.ActionResultKind, got.Kind)
+	assert.Equal(t, now, got.CollectedAt)
+	assert.Equal(t, "pause", got.Action)
+	assert.Equal(t, target, got.Target)
+	assert.Equal(t, v1alpha1.DryRunServer, got.DryRun)
+	assert.False(t, got.Accepted)
+	assert.False(t, got.Applied)
+}
+
+func TestActionResultCanonicalNeverMarksDryRunApplied(t *testing.T) {
+	for _, mode := range []v1alpha1.DryRunMode{v1alpha1.DryRunClient, v1alpha1.DryRunServer} {
+		t.Run(string(mode), func(t *testing.T) {
+			result := actionResult()
+			result.DryRun = mode
+			result.Accepted = true
+			result.Applied = true
+
+			got := result.Canonical()
+
+			assert.Equal(t, mode == v1alpha1.DryRunServer, got.Accepted)
+			assert.False(t, got.Applied)
+		})
+	}
+}
+
+func TestActionResultCanonicalKeepsRealRequestApplication(t *testing.T) {
+	result := actionResult()
+	result.DryRun = v1alpha1.DryRunNone
+	result.Accepted = true
+	result.Applied = true
+
+	got := result.Canonical()
+
+	assert.True(t, got.Accepted)
+	assert.True(t, got.Applied)
+}
+
+func TestActionResultCanonicalEnforcesVersionAndKind(t *testing.T) {
+	result := actionResult()
+	result.APIVersion = "incorrect.example/v9"
+	result.Kind = "IncorrectKind"
+
+	got := result.Canonical()
+
+	assert.Equal(t, v1alpha1.APIVersion, got.APIVersion)
+	assert.Equal(t, v1alpha1.ActionResultKind, got.Kind)
+	assert.Equal(t, "incorrect.example/v9", result.APIVersion)
+	assert.Equal(t, "IncorrectKind", result.Kind)
+}
+
+func TestActionResultTableUsesTypedResult(t *testing.T) {
+	result := actionResult()
+	result.DryRun = v1alpha1.DryRunServer
+	result.Accepted = true
+	result.Applied = false
+	result.RequestID = "request-7"
+	result.RevisionHash = "sha256:abc"
+	result.Message = "request validated"
+	result.FollowUp = "kubectl ome status chat -n prod"
+	var output bytes.Buffer
+
+	require.NoError(t, report.Write(&output, report.FormatTable, result))
+	assert.Equal(t, "ACTION   TARGET                       DRY-RUN   ACCEPTED   APPLIED   REQUEST-ID   REVISION-HASH   MESSAGE             FOLLOW-UP\n"+
+		"pause    InferenceService/prod/chat   server    Yes        No        request-7    sha256:abc      request validated   kubectl ome status chat -n prod\n", output.String())
+}
+
+func TestActionResultTableIncludesOperationalFields(t *testing.T) {
+	result := actionResult()
+	result.RequestID = "request-7"
+	result.RevisionHash = "sha256:abc"
+	result.Message = "request accepted"
+	result.FollowUp = "kubectl ome status chat -n prod"
+
+	got := result.Table()
+
+	assert.Equal(t, []string{
+		"ACTION", "TARGET", "DRY-RUN", "ACCEPTED", "APPLIED",
+		"REQUEST-ID", "REVISION-HASH", "MESSAGE", "FOLLOW-UP",
+	}, got.Headers)
+	assert.Equal(t, [][]string{{
+		"pause", "InferenceService/prod/chat", "none", "No", "No",
+		"request-7", "sha256:abc", "request accepted", "kubectl ome status chat -n prod",
+	}}, got.Rows)
+}
+
+func TestActionResultTableUsesDashesForEmptyOptionalFields(t *testing.T) {
+	result := actionResult()
+
+	got := result.Table()
+
+	assert.Equal(t, []string{"-", "-", "-", "-"}, got.Rows[0][5:])
+}
+
+func TestActionResultMachineOutputContract(t *testing.T) {
+	result := actionResult()
+	result.RequestID = "request-7"
+	result.RevisionHash = "sha256:abc"
+	result.Accepted = true
+	result.Applied = true
+	result.Message = "request accepted"
+	result.FollowUp = "kubectl ome status chat -n prod"
+	tests := []struct {
+		name   string
+		format report.Format
+		want   string
+	}{
+		{
+			name:   "json",
+			format: report.FormatJSON,
+			want: "{\n" +
+				`  "apiVersion": "cli.ome.io/v1alpha1",` + "\n" +
+				`  "kind": "ActionResult",` + "\n" +
+				`  "collectedAt": "2026-08-31T18:30:00Z",` + "\n" +
+				`  "action": "pause",` + "\n" +
+				`  "target": {` + "\n" +
+				`    "kind": "InferenceService",` + "\n" +
+				`    "namespace": "prod",` + "\n" +
+				`    "name": "chat",` + "\n" +
+				`    "uid": "uid-1",` + "\n" +
+				`    "resourceVersion": "42"` + "\n" +
+				"  },\n" +
+				`  "dryRun": "none",` + "\n" +
+				`  "requestID": "request-7",` + "\n" +
+				`  "revisionHash": "sha256:abc",` + "\n" +
+				`  "accepted": true,` + "\n" +
+				`  "applied": true,` + "\n" +
+				`  "message": "request accepted",` + "\n" +
+				`  "followUp": "kubectl ome status chat -n prod"` + "\n" +
+				"}\n",
+		},
+		{
+			name:   "yaml",
+			format: report.FormatYAML,
+			want: "accepted: true\n" +
+				"action: pause\n" +
+				"apiVersion: cli.ome.io/v1alpha1\n" +
+				"applied: true\n" +
+				"collectedAt: \"2026-08-31T18:30:00Z\"\n" +
+				"dryRun: none\n" +
+				"followUp: kubectl ome status chat -n prod\n" +
+				"kind: ActionResult\n" +
+				"message: request accepted\n" +
+				"requestID: request-7\n" +
+				"revisionHash: sha256:abc\n" +
+				"target:\n" +
+				"  kind: InferenceService\n" +
+				"  name: chat\n" +
+				"  namespace: prod\n" +
+				"  resourceVersion: \"42\"\n" +
+				"  uid: uid-1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, report.Write(&output, tt.format, result))
+			assert.Equal(t, tt.want, output.String())
+		})
+	}
+}
+
+func TestActionResultJSONOmitsEmptyOptionalFields(t *testing.T) {
+	var output bytes.Buffer
+
+	require.NoError(t, report.Write(&output, report.FormatJSON, actionResult()))
+	assert.Equal(t, "{\n"+
+		`  "apiVersion": "cli.ome.io/v1alpha1",`+"\n"+
+		`  "kind": "ActionResult",`+"\n"+
+		`  "collectedAt": "2026-08-31T18:30:00Z",`+"\n"+
+		`  "action": "pause",`+"\n"+
+		`  "target": {`+"\n"+
+		`    "kind": "InferenceService",`+"\n"+
+		`    "namespace": "prod",`+"\n"+
+		`    "name": "chat",`+"\n"+
+		`    "uid": "uid-1",`+"\n"+
+		`    "resourceVersion": "42"`+"\n"+
+		"  },\n"+
+		`  "dryRun": "none",`+"\n"+
+		`  "accepted": false,`+"\n"+
+		`  "applied": false`+"\n"+
+		"}\n", output.String())
+}
+
+func TestActionResultSchemaHasNoUnstructuredOrSecretBearingFields(t *testing.T) {
+	assertTypedSchema(t, reflect.TypeOf(v1alpha1.ActionResult{}), map[reflect.Type]bool{})
+}
+
+func actionResult() v1alpha1.ActionResult {
+	return v1alpha1.ActionResult{
+		Action: "pause",
+		Target: v1alpha1.ActionTarget{
+			Kind:            "InferenceService",
+			Namespace:       "prod",
+			Name:            "chat",
+			UID:             "uid-1",
+			ResourceVersion: "42",
+		},
+		CollectedAt: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC),
+		DryRun:      v1alpha1.DryRunNone,
+	}
+}

--- a/pkg/cli/report/v1alpha1/types.go
+++ b/pkg/cli/report/v1alpha1/types.go
@@ -1,0 +1,195 @@
+// Package v1alpha1 defines the alpha diagnostic output contract owned by the
+// kubectl-ome CLI. These objects are reports, not Kubernetes resources for
+// apply, and intentionally have no spec or arbitrary extension fields.
+package v1alpha1
+
+import (
+	"sort"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+const (
+	// APIVersion is the versioned schema identifier for CLI-owned reports.
+	APIVersion = "cli.ome.io/v1alpha1"
+)
+
+// Clock makes report collection timestamps deterministic in tests.
+type Clock interface {
+	Now() time.Time
+}
+
+// ClockFunc adapts a function into a Clock.
+type ClockFunc func() time.Time
+
+// Now implements Clock.
+func (f ClockFunc) Now() time.Time {
+	return f()
+}
+
+// SystemClock reads the process wall clock.
+type SystemClock struct{}
+
+// Now implements Clock.
+func (SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+// Metadata identifies the primary object described by a report.
+type Metadata struct {
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+// EvidenceLevel identifies how the CLI obtained a reported value.
+type EvidenceLevel string
+
+const (
+	EvidenceDeclared    EvidenceLevel = "Declared"
+	EvidenceReported    EvidenceLevel = "Reported"
+	EvidenceObserved    EvidenceLevel = "Observed"
+	EvidenceComputed    EvidenceLevel = "Computed"
+	EvidenceUnavailable EvidenceLevel = "Unavailable"
+)
+
+// UnavailableReason is a bounded reason that source evidence is absent.
+type UnavailableReason string
+
+const (
+	UnavailableNotFound         UnavailableReason = "NotFound"
+	UnavailableForbidden        UnavailableReason = "Forbidden"
+	UnavailableUnsupportedAPI   UnavailableReason = "UnsupportedAPI"
+	UnavailableStaleGeneration  UnavailableReason = "StaleGeneration"
+	UnavailableMalformedPayload UnavailableReason = "MalformedPayload"
+	UnavailableNotConfigured    UnavailableReason = "NotConfigured"
+	UnavailableUnreadable       UnavailableReason = "Unreadable"
+)
+
+// SourceReference identifies one typed source used to build a report.
+type SourceReference struct {
+	Kind              string            `json:"kind"`
+	Namespace         string            `json:"namespace,omitempty"`
+	Name              string            `json:"name"`
+	UID               string            `json:"uid,omitempty"`
+	Generation        int64             `json:"generation,omitempty"`
+	ResourceVersion   string            `json:"resourceVersion,omitempty"`
+	Evidence          EvidenceLevel     `json:"evidence"`
+	CollectedAt       time.Time         `json:"collectedAt"`
+	UnavailableReason UnavailableReason `json:"unavailableReason,omitempty"`
+}
+
+// WarningCode gives consumers a stable category without exposing arbitrary
+// structured data.
+type WarningCode string
+
+const (
+	WarningPartialData       WarningCode = "PartialData"
+	WarningSourceUnavailable WarningCode = "SourceUnavailable"
+	WarningStaleEvidence     WarningCode = "StaleEvidence"
+	WarningTruncated         WarningCode = "Truncated"
+)
+
+// Warning is a typed, ordered diagnostic warning.
+type Warning struct {
+	Code    WarningCode `json:"code"`
+	Message string      `json:"message,omitempty"`
+}
+
+// Content is implemented by the typed content owned by each report kind.
+// Canonical must return a sorted copy with every slice normalized to a
+// non-nil value. Table derives the human view from that same typed content.
+type Content[T any] interface {
+	Canonical() T
+	Table() report.Table
+}
+
+// Envelope carries the fields shared by every v1alpha1 diagnostic report.
+// T remains a concrete compile-time type; arbitrary maps and raw extensions
+// are intentionally not part of this contract.
+type Envelope[T Content[T]] struct {
+	APIVersion  string            `json:"apiVersion"`
+	Kind        string            `json:"kind"`
+	Metadata    Metadata          `json:"metadata"`
+	CollectedAt time.Time         `json:"collectedAt"`
+	Sources     []SourceReference `json:"sources"`
+	Content     T                 `json:"content"`
+	Warnings    []Warning         `json:"warnings"`
+}
+
+// NewEnvelope creates a report using an injectable collection clock.
+func NewEnvelope[T Content[T]](kind string, metadata Metadata, content T, clock Clock) Envelope[T] {
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	return (Envelope[T]{
+		APIVersion:  APIVersion,
+		Kind:        kind,
+		Metadata:    metadata,
+		CollectedAt: clock.Now().UTC(),
+		Sources:     []SourceReference{},
+		Content:     content,
+		Warnings:    []Warning{},
+	}).Canonical()
+}
+
+// Canonical returns a deterministic copy suitable for table or machine
+// rendering. It never reorders caller-owned slices.
+func (e Envelope[T]) Canonical() Envelope[T] {
+	result := e
+	result.APIVersion = APIVersion
+	result.CollectedAt = e.CollectedAt.UTC()
+	result.Sources = append([]SourceReference{}, e.Sources...)
+	for i := range result.Sources {
+		if result.Sources[i].CollectedAt.IsZero() {
+			result.Sources[i].CollectedAt = result.CollectedAt
+		} else {
+			result.Sources[i].CollectedAt = result.Sources[i].CollectedAt.UTC()
+		}
+	}
+	sort.SliceStable(result.Sources, func(i, j int) bool {
+		return sourceLess(result.Sources[i], result.Sources[j])
+	})
+	result.Warnings = append([]Warning{}, e.Warnings...)
+	sort.SliceStable(result.Warnings, func(i, j int) bool {
+		if result.Warnings[i].Code != result.Warnings[j].Code {
+			return result.Warnings[i].Code < result.Warnings[j].Code
+		}
+		return result.Warnings[i].Message < result.Warnings[j].Message
+	})
+	result.Content = e.Content.Canonical()
+	return result
+}
+
+// Table returns the human-readable view of the canonical typed content.
+func (e Envelope[T]) Table() report.Table {
+	return e.Content.Table()
+}
+
+func sourceLess(a, b SourceReference) bool {
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Namespace != b.Namespace {
+		return a.Namespace < b.Namespace
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	if a.UID != b.UID {
+		return a.UID < b.UID
+	}
+	if a.Generation != b.Generation {
+		return a.Generation < b.Generation
+	}
+	if a.ResourceVersion != b.ResourceVersion {
+		return a.ResourceVersion < b.ResourceVersion
+	}
+	if a.Evidence != b.Evidence {
+		return a.Evidence < b.Evidence
+	}
+	if !a.CollectedAt.Equal(b.CollectedAt) {
+		return a.CollectedAt.Before(b.CollectedAt)
+	}
+	return a.UnavailableReason < b.UnavailableReason
+}

--- a/pkg/cli/report/v1alpha1/types_test.go
+++ b/pkg/cli/report/v1alpha1/types_test.go
@@ -1,0 +1,303 @@
+package v1alpha1_test
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestNewEnvelopeUsesVersionedTypedDefaultsAndInjectedTime(t *testing.T) {
+	location := time.FixedZone("test", -7*60*60)
+	now := time.Date(2026, time.August, 31, 11, 45, 0, 0, location)
+
+	got := v1alpha1.NewEnvelope(
+		"InstanceReport",
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		diagnosticContent{},
+		fixedClock{now: now},
+	)
+
+	assert.Equal(t, v1alpha1.APIVersion, got.APIVersion)
+	assert.Equal(t, "InstanceReport", got.Kind)
+	assert.Equal(t, v1alpha1.Metadata{Namespace: "prod", Name: "chat"}, got.Metadata)
+	assert.Equal(t, "2026-08-31T18:45:00Z", got.CollectedAt.Format(time.RFC3339))
+	assert.NotNil(t, got.Sources)
+	assert.NotNil(t, got.Warnings)
+	assert.NotNil(t, got.Content.Rows)
+}
+
+func TestEnvelopeCanonicalReturnsSortedCopy(t *testing.T) {
+	collectedAt := time.Date(2026, time.August, 31, 18, 0, 0, 0, time.UTC)
+	reportValue := v1alpha1.Envelope[diagnosticContent]{
+		APIVersion:  "incorrect.example/v9",
+		Kind:        "InstanceReport",
+		Metadata:    v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		CollectedAt: collectedAt,
+		Sources: []v1alpha1.SourceReference{
+			{Kind: "Pod", Namespace: "prod", Name: "z", Evidence: v1alpha1.EvidenceObserved},
+			{Kind: "InferenceService", Namespace: "prod", Name: "chat", Evidence: v1alpha1.EvidenceReported},
+			{Kind: "Pod", Namespace: "prod", Name: "a", Evidence: v1alpha1.EvidenceObserved},
+		},
+		Warnings: []v1alpha1.Warning{
+			{Code: v1alpha1.WarningTruncated, Message: "later rows omitted"},
+			{Code: v1alpha1.WarningPartialData, Message: "events forbidden"},
+		},
+		Content: diagnosticContent{Rows: []diagnosticRow{{Name: "z"}, {Name: "a"}}},
+	}
+
+	got := reportValue.Canonical()
+
+	assert.Equal(t, v1alpha1.APIVersion, got.APIVersion)
+	assert.Equal(t, []string{"InferenceService/chat", "Pod/a", "Pod/z"}, sourceNames(got.Sources))
+	assert.Equal(t, []v1alpha1.WarningCode{v1alpha1.WarningPartialData, v1alpha1.WarningTruncated}, warningCodes(got.Warnings))
+	assert.Equal(t, []diagnosticRow{{Name: "a"}, {Name: "z"}}, got.Content.Rows)
+	for _, source := range got.Sources {
+		assert.Equal(t, collectedAt, source.CollectedAt)
+	}
+
+	assert.Equal(t, []string{"Pod/z", "InferenceService/chat", "Pod/a"}, sourceNames(reportValue.Sources))
+	assert.Equal(t, []diagnosticRow{{Name: "z"}, {Name: "a"}}, reportValue.Content.Rows)
+}
+
+func TestEnvelopeCanonicalNormalizesNilCollections(t *testing.T) {
+	reportValue := v1alpha1.Envelope[diagnosticContent]{
+		Kind:    "InstanceReport",
+		Content: diagnosticContent{},
+	}
+
+	got := reportValue.Canonical()
+
+	assert.NotNil(t, got.Sources)
+	assert.NotNil(t, got.Warnings)
+	assert.NotNil(t, got.Content.Rows)
+}
+
+func TestEnvelopeCanonicalOrdersEverySourceIdentityField(t *testing.T) {
+	base := v1alpha1.SourceReference{
+		Kind:              "Pod",
+		Namespace:         "prod",
+		Name:              "chat",
+		UID:               "uid-b",
+		Generation:        2,
+		ResourceVersion:   "2",
+		Evidence:          v1alpha1.EvidenceObserved,
+		CollectedAt:       time.Date(2026, time.August, 31, 18, 1, 0, 0, time.UTC),
+		UnavailableReason: v1alpha1.UnavailableNotFound,
+	}
+	tests := []struct {
+		name  string
+		early v1alpha1.SourceReference
+		late  v1alpha1.SourceReference
+	}{
+		{name: "kind", early: withSource(base, func(s *v1alpha1.SourceReference) { s.Kind = "InferenceService" }), late: base},
+		{name: "namespace", early: withSource(base, func(s *v1alpha1.SourceReference) { s.Namespace = "a" }), late: base},
+		{name: "name", early: withSource(base, func(s *v1alpha1.SourceReference) { s.Name = "a" }), late: base},
+		{name: "uid", early: withSource(base, func(s *v1alpha1.SourceReference) { s.UID = "uid-a" }), late: base},
+		{name: "generation", early: withSource(base, func(s *v1alpha1.SourceReference) { s.Generation = 1 }), late: base},
+		{name: "resource version", early: withSource(base, func(s *v1alpha1.SourceReference) { s.ResourceVersion = "1" }), late: base},
+		{name: "evidence", early: withSource(base, func(s *v1alpha1.SourceReference) { s.Evidence = v1alpha1.EvidenceDeclared }), late: base},
+		{name: "collected at", early: withSource(base, func(s *v1alpha1.SourceReference) { s.CollectedAt = s.CollectedAt.Add(-time.Minute) }), late: base},
+		{name: "unavailable reason", early: withSource(base, func(s *v1alpha1.SourceReference) { s.UnavailableReason = v1alpha1.UnavailableForbidden }), late: base},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reportValue := v1alpha1.Envelope[diagnosticContent]{
+				Kind:        "InstanceReport",
+				CollectedAt: base.CollectedAt,
+				Sources:     []v1alpha1.SourceReference{tt.late, tt.early},
+				Content:     diagnosticContent{},
+			}
+
+			got := reportValue.Canonical()
+
+			require.Len(t, got.Sources, 2)
+			assert.Equal(t, tt.early, got.Sources[0])
+			assert.Equal(t, tt.late, got.Sources[1])
+		})
+	}
+}
+
+func TestEnvelopeCanonicalNormalizesSourceTimezoneAndWarningMessageOrder(t *testing.T) {
+	location := time.FixedZone("test", 2*60*60)
+	sourceTime := time.Date(2026, time.August, 31, 20, 0, 0, 0, location)
+	reportValue := v1alpha1.Envelope[diagnosticContent]{
+		Kind: "InstanceReport",
+		Sources: []v1alpha1.SourceReference{
+			{Kind: "Pod", Name: "chat", CollectedAt: sourceTime},
+		},
+		Warnings: []v1alpha1.Warning{
+			{Code: v1alpha1.WarningPartialData, Message: "z"},
+			{Code: v1alpha1.WarningPartialData, Message: "a"},
+		},
+		Content: diagnosticContent{},
+	}
+
+	got := reportValue.Canonical()
+
+	assert.Equal(t, time.UTC, got.Sources[0].CollectedAt.Location())
+	assert.Equal(t, []string{"a", "z"}, []string{got.Warnings[0].Message, got.Warnings[1].Message})
+	assert.Equal(t, "test", reportValue.Sources[0].CollectedAt.Location().String())
+}
+
+func TestEnvelopeTableUsesTypedContent(t *testing.T) {
+	reportValue := v1alpha1.Envelope[diagnosticContent]{
+		Content: diagnosticContent{Rows: []diagnosticRow{{Name: "chat"}}},
+	}
+
+	assert.Equal(t, report.Table{Headers: []string{"NAME"}, Rows: [][]string{{"chat"}}}, reportValue.Table())
+}
+
+func TestClockImplementations(t *testing.T) {
+	want := time.Date(2026, time.August, 31, 18, 0, 0, 0, time.UTC)
+	clock := v1alpha1.ClockFunc(func() time.Time { return want })
+	assert.Equal(t, want, clock.Now())
+
+	before := time.Now()
+	got := (v1alpha1.SystemClock{}).Now()
+	after := time.Now()
+	assert.False(t, got.Before(before))
+	assert.False(t, got.After(after))
+}
+
+func TestConstructorsAcceptDefaultSystemClock(t *testing.T) {
+	before := time.Now().UTC()
+	envelope := v1alpha1.NewEnvelope("InstanceReport", v1alpha1.Metadata{}, diagnosticContent{}, nil)
+	action := v1alpha1.NewActionResult("pause", v1alpha1.ActionTarget{}, v1alpha1.DryRunNone, nil)
+	after := time.Now().UTC()
+
+	for _, got := range []time.Time{envelope.CollectedAt, action.CollectedAt} {
+		assert.False(t, got.Before(before))
+		assert.False(t, got.After(after))
+	}
+}
+
+func TestV1Alpha1EnvelopeSchemaHasNoUnstructuredOrSecretBearingFields(t *testing.T) {
+	assertTypedSchema(t, reflect.TypeOf(v1alpha1.Envelope[diagnosticContent]{}), map[reflect.Type]bool{})
+}
+
+func TestSchemaGuardRecognizesForbiddenNamesAndTypes(t *testing.T) {
+	typ := reflect.TypeOf(struct {
+		Environment []string                  `json:"safeName"`
+		Selector    *corev1.SecretKeySelector `json:"selector"`
+	}{})
+
+	assert.True(t, isForbiddenSchemaField(typ.Field(0)))
+	assert.True(t, isForbiddenSchemaField(typ.Field(1)))
+}
+
+type fixedClock struct {
+	now time.Time
+}
+
+func (c fixedClock) Now() time.Time {
+	return c.now
+}
+
+type diagnosticContent struct {
+	Rows []diagnosticRow `json:"rows"`
+}
+
+func (c diagnosticContent) Canonical() diagnosticContent {
+	result := c
+	result.Rows = append([]diagnosticRow{}, c.Rows...)
+	sort.Slice(result.Rows, func(i, j int) bool {
+		return result.Rows[i].Name < result.Rows[j].Name
+	})
+	return result
+}
+
+func (c diagnosticContent) Table() report.Table {
+	table := report.Table{Headers: []string{"NAME"}, Rows: make([][]string, 0, len(c.Rows))}
+	for _, row := range c.Rows {
+		table.Rows = append(table.Rows, []string{row.Name})
+	}
+	return table
+}
+
+type diagnosticRow struct {
+	Name string `json:"name"`
+}
+
+func sourceNames(sources []v1alpha1.SourceReference) []string {
+	result := make([]string, 0, len(sources))
+	for _, source := range sources {
+		result = append(result, source.Kind+"/"+source.Name)
+	}
+	return result
+}
+
+func warningCodes(warnings []v1alpha1.Warning) []v1alpha1.WarningCode {
+	result := make([]v1alpha1.WarningCode, 0, len(warnings))
+	for _, warning := range warnings {
+		result = append(result, warning.Code)
+	}
+	return result
+}
+
+func withSource(source v1alpha1.SourceReference, change func(*v1alpha1.SourceReference)) v1alpha1.SourceReference {
+	change(&source)
+	return source
+}
+
+func assertTypedSchema(t *testing.T, typ reflect.Type, seen map[reflect.Type]bool) {
+	t.Helper()
+	for typ.Kind() == reflect.Pointer || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array {
+		typ = typ.Elem()
+	}
+	if typ.PkgPath() == "time" || seen[typ] {
+		return
+	}
+	seen[typ] = true
+
+	require.False(t, isForbiddenSchemaType(typ), "schema contains forbidden type %s", typ)
+	require.NotEqual(t, reflect.Interface, typ.Kind(), "schema contains interface field at %s", typ)
+	require.NotEqual(t, reflect.Map, typ.Kind(), "schema contains map field at %s", typ)
+	if typ.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		assert.False(t, isForbiddenSchemaField(field), "schema contains forbidden field %s.%s", typ, field.Name)
+		assertTypedSchema(t, field.Type, seen)
+	}
+}
+
+func isForbiddenSchemaField(field reflect.StructField) bool {
+	jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+	name := strings.ToLower(field.Name + " " + jsonName)
+	for _, fragment := range []string{
+		"annotation", "detail", "environment", "envfrom", "header",
+		"secret", "spec", "template",
+	} {
+		if strings.Contains(name, fragment) {
+			return true
+		}
+	}
+	return isForbiddenSchemaType(field.Type)
+}
+
+func isForbiddenSchemaType(typ reflect.Type) bool {
+	for typ.Kind() == reflect.Pointer || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array {
+		typ = typ.Elem()
+	}
+	if !strings.HasPrefix(typ.PkgPath(), "k8s.io/") {
+		return false
+	}
+	name := strings.ToLower(typ.Name())
+	for _, fragment := range []string{"envvar", "rawextension", "secret", "spec", "template"} {
+		if strings.Contains(name, fragment) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this PR does

### Outcome

This PR establishes the typed output boundary used by upcoming `kubectl ome`
diagnostic and mutating commands:

- versioned diagnostic envelopes use `cli.ome.io/v1alpha1`;
- table, JSON, and YAML come from one canonical typed value;
- source evidence and partial-data warnings have bounded categories;
- timestamps use an injectable clock and are normalized to UTC;
- slices are deterministic and serialize as `[]`, never `null`;
- mutating commands share a separate typed `ActionResult` contract; and
- table cells escape control characters so values cannot create fake rows or
  columns.

### User-visible CLI output

No command is wired to these packages in this foundation PR, so current
`kubectl ome` output does not change. Consumer PRs will add the commands and
their exact domain-specific rows.

The shared action-result table they will emit is pinned by an exact-output
test:

```text
ACTION   TARGET                       DRY-RUN   ACCEPTED   APPLIED   REQUEST-ID   REVISION-HASH   MESSAGE             FOLLOW-UP
pause    InferenceService/prod/chat   server    Yes        No        request-7    sha256:abc      request validated   kubectl ome status chat -n prod
```

The same typed result has a stable JSON contract for automation:

```json
{
  "apiVersion": "cli.ome.io/v1alpha1",
  "kind": "ActionResult",
  "collectedAt": "2026-08-31T18:30:00Z",
  "action": "pause",
  "target": {
    "kind": "InferenceService",
    "namespace": "prod",
    "name": "chat",
    "uid": "uid-1",
    "resourceVersion": "42"
  },
  "dryRun": "server",
  "requestID": "request-7",
  "revisionHash": "sha256:abc",
  "accepted": true,
  "applied": false,
  "message": "request validated",
  "followUp": "kubectl ome status chat -n prod"
}
```

### Contract and safety limits

- Report content is a concrete Go type at compile time. The envelope has no
  `map[string]any`, `interface{}`, or Kubernetes `RawExtension` escape hatch.
- Shared schemas deliberately contain no spec, pod template, annotations,
  environment, headers, or Secret selector fields. Domain report PRs must add
  only explicitly reviewed typed fields.
- `Sources` records identity and evidence level (`Declared`, `Reported`,
  `Observed`, `Computed`, or `Unavailable`) without embedding source objects.
- Client dry-run always canonicalizes both `accepted` and `applied` to false.
  Server dry-run may be accepted by the API server but is never marked applied.
- Preview text, confirmation prompts, and warnings remain stderr concerns;
  they are not mixed into the versioned stdout action result.
- Raw Kubernetes object output remains owned by the existing CLI printers;
  this package is only for CLI-owned reports.

## Why we need it

The planned instance, rollout, autoscaling, runtime, traffic, placement, and
doctor commands join several Kubernetes resources. Without one typed contract,
each command could drift in field names, ordering, missing-data semantics,
redaction, and dry-run behavior. This foundation makes those rules testable
before collectors and mutations depend on them.

Fixes # — N/A; tracked by OEP-0011.1 foundation item 2.

## How to test

```shell
go test -count=1 ./pkg/cli/report/...
go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...
go test -race -count=1 ./pkg/cli/...
go vet ./cmd/kubectl-ome ./pkg/cli/...
go build ./cmd/kubectl-ome
```

The report packages have 98.3% combined statement coverage (`report`: 96.4%,
`v1alpha1`: 100%). Exact-output tests cover table, JSON, and YAML; additional
tests cover ordering without caller mutation, UTC normalization, empty
collections, writer/serialization failures, dry-run invariants, control
characters, and forbidden secret-bearing schema shapes. Linux, Darwin, and
Windows cross-compiles pass for amd64 and arm64 with `CGO_ENABLED=0`.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (the versioned contract and limits are documented above;
  no repository docs are changed in this scoped foundation PR)
- [ ] `make test` passes locally

The final submitted commit passes the scoped CLI suite, race detector, vet,
host build, and six cross-compiles. Required repository CI remains the
authoritative full-suite gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured diagnostic reports with versioned metadata, source references, warnings, and action results.
  * Added table, JSON, and YAML output formats, with table output as the default.
  * Added deterministic sorting, timestamp normalization, and safe escaping for readable reports.
  * Added dry-run and application status details for guarded actions.
* **Bug Fixes**
  * Improved handling of empty values, serialization errors, output failures, and unsupported formats.
  * Ensured sensitive or unstructured fields are excluded from report data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->