### PR TITLE
[Core] Resolve effective CLI runtimes

### DIFF
--- a/pkg/cli/effective/runtime.go
+++ b/pkg/cli/effective/runtime.go
@@ -1,0 +1,788 @@
+// Package effective resolves the authoritative resources and effective
+// configuration behind CLI service targets.
+package effective
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+// ErrUnsafeRuntimeSerialization prevents internal, potentially secret-bearing
+// runtime and component specs from becoming an accidental output contract.
+// Callers must first project them into an allowlisted report type.
+var ErrUnsafeRuntimeSerialization = errors.New("effective runtime configuration must be projected to an allowlisted report before serialization")
+
+// RuntimeSelectionSource identifies whether the service named a runtime or
+// the operator selector chose one from the referenced model.
+type RuntimeSelectionSource string
+
+const (
+	RuntimeExplicit RuntimeSelectionSource = "Explicit"
+	RuntimeSelected RuntimeSelectionSource = "Selected"
+)
+
+type runtimeSelector interface {
+	GetRuntime(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error)
+	SelectRuntime(context.Context, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error)
+	ValidateRuntime(context.Context, string, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) error
+}
+
+// RuntimeAdvisoryCode identifies bounded, non-fatal evidence discovered while
+// resolving the same runtime configuration path as the operator.
+type RuntimeAdvisoryCode string
+
+const (
+	// RuntimeAdvisoryDeclaredCompatibilityMismatch matches the operator's
+	// deliberate choice to continue with a named runtime for a non-sharded
+	// model despite a declared compatibility mismatch.
+	RuntimeAdvisoryDeclaredCompatibilityMismatch RuntimeAdvisoryCode = "DeclaredCompatibilityMismatch"
+	// RuntimeAdvisoryInvalidDeclaredKind records a non-nil runtime Kind that is
+	// not one of the two supported API values. Reads may continue through the
+	// selector's fallback behavior, but pin-aware mutations must fail closed.
+	RuntimeAdvisoryInvalidDeclaredKind RuntimeAdvisoryCode = "InvalidDeclaredKind"
+)
+
+// RuntimeAdvisory is intentionally code-only. In particular, it must not
+// forward selector errors because their text can contain user-authored model
+// and runtime values. A report layer can map each code to fixed presentation.
+type RuntimeAdvisory struct {
+	Code RuntimeAdvisoryCode
+}
+
+// InheritanceObservationState records whether the declared inheritance chain
+// could be observed independently of the authoritative runtime snapshot.
+type InheritanceObservationState string
+
+const (
+	InheritanceObserved    InheritanceObservationState = "Observed"
+	InheritanceUnavailable InheritanceObservationState = "Unavailable"
+)
+
+// InheritanceUnavailableReason is a bounded classification of why declared
+// inheritance provenance could not be observed.
+type InheritanceUnavailableReason string
+
+const (
+	InheritanceNotFound         InheritanceUnavailableReason = "NotFound"
+	InheritanceForbidden        InheritanceUnavailableReason = "Forbidden"
+	InheritanceCycle            InheritanceUnavailableReason = "Cycle"
+	InheritanceMaxDepthExceeded InheritanceUnavailableReason = "MaxDepthExceeded"
+	InheritanceMalformed        InheritanceUnavailableReason = "Malformed"
+	InheritanceUnreadable       InheritanceUnavailableReason = "Unreadable"
+)
+
+// RuntimeSourceReference is a safe identity-only observation of one declared
+// runtime source. It never contains labels, annotations, or a runtime spec.
+type RuntimeSourceReference struct {
+	APIVersion      string
+	Kind            string
+	Namespace       string
+	Name            string
+	UID             types.UID
+	Generation      int64
+	ResourceVersion string
+}
+
+// InheritanceObservation records a same-traversal, root-first source chain or
+// one bounded reason why it is unavailable. Its fields are private so callers
+// cannot construct contradictory state/reason/chain combinations.
+type InheritanceObservation struct {
+	state             InheritanceObservationState
+	chain             []RuntimeSourceReference
+	unavailableReason InheritanceUnavailableReason
+}
+
+func observedInheritance(chain []RuntimeSourceReference) InheritanceObservation {
+	if len(chain) == 0 {
+		return unavailableInheritance(InheritanceMalformed)
+	}
+	return InheritanceObservation{state: InheritanceObserved, chain: append([]RuntimeSourceReference{}, chain...)}
+}
+
+func unavailableInheritance(reason InheritanceUnavailableReason) InheritanceObservation {
+	if !knownInheritanceUnavailableReason(reason) {
+		reason = InheritanceUnreadable
+	}
+	return InheritanceObservation{
+		state:             InheritanceUnavailable,
+		chain:             []RuntimeSourceReference{},
+		unavailableReason: reason,
+	}
+}
+
+// State returns whether the declared chain was observed.
+func (o InheritanceObservation) State() InheritanceObservationState {
+	return o.state
+}
+
+// Chain returns a defensive copy of the root-first source identities.
+func (o InheritanceObservation) Chain() []RuntimeSourceReference {
+	return append([]RuntimeSourceReference{}, o.chain...)
+}
+
+// UnavailableReason returns the bounded reason when State is Unavailable.
+func (o InheritanceObservation) UnavailableReason() InheritanceUnavailableReason {
+	return o.unavailableReason
+}
+
+// Validate rejects zero, unknown, and contradictory observations.
+func (o InheritanceObservation) Validate() error {
+	switch o.state {
+	case InheritanceObserved:
+		if len(o.chain) == 0 || o.unavailableReason != "" {
+			return errors.New("observed inheritance requires a nonempty chain and no unavailable reason")
+		}
+		return nil
+	case InheritanceUnavailable:
+		if len(o.chain) != 0 || !knownInheritanceUnavailableReason(o.unavailableReason) {
+			return errors.New("unavailable inheritance requires an empty chain and one known reason")
+		}
+		return nil
+	default:
+		return errors.New("inheritance observation state is invalid")
+	}
+}
+
+func knownInheritanceUnavailableReason(reason InheritanceUnavailableReason) bool {
+	switch reason {
+	case InheritanceNotFound, InheritanceForbidden, InheritanceCycle,
+		InheritanceMaxDepthExceeded, InheritanceMalformed, InheritanceUnreadable:
+		return true
+	default:
+		return false
+	}
+}
+
+// ModelResolution records the actual model scope selected by the same
+// namespaced-first lookup used by the operator.
+type ModelResolution struct {
+	Name            string
+	Kind            string
+	Namespace       string
+	UID             types.UID
+	Generation      int64
+	ResourceVersion string
+	spec            *v1beta1.BaseModelSpec
+}
+
+// MarshalJSON rejects direct serialization because the private spec can contain
+// user-authored model configuration that is not an allowlisted CLI schema.
+func (ModelResolution) MarshalJSON() ([]byte, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// MarshalYAML rejects direct YAML serialization for the same reason as
+// MarshalJSON.
+func (ModelResolution) MarshalYAML() (any, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// RuntimePinSourceState records whether controller pin-source identity is
+// relevant and safe to claim for this live resolution.
+type RuntimePinSourceState string
+
+const (
+	RuntimePinSourceNotApplicable RuntimePinSourceState = "NotApplicable"
+	RuntimePinSourceResolved      RuntimePinSourceState = "Resolved"
+	RuntimePinSourceInvalid       RuntimePinSourceState = "Invalid"
+)
+
+// RuntimePinSource preserves the controller's revision naming/label scope.
+// It is deliberately separate from the actual live runtime scope because a
+// cluster-declared lookup can fall back to a namespaced live object.
+type RuntimePinSource struct {
+	State     RuntimePinSourceState
+	Kind      string
+	Namespace string
+}
+
+// Validate rejects unknown and contradictory pin-source state.
+func (s RuntimePinSource) Validate() error {
+	switch s.State {
+	case RuntimePinSourceNotApplicable, RuntimePinSourceInvalid:
+		if s.Kind != "" || s.Namespace != "" {
+			return errors.New("non-resolved runtime pin source must not claim kind or namespace")
+		}
+		return nil
+	case RuntimePinSourceResolved:
+		switch s.Kind {
+		case runtimeselector.KindClusterServingRuntime:
+			if s.Namespace != "" {
+				return errors.New("cluster runtime pin source must not have a namespace")
+			}
+			return nil
+		case runtimeselector.KindServingRuntime:
+			if s.Namespace == "" {
+				return errors.New("namespaced runtime pin source requires a namespace")
+			}
+			return nil
+		default:
+			return errors.New("resolved runtime pin source kind is invalid")
+		}
+	default:
+		return errors.New("runtime pin source state is invalid")
+	}
+}
+
+// RuntimeResolution records the actual runtime scope, the separately observed
+// declared inheritance chain, and the exact live spec snapshot the operator
+// uses for its component merge. Namespace is empty for a
+// ClusterServingRuntime.
+//
+// Auto-selected runtimes deliberately retain the selector's raw spec snapshot:
+// the current operator does not re-resolve inheritance after selection.
+// DeclaredInheritance is an independent object-identity observation and does
+// not claim to be the snapshot that produced spec. When AutoSync is false,
+// pin-aware consumers must resolve the ControllerRevision before presenting it
+// as the active configuration; the separate pin-provenance layer owns that
+// step.
+//
+// spec may contain literal credentials in container fields. It is private
+// resolution state and must never be serialized directly; report layers use
+// an allowlisted redacted summary.
+type RuntimeResolution struct {
+	Name                string
+	Kind                string
+	Namespace           string
+	SelectionSource     RuntimeSelectionSource
+	RequestedKind       string
+	RequestedKindSet    bool
+	PinSource           RuntimePinSource
+	DeclaredInheritance InheritanceObservation
+	spec                *v1beta1.ServingRuntimeSpec
+	AutoSync            bool
+	RequestedRevision   string
+}
+
+// MarshalJSON rejects direct serialization because the private spec can
+// contain literal credentials in pod-template fields.
+func (RuntimeResolution) MarshalJSON() ([]byte, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// MarshalYAML rejects direct YAML serialization for the same reason as
+// MarshalJSON.
+func (RuntimeResolution) MarshalYAML() (any, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// ComponentDeploymentModeSource records the precedence rung that selected a
+// component's effective deployment mode.
+type ComponentDeploymentModeSource string
+
+const (
+	DeploymentModeComponentAnnotation ComponentDeploymentModeSource = "ComponentAnnotation"
+	DeploymentModeServiceSpec         ComponentDeploymentModeSource = "ServiceSpec"
+	DeploymentModeLeaderWorkerShape   ComponentDeploymentModeSource = "LeaderWorkerShape"
+	DeploymentModeDefault             ComponentDeploymentModeSource = "Default"
+)
+
+// EffectiveComponent is one merged runtime/InferenceService component. Only
+// the private spec matching Type is populated.
+type EffectiveComponent struct {
+	Type                 v1beta1.ComponentType
+	DeploymentMode       constants.DeploymentModeType
+	DeploymentModeSource ComponentDeploymentModeSource
+	engine               *v1beta1.EngineSpec
+	decoder              *v1beta1.DecoderSpec
+	router               *v1beta1.RouterSpec
+}
+
+// MarshalJSON rejects direct serialization because merged component specs can
+// contain literal credentials in pod-template fields.
+func (EffectiveComponent) MarshalJSON() ([]byte, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// MarshalYAML rejects direct YAML serialization for the same reason as
+// MarshalJSON.
+func (EffectiveComponent) MarshalYAML() (any, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// LiveConfiguration is the operator-faithful merge against the authoritative
+// live runtime snapshot. Components are ordered engine, decoder, router. Its
+// full runtime and component specs are internal and must not be rendered
+// without the separate redaction layer.
+type LiveConfiguration struct {
+	Model      *ModelResolution
+	Runtime    RuntimeResolution
+	Components []EffectiveComponent
+	Advisories []RuntimeAdvisory
+}
+
+// MarshalJSON rejects direct serialization of the complete internal
+// resolution. Report layers must copy reviewed fields into an allowlisted
+// versioned schema instead.
+func (LiveConfiguration) MarshalJSON() ([]byte, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// MarshalYAML rejects direct YAML serialization for the same reason as
+// MarshalJSON.
+func (LiveConfiguration) MarshalYAML() (any, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// RuntimeResolver resolves model/runtime references through the same selector
+// used by the operator and observes declared inheritance as separate
+// provenance.
+type RuntimeResolver struct {
+	client   ctrlclient.Client
+	selector runtimeSelector
+}
+
+func NewRuntimeResolver(client ctrlclient.Client) *RuntimeResolver {
+	return newRuntimeResolver(client, runtimeselector.New(client))
+}
+
+func newRuntimeResolver(client ctrlclient.Client, selector runtimeSelector) *RuntimeResolver {
+	return &RuntimeResolver{client: client, selector: selector}
+}
+
+// ResolveLive resolves the exact live runtime snapshot used by the operator
+// and merges it with the service. See RuntimeResolution for selection,
+// redaction, and AutoSync=false caveats.
+func (r *RuntimeResolver) ResolveLive(ctx context.Context, isvc *v1beta1.InferenceService) (*LiveConfiguration, error) {
+	if r == nil || r.client == nil || r.selector == nil {
+		return nil, errors.New("runtime resolver is not configured")
+	}
+	if isvc == nil {
+		return nil, errors.New("InferenceService must not be nil")
+	}
+	if isvc.Namespace == "" {
+		return nil, errors.New("InferenceService namespace must not be empty")
+	}
+
+	model, err := resolveModel(ctx, r.client, isvc)
+	if err != nil {
+		return nil, err
+	}
+
+	reference, err := r.resolveRuntimeReference(ctx, isvc, model)
+	if err != nil {
+		return nil, err
+	}
+
+	if reference.spec == nil {
+		return nil, fmt.Errorf("resolve runtime %q: empty runtime spec", reference.name)
+	}
+	if reference.spec.IsDisabled() {
+		return nil, &runtimeselector.RuntimeDisabledError{RuntimeName: reference.name, IsCluster: reference.cluster}
+	}
+
+	components, err := MergeEffectiveComponents(isvc, reference.spec)
+	if err != nil {
+		return nil, err
+	}
+	declaredInheritance, err := observeDeclaredInheritance(
+		ctx, r.client, isvc.Namespace, reference.name, reference.cluster,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	autoSync, requestedKind, requestedKindSet, requestedRevision, pinSource := runtimeReferenceIntent(isvc, reference.source)
+
+	kind := runtimeselector.KindServingRuntime
+	namespace := isvc.Namespace
+	if reference.cluster {
+		kind = runtimeselector.KindClusterServingRuntime
+		namespace = ""
+	}
+	return &LiveConfiguration{
+		Model: model,
+		Runtime: RuntimeResolution{
+			Name:                reference.name,
+			Kind:                kind,
+			Namespace:           namespace,
+			SelectionSource:     reference.source,
+			RequestedKind:       requestedKind,
+			RequestedKindSet:    requestedKindSet,
+			PinSource:           pinSource,
+			DeclaredInheritance: declaredInheritance,
+			spec:                reference.spec.DeepCopy(),
+			AutoSync:            autoSync,
+			RequestedRevision:   requestedRevision,
+		},
+		Components: components,
+		Advisories: append([]RuntimeAdvisory{}, reference.advisories...),
+	}, nil
+}
+
+type resolvedRuntimeReference struct {
+	name       string
+	cluster    bool
+	source     RuntimeSelectionSource
+	spec       *v1beta1.ServingRuntimeSpec
+	advisories []RuntimeAdvisory
+}
+
+func (r *RuntimeResolver) resolveRuntimeReference(
+	ctx context.Context,
+	isvc *v1beta1.InferenceService,
+	model *ModelResolution,
+) (*resolvedRuntimeReference, error) {
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+		name := isvc.Spec.Runtime.Name
+		advisories := []RuntimeAdvisory{}
+		if !validDeclaredRuntimeKind(isvc.Spec.Runtime.Kind) {
+			advisories = append(advisories, RuntimeAdvisory{Code: RuntimeAdvisoryInvalidDeclaredKind})
+		}
+		if model != nil && runtimeAutoSyncEnabled(isvc.Spec.Runtime) {
+			if err := r.selector.ValidateRuntime(ctx, name, model.spec, isvc); err != nil {
+				var compatibilityErr *runtimeselector.RuntimeCompatibilityError
+				if errors.As(err, &compatibilityErr) && !isvcutils.IsShardedBaseModel(model.spec) {
+					advisories = append(advisories, RuntimeAdvisory{
+						Code: RuntimeAdvisoryDeclaredCompatibilityMismatch,
+					})
+				} else {
+					return nil, fmt.Errorf("validate explicit runtime %q: %w", name, err)
+				}
+			}
+		}
+		spec, cluster, err := r.selector.GetRuntime(ctx, name, isvc.Namespace, runtimeselector.RefKind(isvc.Spec.Runtime))
+		if err != nil {
+			return nil, fmt.Errorf("resolve explicit runtime %q: %w", name, err)
+		}
+		return &resolvedRuntimeReference{
+			name: name, cluster: cluster, source: RuntimeExplicit, spec: spec, advisories: advisories,
+		}, nil
+	}
+	if model == nil {
+		return nil, errors.New("InferenceService must reference a model or runtime")
+	}
+	selection, err := r.selector.SelectRuntime(ctx, model.spec, isvc)
+	if err != nil {
+		return nil, fmt.Errorf("select runtime for model %q: %w", model.Name, err)
+	}
+	if selection == nil || selection.Name == "" || selection.Spec == nil {
+		return nil, fmt.Errorf("select runtime for model %q: selector returned an empty result", model.Name)
+	}
+	return &resolvedRuntimeReference{
+		name: selection.Name, cluster: selection.IsCluster, source: RuntimeSelected, spec: selection.Spec,
+		advisories: []RuntimeAdvisory{},
+	}, nil
+}
+
+func runtimeAutoSyncEnabled(reference *v1beta1.ServingRuntimeRef) bool {
+	return reference.AutoSync == nil || *reference.AutoSync
+}
+
+func runtimeReferenceIntent(
+	isvc *v1beta1.InferenceService,
+	selectionSource RuntimeSelectionSource,
+) (bool, string, bool, string, RuntimePinSource) {
+	notApplicable := RuntimePinSource{State: RuntimePinSourceNotApplicable}
+	if selectionSource != RuntimeExplicit || isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name == "" {
+		return true, "", false, "", notApplicable
+	}
+
+	reference := isvc.Spec.Runtime
+	autoSync := runtimeAutoSyncEnabled(reference)
+	requestedKind := ""
+	requestedKindSet := reference.Kind != nil
+	if requestedKindSet {
+		requestedKind = *reference.Kind
+	}
+	requestedRevision := ""
+	if reference.Revision != nil {
+		requestedRevision = *reference.Revision
+	}
+	if autoSync {
+		return true, requestedKind, requestedKindSet, requestedRevision, notApplicable
+	}
+	if !validDeclaredRuntimeKind(reference.Kind) {
+		return false, requestedKind, requestedKindSet, requestedRevision, RuntimePinSource{State: RuntimePinSourceInvalid}
+	}
+	if reference.Kind == nil || *reference.Kind == runtimeselector.KindClusterServingRuntime {
+		return false, requestedKind, requestedKindSet, requestedRevision, RuntimePinSource{
+			State: RuntimePinSourceResolved,
+			Kind:  runtimeselector.KindClusterServingRuntime,
+		}
+	}
+	return false, requestedKind, requestedKindSet, requestedRevision, RuntimePinSource{
+		State:     RuntimePinSourceResolved,
+		Kind:      runtimeselector.KindServingRuntime,
+		Namespace: isvc.Namespace,
+	}
+}
+
+func validDeclaredRuntimeKind(kind *string) bool {
+	return kind == nil || *kind == runtimeselector.KindClusterServingRuntime || *kind == runtimeselector.KindServingRuntime
+}
+
+func resolveModel(ctx context.Context, client ctrlclient.Client, isvc *v1beta1.InferenceService) (*ModelResolution, error) {
+	if isvc.Spec.Model == nil || isvc.Spec.Model.Name == "" {
+		return nil, nil
+	}
+	name := isvc.Spec.Model.Name
+	model := &v1beta1.BaseModel{}
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: isvc.Namespace}, model)
+	if err == nil {
+		if model.Spec.Disabled != nil && *model.Spec.Disabled {
+			return nil, fmt.Errorf("model %q is disabled", name)
+		}
+		return &ModelResolution{
+			Name: name, Kind: "BaseModel", Namespace: isvc.Namespace,
+			UID: model.UID, Generation: model.Generation, ResourceVersion: model.ResourceVersion,
+			spec: model.Spec.DeepCopy(),
+		}, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("resolve model %q: %w", name, err)
+	}
+
+	clusterModel := &v1beta1.ClusterBaseModel{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name}, clusterModel); err != nil {
+		return nil, fmt.Errorf("resolve model %q: %w", name, err)
+	}
+	if clusterModel.Spec.Disabled != nil && *clusterModel.Spec.Disabled {
+		return nil, fmt.Errorf("model %q is disabled", name)
+	}
+	return &ModelResolution{
+		Name: name, Kind: "ClusterBaseModel",
+		UID: clusterModel.UID, Generation: clusterModel.Generation, ResourceVersion: clusterModel.ResourceVersion,
+		spec: clusterModel.Spec.DeepCopy(),
+	}, nil
+}
+
+type inheritanceReadError struct {
+	cause error
+}
+
+func (e *inheritanceReadError) Error() string {
+	return "runtime inheritance source read failed"
+}
+
+func (e *inheritanceReadError) Unwrap() error {
+	return e.cause
+}
+
+func observeDeclaredInheritance(
+	ctx context.Context,
+	client ctrlclient.Client,
+	namespace, name string,
+	cluster bool,
+) (InheritanceObservation, error) {
+	chain, err := observeRuntimeInheritance(ctx, client, namespace, name, cluster)
+	if err == nil {
+		return observedInheritance(chain), nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return InheritanceObservation{}, fmt.Errorf("observe declared runtime inheritance: %w", ctxErr)
+	}
+	return unavailableInheritance(classifyInheritanceUnavailable(err)), nil
+}
+
+func observeRuntimeInheritance(
+	ctx context.Context,
+	client ctrlclient.Client,
+	namespace, name string,
+	cluster bool,
+) ([]RuntimeSourceReference, error) {
+	sources := map[string]RuntimeSourceReference{}
+	var start *runtimeinheritance.RuntimeRef
+	var fetch runtimeinheritance.Fetcher
+	var err error
+	if cluster {
+		fetch = clusterRuntimeObserver(client, sources)
+		start, err = fetch(ctx, name)
+	} else {
+		start, err = namespacedRuntimeHead(ctx, client, namespace, name, sources)
+		fetch = namespacedRuntimeObserver(client, namespace, sources)
+	}
+	if err != nil {
+		return nil, err
+	}
+	_, chain, err := runtimeinheritance.Resolve(ctx, start, fetch, constants.RuntimeInheritMaxDepth)
+	if err != nil {
+		return nil, err
+	}
+	references := make([]RuntimeSourceReference, 0, len(chain))
+	for _, sourceName := range chain {
+		reference, found := sources[sourceName]
+		if !found {
+			return nil, errors.New("runtime inheritance traversal omitted source identity")
+		}
+		references = append(references, reference)
+	}
+	return references, nil
+}
+
+func clusterRuntimeObserver(
+	client ctrlclient.Client,
+	sources map[string]RuntimeSourceReference,
+) runtimeinheritance.Fetcher {
+	return func(ctx context.Context, name string) (*runtimeinheritance.RuntimeRef, error) {
+		runtimeObject := &v1beta1.ClusterServingRuntime{}
+		if err := client.Get(ctx, types.NamespacedName{Name: name}, runtimeObject); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, errors.Join(runtimeinheritance.ErrParentNotFound, err)
+			}
+			return nil, &inheritanceReadError{cause: err}
+		}
+		sources[runtimeObject.Name] = runtimeSourceReference(runtimeselector.KindClusterServingRuntime, runtimeObject)
+		return &runtimeinheritance.RuntimeRef{
+			Name: runtimeObject.Name, Spec: &runtimeObject.Spec,
+			ParentName: runtimeObject.Annotations[constants.RuntimeInheritFromAnnotationKey],
+		}, nil
+	}
+}
+
+func namespacedRuntimeHead(
+	ctx context.Context,
+	client ctrlclient.Client,
+	namespace, name string,
+	sources map[string]RuntimeSourceReference,
+) (*runtimeinheritance.RuntimeRef, error) {
+	runtimeObject := &v1beta1.ServingRuntime{}
+	if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, runtimeObject); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.Join(runtimeinheritance.ErrParentNotFound, err)
+		}
+		return nil, &inheritanceReadError{cause: err}
+	}
+	sources[runtimeObject.Name] = runtimeSourceReference(runtimeselector.KindServingRuntime, runtimeObject)
+	return &runtimeinheritance.RuntimeRef{
+		Name: runtimeObject.Name, Spec: &runtimeObject.Spec,
+		ParentName: runtimeObject.Annotations[constants.RuntimeInheritFromAnnotationKey],
+	}, nil
+}
+
+func namespacedRuntimeObserver(
+	client ctrlclient.Client,
+	namespace string,
+	sources map[string]RuntimeSourceReference,
+) runtimeinheritance.Fetcher {
+	clusterObserver := clusterRuntimeObserver(client, sources)
+	return func(ctx context.Context, name string) (*runtimeinheritance.RuntimeRef, error) {
+		runtimeObject := &v1beta1.ServingRuntime{}
+		err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, runtimeObject)
+		if err == nil {
+			sources[runtimeObject.Name] = runtimeSourceReference(runtimeselector.KindServingRuntime, runtimeObject)
+			return &runtimeinheritance.RuntimeRef{
+				Name: runtimeObject.Name, Spec: &runtimeObject.Spec,
+				ParentName: runtimeObject.Annotations[constants.RuntimeInheritFromAnnotationKey],
+			}, nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, &inheritanceReadError{cause: err}
+		}
+		return clusterObserver(ctx, name)
+	}
+}
+
+func runtimeSourceReference(kind string, object metav1.Object) RuntimeSourceReference {
+	return RuntimeSourceReference{
+		APIVersion: v1beta1.SchemeGroupVersion.String(),
+		Kind:       kind, Namespace: object.GetNamespace(), Name: object.GetName(),
+		UID: object.GetUID(), Generation: object.GetGeneration(), ResourceVersion: object.GetResourceVersion(),
+	}
+}
+
+func classifyInheritanceUnavailable(err error) InheritanceUnavailableReason {
+	var cycle *runtimeinheritance.CycleError
+	if errors.As(err, &cycle) {
+		return InheritanceCycle
+	}
+	var depth *runtimeinheritance.MaxDepthExceededError
+	if errors.As(err, &depth) {
+		return InheritanceMaxDepthExceeded
+	}
+	var parentNotFound *runtimeinheritance.ParentNotFoundError
+	if errors.As(err, &parentNotFound) || errors.Is(err, runtimeinheritance.ErrParentNotFound) || apierrors.IsNotFound(err) {
+		return InheritanceNotFound
+	}
+	if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+		return InheritanceForbidden
+	}
+	var readErr *inheritanceReadError
+	if errors.As(err, &readErr) {
+		return InheritanceUnreadable
+	}
+	return InheritanceMalformed
+}
+
+// MergeEffectiveComponents applies an authoritative operator runtime snapshot
+// to the service and resolves each resulting deployment mode. Inputs are not
+// modified.
+func MergeEffectiveComponents(isvc *v1beta1.InferenceService, runtimeSpec *v1beta1.ServingRuntimeSpec) ([]EffectiveComponent, error) {
+	if isvc == nil {
+		return nil, errors.New("InferenceService must not be nil")
+	}
+	if runtimeSpec == nil {
+		return nil, errors.New("runtime spec must not be nil")
+	}
+	engine, decoder, router, err := isvcutils.MergeRuntimeSpecs(isvc.DeepCopy(), runtimeSpec.DeepCopy(), logr.Discard())
+	if err != nil {
+		return nil, fmt.Errorf("merge runtime and InferenceService components: %w", err)
+	}
+	engineMode, decoderMode, routerMode, err := isvcutils.DetermineDeploymentModes(
+		engine,
+		decoder,
+		router,
+		runtimeSpec,
+		isvc.Spec.DeploymentMode,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve component deployment modes: %w", err)
+	}
+
+	components := make([]EffectiveComponent, 0, 3)
+	if engine != nil {
+		components = append(components, EffectiveComponent{
+			Type:                 v1beta1.EngineComponent,
+			DeploymentMode:       engineMode,
+			DeploymentModeSource: componentDeploymentModeSource(engine.Annotations, engine.Leader != nil || engine.Worker != nil, isvc.Spec.DeploymentMode),
+			engine:               engine,
+		})
+	}
+	if decoder != nil {
+		components = append(components, EffectiveComponent{
+			Type:                 v1beta1.DecoderComponent,
+			DeploymentMode:       decoderMode,
+			DeploymentModeSource: componentDeploymentModeSource(decoder.Annotations, decoder.Leader != nil || decoder.Worker != nil, isvc.Spec.DeploymentMode),
+			decoder:              decoder,
+		})
+	}
+	if router != nil {
+		components = append(components, EffectiveComponent{
+			Type:                 v1beta1.RouterComponent,
+			DeploymentMode:       routerMode,
+			DeploymentModeSource: componentDeploymentModeSource(router.Annotations, false, isvc.Spec.DeploymentMode),
+			router:               router,
+		})
+	}
+	return components, nil
+}
+
+func componentDeploymentModeSource(
+	annotations map[string]string,
+	hasLeaderWorkerShape bool,
+	specMode *constants.DeploymentModeType,
+) ComponentDeploymentModeSource {
+	if _, found := isvcutils.GetDeploymentModeFromAnnotations(annotations); found {
+		return DeploymentModeComponentAnnotation
+	}
+	if specMode != nil && specMode.IsValid() {
+		return DeploymentModeServiceSpec
+	}
+	if hasLeaderWorkerShape {
+		return DeploymentModeLeaderWorkerShape
+	}
+	return DeploymentModeDefault
+}

--- a/pkg/cli/effective/runtime_test.go
+++ b/pkg/cli/effective/runtime_test.go
@@ -1,0 +1,1098 @@
+package effective
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+type selectorStub struct {
+	get           func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error)
+	selectRuntime func(context.Context, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error)
+	validate      func(context.Context, string, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) error
+}
+
+type getErrorClient struct {
+	ctrlclient.Client
+	err error
+}
+
+func (c getErrorClient) Get(context.Context, ctrlclient.ObjectKey, ctrlclient.Object, ...ctrlclient.GetOption) error {
+	return c.err
+}
+
+type keyedGetErrorClient struct {
+	ctrlclient.Client
+	key ctrlclient.ObjectKey
+	err error
+}
+
+func (c keyedGetErrorClient) Get(
+	ctx context.Context,
+	key ctrlclient.ObjectKey,
+	object ctrlclient.Object,
+	options ...ctrlclient.GetOption,
+) error {
+	if key == c.key {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, object, options...)
+}
+
+func (s selectorStub) GetRuntime(ctx context.Context, name, namespace, kind string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+	if s.get == nil {
+		return nil, false, errors.New("unexpected GetRuntime call")
+	}
+	return s.get(ctx, name, namespace, kind)
+}
+
+func (s selectorStub) SelectRuntime(ctx context.Context, model *v1beta1.BaseModelSpec, isvc *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+	if s.selectRuntime == nil {
+		return nil, errors.New("unexpected SelectRuntime call")
+	}
+	return s.selectRuntime(ctx, model, isvc)
+}
+
+func (s selectorStub) ValidateRuntime(ctx context.Context, name string, model *v1beta1.BaseModelSpec, isvc *v1beta1.InferenceService) error {
+	if s.validate == nil {
+		return errors.New("unexpected ValidateRuntime call")
+	}
+	return s.validate(ctx, name, model, isvc)
+}
+
+func targetScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	return scheme
+}
+
+func runtimeSourceNames(references []RuntimeSourceReference) []string {
+	names := make([]string, 0, len(references))
+	for _, reference := range references {
+		names = append(names, reference.Name)
+	}
+	return names
+}
+
+func TestResolveLiveExplicitRuntimeMergesInheritanceAndISVC(t *testing.T) {
+	parent := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "base", UID: "base-uid", Generation: 3, ResourceVersion: "30"},
+		Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{
+				Name:  "runner",
+				Image: "base:image",
+				Env:   []corev1.EnvVar{{Name: "FROM_PARENT", Value: "yes"}},
+			}},
+		}},
+	}
+	child := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "team-runtime",
+			Namespace:       "workloads",
+			UID:             "runtime-uid",
+			Generation:      5,
+			ResourceVersion: "50",
+			Annotations:     map[string]string{constants.RuntimeInheritFromAnnotationKey: "base"},
+		},
+		Spec: v1beta1.ServingRuntimeSpec{},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(parent, child).Build()
+	selector := runtimeselector.New(client)
+	resolver := newRuntimeResolver(client, selector)
+	mode := constants.OMENative
+	autoSync := false
+	revision := "team-runtime-revision"
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			DeploymentMode: &mode,
+			Runtime: &v1beta1.ServingRuntimeRef{
+				Name:     "team-runtime",
+				Kind:     ptr.To(runtimeselector.KindServingRuntime),
+				AutoSync: &autoSync,
+				Revision: &revision,
+			},
+			Engine: &v1beta1.EngineSpec{Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Image: "override:image"}}},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeExplicit, got.Runtime.SelectionSource)
+	assert.Equal(t, "team-runtime", got.Runtime.Name)
+	assert.Equal(t, runtimeselector.KindServingRuntime, got.Runtime.Kind)
+	assert.Equal(t, runtimeselector.KindServingRuntime, got.Runtime.RequestedKind)
+	assert.True(t, got.Runtime.RequestedKindSet)
+	assert.Equal(t, RuntimePinSource{
+		State: RuntimePinSourceResolved, Kind: runtimeselector.KindServingRuntime, Namespace: "workloads",
+	}, got.Runtime.PinSource)
+	assert.Equal(t, "workloads", got.Runtime.Namespace)
+	assert.Equal(t, InheritanceObserved, got.Runtime.DeclaredInheritance.State())
+	assert.Equal(t, []string{"base", "team-runtime"}, runtimeSourceNames(got.Runtime.DeclaredInheritance.Chain()))
+	assert.Equal(t, []RuntimeSourceReference{
+		{
+			APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: runtimeselector.KindClusterServingRuntime,
+			Name: "base", UID: "base-uid", Generation: 3, ResourceVersion: "30",
+		},
+		{
+			APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: runtimeselector.KindServingRuntime,
+			Namespace: "workloads", Name: "team-runtime", UID: "runtime-uid", Generation: 5, ResourceVersion: "50",
+		},
+	}, got.Runtime.DeclaredInheritance.Chain())
+	assert.Empty(t, got.Runtime.DeclaredInheritance.UnavailableReason())
+	assert.False(t, got.Runtime.AutoSync)
+	assert.Equal(t, "team-runtime-revision", got.Runtime.RequestedRevision)
+	require.Len(t, got.Components, 1)
+	assert.Equal(t, v1beta1.EngineComponent, got.Components[0].Type)
+	assert.Equal(t, constants.OMENative, got.Components[0].DeploymentMode)
+	require.NotNil(t, got.Components[0].engine)
+	assert.Equal(t, "override:image", got.Components[0].engine.Runner.Image)
+	assert.Equal(t, "runner", got.Components[0].engine.Runner.Name)
+	assert.Equal(t, []corev1.EnvVar{{Name: "FROM_PARENT", Value: "yes"}}, got.Components[0].engine.Runner.Env)
+
+	// Resolution and merging must not modify source API objects.
+	assert.Equal(t, "base:image", parent.Spec.EngineConfig.Runner.Image)
+	assert.Empty(t, isvc.Spec.Engine.Runner.Name)
+}
+
+func TestResolveLiveAutoSelectsAfterResolvingModel(t *testing.T) {
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "workloads"},
+		Spec:       v1beta1.BaseModelSpec{},
+	}
+	parent := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "base-runtime"},
+		Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "parent-runner", Image: "parent:image"}},
+		}},
+	}
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "cluster-runtime",
+			Annotations: map[string]string{constants.RuntimeInheritFromAnnotationKey: parent.Name},
+		},
+		Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "live-runner", Image: "live:image"}},
+		}},
+	}
+	selectionSpec := &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+		Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "selected-runner", Image: "selected:image"}},
+	}}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(model, parent, runtimeObject).Build()
+	selector := selectorStub{selectRuntime: func(_ context.Context, gotModel *v1beta1.BaseModelSpec, gotISVC *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+		assert.Equal(t, &model.Spec, gotModel)
+		assert.Equal(t, "chat", gotISVC.Name)
+		return &runtimeselector.RuntimeSelection{Name: "cluster-runtime", IsCluster: true, Spec: selectionSpec}, nil
+	}}
+	resolver := newRuntimeResolver(client, selector)
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model:  &v1beta1.ModelRef{Name: "llama"},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	require.NotNil(t, got.Model)
+	assert.Equal(t, "llama", got.Model.Name)
+	assert.Equal(t, "BaseModel", got.Model.Kind)
+	assert.Equal(t, "workloads", got.Model.Namespace)
+	assert.Equal(t, RuntimeSelected, got.Runtime.SelectionSource)
+	assert.Empty(t, got.Runtime.RequestedKind)
+	assert.False(t, got.Runtime.RequestedKindSet)
+	assert.Equal(t, RuntimePinSource{State: RuntimePinSourceNotApplicable}, got.Runtime.PinSource)
+	assert.Equal(t, runtimeselector.KindClusterServingRuntime, got.Runtime.Kind)
+	assert.Empty(t, got.Runtime.Namespace)
+	assert.Equal(t, InheritanceObserved, got.Runtime.DeclaredInheritance.State())
+	assert.Equal(t, []string{"base-runtime", "cluster-runtime"}, runtimeSourceNames(got.Runtime.DeclaredInheritance.Chain()))
+	assert.Empty(t, got.Runtime.DeclaredInheritance.UnavailableReason())
+	require.NotNil(t, got.Runtime.spec.EngineConfig.Runner)
+	assert.Equal(t, "selected:image", got.Runtime.spec.EngineConfig.Runner.Image)
+	require.Len(t, got.Components, 1)
+	assert.Equal(t, constants.RawDeployment, got.Components[0].DeploymentMode)
+	require.NotNil(t, got.Components[0].engine.Runner)
+	assert.Equal(t, "selected:image", got.Components[0].engine.Runner.Image)
+	assert.Equal(t, "selected-runner", got.Components[0].engine.Runner.Name)
+	assert.NotNil(t, got.Advisories)
+
+	got.Runtime.spec.EngineConfig.Runner.Image = "mutated-runtime:image"
+	got.Components[0].engine.Runner.Image = "mutated-component:image"
+	assert.Equal(t, "selected:image", selectionSpec.EngineConfig.Runner.Image)
+}
+
+func TestResolveLiveExplicitUsesGetRuntimeSnapshot(t *testing.T) {
+	liveObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime"},
+		Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Image: "later-live:image"}},
+		}},
+	}
+	authoritativeSpec := &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+		Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Image: "get-runtime-snapshot:image"}},
+	}}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(liveObject).Build()
+	resolver := newRuntimeResolver(client, selectorStub{get: func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+		return authoritativeSpec, true, nil
+	}})
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: liveObject.Name},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	assert.Equal(t, "get-runtime-snapshot:image", got.Runtime.spec.EngineConfig.Runner.Image)
+	assert.Equal(t, "get-runtime-snapshot:image", got.Components[0].engine.Runner.Image)
+	assert.Equal(t, InheritanceObserved, got.Runtime.DeclaredInheritance.State())
+	assert.Equal(t, []string{"runtime"}, runtimeSourceNames(got.Runtime.DeclaredInheritance.Chain()))
+}
+
+func TestResolveLiveKeepsSelectedSnapshotWhenInheritanceCannotBeObserved(t *testing.T) {
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "workloads"},
+		Spec:       v1beta1.BaseModelSpec{},
+	}
+	selectedSpec := &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+		Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Image: "selected:image"}},
+	}}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(model).Build()
+	resolver := newRuntimeResolver(client, selectorStub{selectRuntime: func(context.Context, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+		return &runtimeselector.RuntimeSelection{Name: "deleted-runtime", IsCluster: true, Spec: selectedSpec}, nil
+	}})
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model:  &v1beta1.ModelRef{Name: model.Name},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	assert.Equal(t, InheritanceUnavailable, got.Runtime.DeclaredInheritance.State())
+	assert.Equal(t, InheritanceNotFound, got.Runtime.DeclaredInheritance.UnavailableReason())
+	assert.Empty(t, got.Runtime.DeclaredInheritance.Chain())
+	assert.Equal(t, "selected:image", got.Components[0].engine.Runner.Image)
+}
+
+func TestResolveLiveClassifiesForbiddenInheritanceObservation(t *testing.T) {
+	base := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).Build()
+	client := getErrorClient{
+		Client: base,
+		err: apierrors.NewForbidden(
+			schema.GroupResource{Group: v1beta1.SchemeGroupVersion.Group, Resource: "clusterservingruntimes"},
+			"runtime",
+			errors.New("denied"),
+		),
+	}
+	resolver := newRuntimeResolver(client, selectorStub{get: func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+		return &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}}, true, nil
+	}})
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "runtime"},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	assert.Equal(t, InheritanceUnavailable, got.Runtime.DeclaredInheritance.State())
+	assert.Equal(t, InheritanceForbidden, got.Runtime.DeclaredInheritance.UnavailableReason())
+	assert.Empty(t, got.Runtime.DeclaredInheritance.Chain())
+}
+
+func TestResolveLivePropagatesCanceledInheritanceObservation(t *testing.T) {
+	base := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).Build()
+	client := getErrorClient{Client: base, err: context.Canceled}
+	resolver := newRuntimeResolver(client, selectorStub{get: func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+		return &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}}, true, nil
+	}})
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "runtime"},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := resolver.ResolveLive(ctx, isvc)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, got)
+}
+
+func TestObserveDeclaredInheritanceTracksNamespacedParents(t *testing.T) {
+	parent := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "base", Namespace: "workloads", UID: "base-uid", ResourceVersion: "base-rv"},
+		Spec:       v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	child := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "child", Namespace: "workloads", UID: "child-uid", ResourceVersion: "child-rv",
+			Annotations: map[string]string{constants.RuntimeInheritFromAnnotationKey: parent.Name},
+		},
+		Spec: v1beta1.ServingRuntimeSpec{},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(parent, child).Build()
+
+	got, err := observeDeclaredInheritance(context.Background(), client, "workloads", child.Name, false)
+	require.NoError(t, err)
+	require.NoError(t, got.Validate())
+	assert.Equal(t, []RuntimeSourceReference{
+		{
+			APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: runtimeselector.KindServingRuntime,
+			Namespace: "workloads", Name: parent.Name, UID: "base-uid", ResourceVersion: "base-rv",
+		},
+		{
+			APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: runtimeselector.KindServingRuntime,
+			Namespace: "workloads", Name: child.Name, UID: "child-uid", ResourceVersion: "child-rv",
+		},
+	}, got.Chain())
+}
+
+func TestObserveDeclaredInheritanceClassifiesNamespacedReadFailures(t *testing.T) {
+	base := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).Build()
+	notFound, err := observeDeclaredInheritance(context.Background(), base, "workloads", "missing", false)
+	require.NoError(t, err)
+	assert.Equal(t, InheritanceNotFound, notFound.UnavailableReason())
+
+	deniedClient := getErrorClient{
+		Client: base,
+		err: apierrors.NewForbidden(
+			schema.GroupResource{Resource: "servingruntimes"}, "runtime", errors.New("denied"),
+		),
+	}
+	forbidden, err := observeDeclaredInheritance(context.Background(), deniedClient, "workloads", "runtime", false)
+	require.NoError(t, err)
+	assert.Equal(t, InheritanceForbidden, forbidden.UnavailableReason())
+}
+
+func TestObserveDeclaredInheritanceClassifiesParentReadFailure(t *testing.T) {
+	child := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "child", Namespace: "workloads",
+			Annotations: map[string]string{constants.RuntimeInheritFromAnnotationKey: "parent"},
+		},
+		Spec: v1beta1.ServingRuntimeSpec{},
+	}
+	base := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(child).Build()
+	client := keyedGetErrorClient{
+		Client: base,
+		key:    ctrlclient.ObjectKey{Name: "parent", Namespace: "workloads"},
+		err:    errors.New("transport failed with redaction-canary"),
+	}
+
+	got, err := observeDeclaredInheritance(context.Background(), client, "workloads", child.Name, false)
+	require.NoError(t, err)
+	assert.Equal(t, InheritanceUnreadable, got.UnavailableReason())
+}
+
+func TestResolveLiveMirrorsExplicitRuntimeValidation(t *testing.T) {
+	compatibilityErr := &runtimeselector.RuntimeCompatibilityError{
+		RuntimeName: "runtime", ModelName: "llama", ModelFormat: "safetensors", Reason: "untrusted raw mismatch details",
+	}
+	hardErr := &runtimeselector.ModelValidationError{Field: "modelFormat.name", Message: "required"}
+	runtimeSpec := &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}}
+
+	tests := []struct {
+		name         string
+		distribution *v1beta1.Distribution
+		autoSync     *bool
+		validateErr  error
+		wantErr      error
+		wantAdvisory bool
+		wantValidate bool
+	}{
+		{name: "valid live runtime", validateErr: nil, wantValidate: true},
+		{name: "non-sharded compatibility advisory", validateErr: compatibilityErr, wantAdvisory: true, wantValidate: true},
+		{name: "sharded compatibility hard failure", distribution: ptr.To(v1beta1.DistributionSharded), validateErr: compatibilityErr, wantErr: compatibilityErr, wantValidate: true},
+		{name: "malformed model hard failure", validateErr: hardErr, wantErr: hardErr, wantValidate: true},
+		{name: "pinned runtime skips live validation", autoSync: ptr.To(false), validateErr: hardErr},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "workloads"},
+				Spec:       v1beta1.BaseModelSpec{Distribution: test.distribution},
+			}
+			client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(model).Build()
+			validated := false
+			resolver := newRuntimeResolver(client, selectorStub{
+				validate: func(_ context.Context, name string, gotModel *v1beta1.BaseModelSpec, _ *v1beta1.InferenceService) error {
+					validated = true
+					assert.Equal(t, "runtime", name)
+					assert.Equal(t, &model.Spec, gotModel)
+					return test.validateErr
+				},
+				get: func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+					return runtimeSpec, true, nil
+				},
+			})
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model:   &v1beta1.ModelRef{Name: model.Name},
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "runtime", AutoSync: test.autoSync},
+					Engine:  &v1beta1.EngineSpec{},
+				},
+			}
+
+			got, err := resolver.ResolveLive(context.Background(), isvc)
+			assert.Equal(t, test.wantValidate, validated)
+			if test.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, test.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			if test.wantAdvisory {
+				require.Equal(t, []RuntimeAdvisory{{Code: RuntimeAdvisoryDeclaredCompatibilityMismatch}}, got.Advisories)
+			} else {
+				assert.Empty(t, got.Advisories)
+			}
+		})
+	}
+}
+
+func TestResolveLiveUsesActualScopeAfterDefaultKindFallback(t *testing.T) {
+	autoSync := false
+	tests := []struct {
+		name             string
+		kind             *string
+		wantRequested    string
+		wantRequestedSet bool
+	}{
+		{name: "nil kind", wantRequestedSet: false},
+		{
+			name: "declared cluster kind", kind: ptr.To(runtimeselector.KindClusterServingRuntime),
+			wantRequested: runtimeselector.KindClusterServingRuntime, wantRequestedSet: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtimeObject := &v1beta1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "fallback", Namespace: "workloads"},
+				Spec:       v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+			}
+			client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(runtimeObject).Build()
+			resolver := NewRuntimeResolver(client)
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "fallback", Kind: test.kind, AutoSync: &autoSync},
+					Engine:  &v1beta1.EngineSpec{},
+				},
+			}
+
+			got, err := resolver.ResolveLive(context.Background(), isvc)
+			require.NoError(t, err)
+			assert.Equal(t, runtimeselector.KindServingRuntime, got.Runtime.Kind)
+			assert.Equal(t, "workloads", got.Runtime.Namespace)
+			assert.Equal(t, test.wantRequested, got.Runtime.RequestedKind)
+			assert.Equal(t, test.wantRequestedSet, got.Runtime.RequestedKindSet)
+			assert.Equal(t, RuntimePinSource{
+				State: RuntimePinSourceResolved, Kind: runtimeselector.KindClusterServingRuntime,
+			}, got.Runtime.PinSource)
+		})
+	}
+}
+
+func TestRuntimeReferenceIntentPreservesPinSignificantKindState(t *testing.T) {
+	autoSyncFalse := false
+	autoSyncTrue := true
+	emptyKind := ""
+	unknownKind := "UnknownRuntime"
+	tests := []struct {
+		name          string
+		source        RuntimeSelectionSource
+		reference     *v1beta1.ServingRuntimeRef
+		wantAutoSync  bool
+		wantKind      string
+		wantKindSet   bool
+		wantRevision  string
+		wantPinSource RuntimePinSource
+	}{
+		{
+			name: "selected ignores empty-name runtime options", source: RuntimeSelected,
+			reference:    &v1beta1.ServingRuntimeRef{Name: "", Kind: ptr.To(runtimeselector.KindServingRuntime), AutoSync: &autoSyncFalse, Revision: ptr.To("ignored")},
+			wantAutoSync: true, wantPinSource: RuntimePinSource{State: RuntimePinSourceNotApplicable},
+		},
+		{
+			name: "nil kind pins cluster source", source: RuntimeExplicit,
+			reference:     &v1beta1.ServingRuntimeRef{Name: "runtime", AutoSync: &autoSyncFalse},
+			wantPinSource: RuntimePinSource{State: RuntimePinSourceResolved, Kind: runtimeselector.KindClusterServingRuntime},
+		},
+		{
+			name: "cluster kind pins cluster source", source: RuntimeExplicit,
+			reference: &v1beta1.ServingRuntimeRef{Name: "runtime", Kind: ptr.To(runtimeselector.KindClusterServingRuntime), AutoSync: &autoSyncFalse},
+			wantKind:  runtimeselector.KindClusterServingRuntime, wantKindSet: true,
+			wantPinSource: RuntimePinSource{State: RuntimePinSourceResolved, Kind: runtimeselector.KindClusterServingRuntime},
+		},
+		{
+			name: "serving kind pins workload namespace", source: RuntimeExplicit,
+			reference: &v1beta1.ServingRuntimeRef{Name: "runtime", Kind: ptr.To(runtimeselector.KindServingRuntime), AutoSync: &autoSyncFalse, Revision: ptr.To("revision-1")},
+			wantKind:  runtimeselector.KindServingRuntime, wantKindSet: true, wantRevision: "revision-1",
+			wantPinSource: RuntimePinSource{State: RuntimePinSourceResolved, Kind: runtimeselector.KindServingRuntime, Namespace: "workloads"},
+		},
+		{
+			name: "pointer-to-empty kind is invalid", source: RuntimeExplicit,
+			reference:   &v1beta1.ServingRuntimeRef{Name: "runtime", Kind: &emptyKind, AutoSync: &autoSyncFalse},
+			wantKindSet: true, wantPinSource: RuntimePinSource{State: RuntimePinSourceInvalid},
+		},
+		{
+			name: "unknown kind is invalid", source: RuntimeExplicit,
+			reference: &v1beta1.ServingRuntimeRef{Name: "runtime", Kind: &unknownKind, AutoSync: &autoSyncFalse},
+			wantKind:  unknownKind, wantKindSet: true, wantPinSource: RuntimePinSource{State: RuntimePinSourceInvalid},
+		},
+		{
+			name: "auto sync has no active pin source", source: RuntimeExplicit,
+			reference:    &v1beta1.ServingRuntimeRef{Name: "runtime", Kind: ptr.To(runtimeselector.KindServingRuntime), AutoSync: &autoSyncTrue, Revision: ptr.To("ignored-live-revision")},
+			wantAutoSync: true, wantKind: runtimeselector.KindServingRuntime, wantKindSet: true,
+			wantRevision: "ignored-live-revision", wantPinSource: RuntimePinSource{State: RuntimePinSourceNotApplicable},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "workloads"},
+				Spec:       v1beta1.InferenceServiceSpec{Runtime: test.reference},
+			}
+			autoSync, kind, kindSet, revision, pinSource := runtimeReferenceIntent(isvc, test.source)
+			assert.Equal(t, test.wantAutoSync, autoSync)
+			assert.Equal(t, test.wantKind, kind)
+			assert.Equal(t, test.wantKindSet, kindSet)
+			assert.Equal(t, test.wantRevision, revision)
+			assert.Equal(t, test.wantPinSource, pinSource)
+			require.NoError(t, pinSource.Validate())
+		})
+	}
+}
+
+func TestRuntimePinSourceValidation(t *testing.T) {
+	valid := []RuntimePinSource{
+		{State: RuntimePinSourceNotApplicable},
+		{State: RuntimePinSourceInvalid},
+		{State: RuntimePinSourceResolved, Kind: runtimeselector.KindClusterServingRuntime},
+		{State: RuntimePinSourceResolved, Kind: runtimeselector.KindServingRuntime, Namespace: "workloads"},
+	}
+	for _, source := range valid {
+		require.NoError(t, source.Validate())
+	}
+
+	invalid := []RuntimePinSource{
+		{},
+		{State: "Unknown"},
+		{State: RuntimePinSourceNotApplicable, Kind: runtimeselector.KindServingRuntime},
+		{State: RuntimePinSourceInvalid, Namespace: "workloads"},
+		{State: RuntimePinSourceResolved},
+		{State: RuntimePinSourceResolved, Kind: runtimeselector.KindClusterServingRuntime, Namespace: "workloads"},
+		{State: RuntimePinSourceResolved, Kind: runtimeselector.KindServingRuntime},
+		{State: RuntimePinSourceResolved, Kind: "UnknownRuntime"},
+	}
+	for _, source := range invalid {
+		require.Error(t, source.Validate())
+	}
+}
+
+func TestResolveLiveIgnoresEmptyNameRuntimeOptionsDuringSelection(t *testing.T) {
+	autoSync := false
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "workloads"},
+		Spec:       v1beta1.BaseModelSpec{},
+	}
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "selected"},
+		Spec:       v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(model, runtimeObject).Build()
+	resolver := newRuntimeResolver(client, selectorStub{selectRuntime: func(context.Context, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+		return &runtimeselector.RuntimeSelection{Name: runtimeObject.Name, IsCluster: true, Spec: runtimeObject.Spec.DeepCopy()}, nil
+	}})
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model: &v1beta1.ModelRef{Name: model.Name},
+			Runtime: &v1beta1.ServingRuntimeRef{
+				Kind: ptr.To(runtimeselector.KindServingRuntime), AutoSync: &autoSync, Revision: ptr.To("ignored"),
+			},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeSelected, got.Runtime.SelectionSource)
+	assert.True(t, got.Runtime.AutoSync)
+	assert.False(t, got.Runtime.RequestedKindSet)
+	assert.Empty(t, got.Runtime.RequestedRevision)
+	assert.Equal(t, RuntimePinSource{State: RuntimePinSourceNotApplicable}, got.Runtime.PinSource)
+}
+
+func TestResolveLiveReportsInvalidDeclaredRuntimeKind(t *testing.T) {
+	autoSync := false
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime"},
+		Spec:       v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(runtimeObject).Build()
+	for _, kind := range []string{"", "UnknownRuntime"} {
+		t.Run(kind, func(t *testing.T) {
+			resolver := newRuntimeResolver(client, selectorStub{get: func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+				return runtimeObject.Spec.DeepCopy(), true, nil
+			}})
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name, Kind: &kind, AutoSync: &autoSync},
+					Engine:  &v1beta1.EngineSpec{},
+				},
+			}
+
+			got, err := resolver.ResolveLive(context.Background(), isvc)
+			require.NoError(t, err)
+			assert.Equal(t, RuntimePinSource{State: RuntimePinSourceInvalid}, got.Runtime.PinSource)
+			assert.Equal(t, []RuntimeAdvisory{{Code: RuntimeAdvisoryInvalidDeclaredKind}}, got.Advisories)
+		})
+	}
+}
+
+func TestMergeEffectiveComponentsReportsDeploymentModeSource(t *testing.T) {
+	omeNative := constants.OMENative
+	tests := []struct {
+		name       string
+		engine     *v1beta1.EngineSpec
+		specMode   *constants.DeploymentModeType
+		wantMode   constants.DeploymentModeType
+		wantSource ComponentDeploymentModeSource
+	}{
+		{
+			name: "component annotation",
+			engine: &v1beta1.EngineSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+				Annotations: map[string]string{constants.DeploymentMode: string(constants.RawDeployment)},
+			}},
+			specMode:   &omeNative,
+			wantMode:   constants.RawDeployment,
+			wantSource: DeploymentModeComponentAnnotation,
+		},
+		{
+			name:       "service spec",
+			engine:     &v1beta1.EngineSpec{},
+			specMode:   &omeNative,
+			wantMode:   constants.OMENative,
+			wantSource: DeploymentModeServiceSpec,
+		},
+		{
+			name:       "leader worker shape",
+			engine:     &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}},
+			wantMode:   constants.OMENative,
+			wantSource: DeploymentModeLeaderWorkerShape,
+		},
+		{
+			name:       "default",
+			engine:     &v1beta1.EngineSpec{},
+			wantMode:   constants.RawDeployment,
+			wantSource: DeploymentModeDefault,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{
+				DeploymentMode: test.specMode,
+				Engine:         test.engine,
+			}}
+			got, err := MergeEffectiveComponents(isvc, &v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}})
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, test.wantMode, got[0].DeploymentMode)
+			assert.Equal(t, test.wantSource, got[0].DeploymentModeSource)
+		})
+	}
+}
+
+func TestResolveLiveFallsBackToClusterModel(t *testing.T) {
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama"},
+		Spec:       v1beta1.BaseModelSpec{},
+	}
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-runtime"},
+		Spec:       v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(model, runtimeObject).Build()
+	resolver := newRuntimeResolver(client, selectorStub{selectRuntime: func(_ context.Context, gotModel *v1beta1.BaseModelSpec, _ *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+		assert.Equal(t, &model.Spec, gotModel)
+		return &runtimeselector.RuntimeSelection{Name: runtimeObject.Name, IsCluster: true, Spec: runtimeObject.Spec.DeepCopy()}, nil
+	}})
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model:  &v1beta1.ModelRef{Name: "llama"},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	require.NotNil(t, got.Model)
+	assert.Equal(t, "ClusterBaseModel", got.Model.Kind)
+	assert.Empty(t, got.Model.Namespace)
+	assert.True(t, got.Runtime.AutoSync)
+	assert.Empty(t, got.Runtime.RequestedRevision)
+}
+
+func TestResolveLiveReturnsComponentsInStableOrder(t *testing.T) {
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			EngineConfig:  &v1beta1.EngineSpec{},
+			DecoderConfig: &v1beta1.DecoderSpec{},
+			RouterConfig:  &v1beta1.RouterSpec{},
+		},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(runtimeObject).Build()
+	resolver := newRuntimeResolver(client, runtimeselector.New(client))
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "runtime"},
+			Engine:  &v1beta1.EngineSpec{},
+			Decoder: &v1beta1.DecoderSpec{},
+			Router:  &v1beta1.RouterSpec{},
+		},
+	}
+
+	got, err := resolver.ResolveLive(context.Background(), isvc)
+	require.NoError(t, err)
+	require.Len(t, got.Components, 3)
+	assert.Equal(t, []v1beta1.ComponentType{
+		v1beta1.EngineComponent,
+		v1beta1.DecoderComponent,
+		v1beta1.RouterComponent,
+	}, []v1beta1.ComponentType{got.Components[0].Type, got.Components[1].Type, got.Components[2].Type})
+}
+
+func TestResolveLiveRejectsInvalidOrDisabledInputs(t *testing.T) {
+	disabledModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-model", Namespace: "workloads"},
+		Spec: v1beta1.BaseModelSpec{
+			ModelExtensionSpec: v1beta1.ModelExtensionSpec{Disabled: ptr.To(true)},
+		},
+	}
+	disabledRuntime := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-runtime"},
+		Spec:       v1beta1.ServingRuntimeSpec{Disabled: ptr.To(true), EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(disabledModel, disabledRuntime).Build()
+	resolver := newRuntimeResolver(client, runtimeselector.New(client))
+
+	tests := []struct {
+		name string
+		isvc *v1beta1.InferenceService
+		want string
+	}{
+		{name: "nil target", want: "must not be nil"},
+		{name: "missing namespace", isvc: &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat"}}, want: "namespace"},
+		{name: "no model or runtime", isvc: &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"}, Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}}}, want: "model or runtime"},
+		{name: "disabled model", isvc: &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"}, Spec: v1beta1.InferenceServiceSpec{Model: &v1beta1.ModelRef{Name: "disabled-model"}, Engine: &v1beta1.EngineSpec{}}}, want: "disabled"},
+		{name: "disabled runtime", isvc: &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"}, Spec: v1beta1.InferenceServiceSpec{Runtime: &v1beta1.ServingRuntimeRef{Name: "disabled-runtime"}, Engine: &v1beta1.EngineSpec{}}}, want: "disabled"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := resolver.ResolveLive(context.Background(), test.isvc)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestResolveLivePropagatesResolutionFailures(t *testing.T) {
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime"},
+		Spec:       v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	model := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "workloads"}}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(runtimeObject, model).Build()
+
+	t.Run("unconfigured resolver", func(t *testing.T) {
+		_, err := (&RuntimeResolver{}).ResolveLive(context.Background(), &v1beta1.InferenceService{})
+		require.ErrorContains(t, err, "not configured")
+	})
+
+	t.Run("explicit lookup", func(t *testing.T) {
+		resolver := newRuntimeResolver(client, selectorStub{get: func(context.Context, string, string, string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+			return nil, false, errors.New("lookup denied")
+		}})
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+			Spec:       v1beta1.InferenceServiceSpec{Runtime: &v1beta1.ServingRuntimeRef{Name: "runtime"}, Engine: &v1beta1.EngineSpec{}},
+		}
+		_, err := resolver.ResolveLive(context.Background(), isvc)
+		require.ErrorContains(t, err, "lookup denied")
+	})
+
+	t.Run("automatic selection", func(t *testing.T) {
+		resolver := newRuntimeResolver(client, selectorStub{selectRuntime: func(context.Context, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+			return nil, errors.New("selection failed")
+		}})
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+			Spec:       v1beta1.InferenceServiceSpec{Model: &v1beta1.ModelRef{Name: "model"}, Engine: &v1beta1.EngineSpec{}},
+		}
+		_, err := resolver.ResolveLive(context.Background(), isvc)
+		require.ErrorContains(t, err, "selection failed")
+	})
+
+	t.Run("empty automatic selection", func(t *testing.T) {
+		resolver := newRuntimeResolver(client, selectorStub{selectRuntime: func(context.Context, *v1beta1.BaseModelSpec, *v1beta1.InferenceService) (*runtimeselector.RuntimeSelection, error) {
+			return &runtimeselector.RuntimeSelection{}, nil
+		}})
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+			Spec:       v1beta1.InferenceServiceSpec{Model: &v1beta1.ModelRef{Name: "model"}, Engine: &v1beta1.EngineSpec{}},
+		}
+		_, err := resolver.ResolveLive(context.Background(), isvc)
+		require.ErrorContains(t, err, "empty result")
+	})
+
+	t.Run("missing model", func(t *testing.T) {
+		resolver := newRuntimeResolver(client, selectorStub{})
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+			Spec:       v1beta1.InferenceServiceSpec{Model: &v1beta1.ModelRef{Name: "missing"}, Engine: &v1beta1.EngineSpec{}},
+		}
+		_, err := resolver.ResolveLive(context.Background(), isvc)
+		require.ErrorContains(t, err, "missing")
+	})
+}
+
+func TestMergeEffectiveComponentsValidatesInputs(t *testing.T) {
+	_, err := MergeEffectiveComponents(nil, &v1beta1.ServingRuntimeSpec{})
+	require.ErrorContains(t, err, "must not be nil")
+
+	_, err = MergeEffectiveComponents(&v1beta1.InferenceService{}, nil)
+	require.ErrorContains(t, err, "must not be nil")
+
+	_, err = MergeEffectiveComponents(&v1beta1.InferenceService{}, &v1beta1.ServingRuntimeSpec{})
+	require.ErrorContains(t, err, "engine component is required")
+}
+
+func TestResolveLivePreservesTypedInheritanceErrors(t *testing.T) {
+	child := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "child",
+			Annotations: map[string]string{constants.RuntimeInheritFromAnnotationKey: "missing"},
+		},
+		Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{}},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(targetScheme(t)).WithObjects(child).Build()
+	resolver := newRuntimeResolver(client, runtimeselector.New(client))
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "child"},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+
+	_, err := resolver.ResolveLive(context.Background(), isvc)
+	require.Error(t, err)
+	var typed *runtimeinheritance.ParentNotFoundError
+	assert.True(t, errors.As(err, &typed))
+	assert.ErrorContains(t, err, "missing")
+}
+
+func TestResolvedRuntimeTypesRejectSerialization(t *testing.T) {
+	const sentinel = "redaction-canary-do-not-emit"
+	model := ModelResolution{spec: &v1beta1.BaseModelSpec{
+		ModelConfiguration: runtime.RawExtension{Raw: []byte(`{"headers":"redaction-canary-do-not-emit","extensions":"redaction-canary-do-not-emit"}`)},
+		AdditionalMetadata: map[string]string{"secret": sentinel},
+	}}
+	runtimeResolution := RuntimeResolution{spec: &v1beta1.ServingRuntimeSpec{
+		EngineConfig: &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Annotations: map[string]string{"secret": sentinel}},
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{
+				Args: []string{sentinel}, Env: []corev1.EnvVar{{Name: "SECRET", Value: sentinel}},
+			}},
+		},
+	}}
+	component := EffectiveComponent{engine: runtimeResolution.spec.EngineConfig.DeepCopy()}
+	values := []any{
+		model,
+		runtimeResolution,
+		component,
+		LiveConfiguration{Model: &model, Runtime: runtimeResolution, Components: []EffectiveComponent{component}},
+	}
+	encoders := map[string]func(any) ([]byte, error){
+		"json":            json.Marshal,
+		"Kubernetes YAML": sigsyaml.Marshal,
+	}
+	for _, value := range values {
+		for name, encode := range encoders {
+			t.Run(name, func(t *testing.T) {
+				encoded, err := encode(value)
+				require.ErrorIs(t, err, ErrUnsafeRuntimeSerialization)
+				assert.False(t, strings.Contains(string(encoded), sentinel))
+			})
+		}
+		yamlMarshaler, ok := value.(interface {
+			MarshalYAML() (any, error)
+		})
+		require.True(t, ok)
+		yamlValue, err := yamlMarshaler.MarshalYAML()
+		require.ErrorIs(t, err, ErrUnsafeRuntimeSerialization)
+		assert.Nil(t, yamlValue)
+	}
+}
+
+func TestSensitiveResolutionFieldsArePrivate(t *testing.T) {
+	tests := []struct {
+		typeOf reflect.Type
+		fields []string
+	}{
+		{typeOf: reflect.TypeOf(ModelResolution{}), fields: []string{"spec"}},
+		{typeOf: reflect.TypeOf(RuntimeResolution{}), fields: []string{"spec"}},
+		{typeOf: reflect.TypeOf(EffectiveComponent{}), fields: []string{"engine", "decoder", "router"}},
+	}
+	for _, test := range tests {
+		for _, fieldName := range test.fields {
+			field, found := test.typeOf.FieldByName(fieldName)
+			require.True(t, found)
+			assert.NotEmpty(t, field.PkgPath, "%s.%s must remain unexported", test.typeOf.Name(), fieldName)
+		}
+	}
+}
+
+func TestInheritanceObservationValidation(t *testing.T) {
+	reference := RuntimeSourceReference{Kind: runtimeselector.KindClusterServingRuntime, Name: "runtime"}
+	observed := observedInheritance([]RuntimeSourceReference{reference})
+	require.NoError(t, observed.Validate())
+	returnedChain := observed.Chain()
+	returnedChain[0].Name = "mutated"
+	assert.Equal(t, "runtime", observed.Chain()[0].Name)
+	for _, reason := range []InheritanceUnavailableReason{
+		InheritanceNotFound,
+		InheritanceForbidden,
+		InheritanceCycle,
+		InheritanceMaxDepthExceeded,
+		InheritanceMalformed,
+		InheritanceUnreadable,
+	} {
+		require.NoError(t, unavailableInheritance(reason).Validate())
+	}
+	unknownReason := unavailableInheritance("Unknown")
+	require.NoError(t, unknownReason.Validate())
+	assert.Equal(t, InheritanceUnreadable, unknownReason.UnavailableReason())
+	emptyObserved := observedInheritance(nil)
+	require.NoError(t, emptyObserved.Validate())
+	assert.Equal(t, InheritanceUnavailable, emptyObserved.State())
+	assert.Equal(t, InheritanceMalformed, emptyObserved.UnavailableReason())
+
+	invalid := []InheritanceObservation{
+		{},
+		{state: "Unknown"},
+		{state: InheritanceObserved},
+		{state: InheritanceObserved, chain: []RuntimeSourceReference{reference}, unavailableReason: InheritanceUnreadable},
+		{state: InheritanceUnavailable, chain: []RuntimeSourceReference{reference}, unavailableReason: InheritanceUnreadable},
+		{state: InheritanceUnavailable},
+		{state: InheritanceUnavailable, unavailableReason: "Unknown"},
+	}
+	for _, observation := range invalid {
+		require.Error(t, observation.Validate())
+	}
+}
+
+func TestInheritanceReadErrorDoesNotExposeCauseText(t *testing.T) {
+	cause := errors.New("redaction-canary-do-not-emit")
+	err := &inheritanceReadError{cause: cause}
+	assert.Equal(t, "runtime inheritance source read failed", err.Error())
+	assert.NotContains(t, err.Error(), cause.Error())
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestClassifyInheritanceUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want InheritanceUnavailableReason
+	}{
+		{
+			name: "typed missing parent",
+			err:  &runtimeinheritance.ParentNotFoundError{Parent: "base"},
+			want: InheritanceNotFound,
+		},
+		{
+			name: "API not found",
+			err:  apierrors.NewNotFound(schema.GroupResource{Resource: "servingruntimes"}, "base"),
+			want: InheritanceNotFound,
+		},
+		{
+			name: "forbidden",
+			err: apierrors.NewForbidden(
+				schema.GroupResource{Resource: "servingruntimes"}, "base", errors.New("denied"),
+			),
+			want: InheritanceForbidden,
+		},
+		{
+			name: "unauthorized",
+			err:  apierrors.NewUnauthorized("expired token"),
+			want: InheritanceForbidden,
+		},
+		{
+			name: "cycle",
+			err:  &runtimeinheritance.CycleError{Cycle: []string{"a", "b", "a"}},
+			want: InheritanceCycle,
+		},
+		{
+			name: "maximum depth",
+			err:  &runtimeinheritance.MaxDepthExceededError{MaxDepth: 5},
+			want: InheritanceMaxDepthExceeded,
+		},
+		{
+			name: "other read failure",
+			err:  &inheritanceReadError{cause: errors.New("connection reset")},
+			want: InheritanceUnreadable,
+		},
+		{
+			name: "malformed inheritance",
+			err:  errors.New("merge failed"),
+			want: InheritanceMalformed,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, classifyInheritanceUnavailable(test.err))
+		})
+	}
+}
+
+var _ runtimeSelector = selectorStub{}


### PR DESCRIPTION
## What this PR does

### Outcome

This PR adds the operator-faithful runtime-resolution foundation used by
upcoming `kubectl ome runtime`, service-target, rollout, and doctor commands.
It resolves the same configuration inputs the controller uses while keeping
selection evidence, live configuration, and declared inheritance provenance
distinct:

- model references use the controller's namespaced-first, then cluster lookup;
- explicitly named runtimes merge the exact `GetRuntime` snapshot;
- automatically selected runtimes merge the exact selector result instead of
  performing a second, potentially divergent lookup;
- explicit live runtimes mirror the controller's compatibility-validation
  behavior, including the non-sharded advisory exception;
- runtime and InferenceService component specs merge through the controller's
  existing helpers;
- engine, decoder, and router deployment modes record both their effective
  value and the precedence source that selected it; and
- declared and resolved runtime kind remain separate when scoped lookup falls
  back from a requested cluster runtime to a namespaced runtime;
- pin-source kind/namespace remain separate from the live source, matching the
  ControllerRevision naming contract; and
- inheritance observations carry kind, namespace, UID, generation, and
  resourceVersion from one root-first traversal.

### User-visible CLI output

No command is wired to this internal package in this foundation PR, so current
`kubectl ome` output does not change. Consumer PRs will project this internal
result into the versioned, redacted report contract and will include their
exact table, JSON, and YAML output.

A representative internal resolution record is:

```text
selection source:             Explicit
runtime name:                 team-runtime
requested kind:               ClusterServingRuntime
resolved kind:                ServingRuntime
resolved namespace:           workloads
auto sync:                    false
pin source kind:              ClusterServingRuntime
pin source namespace:         -
declared inheritance:         Observed
inheritance chain:            ClusterServingRuntime/base-runtime -> ServingRuntime/workloads/team-runtime
engine deployment mode:       OMENative
engine deployment-mode source: LeaderWorkerShape
advisories:                   []
```

If the independently observed inheritance chain cannot be read, the selected
runtime snapshot remains usable and provenance is bounded rather than guessed:

```text
declared inheritance: Unavailable
unavailable reason:   Forbidden
inheritance chain:    []
```

The allowlisted unavailability reasons are `NotFound`, `Forbidden`, `Cycle`,
`MaxDepthExceeded`, `Malformed`, and `Unreadable`. Parent context cancellation
remains a top-level cancellation error.

### Safety and pinning contract

- Runtime compatibility advisories contain a fixed code only; raw selector
  errors and user-authored mismatch text are never retained.
- Full model, runtime, and merged component specs are private and may contain
  literal credentials. Direct JSON or YAML serialization of any resolved type
  fails with `ErrUnsafeRuntimeSerialization`; tests cover `encoding/json`, the
  Kubernetes JSON-backed YAML encoder, and the `MarshalYAML` guard used by
  reflection-based YAML encoders.
- Future report commands must copy reviewed fields into an allowlisted
  `cli.ome.io/v1alpha1` summary instead of serializing this result.
- `AutoSync=false` records the requested revision but this PR does not claim
  that the live runtime is the active configuration. The runtime-pin collector
  must resolve and validate the ControllerRevision independently—even when the
  live runtime is missing or disabled—before reporting active component
  configuration.
- Runtime options on an empty-name reference are ignored exactly as the
  controller ignores them during automatic selection. Nil, explicit, empty,
  and unknown runtime kinds remain distinguishable; invalid declared kinds
  produce a fixed advisory and an invalid pin-source state.
- Declared inheritance is a separate provenance observation. It never replaces
  the exact runtime snapshot used for the effective merge.
- This package performs reads and pure merges only. It does not write
  Kubernetes resources, choose mutation targets, or contact workload pods.

## Why we need it

OME now supports inherited runtimes, explicit and automatic runtime selection,
runtime pinning, per-component deployment modes, and mixed engine/decoder/router
topologies. Operational commands cannot safely infer those results from the raw
InferenceService alone. This foundation gives later commands one tested source
of operator-consistent live configuration without turning sensitive pod
templates into CLI output.

Fixes # — N/A; tracked by OEP-0011.1 effective-runtime foundation work.

## How to test

```shell
go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...
go test -race -count=1 ./pkg/cli/...
go test -shuffle=on -count=25 ./pkg/cli/effective
go vet ./cmd/kubectl-ome ./pkg/cli/...
go build ./cmd/kubectl-ome
```

The focused package has 97.4% statement coverage. Tests cover explicit and
automatic snapshot fidelity, model and runtime scope fallback, inheritance,
disabled resources, validation and advisory behavior, deployment-mode
precedence sources, nil/empty/invalid declared kinds, controller pin-source
scope, typed same-traversal source identities, bounded unavailable-reason
mapping, cancellation, immutability, malformed inputs, private sensitive
fields, three direct serialization rejection paths, redaction canaries, and
typed-error preservation. Linux, Darwin, and Windows cross-compiles pass for
amd64 and arm64 with `CGO_ENABLED=0`.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (the resolution, pinning, and output contracts are documented
  above; no repository documentation is changed in this scoped foundation PR)
- [ ] `make test` passes locally

The final submitted commit passes the scoped CLI suite, race detector, vet,
host build, shuffled stress run, and six cross-compiles. Required repository CI
remains the authoritative full-suite gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added effective runtime and model resolution for inference services.
  - Supports explicit and automatic runtime selection across namespaced and cluster scopes.
  - Added runtime inheritance tracking, validation, deployment-mode detection, and bounded advisories.
  - Merges runtime components with inference service settings in a stable, validated configuration.
  - Prevents unsafe direct serialization of sensitive runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->