### PR TITLE
[Core] Add runtime report contracts

### DIFF
--- a/pkg/cli/report/v1alpha1/action_result.go
+++ b/pkg/cli/report/v1alpha1/action_result.go
@@ -112,10 +112,3 @@ func yesNo(value bool) string {
 	}
 	return "No"
 }
-
-func orDash(value string) string {
-	if value == "" {
-		return "-"
-	}
-	return value
-}

--- a/pkg/cli/report/v1alpha1/runtime_common.go
+++ b/pkg/cli/report/v1alpha1/runtime_common.go
@@ -1,0 +1,348 @@
+package v1alpha1
+
+import (
+	"sort"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+// RuntimeKind identifies the supported runtime object scopes.
+type RuntimeKind string
+
+const (
+	RuntimeKindUnknown               RuntimeKind = "Unknown"
+	RuntimeKindServingRuntime        RuntimeKind = "ServingRuntime"
+	RuntimeKindClusterServingRuntime RuntimeKind = "ClusterServingRuntime"
+)
+
+// RuntimeSelectionSource identifies how the runtime was chosen.
+type RuntimeSelectionSource string
+
+const (
+	RuntimeSelectionSourceExplicit RuntimeSelectionSource = "Explicit"
+	RuntimeSelectionSourceSelected RuntimeSelectionSource = "Selected"
+)
+
+// RuntimeComponentType identifies a runtime serving component.
+type RuntimeComponentType string
+
+const (
+	RuntimeComponentEngine  RuntimeComponentType = "engine"
+	RuntimeComponentDecoder RuntimeComponentType = "decoder"
+	RuntimeComponentRouter  RuntimeComponentType = "router"
+)
+
+// DeploymentMode identifies the workload shape used by a component.
+type DeploymentMode string
+
+const (
+	DeploymentModeRawDeployment     DeploymentMode = "RawDeployment"
+	DeploymentModeMultiNode         DeploymentMode = "MultiNode"
+	DeploymentModeVirtualDeployment DeploymentMode = "VirtualDeployment"
+	DeploymentModeOMENative         DeploymentMode = "OMENative"
+)
+
+// DeploymentModeSource identifies the evidence used to determine a mode.
+type DeploymentModeSource string
+
+const (
+	DeploymentModeSourceComponentAnnotation DeploymentModeSource = "ComponentAnnotation"
+	DeploymentModeSourceServiceSpec         DeploymentModeSource = "ServiceSpec"
+	DeploymentModeSourceLeaderWorkerShape   DeploymentModeSource = "LeaderWorkerShape"
+	DeploymentModeSourceDefault             DeploymentModeSource = "Default"
+)
+
+// InheritanceState identifies whether declared inheritance was observed.
+type InheritanceState string
+
+const (
+	InheritanceStateObserved    InheritanceState = "Observed"
+	InheritanceStateUnavailable InheritanceState = "Unavailable"
+)
+
+// RuntimePinMode identifies the requested runtime synchronization policy.
+type RuntimePinMode string
+
+const (
+	RuntimePinModeAutoSync    RuntimePinMode = "AutoSync"
+	RuntimePinModeManagedPin  RuntimePinMode = "ManagedPin"
+	RuntimePinModeExplicitPin RuntimePinMode = "ExplicitPin"
+	RuntimePinModeInvalidPin  RuntimePinMode = "InvalidPin"
+)
+
+// RuntimePinState identifies the observed pin resolution outcome.
+type RuntimePinState string
+
+const (
+	RuntimePinStateNotApplicable           RuntimePinState = "NotApplicable"
+	RuntimePinStateAwaitingPin             RuntimePinState = "AwaitingPin"
+	RuntimePinStateResolved                RuntimePinState = "Resolved"
+	RuntimePinStateDesiredReportedMismatch RuntimePinState = "DesiredReportedMismatch"
+	RuntimePinStateRevisionMissing         RuntimePinState = "RevisionMissing"
+	RuntimePinStateRevisionInvalid         RuntimePinState = "RevisionInvalid"
+	RuntimePinStateRevisionDisabled        RuntimePinState = "RevisionDisabled"
+	RuntimePinStateUnavailable             RuntimePinState = "Unavailable"
+	RuntimePinStateInvalidIntent           RuntimePinState = "InvalidIntent"
+)
+
+// StatusFreshness relates status observedGeneration to object generation.
+type StatusFreshness string
+
+const (
+	StatusFreshnessCurrent    StatusFreshness = "Current"
+	StatusFreshnessStale      StatusFreshness = "Stale"
+	StatusFreshnessUnobserved StatusFreshness = "Unobserved"
+	StatusFreshnessInvalid    StatusFreshness = "Invalid"
+)
+
+// DriftConditionState identifies the bounded state of reported drift.
+type DriftConditionState string
+
+const (
+	DriftConditionStateNotReported     DriftConditionState = "NotReported"
+	DriftConditionStateReportedTrue    DriftConditionState = "ReportedTrue"
+	DriftConditionStateReportedFalse   DriftConditionState = "ReportedFalse"
+	DriftConditionStateReportedUnknown DriftConditionState = "ReportedUnknown"
+	DriftConditionStateMalformed       DriftConditionState = "Malformed"
+)
+
+// RuntimeDriftCause is a bounded classification of a reported drift cause.
+type RuntimeDriftCause string
+
+const (
+	RuntimeDriftCauseRevisionMismatch     RuntimeDriftCause = "RevisionMismatch"
+	RuntimeDriftCauseRevisionMissing      RuntimeDriftCause = "RevisionMissing"
+	RuntimeDriftCauseSourceRuntimeMissing RuntimeDriftCause = "SourceRuntimeMissing"
+	RuntimeDriftCauseRuntimeMismatch      RuntimeDriftCause = "RuntimeMismatch"
+	RuntimeDriftCausePinAdvanced          RuntimeDriftCause = "PinAdvanced"
+	RuntimeDriftCauseOther                RuntimeDriftCause = "Other"
+)
+
+// RuntimeSyncState identifies the relationship between synchronization values
+// without exposing those values.
+type RuntimeSyncState string
+
+const (
+	RuntimeSyncStateAbsent       RuntimeSyncState = "Absent"
+	RuntimeSyncStateAcknowledged RuntimeSyncState = "Acknowledged"
+	RuntimeSyncStatePending      RuntimeSyncState = "Pending"
+	RuntimeSyncStateStatusOnly   RuntimeSyncState = "StatusOnly"
+)
+
+// ConfigurationState identifies whether a runtime configuration is available.
+type ConfigurationState string
+
+const (
+	ConfigurationStateAvailable   ConfigurationState = "Available"
+	ConfigurationStateUnavailable ConfigurationState = "Unavailable"
+)
+
+// ConfigurationOrigin identifies where a runtime configuration was observed.
+type ConfigurationOrigin string
+
+const (
+	ConfigurationOriginLiveRuntime        ConfigurationOrigin = "LiveRuntime"
+	ConfigurationOriginControllerRevision ConfigurationOrigin = "ControllerRevision"
+)
+
+// RuntimeHashRelation identifies the relation between two bounded hashes.
+type RuntimeHashRelation string
+
+const (
+	RuntimeHashRelationUnknown   RuntimeHashRelation = "Unknown"
+	RuntimeHashRelationEqual     RuntimeHashRelation = "Equal"
+	RuntimeHashRelationDifferent RuntimeHashRelation = "Different"
+	RuntimeHashRelationAmbiguous RuntimeHashRelation = "Ambiguous"
+)
+
+// RuntimeRevisionRole identifies why a revision appears in a report.
+type RuntimeRevisionRole string
+
+const (
+	RuntimeRevisionRoleActive    RuntimeRevisionRole = "Active"
+	RuntimeRevisionRoleRequested RuntimeRevisionRole = "Requested"
+	RuntimeRevisionRoleReported  RuntimeRevisionRole = "Reported"
+	RuntimeRevisionRoleHistory   RuntimeRevisionRole = "History"
+)
+
+// RevisionConsistency describes consistency with the controller writer
+// contract. It does not make a cryptographic claim.
+type RevisionConsistency string
+
+const (
+	RevisionConsistencyConsistent   RevisionConsistency = "Consistent"
+	RevisionConsistencyInconsistent RevisionConsistency = "Inconsistent"
+	RevisionConsistencyUnknown      RevisionConsistency = "Unknown"
+)
+
+// RevisionRelation identifies a revision's relation to the live runtime.
+type RevisionRelation string
+
+const (
+	RevisionRelationMatchesLive     RevisionRelation = "MatchesLive"
+	RevisionRelationDiffersFromLive RevisionRelation = "DiffersFromLive"
+	RevisionRelationAmbiguous       RevisionRelation = "Ambiguous"
+	RevisionRelationUnknown         RevisionRelation = "Unknown"
+)
+
+// HistoryObservationState identifies the outcome of history collection.
+type HistoryObservationState string
+
+const (
+	HistoryObservationStateNotRequested HistoryObservationState = "NotRequested"
+	HistoryObservationStateComplete     HistoryObservationState = "Complete"
+	HistoryObservationStatePartial      HistoryObservationState = "Partial"
+	HistoryObservationStateUnavailable  HistoryObservationState = "Unavailable"
+)
+
+// HistoryCompleteness describes the bounds on reported revision history.
+type HistoryCompleteness string
+
+const (
+	HistoryCompletenessNotRequested     HistoryCompleteness = "NotRequested"
+	HistoryCompletenessRetentionBounded HistoryCompleteness = "RetentionBounded"
+	HistoryCompletenessIncomplete       HistoryCompleteness = "Incomplete"
+)
+
+// RuntimeIssueCode is an extensible, message-free runtime issue identifier.
+type RuntimeIssueCode string
+
+const (
+	RuntimeIssueDeclaredCompatibilityMismatch RuntimeIssueCode = "DeclaredCompatibilityMismatch"
+	RuntimeIssueInvalidDeclaredKind           RuntimeIssueCode = "InvalidDeclaredKind"
+	RuntimeIssueInheritanceUnavailable        RuntimeIssueCode = "InheritanceUnavailable"
+	RuntimeIssueStatusUnobserved              RuntimeIssueCode = "StatusUnobserved"
+	RuntimeIssueStatusStale                   RuntimeIssueCode = "StatusStale"
+	RuntimeIssueStatusInvalid                 RuntimeIssueCode = "StatusInvalid"
+	RuntimeIssueLiveRuntimeUnavailable        RuntimeIssueCode = "LiveRuntimeUnavailable"
+	RuntimeIssueActiveRevisionUnreported      RuntimeIssueCode = "ActiveRevisionUnreported"
+	RuntimeIssueActiveRevisionUnavailable     RuntimeIssueCode = "ActiveRevisionUnavailable"
+	RuntimeIssueRevisionNotOMEManaged         RuntimeIssueCode = "RevisionNotOMEManaged"
+	RuntimeIssueRevisionSourceMismatch        RuntimeIssueCode = "RevisionSourceMismatch"
+	RuntimeIssueRevisionHashInvalid           RuntimeIssueCode = "RevisionHashInvalid"
+	RuntimeIssueRevisionPayloadMalformed      RuntimeIssueCode = "RevisionPayloadMalformed"
+	RuntimeIssueRevisionHashMismatch          RuntimeIssueCode = "RevisionHashMismatch"
+	RuntimeIssueRevisionNameMismatch          RuntimeIssueCode = "RevisionNameMismatch"
+	RuntimeIssueRevisionOrdinalUnexpected     RuntimeIssueCode = "RevisionOrdinalUnexpected"
+	RuntimeIssueRevisionPayloadNonCanonical   RuntimeIssueCode = "RevisionPayloadNonCanonical"
+	RuntimeIssueRevisionDataObjectPresent     RuntimeIssueCode = "RevisionDataObjectPresent"
+	RuntimeIssueRevisionIdentityMismatch      RuntimeIssueCode = "RevisionIdentityMismatch"
+	RuntimeIssueRevisionDisabled              RuntimeIssueCode = "RevisionDisabled"
+	RuntimeIssueDuplicateRevision             RuntimeIssueCode = "DuplicateRevision"
+	RuntimeIssueRevisionHashCollision         RuntimeIssueCode = "RevisionHashCollision"
+	RuntimeIssueReportedDriftConflict         RuntimeIssueCode = "ReportedDriftConflict"
+	RuntimeIssueHistoryUnavailable            RuntimeIssueCode = "HistoryUnavailable"
+	RuntimeIssueHistoryTruncated              RuntimeIssueCode = "HistoryTruncated"
+)
+
+// RuntimeWarning is a message-free warning emitted by a runtime report.
+// Runtime reports intentionally expose only stable, bounded warning codes.
+type RuntimeWarning struct {
+	Code WarningCode `json:"code"`
+}
+
+type runtimeContent[T any] interface {
+	Content[T]
+	runtimeReportKind() string
+}
+
+// RuntimeEnvelope carries the fields shared by runtime reports. It is kept
+// separate from the general diagnostic envelope so runtime output cannot
+// carry arbitrary warning messages. Its sealed content contract also lets
+// canonicalization restore the report kind.
+type RuntimeEnvelope[T runtimeContent[T]] struct {
+	APIVersion  string            `json:"apiVersion"`
+	Kind        string            `json:"kind"`
+	Metadata    Metadata          `json:"metadata"`
+	CollectedAt time.Time         `json:"collectedAt"`
+	Sources     []SourceReference `json:"sources"`
+	Content     T                 `json:"content"`
+	Warnings    []RuntimeWarning  `json:"warnings"`
+}
+
+func newRuntimeEnvelope[T runtimeContent[T]](metadata Metadata, content T, clock Clock) RuntimeEnvelope[T] {
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	return (RuntimeEnvelope[T]{
+		APIVersion:  APIVersion,
+		Kind:        content.runtimeReportKind(),
+		Metadata:    metadata,
+		CollectedAt: clock.Now().UTC(),
+		Sources:     []SourceReference{},
+		Content:     content,
+		Warnings:    []RuntimeWarning{},
+	}).Canonical()
+}
+
+// Canonical returns a deterministic deep-enough copy suitable for rendering.
+// It never reorders caller-owned slices.
+func (e RuntimeEnvelope[T]) Canonical() RuntimeEnvelope[T] {
+	result := e
+	result.APIVersion = APIVersion
+	result.Kind = e.Content.runtimeReportKind()
+	result.CollectedAt = e.CollectedAt.UTC()
+	result.Sources = append([]SourceReference{}, e.Sources...)
+	for i := range result.Sources {
+		if result.Sources[i].CollectedAt.IsZero() {
+			result.Sources[i].CollectedAt = result.CollectedAt
+		} else {
+			result.Sources[i].CollectedAt = result.Sources[i].CollectedAt.UTC()
+		}
+	}
+	sort.SliceStable(result.Sources, func(i, j int) bool {
+		return sourceLess(result.Sources[i], result.Sources[j])
+	})
+	result.Warnings = append([]RuntimeWarning{}, e.Warnings...)
+	sort.SliceStable(result.Warnings, func(i, j int) bool {
+		return result.Warnings[i].Code < result.Warnings[j].Code
+	})
+	result.Content = e.Content.Canonical()
+	return result
+}
+
+// Table returns the human-readable view of the canonical typed content.
+func (e RuntimeEnvelope[T]) Table() report.Table {
+	return e.Content.Table()
+}
+
+// RuntimeObjectReference is an allowlisted runtime object identity.
+type RuntimeObjectReference struct {
+	APIVersion      string      `json:"apiVersion"`
+	Kind            RuntimeKind `json:"kind"`
+	Namespace       string      `json:"namespace,omitempty"`
+	Name            string      `json:"name"`
+	UID             string      `json:"uid,omitempty"`
+	Generation      int64       `json:"generation,omitempty"`
+	ResourceVersion string      `json:"resourceVersion,omitempty"`
+}
+
+// RuntimeRevisionReference is an allowlisted ControllerRevision identity.
+type RuntimeRevisionReference struct {
+	Namespace       string    `json:"namespace"`
+	Name            string    `json:"name"`
+	UID             string    `json:"uid,omitempty"`
+	ResourceVersion string    `json:"resourceVersion,omitempty"`
+	CreatedAt       time.Time `json:"createdAt"`
+}
+
+// RuntimeComponent summarizes one runtime component's deployment mode.
+type RuntimeComponent struct {
+	Type                 RuntimeComponentType `json:"type"`
+	DeploymentMode       DeploymentMode       `json:"deploymentMode"`
+	DeploymentModeSource DeploymentModeSource `json:"deploymentModeSource"`
+}
+
+// RuntimeIssue identifies a bounded issue and its optional revision.
+type RuntimeIssue struct {
+	Code     RuntimeIssueCode `json:"code"`
+	Revision string           `json:"revision,omitempty"`
+}
+
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}

--- a/pkg/cli/report/v1alpha1/runtime_common.go
+++ b/pkg/cli/report/v1alpha1/runtime_common.go
@@ -242,9 +242,23 @@ type RuntimeWarning struct {
 	Code WarningCode `json:"code"`
 }
 
+// RuntimeSourceReference identifies one allowlisted source used to build a
+// runtime report. It deliberately omits Kubernetes resource versions.
+type RuntimeSourceReference struct {
+	Kind              string            `json:"kind"`
+	Namespace         string            `json:"namespace,omitempty"`
+	Name              string            `json:"name"`
+	UID               string            `json:"uid,omitempty"`
+	Generation        int64             `json:"generation,omitempty"`
+	Evidence          EvidenceLevel     `json:"evidence"`
+	CollectedAt       time.Time         `json:"collectedAt"`
+	UnavailableReason UnavailableReason `json:"unavailableReason,omitempty"`
+}
+
 type runtimeContent[T any] interface {
 	Content[T]
 	runtimeReportKind() string
+	RuntimeEffectiveContent | RuntimeHistoryContent
 }
 
 // RuntimeEnvelope carries the fields shared by runtime reports. It is kept
@@ -252,13 +266,13 @@ type runtimeContent[T any] interface {
 // carry arbitrary warning messages. Its sealed content contract also lets
 // canonicalization restore the report kind.
 type RuntimeEnvelope[T runtimeContent[T]] struct {
-	APIVersion  string            `json:"apiVersion"`
-	Kind        string            `json:"kind"`
-	Metadata    Metadata          `json:"metadata"`
-	CollectedAt time.Time         `json:"collectedAt"`
-	Sources     []SourceReference `json:"sources"`
-	Content     T                 `json:"content"`
-	Warnings    []RuntimeWarning  `json:"warnings"`
+	APIVersion  string                   `json:"apiVersion"`
+	Kind        string                   `json:"kind"`
+	Metadata    Metadata                 `json:"metadata"`
+	CollectedAt time.Time                `json:"collectedAt"`
+	Sources     []RuntimeSourceReference `json:"sources"`
+	Content     T                        `json:"content"`
+	Warnings    []RuntimeWarning         `json:"warnings"`
 }
 
 func newRuntimeEnvelope[T runtimeContent[T]](metadata Metadata, content T, clock Clock) RuntimeEnvelope[T] {
@@ -270,7 +284,7 @@ func newRuntimeEnvelope[T runtimeContent[T]](metadata Metadata, content T, clock
 		Kind:        content.runtimeReportKind(),
 		Metadata:    metadata,
 		CollectedAt: clock.Now().UTC(),
-		Sources:     []SourceReference{},
+		Sources:     []RuntimeSourceReference{},
 		Content:     content,
 		Warnings:    []RuntimeWarning{},
 	}).Canonical()
@@ -283,7 +297,7 @@ func (e RuntimeEnvelope[T]) Canonical() RuntimeEnvelope[T] {
 	result.APIVersion = APIVersion
 	result.Kind = e.Content.runtimeReportKind()
 	result.CollectedAt = e.CollectedAt.UTC()
-	result.Sources = append([]SourceReference{}, e.Sources...)
+	result.Sources = append([]RuntimeSourceReference{}, e.Sources...)
 	for i := range result.Sources {
 		if result.Sources[i].CollectedAt.IsZero() {
 			result.Sources[i].CollectedAt = result.CollectedAt
@@ -292,7 +306,7 @@ func (e RuntimeEnvelope[T]) Canonical() RuntimeEnvelope[T] {
 		}
 	}
 	sort.SliceStable(result.Sources, func(i, j int) bool {
-		return sourceLess(result.Sources[i], result.Sources[j])
+		return runtimeSourceLess(result.Sources[i], result.Sources[j])
 	})
 	result.Warnings = append([]RuntimeWarning{}, e.Warnings...)
 	sort.SliceStable(result.Warnings, func(i, j int) bool {
@@ -302,6 +316,31 @@ func (e RuntimeEnvelope[T]) Canonical() RuntimeEnvelope[T] {
 	return result
 }
 
+func runtimeSourceLess(a, b RuntimeSourceReference) bool {
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Namespace != b.Namespace {
+		return a.Namespace < b.Namespace
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	if a.UID != b.UID {
+		return a.UID < b.UID
+	}
+	if a.Generation != b.Generation {
+		return a.Generation < b.Generation
+	}
+	if a.Evidence != b.Evidence {
+		return a.Evidence < b.Evidence
+	}
+	if !a.CollectedAt.Equal(b.CollectedAt) {
+		return a.CollectedAt.Before(b.CollectedAt)
+	}
+	return a.UnavailableReason < b.UnavailableReason
+}
+
 // Table returns the human-readable view of the canonical typed content.
 func (e RuntimeEnvelope[T]) Table() report.Table {
 	return e.Content.Table()
@@ -309,22 +348,20 @@ func (e RuntimeEnvelope[T]) Table() report.Table {
 
 // RuntimeObjectReference is an allowlisted runtime object identity.
 type RuntimeObjectReference struct {
-	APIVersion      string      `json:"apiVersion"`
-	Kind            RuntimeKind `json:"kind"`
-	Namespace       string      `json:"namespace,omitempty"`
-	Name            string      `json:"name"`
-	UID             string      `json:"uid,omitempty"`
-	Generation      int64       `json:"generation,omitempty"`
-	ResourceVersion string      `json:"resourceVersion,omitempty"`
+	APIVersion string      `json:"apiVersion"`
+	Kind       RuntimeKind `json:"kind"`
+	Namespace  string      `json:"namespace,omitempty"`
+	Name       string      `json:"name"`
+	UID        string      `json:"uid,omitempty"`
+	Generation int64       `json:"generation,omitempty"`
 }
 
 // RuntimeRevisionReference is an allowlisted ControllerRevision identity.
 type RuntimeRevisionReference struct {
-	Namespace       string    `json:"namespace"`
-	Name            string    `json:"name"`
-	UID             string    `json:"uid,omitempty"`
-	ResourceVersion string    `json:"resourceVersion,omitempty"`
-	CreatedAt       time.Time `json:"createdAt"`
+	Namespace string    `json:"namespace"`
+	Name      string    `json:"name"`
+	UID       string    `json:"uid,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 }
 
 // RuntimeComponent summarizes one runtime component's deployment mode.

--- a/pkg/cli/report/v1alpha1/runtime_common_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_common_test.go
@@ -1,0 +1,290 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestRuntimeReportEnumValuesAreStable(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"runtime kind unknown", string(v1alpha1.RuntimeKindUnknown), "Unknown"},
+		{"runtime kind namespaced", string(v1alpha1.RuntimeKindServingRuntime), "ServingRuntime"},
+		{"runtime kind cluster", string(v1alpha1.RuntimeKindClusterServingRuntime), "ClusterServingRuntime"},
+		{"selection explicit", string(v1alpha1.RuntimeSelectionSourceExplicit), "Explicit"},
+		{"selection selected", string(v1alpha1.RuntimeSelectionSourceSelected), "Selected"},
+		{"component engine", string(v1alpha1.RuntimeComponentEngine), "engine"},
+		{"component decoder", string(v1alpha1.RuntimeComponentDecoder), "decoder"},
+		{"component router", string(v1alpha1.RuntimeComponentRouter), "router"},
+		{"mode raw", string(v1alpha1.DeploymentModeRawDeployment), "RawDeployment"},
+		{"mode multi-node", string(v1alpha1.DeploymentModeMultiNode), "MultiNode"},
+		{"mode virtual", string(v1alpha1.DeploymentModeVirtualDeployment), "VirtualDeployment"},
+		{"mode native", string(v1alpha1.DeploymentModeOMENative), "OMENative"},
+		{"mode source annotation", string(v1alpha1.DeploymentModeSourceComponentAnnotation), "ComponentAnnotation"},
+		{"mode source service", string(v1alpha1.DeploymentModeSourceServiceSpec), "ServiceSpec"},
+		{"mode source leader worker", string(v1alpha1.DeploymentModeSourceLeaderWorkerShape), "LeaderWorkerShape"},
+		{"mode source default", string(v1alpha1.DeploymentModeSourceDefault), "Default"},
+		{"inheritance observed", string(v1alpha1.InheritanceStateObserved), "Observed"},
+		{"inheritance unavailable", string(v1alpha1.InheritanceStateUnavailable), "Unavailable"},
+		{"pin auto", string(v1alpha1.RuntimePinModeAutoSync), "AutoSync"},
+		{"pin managed", string(v1alpha1.RuntimePinModeManagedPin), "ManagedPin"},
+		{"pin explicit", string(v1alpha1.RuntimePinModeExplicitPin), "ExplicitPin"},
+		{"pin invalid", string(v1alpha1.RuntimePinModeInvalidPin), "InvalidPin"},
+		{"pin state not applicable", string(v1alpha1.RuntimePinStateNotApplicable), "NotApplicable"},
+		{"pin state awaiting", string(v1alpha1.RuntimePinStateAwaitingPin), "AwaitingPin"},
+		{"pin state resolved", string(v1alpha1.RuntimePinStateResolved), "Resolved"},
+		{"pin state mismatch", string(v1alpha1.RuntimePinStateDesiredReportedMismatch), "DesiredReportedMismatch"},
+		{"pin state missing", string(v1alpha1.RuntimePinStateRevisionMissing), "RevisionMissing"},
+		{"pin state invalid revision", string(v1alpha1.RuntimePinStateRevisionInvalid), "RevisionInvalid"},
+		{"pin state disabled", string(v1alpha1.RuntimePinStateRevisionDisabled), "RevisionDisabled"},
+		{"pin state unavailable", string(v1alpha1.RuntimePinStateUnavailable), "Unavailable"},
+		{"pin state invalid intent", string(v1alpha1.RuntimePinStateInvalidIntent), "InvalidIntent"},
+		{"freshness current", string(v1alpha1.StatusFreshnessCurrent), "Current"},
+		{"freshness stale", string(v1alpha1.StatusFreshnessStale), "Stale"},
+		{"freshness unobserved", string(v1alpha1.StatusFreshnessUnobserved), "Unobserved"},
+		{"freshness invalid", string(v1alpha1.StatusFreshnessInvalid), "Invalid"},
+		{"drift absent", string(v1alpha1.DriftConditionStateNotReported), "NotReported"},
+		{"drift true", string(v1alpha1.DriftConditionStateReportedTrue), "ReportedTrue"},
+		{"drift false", string(v1alpha1.DriftConditionStateReportedFalse), "ReportedFalse"},
+		{"drift unknown", string(v1alpha1.DriftConditionStateReportedUnknown), "ReportedUnknown"},
+		{"drift malformed", string(v1alpha1.DriftConditionStateMalformed), "Malformed"},
+		{"drift cause revision mismatch", string(v1alpha1.RuntimeDriftCauseRevisionMismatch), "RevisionMismatch"},
+		{"drift cause revision missing", string(v1alpha1.RuntimeDriftCauseRevisionMissing), "RevisionMissing"},
+		{"drift cause source missing", string(v1alpha1.RuntimeDriftCauseSourceRuntimeMissing), "SourceRuntimeMissing"},
+		{"drift cause runtime mismatch", string(v1alpha1.RuntimeDriftCauseRuntimeMismatch), "RuntimeMismatch"},
+		{"drift cause pin advanced", string(v1alpha1.RuntimeDriftCausePinAdvanced), "PinAdvanced"},
+		{"drift cause other", string(v1alpha1.RuntimeDriftCauseOther), "Other"},
+		{"sync absent", string(v1alpha1.RuntimeSyncStateAbsent), "Absent"},
+		{"sync acknowledged", string(v1alpha1.RuntimeSyncStateAcknowledged), "Acknowledged"},
+		{"sync pending", string(v1alpha1.RuntimeSyncStatePending), "Pending"},
+		{"sync status only", string(v1alpha1.RuntimeSyncStateStatusOnly), "StatusOnly"},
+		{"configuration available", string(v1alpha1.ConfigurationStateAvailable), "Available"},
+		{"configuration unavailable", string(v1alpha1.ConfigurationStateUnavailable), "Unavailable"},
+		{"origin live", string(v1alpha1.ConfigurationOriginLiveRuntime), "LiveRuntime"},
+		{"origin revision", string(v1alpha1.ConfigurationOriginControllerRevision), "ControllerRevision"},
+		{"hash unknown", string(v1alpha1.RuntimeHashRelationUnknown), "Unknown"},
+		{"hash equal", string(v1alpha1.RuntimeHashRelationEqual), "Equal"},
+		{"hash different", string(v1alpha1.RuntimeHashRelationDifferent), "Different"},
+		{"hash ambiguous", string(v1alpha1.RuntimeHashRelationAmbiguous), "Ambiguous"},
+		{"role active", string(v1alpha1.RuntimeRevisionRoleActive), "Active"},
+		{"role requested", string(v1alpha1.RuntimeRevisionRoleRequested), "Requested"},
+		{"role reported", string(v1alpha1.RuntimeRevisionRoleReported), "Reported"},
+		{"role history", string(v1alpha1.RuntimeRevisionRoleHistory), "History"},
+		{"consistency consistent", string(v1alpha1.RevisionConsistencyConsistent), "Consistent"},
+		{"consistency inconsistent", string(v1alpha1.RevisionConsistencyInconsistent), "Inconsistent"},
+		{"consistency unknown", string(v1alpha1.RevisionConsistencyUnknown), "Unknown"},
+		{"relation matches", string(v1alpha1.RevisionRelationMatchesLive), "MatchesLive"},
+		{"relation differs", string(v1alpha1.RevisionRelationDiffersFromLive), "DiffersFromLive"},
+		{"relation ambiguous", string(v1alpha1.RevisionRelationAmbiguous), "Ambiguous"},
+		{"relation unknown", string(v1alpha1.RevisionRelationUnknown), "Unknown"},
+		{"observation not requested", string(v1alpha1.HistoryObservationStateNotRequested), "NotRequested"},
+		{"observation complete", string(v1alpha1.HistoryObservationStateComplete), "Complete"},
+		{"observation partial", string(v1alpha1.HistoryObservationStatePartial), "Partial"},
+		{"observation unavailable", string(v1alpha1.HistoryObservationStateUnavailable), "Unavailable"},
+		{"completeness not requested", string(v1alpha1.HistoryCompletenessNotRequested), "NotRequested"},
+		{"completeness retention", string(v1alpha1.HistoryCompletenessRetentionBounded), "RetentionBounded"},
+		{"completeness incomplete", string(v1alpha1.HistoryCompletenessIncomplete), "Incomplete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+func TestRuntimeReportCommonSchemaIsTypedAndAllowlisted(t *testing.T) {
+	types := []reflect.Type{
+		reflect.TypeOf(v1alpha1.RuntimeEnvelope[v1alpha1.RuntimeEffectiveContent]{}),
+		reflect.TypeOf(v1alpha1.RuntimeEnvelope[v1alpha1.RuntimeHistoryContent]{}),
+		reflect.TypeOf(v1alpha1.RuntimeObjectReference{}),
+		reflect.TypeOf(v1alpha1.RuntimeRevisionReference{}),
+		reflect.TypeOf(v1alpha1.RuntimeComponent{}),
+		reflect.TypeOf(v1alpha1.RuntimeIssue{}),
+	}
+	for _, typ := range types {
+		assertRuntimeReportSchema(t, typ, map[reflect.Type]bool{})
+	}
+}
+
+func TestRuntimeEnvelopeWarningsAreCodeOnlyAndCanonical(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)
+	sourceTime := time.Date(2026, time.August, 31, 11, 20, 0, 0, time.FixedZone("test", -7*60*60))
+	reportValue := v1alpha1.NewRuntimeEffectiveReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RuntimeEffectiveContent{},
+		fixedClock{now: now},
+	)
+	reportValue.Sources = []v1alpha1.SourceReference{
+		{Kind: "Pod", Namespace: "prod", Name: "z", CollectedAt: sourceTime},
+		{Kind: "InferenceService", Namespace: "prod", Name: "chat"},
+	}
+	reportValue.Warnings = []v1alpha1.RuntimeWarning{
+		{Code: v1alpha1.WarningTruncated},
+		{Code: v1alpha1.WarningPartialData},
+	}
+
+	canonical := reportValue.Canonical()
+
+	assert.Equal(t, []v1alpha1.RuntimeWarning{
+		{Code: v1alpha1.WarningPartialData},
+		{Code: v1alpha1.WarningTruncated},
+	}, canonical.Warnings)
+	assert.Equal(t, []v1alpha1.RuntimeWarning{
+		{Code: v1alpha1.WarningTruncated},
+		{Code: v1alpha1.WarningPartialData},
+	}, reportValue.Warnings, "canonicalization must not reorder caller-owned warnings")
+	require.Len(t, canonical.Sources, 2)
+	assert.Equal(t, "InferenceService", canonical.Sources[0].Kind)
+	assert.Equal(t, now, canonical.Sources[0].CollectedAt)
+	assert.Equal(t, "Pod", canonical.Sources[1].Kind)
+	assert.Equal(t, time.UTC, canonical.Sources[1].CollectedAt.Location())
+	assert.Equal(t, "Pod", reportValue.Sources[0].Kind, "canonicalization must not reorder caller-owned sources")
+	assert.Equal(t, "test", reportValue.Sources[0].CollectedAt.Location().String())
+
+	warningType := reflect.TypeOf(v1alpha1.RuntimeWarning{})
+	require.Equal(t, 1, warningType.NumField(), "runtime warnings must not gain arbitrary text fields")
+	assert.Equal(t, "Code", warningType.Field(0).Name)
+
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatJSON, reportValue))
+	assert.NotContains(t, output.String(), `"message"`)
+}
+
+func TestRuntimeEnvelopeAcceptsDefaultSystemClock(t *testing.T) {
+	before := time.Now().UTC()
+	reportValue := v1alpha1.NewRuntimeHistoryReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RuntimeHistoryContent{},
+		nil,
+	)
+	after := time.Now().UTC()
+
+	assert.False(t, reportValue.CollectedAt.Before(before))
+	assert.False(t, reportValue.CollectedAt.After(after))
+}
+
+func TestRuntimeEnvelopeCanonicalRestoresFixedKind(t *testing.T) {
+	effective := v1alpha1.NewRuntimeEffectiveReport(
+		v1alpha1.Metadata{Name: "chat"},
+		v1alpha1.RuntimeEffectiveContent{},
+		fixedClock{},
+	)
+	history := v1alpha1.NewRuntimeHistoryReport(
+		v1alpha1.Metadata{Name: "chat"},
+		v1alpha1.RuntimeHistoryContent{},
+		fixedClock{},
+	)
+	effective.Kind = v1alpha1.RuntimeHistoryReportKind
+	history.Kind = v1alpha1.RuntimeEffectiveReportKind
+
+	assert.Equal(t, v1alpha1.RuntimeEffectiveReportKind, effective.Canonical().Kind)
+	assert.Equal(t, v1alpha1.RuntimeHistoryReportKind, history.Canonical().Kind)
+}
+
+func TestRuntimeReportSchemaAuditRejectsEveryUnsafeFieldCategory(t *testing.T) {
+	typ := reflect.TypeOf(struct {
+		Image       string   `json:"image"`
+		Command     string   `json:"command"`
+		Args        []string `json:"args"`
+		Env         []string `json:"env"`
+		Environment []string `json:"environment"`
+		Secret      string   `json:"secret"`
+		Label       string   `json:"label"`
+		Annotation  string   `json:"annotation"`
+		RawReason   string   `json:"rawReason"`
+		Error       string   `json:"error"`
+		Message     string   `json:"message"`
+		Token       string   `json:"token"`
+		SyncToken   string   `json:"syncToken"`
+	}{})
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		assert.True(t, isForbiddenRuntimeSchemaField(field), "unsafe category %s was not rejected", field.Name)
+	}
+}
+
+func TestRuntimeIssueCodesUseBoundedIdentifiers(t *testing.T) {
+	want := []string{
+		"DeclaredCompatibilityMismatch", "InvalidDeclaredKind", "InheritanceUnavailable",
+		"StatusUnobserved", "StatusStale", "StatusInvalid", "LiveRuntimeUnavailable",
+		"ActiveRevisionUnreported", "ActiveRevisionUnavailable", "RevisionNotOMEManaged",
+		"RevisionSourceMismatch", "RevisionHashInvalid", "RevisionPayloadMalformed",
+		"RevisionHashMismatch", "RevisionNameMismatch", "RevisionOrdinalUnexpected",
+		"RevisionPayloadNonCanonical", "RevisionDataObjectPresent", "RevisionIdentityMismatch",
+		"RevisionDisabled", "DuplicateRevision", "RevisionHashCollision", "ReportedDriftConflict",
+		"HistoryUnavailable", "HistoryTruncated",
+	}
+	got := []string{
+		string(v1alpha1.RuntimeIssueDeclaredCompatibilityMismatch), string(v1alpha1.RuntimeIssueInvalidDeclaredKind),
+		string(v1alpha1.RuntimeIssueInheritanceUnavailable), string(v1alpha1.RuntimeIssueStatusUnobserved),
+		string(v1alpha1.RuntimeIssueStatusStale), string(v1alpha1.RuntimeIssueStatusInvalid),
+		string(v1alpha1.RuntimeIssueLiveRuntimeUnavailable), string(v1alpha1.RuntimeIssueActiveRevisionUnreported),
+		string(v1alpha1.RuntimeIssueActiveRevisionUnavailable), string(v1alpha1.RuntimeIssueRevisionNotOMEManaged),
+		string(v1alpha1.RuntimeIssueRevisionSourceMismatch), string(v1alpha1.RuntimeIssueRevisionHashInvalid),
+		string(v1alpha1.RuntimeIssueRevisionPayloadMalformed), string(v1alpha1.RuntimeIssueRevisionHashMismatch),
+		string(v1alpha1.RuntimeIssueRevisionNameMismatch), string(v1alpha1.RuntimeIssueRevisionOrdinalUnexpected),
+		string(v1alpha1.RuntimeIssueRevisionPayloadNonCanonical), string(v1alpha1.RuntimeIssueRevisionDataObjectPresent),
+		string(v1alpha1.RuntimeIssueRevisionIdentityMismatch), string(v1alpha1.RuntimeIssueRevisionDisabled),
+		string(v1alpha1.RuntimeIssueDuplicateRevision), string(v1alpha1.RuntimeIssueRevisionHashCollision),
+		string(v1alpha1.RuntimeIssueReportedDriftConflict), string(v1alpha1.RuntimeIssueHistoryUnavailable),
+		string(v1alpha1.RuntimeIssueHistoryTruncated),
+	}
+	assert.Equal(t, want, got)
+}
+
+func assertRuntimeReportSchema(t *testing.T, typ reflect.Type, seen map[reflect.Type]bool) {
+	t.Helper()
+	assertTypedSchema(t, typ, map[reflect.Type]bool{})
+	assertRuntimeReportFieldNames(t, typ, seen)
+}
+
+func assertRuntimeReportFieldNames(t *testing.T, typ reflect.Type, seen map[reflect.Type]bool) {
+	t.Helper()
+	for typ.Kind() == reflect.Pointer || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array {
+		typ = typ.Elem()
+	}
+	if typ.PkgPath() == "time" || seen[typ] {
+		return
+	}
+	seen[typ] = true
+	if typ.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		require.False(t, isForbiddenRuntimeSchemaField(field), "runtime schema contains unsafe field %s.%s", typ, field.Name)
+		assertRuntimeReportFieldNames(t, field.Type, seen)
+	}
+}
+
+func isForbiddenRuntimeSchemaField(field reflect.StructField) bool {
+	jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+	for _, name := range []string{strings.ToLower(field.Name), strings.ToLower(jsonName)} {
+		if name == "env" || name == "reason" || strings.Contains(name, "rawreason") {
+			return true
+		}
+		for _, fragment := range []string{
+			"image", "command", "args", "environment", "secret", "label",
+			"annotation", "error", "message", "token",
+		} {
+			if strings.Contains(name, fragment) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/cli/report/v1alpha1/runtime_common_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_common_test.go
@@ -2,6 +2,7 @@ package v1alpha1_test
 
 import (
 	"bytes"
+	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -109,6 +110,7 @@ func TestRuntimeReportCommonSchemaIsTypedAndAllowlisted(t *testing.T) {
 	types := []reflect.Type{
 		reflect.TypeOf(v1alpha1.RuntimeEnvelope[v1alpha1.RuntimeEffectiveContent]{}),
 		reflect.TypeOf(v1alpha1.RuntimeEnvelope[v1alpha1.RuntimeHistoryContent]{}),
+		reflect.TypeOf(v1alpha1.RuntimeSourceReference{}),
 		reflect.TypeOf(v1alpha1.RuntimeObjectReference{}),
 		reflect.TypeOf(v1alpha1.RuntimeRevisionReference{}),
 		reflect.TypeOf(v1alpha1.RuntimeComponent{}),
@@ -119,6 +121,14 @@ func TestRuntimeReportCommonSchemaIsTypedAndAllowlisted(t *testing.T) {
 	}
 }
 
+func TestRuntimeEnvelopeRejectsEmbeddedExternalContent(t *testing.T) {
+	command := exec.CommandContext(t.Context(), "go", "test", "./testdata/hostile_runtime_content")
+	output, err := command.CombinedOutput()
+
+	require.Error(t, err, "hostile embedded content unexpectedly instantiated RuntimeEnvelope:\n%s", output)
+	assert.Contains(t, string(output), "hostileContent does not satisfy")
+}
+
 func TestRuntimeEnvelopeWarningsAreCodeOnlyAndCanonical(t *testing.T) {
 	now := time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)
 	sourceTime := time.Date(2026, time.August, 31, 11, 20, 0, 0, time.FixedZone("test", -7*60*60))
@@ -127,7 +137,7 @@ func TestRuntimeEnvelopeWarningsAreCodeOnlyAndCanonical(t *testing.T) {
 		v1alpha1.RuntimeEffectiveContent{},
 		fixedClock{now: now},
 	)
-	reportValue.Sources = []v1alpha1.SourceReference{
+	reportValue.Sources = []v1alpha1.RuntimeSourceReference{
 		{Kind: "Pod", Namespace: "prod", Name: "z", CollectedAt: sourceTime},
 		{Kind: "InferenceService", Namespace: "prod", Name: "chat"},
 	}
@@ -163,6 +173,111 @@ func TestRuntimeEnvelopeWarningsAreCodeOnlyAndCanonical(t *testing.T) {
 	assert.NotContains(t, output.String(), `"message"`)
 }
 
+func TestRuntimeEnvelopeCanonicalOrdersEveryRuntimeSourceField(t *testing.T) {
+	collectedAt := time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)
+	base := v1alpha1.RuntimeSourceReference{
+		Kind: "Pod", Namespace: "prod", Name: "runtime", UID: "uid", Generation: 2,
+		Evidence: v1alpha1.EvidenceObserved, CollectedAt: collectedAt,
+		UnavailableReason: v1alpha1.UnavailableNotFound,
+	}
+	tests := []struct {
+		name  string
+		early v1alpha1.RuntimeSourceReference
+		late  v1alpha1.RuntimeSourceReference
+	}{
+		{
+			name: "kind",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Kind = "A"
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Kind = "Z"
+			}),
+		},
+		{
+			name: "namespace",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Namespace = "a"
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Namespace = "z"
+			}),
+		},
+		{
+			name: "name",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Name = "a"
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Name = "z"
+			}),
+		},
+		{
+			name: "uid",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.UID = "a"
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.UID = "z"
+			}),
+		},
+		{
+			name: "generation",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Generation = 1
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Generation = 3
+			}),
+		},
+		{
+			name: "evidence",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Evidence = v1alpha1.EvidenceDeclared
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.Evidence = v1alpha1.EvidenceReported
+			}),
+		},
+		{
+			name: "collected at",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.CollectedAt = collectedAt.Add(-time.Minute)
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.CollectedAt = collectedAt.Add(time.Minute)
+			}),
+		},
+		{
+			name: "unavailable reason",
+			early: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.UnavailableReason = v1alpha1.UnavailableNotFound
+			}),
+			late: withRuntimeSource(base, func(source *v1alpha1.RuntimeSourceReference) {
+				source.UnavailableReason = v1alpha1.UnavailableUnsupportedAPI
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forward := v1alpha1.NewRuntimeEffectiveReport(
+				v1alpha1.Metadata{}, v1alpha1.RuntimeEffectiveContent{}, fixedClock{now: collectedAt},
+			)
+			forward.Sources = []v1alpha1.RuntimeSourceReference{tt.early, tt.late}
+			reverse := forward
+			reverse.Sources = []v1alpha1.RuntimeSourceReference{tt.late, tt.early}
+
+			forward = forward.Canonical()
+			reverse = reverse.Canonical()
+
+			assert.Equal(t, forward.Sources, reverse.Sources, "input order must not affect canonical source ordering")
+			require.Len(t, forward.Sources, 2)
+			assert.Equal(t, tt.early, forward.Sources[0])
+		})
+	}
+}
+
 func TestRuntimeEnvelopeAcceptsDefaultSystemClock(t *testing.T) {
 	before := time.Now().UTC()
 	reportValue := v1alpha1.NewRuntimeHistoryReport(
@@ -196,19 +311,20 @@ func TestRuntimeEnvelopeCanonicalRestoresFixedKind(t *testing.T) {
 
 func TestRuntimeReportSchemaAuditRejectsEveryUnsafeFieldCategory(t *testing.T) {
 	typ := reflect.TypeOf(struct {
-		Image       string   `json:"image"`
-		Command     string   `json:"command"`
-		Args        []string `json:"args"`
-		Env         []string `json:"env"`
-		Environment []string `json:"environment"`
-		Secret      string   `json:"secret"`
-		Label       string   `json:"label"`
-		Annotation  string   `json:"annotation"`
-		RawReason   string   `json:"rawReason"`
-		Error       string   `json:"error"`
-		Message     string   `json:"message"`
-		Token       string   `json:"token"`
-		SyncToken   string   `json:"syncToken"`
+		Image           string   `json:"image"`
+		Command         string   `json:"command"`
+		Args            []string `json:"args"`
+		Env             []string `json:"env"`
+		Environment     []string `json:"environment"`
+		Secret          string   `json:"secret"`
+		Label           string   `json:"label"`
+		Annotation      string   `json:"annotation"`
+		RawReason       string   `json:"rawReason"`
+		Error           string   `json:"error"`
+		Message         string   `json:"message"`
+		Token           string   `json:"token"`
+		SyncToken       string   `json:"syncToken"`
+		ResourceVersion string   `json:"resourceVersion"`
 	}{})
 
 	for i := 0; i < typ.NumField(); i++ {
@@ -274,7 +390,7 @@ func assertRuntimeReportFieldNames(t *testing.T, typ reflect.Type, seen map[refl
 func isForbiddenRuntimeSchemaField(field reflect.StructField) bool {
 	jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
 	for _, name := range []string{strings.ToLower(field.Name), strings.ToLower(jsonName)} {
-		if name == "env" || name == "reason" || strings.Contains(name, "rawreason") {
+		if name == "env" || name == "reason" || name == "resourceversion" || strings.Contains(name, "rawreason") {
 			return true
 		}
 		for _, fragment := range []string{
@@ -287,4 +403,12 @@ func isForbiddenRuntimeSchemaField(field reflect.StructField) bool {
 		}
 	}
 	return false
+}
+
+func withRuntimeSource(
+	source v1alpha1.RuntimeSourceReference,
+	change func(*v1alpha1.RuntimeSourceReference),
+) v1alpha1.RuntimeSourceReference {
+	change(&source)
+	return source
 }

--- a/pkg/cli/report/v1alpha1/runtime_effective.go
+++ b/pkg/cli/report/v1alpha1/runtime_effective.go
@@ -1,0 +1,236 @@
+package v1alpha1
+
+import (
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+const RuntimeEffectiveReportKind = "RuntimeEffectiveReport"
+
+// RuntimeSelection reports how and, when observed, which runtime was selected.
+type RuntimeSelection struct {
+	Source  RuntimeSelectionSource  `json:"source"`
+	Runtime *RuntimeObjectReference `json:"runtime,omitempty"`
+}
+
+// RuntimeInheritance reports the root-first runtime inheritance chain.
+type RuntimeInheritance struct {
+	State             InheritanceState         `json:"state"`
+	Sources           []RuntimeObjectReference `json:"sources"`
+	UnavailableReason UnavailableReason        `json:"unavailableReason,omitempty"`
+}
+
+// RuntimeStatusObservation reports bounded generation freshness evidence.
+type RuntimeStatusObservation struct {
+	Generation         int64           `json:"generation"`
+	ObservedGeneration int64           `json:"observedGeneration"`
+	Freshness          StatusFreshness `json:"freshness"`
+}
+
+// RuntimeDriftObservation reports the bounded controller drift condition.
+type RuntimeDriftObservation struct {
+	State DriftConditionState `json:"state"`
+	Cause RuntimeDriftCause   `json:"cause,omitempty"`
+}
+
+// RuntimePin reports pin intent and bounded status relationships.
+type RuntimePin struct {
+	Mode              RuntimePinMode           `json:"mode"`
+	State             RuntimePinState          `json:"state"`
+	RequestedRevision string                   `json:"requestedRevision,omitempty"`
+	ReportedRevision  string                   `json:"reportedRevision,omitempty"`
+	Status            RuntimeStatusObservation `json:"status"`
+	ReportedDrift     RuntimeDriftObservation  `json:"reportedDrift"`
+	SyncState         RuntimeSyncState         `json:"syncState"`
+}
+
+// RuntimeConfiguration is an allowlisted runtime configuration summary.
+type RuntimeConfiguration struct {
+	State             ConfigurationState        `json:"state"`
+	Origin            ConfigurationOrigin       `json:"origin,omitempty"`
+	Source            *RuntimeObjectReference   `json:"source,omitempty"`
+	Revision          *RuntimeRevisionReference `json:"revision,omitempty"`
+	Hash              string                    `json:"hash,omitempty"`
+	Components        []RuntimeComponent        `json:"components"`
+	UnavailableReason UnavailableReason         `json:"unavailableReason,omitempty"`
+}
+
+// RuntimeEffectiveContent compares live and active runtime configuration.
+type RuntimeEffectiveContent struct {
+	Selection    RuntimeSelection     `json:"selection"`
+	Inheritance  RuntimeInheritance   `json:"inheritance"`
+	Pin          RuntimePin           `json:"pin"`
+	Live         RuntimeConfiguration `json:"live"`
+	Active       RuntimeConfiguration `json:"active"`
+	LiveToActive RuntimeHashRelation  `json:"liveToActive"`
+	Issues       []RuntimeIssue       `json:"issues"`
+}
+
+// NewRuntimeEffectiveReport creates a canonical effective report.
+func NewRuntimeEffectiveReport(metadata Metadata, content RuntimeEffectiveContent, clock Clock) RuntimeEnvelope[RuntimeEffectiveContent] {
+	return newRuntimeEnvelope(metadata, content, clock)
+}
+
+func (RuntimeEffectiveContent) runtimeReportKind() string {
+	return RuntimeEffectiveReportKind
+}
+
+// Canonical returns a deeply copied deterministic effective report content.
+func (c RuntimeEffectiveContent) Canonical() RuntimeEffectiveContent {
+	result := c
+	result.Selection.Runtime = copyRuntimeObjectReference(c.Selection.Runtime)
+	result.Inheritance.Sources = append([]RuntimeObjectReference{}, c.Inheritance.Sources...)
+	result.Live = c.Live.canonical()
+	result.Active = c.Active.canonical()
+	result.Issues = append([]RuntimeIssue{}, c.Issues...)
+	sort.Slice(result.Issues, func(i, j int) bool {
+		if result.Issues[i].Code != result.Issues[j].Code {
+			return result.Issues[i].Code < result.Issues[j].Code
+		}
+		return result.Issues[i].Revision < result.Issues[j].Revision
+	})
+	return result
+}
+
+// Table returns the deterministic human-readable effective configuration view.
+func (c RuntimeEffectiveContent) Table() report.Table {
+	canonical := c.Canonical()
+	table := report.Table{
+		Headers: []string{
+			"VIEW", "STATE", "REASON", "RUNTIME", "REVISION", "HASH",
+			"COMPONENT", "MODE", "MODE-SOURCE", "PIN", "PIN-STATE", "SYNC",
+			"STATUS", "DRIFT", "LIVE-RELATION", "ISSUES",
+		},
+		Rows: [][]string{},
+	}
+	table.Rows = appendConfigurationRows(
+		table.Rows, "Live", canonical.Live, canonical.Pin, canonical.LiveToActive, canonical.Issues,
+	)
+	table.Rows = appendConfigurationRows(
+		table.Rows, "Active", canonical.Active, canonical.Pin, canonical.LiveToActive, canonical.Issues,
+	)
+	return table
+}
+
+func (c RuntimeConfiguration) canonical() RuntimeConfiguration {
+	result := c
+	result.Source = copyRuntimeObjectReference(c.Source)
+	if c.Revision != nil {
+		revision := *c.Revision
+		revision.CreatedAt = revision.CreatedAt.UTC()
+		result.Revision = &revision
+	}
+	result.Components = append([]RuntimeComponent{}, c.Components...)
+	sort.Slice(result.Components, func(i, j int) bool {
+		a, b := result.Components[i], result.Components[j]
+		if componentOrder(a.Type) != componentOrder(b.Type) {
+			return componentOrder(a.Type) < componentOrder(b.Type)
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		if a.DeploymentMode != b.DeploymentMode {
+			return a.DeploymentMode < b.DeploymentMode
+		}
+		return a.DeploymentModeSource < b.DeploymentModeSource
+	})
+	return result
+}
+
+func copyRuntimeObjectReference(source *RuntimeObjectReference) *RuntimeObjectReference {
+	if source == nil {
+		return nil
+	}
+	result := *source
+	return &result
+}
+
+func componentOrder(component RuntimeComponentType) int {
+	switch component {
+	case RuntimeComponentEngine:
+		return 0
+	case RuntimeComponentDecoder:
+		return 1
+	case RuntimeComponentRouter:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func appendConfigurationRows(
+	rows [][]string,
+	view string,
+	configuration RuntimeConfiguration,
+	pin RuntimePin,
+	relation RuntimeHashRelation,
+	issues []RuntimeIssue,
+) [][]string {
+	components := configuration.Components
+	if len(components) == 0 {
+		components = []RuntimeComponent{{}}
+	}
+	for _, component := range components {
+		rows = append(rows, []string{
+			view,
+			orDash(string(configuration.State)),
+			orDash(string(configuration.UnavailableReason)),
+			runtimeReferenceDisplay(configuration.Source),
+			revisionReferenceDisplay(configuration.Revision),
+			orDash(configuration.Hash),
+			orDash(string(component.Type)),
+			orDash(string(component.DeploymentMode)),
+			orDash(string(component.DeploymentModeSource)),
+			orDash(string(pin.Mode)),
+			orDash(string(pin.State)),
+			orDash(string(pin.SyncState)),
+			orDash(string(pin.Status.Freshness)),
+			runtimeDriftDisplay(pin.ReportedDrift),
+			orDash(string(relation)),
+			joinRuntimeIssues(issues),
+		})
+	}
+	return rows
+}
+
+func runtimeDriftDisplay(drift RuntimeDriftObservation) string {
+	if drift.State == "" {
+		return "-"
+	}
+	if drift.Cause == "" {
+		return string(drift.State)
+	}
+	return string(drift.State) + "/" + string(drift.Cause)
+}
+
+func joinRuntimeIssues(issues []RuntimeIssue) string {
+	values := make([]string, len(issues))
+	for i, issue := range issues {
+		values[i] = string(issue.Code)
+		if issue.Revision != "" {
+			values[i] += "(" + issue.Revision + ")"
+		}
+	}
+	return orDash(strings.Join(values, ","))
+}
+
+func runtimeReferenceDisplay(reference *RuntimeObjectReference) string {
+	if reference == nil {
+		return "-"
+	}
+	parts := []string{string(reference.Kind)}
+	if reference.Namespace != "" {
+		parts = append(parts, reference.Namespace)
+	}
+	parts = append(parts, reference.Name)
+	return strings.Join(parts, "/")
+}
+
+func revisionReferenceDisplay(reference *RuntimeRevisionReference) string {
+	if reference == nil {
+		return "-"
+	}
+	return orDash(reference.Name)
+}

--- a/pkg/cli/report/v1alpha1/runtime_effective_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_effective_test.go
@@ -1,0 +1,399 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestRuntimeEffectiveCanonicalReturnsDeepOrderedCopy(t *testing.T) {
+	content := runtimeEffectiveContent()
+	wantOriginal := runtimeEffectiveContent()
+	originalSelectionRuntime := content.Selection.Runtime
+	originalLiveSource := content.Live.Source
+	originalActiveRevision := content.Active.Revision
+
+	got := content.Canonical()
+
+	assert.Equal(t, []v1alpha1.RuntimeObjectReference{
+		content.Inheritance.Sources[0], content.Inheritance.Sources[1],
+	}, got.Inheritance.Sources, "inheritance remains root-first")
+	assert.Equal(t, []v1alpha1.RuntimeComponentType{
+		v1alpha1.RuntimeComponentEngine, v1alpha1.RuntimeComponentDecoder, v1alpha1.RuntimeComponentRouter,
+	}, componentTypes(got.Live.Components))
+	assert.Equal(t, []v1alpha1.RuntimeIssue{
+		{Code: v1alpha1.RuntimeIssueRevisionHashMismatch, Revision: "revision-a"},
+		{Code: v1alpha1.RuntimeIssueStatusStale},
+	}, got.Issues)
+	assert.Equal(t, time.UTC, got.Active.Revision.CreatedAt.Location())
+
+	require.NotSame(t, originalLiveSource, got.Live.Source)
+	require.NotSame(t, originalSelectionRuntime, got.Selection.Runtime)
+	require.NotSame(t, originalActiveRevision, got.Active.Revision)
+	got.Inheritance.Sources[0].Name = "returned-inheritance-source"
+	got.Selection.Runtime.Name = "returned-selection-runtime"
+	got.Live.Source.Name = "returned-live-source"
+	got.Active.Revision.Name = "returned-active-revision"
+	got.Live.Components[0].DeploymentMode = v1alpha1.DeploymentMode("ReturnedLiveMode")
+	got.Active.Components[0].Type = v1alpha1.RuntimeComponentType("returned-active-component")
+	got.Issues[0].Revision = "returned-effective-issue"
+
+	assert.Equal(t, wantOriginal, content)
+}
+
+func TestRuntimeEffectiveCanonicalNormalizesNilSlices(t *testing.T) {
+	got := (v1alpha1.RuntimeEffectiveContent{}).Canonical()
+
+	assert.NotNil(t, got.Inheritance.Sources)
+	assert.NotNil(t, got.Live.Components)
+	assert.NotNil(t, got.Active.Components)
+	assert.NotNil(t, got.Issues)
+}
+
+func TestNewRuntimeEffectiveReportUsesFixedKindAndUTCClock(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 11, 30, 0, 0, time.FixedZone("test", -7*60*60))
+
+	got := v1alpha1.NewRuntimeEffectiveReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RuntimeEffectiveContent{},
+		fixedClock{now: now},
+	)
+
+	assert.Equal(t, v1alpha1.RuntimeEffectiveReportKind, got.Kind)
+	assert.Equal(t, "2026-08-31T18:30:00Z", got.CollectedAt.Format(time.RFC3339))
+	assert.NotNil(t, got.Content.Inheritance.Sources)
+	assert.NotNil(t, got.Content.Live.Components)
+	assert.NotNil(t, got.Content.Active.Components)
+	assert.NotNil(t, got.Content.Issues)
+}
+
+func TestRuntimeEffectiveTableContract(t *testing.T) {
+	reportValue := v1alpha1.NewRuntimeEffectiveReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		runtimeEffectiveContent(),
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+
+	assert.Equal(t, report.Table{
+		Headers: []string{
+			"VIEW", "STATE", "REASON", "RUNTIME", "REVISION", "HASH", "COMPONENT", "MODE", "MODE-SOURCE",
+			"PIN", "PIN-STATE", "SYNC", "STATUS", "DRIFT", "LIVE-RELATION", "ISSUES",
+		},
+		Rows: [][]string{
+			{"Live", "Available", "-", "ServingRuntime/prod/vllm", "-", "11223344", "engine", "RawDeployment", "Default", "ManagedPin", "Resolved", "Pending", "Stale", "ReportedTrue/PinAdvanced", "Different", "RevisionHashMismatch(revision-a),StatusStale"},
+			{"Live", "Available", "-", "ServingRuntime/prod/vllm", "-", "11223344", "decoder", "MultiNode", "LeaderWorkerShape", "ManagedPin", "Resolved", "Pending", "Stale", "ReportedTrue/PinAdvanced", "Different", "RevisionHashMismatch(revision-a),StatusStale"},
+			{"Live", "Available", "-", "ServingRuntime/prod/vllm", "-", "11223344", "router", "VirtualDeployment", "ServiceSpec", "ManagedPin", "Resolved", "Pending", "Stale", "ReportedTrue/PinAdvanced", "Different", "RevisionHashMismatch(revision-a),StatusStale"},
+			{"Active", "Available", "-", "ClusterServingRuntime/cluster-vllm", "revision-a", "aabbccdd", "engine", "OMENative", "ComponentAnnotation", "ManagedPin", "Resolved", "Pending", "Stale", "ReportedTrue/PinAdvanced", "Different", "RevisionHashMismatch(revision-a),StatusStale"},
+		},
+	}, reportValue.Table())
+
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatTable, reportValue))
+	assert.Equal(t,
+		"VIEW     STATE       REASON   RUNTIME                              REVISION     HASH       COMPONENT   MODE                MODE-SOURCE           PIN          PIN-STATE   SYNC      STATUS   DRIFT                      LIVE-RELATION   ISSUES\n"+
+			"Live     Available   -        ServingRuntime/prod/vllm             -            11223344   engine      RawDeployment       Default               ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale\n"+
+			"Live     Available   -        ServingRuntime/prod/vllm             -            11223344   decoder     MultiNode           LeaderWorkerShape     ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale\n"+
+			"Live     Available   -        ServingRuntime/prod/vllm             -            11223344   router      VirtualDeployment   ServiceSpec           ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale\n"+
+			"Active   Available   -        ClusterServingRuntime/cluster-vllm   revision-a   aabbccdd   engine      OMENative           ComponentAnnotation   ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale\n",
+		output.String())
+}
+
+func TestRuntimeEffectiveTableUsesDashRowForConfigurationWithoutComponents(t *testing.T) {
+	content := v1alpha1.RuntimeEffectiveContent{
+		Pin: v1alpha1.RuntimePin{
+			Mode:      v1alpha1.RuntimePinModeAutoSync,
+			State:     v1alpha1.RuntimePinStateNotApplicable,
+			SyncState: v1alpha1.RuntimeSyncStateAbsent,
+			Status:    v1alpha1.RuntimeStatusObservation{Freshness: v1alpha1.StatusFreshnessUnobserved},
+		},
+		Live: v1alpha1.RuntimeConfiguration{State: v1alpha1.ConfigurationStateUnavailable},
+		Active: v1alpha1.RuntimeConfiguration{
+			State:             v1alpha1.ConfigurationStateUnavailable,
+			UnavailableReason: v1alpha1.UnavailableNotFound,
+		},
+	}
+
+	assert.Equal(t, [][]string{
+		{"Live", "Unavailable", "-", "-", "-", "-", "-", "-", "-", "AutoSync", "NotApplicable", "Absent", "Unobserved", "-", "-", "-"},
+		{"Active", "Unavailable", "NotFound", "-", "-", "-", "-", "-", "-", "AutoSync", "NotApplicable", "Absent", "Unobserved", "-", "-", "-"},
+	}, content.Table().Rows)
+}
+
+func TestRuntimeEffectiveSelectionAllowsMissingOrUnknownRuntimeIdentity(t *testing.T) {
+	missing := v1alpha1.NewRuntimeEffectiveReport(
+		v1alpha1.Metadata{Name: "chat"},
+		v1alpha1.RuntimeEffectiveContent{
+			Selection: v1alpha1.RuntimeSelection{Source: v1alpha1.RuntimeSelectionSourceSelected},
+		},
+		fixedClock{},
+	)
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatJSON, missing))
+	assert.Contains(t, output.String(), "\"selection\": {\n      \"source\": \"Selected\"\n    }")
+	assert.NotContains(t, output.String(), `"kind": ""`)
+
+	unknown := runtimeObject(v1alpha1.RuntimeKindUnknown, "", "unresolved")
+	content := v1alpha1.RuntimeEffectiveContent{
+		Selection: v1alpha1.RuntimeSelection{Source: v1alpha1.RuntimeSelectionSourceExplicit, Runtime: &unknown},
+	}
+	output.Reset()
+	require.NoError(t, report.Write(&output, report.FormatJSON, content))
+	assert.Contains(t, output.String(), `"kind": "Unknown"`)
+}
+
+func TestRuntimeEffectiveMachineOutputContract(t *testing.T) {
+	reportValue := v1alpha1.NewRuntimeEffectiveReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		runtimeEffectiveMachineContent(),
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+	tests := []struct {
+		name   string
+		format report.Format
+		want   string
+	}{
+		{
+			name:   "json",
+			format: report.FormatJSON,
+			want: "{\n" +
+				`  "apiVersion": "cli.ome.io/v1alpha1",` + "\n" +
+				`  "kind": "RuntimeEffectiveReport",` + "\n" +
+				`  "metadata": {` + "\n" +
+				`    "namespace": "prod",` + "\n" +
+				`    "name": "chat"` + "\n" +
+				"  },\n" +
+				`  "collectedAt": "2026-08-31T18:30:00Z",` + "\n" +
+				`  "sources": [],` + "\n" +
+				`  "content": {` + "\n" +
+				`    "selection": {` + "\n" +
+				`      "source": "Explicit",` + "\n" +
+				`      "runtime": {` + "\n" +
+				`        "apiVersion": "ome.io/v1beta1",` + "\n" +
+				`        "kind": "ServingRuntime",` + "\n" +
+				`        "namespace": "prod",` + "\n" +
+				`        "name": "vllm"` + "\n" +
+				"      }\n" +
+				"    },\n" +
+				`    "inheritance": {` + "\n" +
+				`      "state": "Unavailable",` + "\n" +
+				`      "sources": [],` + "\n" +
+				`      "unavailableReason": "NotFound"` + "\n" +
+				"    },\n" +
+				`    "pin": {` + "\n" +
+				`      "mode": "ManagedPin",` + "\n" +
+				`      "state": "RevisionMissing",` + "\n" +
+				`      "reportedRevision": "revision-a",` + "\n" +
+				`      "status": {` + "\n" +
+				`        "generation": 7,` + "\n" +
+				`        "observedGeneration": 7,` + "\n" +
+				`        "freshness": "Current"` + "\n" +
+				"      },\n" +
+				`      "reportedDrift": {` + "\n" +
+				`        "state": "ReportedFalse"` + "\n" +
+				"      },\n" +
+				`      "syncState": "Acknowledged"` + "\n" +
+				"    },\n" +
+				`    "live": {` + "\n" +
+				`      "state": "Available",` + "\n" +
+				`      "origin": "LiveRuntime",` + "\n" +
+				`      "source": {` + "\n" +
+				`        "apiVersion": "ome.io/v1beta1",` + "\n" +
+				`        "kind": "ServingRuntime",` + "\n" +
+				`        "namespace": "prod",` + "\n" +
+				`        "name": "vllm"` + "\n" +
+				"      },\n" +
+				`      "hash": "11223344",` + "\n" +
+				`      "components": [` + "\n" +
+				"        {\n" +
+				`          "type": "engine",` + "\n" +
+				`          "deploymentMode": "RawDeployment",` + "\n" +
+				`          "deploymentModeSource": "Default"` + "\n" +
+				"        }\n" +
+				"      ]\n" +
+				"    },\n" +
+				`    "active": {` + "\n" +
+				`      "state": "Unavailable",` + "\n" +
+				`      "components": [],` + "\n" +
+				`      "unavailableReason": "NotFound"` + "\n" +
+				"    },\n" +
+				`    "liveToActive": "Unknown",` + "\n" +
+				`    "issues": [` + "\n" +
+				"      {\n" +
+				`        "code": "ActiveRevisionUnavailable",` + "\n" +
+				`        "revision": "revision-a"` + "\n" +
+				"      }\n" +
+				"    ]\n" +
+				"  },\n" +
+				`  "warnings": []` + "\n" +
+				"}\n",
+		},
+		{
+			name:   "yaml",
+			format: report.FormatYAML,
+			want: "apiVersion: cli.ome.io/v1alpha1\n" +
+				"collectedAt: \"2026-08-31T18:30:00Z\"\n" +
+				"content:\n" +
+				"  active:\n" +
+				"    components: []\n" +
+				"    state: Unavailable\n" +
+				"    unavailableReason: NotFound\n" +
+				"  inheritance:\n" +
+				"    sources: []\n" +
+				"    state: Unavailable\n" +
+				"    unavailableReason: NotFound\n" +
+				"  issues:\n" +
+				"  - code: ActiveRevisionUnavailable\n" +
+				"    revision: revision-a\n" +
+				"  live:\n" +
+				"    components:\n" +
+				"    - deploymentMode: RawDeployment\n" +
+				"      deploymentModeSource: Default\n" +
+				"      type: engine\n" +
+				"    hash: \"11223344\"\n" +
+				"    origin: LiveRuntime\n" +
+				"    source:\n" +
+				"      apiVersion: ome.io/v1beta1\n" +
+				"      kind: ServingRuntime\n" +
+				"      name: vllm\n" +
+				"      namespace: prod\n" +
+				"    state: Available\n" +
+				"  liveToActive: Unknown\n" +
+				"  pin:\n" +
+				"    mode: ManagedPin\n" +
+				"    reportedDrift:\n" +
+				"      state: ReportedFalse\n" +
+				"    reportedRevision: revision-a\n" +
+				"    state: RevisionMissing\n" +
+				"    status:\n" +
+				"      freshness: Current\n" +
+				"      generation: 7\n" +
+				"      observedGeneration: 7\n" +
+				"    syncState: Acknowledged\n" +
+				"  selection:\n" +
+				"    runtime:\n" +
+				"      apiVersion: ome.io/v1beta1\n" +
+				"      kind: ServingRuntime\n" +
+				"      name: vllm\n" +
+				"      namespace: prod\n" +
+				"    source: Explicit\n" +
+				"kind: RuntimeEffectiveReport\n" +
+				"metadata:\n" +
+				"  name: chat\n" +
+				"  namespace: prod\n" +
+				"sources: []\n" +
+				"warnings: []\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, report.Write(&output, tt.format, reportValue))
+			assert.Equal(t, tt.want, output.String())
+		})
+	}
+}
+
+func TestRuntimeEffectiveSchemaIsStrictlyAllowlisted(t *testing.T) {
+	assertRuntimeReportSchema(t, reflect.TypeOf(v1alpha1.RuntimeEnvelope[v1alpha1.RuntimeEffectiveContent]{}), map[reflect.Type]bool{})
+}
+
+func runtimeEffectiveContent() v1alpha1.RuntimeEffectiveContent {
+	live := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
+	active := runtimeObject(v1alpha1.RuntimeKindClusterServingRuntime, "", "cluster-vllm")
+	return v1alpha1.RuntimeEffectiveContent{
+		Selection: v1alpha1.RuntimeSelection{Source: v1alpha1.RuntimeSelectionSourceExplicit, Runtime: &live},
+		Inheritance: v1alpha1.RuntimeInheritance{
+			State: v1alpha1.InheritanceStateObserved,
+			Sources: []v1alpha1.RuntimeObjectReference{
+				runtimeObject(v1alpha1.RuntimeKindClusterServingRuntime, "", "cluster-base"),
+				live,
+			},
+		},
+		Pin: v1alpha1.RuntimePin{
+			Mode:              v1alpha1.RuntimePinModeManagedPin,
+			State:             v1alpha1.RuntimePinStateResolved,
+			RequestedRevision: "revision-b",
+			ReportedRevision:  "revision-a",
+			Status: v1alpha1.RuntimeStatusObservation{
+				Generation: 7, ObservedGeneration: 6, Freshness: v1alpha1.StatusFreshnessStale,
+			},
+			ReportedDrift: v1alpha1.RuntimeDriftObservation{
+				State: v1alpha1.DriftConditionStateReportedTrue, Cause: v1alpha1.RuntimeDriftCausePinAdvanced,
+			},
+			SyncState: v1alpha1.RuntimeSyncStatePending,
+		},
+		Live: v1alpha1.RuntimeConfiguration{
+			State: v1alpha1.ConfigurationStateAvailable, Origin: v1alpha1.ConfigurationOriginLiveRuntime,
+			Source: &live, Hash: "11223344",
+			Components: []v1alpha1.RuntimeComponent{
+				{Type: v1alpha1.RuntimeComponentRouter, DeploymentMode: v1alpha1.DeploymentModeVirtualDeployment, DeploymentModeSource: v1alpha1.DeploymentModeSourceServiceSpec},
+				{Type: v1alpha1.RuntimeComponentEngine, DeploymentMode: v1alpha1.DeploymentModeRawDeployment, DeploymentModeSource: v1alpha1.DeploymentModeSourceDefault},
+				{Type: v1alpha1.RuntimeComponentDecoder, DeploymentMode: v1alpha1.DeploymentModeMultiNode, DeploymentModeSource: v1alpha1.DeploymentModeSourceLeaderWorkerShape},
+			},
+		},
+		Active: v1alpha1.RuntimeConfiguration{
+			State: v1alpha1.ConfigurationStateAvailable, Origin: v1alpha1.ConfigurationOriginControllerRevision,
+			Source: &active,
+			Revision: &v1alpha1.RuntimeRevisionReference{
+				Namespace: "ome", Name: "revision-a", CreatedAt: time.Date(2026, time.August, 31, 11, 0, 0, 0, time.FixedZone("test", -7*60*60)),
+			},
+			Hash: "aabbccdd",
+			Components: []v1alpha1.RuntimeComponent{
+				{Type: v1alpha1.RuntimeComponentEngine, DeploymentMode: v1alpha1.DeploymentModeOMENative, DeploymentModeSource: v1alpha1.DeploymentModeSourceComponentAnnotation},
+			},
+		},
+		LiveToActive: v1alpha1.RuntimeHashRelationDifferent,
+		Issues: []v1alpha1.RuntimeIssue{
+			{Code: v1alpha1.RuntimeIssueStatusStale},
+			{Code: v1alpha1.RuntimeIssueRevisionHashMismatch, Revision: "revision-a"},
+		},
+	}
+}
+
+func runtimeEffectiveMachineContent() v1alpha1.RuntimeEffectiveContent {
+	live := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
+	return v1alpha1.RuntimeEffectiveContent{
+		Selection:   v1alpha1.RuntimeSelection{Source: v1alpha1.RuntimeSelectionSourceExplicit, Runtime: &live},
+		Inheritance: v1alpha1.RuntimeInheritance{State: v1alpha1.InheritanceStateUnavailable, UnavailableReason: v1alpha1.UnavailableNotFound},
+		Pin: v1alpha1.RuntimePin{
+			Mode: v1alpha1.RuntimePinModeManagedPin, State: v1alpha1.RuntimePinStateRevisionMissing, ReportedRevision: "revision-a",
+			Status:        v1alpha1.RuntimeStatusObservation{Generation: 7, ObservedGeneration: 7, Freshness: v1alpha1.StatusFreshnessCurrent},
+			ReportedDrift: v1alpha1.RuntimeDriftObservation{State: v1alpha1.DriftConditionStateReportedFalse},
+			SyncState:     v1alpha1.RuntimeSyncStateAcknowledged,
+		},
+		Live: v1alpha1.RuntimeConfiguration{
+			State: v1alpha1.ConfigurationStateAvailable, Origin: v1alpha1.ConfigurationOriginLiveRuntime,
+			Source: &live, Hash: "11223344",
+			Components: []v1alpha1.RuntimeComponent{{
+				Type: v1alpha1.RuntimeComponentEngine, DeploymentMode: v1alpha1.DeploymentModeRawDeployment, DeploymentModeSource: v1alpha1.DeploymentModeSourceDefault,
+			}},
+		},
+		Active:       v1alpha1.RuntimeConfiguration{State: v1alpha1.ConfigurationStateUnavailable, UnavailableReason: v1alpha1.UnavailableNotFound},
+		LiveToActive: v1alpha1.RuntimeHashRelationUnknown,
+		Issues: []v1alpha1.RuntimeIssue{{
+			Code: v1alpha1.RuntimeIssueActiveRevisionUnavailable, Revision: "revision-a",
+		}},
+	}
+}
+
+func runtimeObject(kind v1alpha1.RuntimeKind, namespace, name string) v1alpha1.RuntimeObjectReference {
+	return v1alpha1.RuntimeObjectReference{
+		APIVersion: "ome.io/v1beta1", Kind: kind, Namespace: namespace, Name: name,
+	}
+}
+
+func componentTypes(components []v1alpha1.RuntimeComponent) []v1alpha1.RuntimeComponentType {
+	result := make([]v1alpha1.RuntimeComponentType, 0, len(components))
+	for _, component := range components {
+		result = append(result, component.Type)
+	}
+	return result
+}

--- a/pkg/cli/report/v1alpha1/runtime_history.go
+++ b/pkg/cli/report/v1alpha1/runtime_history.go
@@ -1,0 +1,212 @@
+package v1alpha1
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+const RuntimeHistoryReportKind = "RuntimeHistoryReport"
+
+// RuntimeRevisionEntry is an allowlisted revision history observation.
+type RuntimeRevisionEntry struct {
+	Revision       RuntimeRevisionReference `json:"revision"`
+	Source         *RuntimeObjectReference  `json:"source,omitempty"`
+	Hash           string                   `json:"hash,omitempty"`
+	Roles          []RuntimeRevisionRole    `json:"roles"`
+	Consistency    RevisionConsistency      `json:"consistency"`
+	RelationToLive RevisionRelation         `json:"relationToLive"`
+	Issues         []RuntimeIssueCode       `json:"issues"`
+}
+
+// RuntimeHistoryContent reports a bounded runtime revision history window.
+type RuntimeHistoryContent struct {
+	Runtime        *RuntimeObjectReference `json:"runtime,omitempty"`
+	Observation    HistoryObservationState `json:"observation"`
+	Completeness   HistoryCompleteness     `json:"completeness"`
+	RequestedPages int                     `json:"requestedPages"`
+	ObservedPages  int                     `json:"observedPages"`
+	Revisions      []RuntimeRevisionEntry  `json:"revisions"`
+	Issues         []RuntimeIssue          `json:"issues"`
+}
+
+// NewRuntimeHistoryReport creates a canonical runtime history report.
+func NewRuntimeHistoryReport(metadata Metadata, content RuntimeHistoryContent, clock Clock) RuntimeEnvelope[RuntimeHistoryContent] {
+	return newRuntimeEnvelope(metadata, content, clock)
+}
+
+func (RuntimeHistoryContent) runtimeReportKind() string {
+	return RuntimeHistoryReportKind
+}
+
+// Canonical returns a deeply copied deterministic history report content.
+func (c RuntimeHistoryContent) Canonical() RuntimeHistoryContent {
+	result := c
+	result.Runtime = copyRuntimeObjectReference(c.Runtime)
+	result.Revisions = make([]RuntimeRevisionEntry, len(c.Revisions))
+	for i := range c.Revisions {
+		result.Revisions[i] = c.Revisions[i].canonical()
+	}
+	sort.Slice(result.Revisions, func(i, j int) bool {
+		return compareRuntimeRevisionEntries(result.Revisions[i], result.Revisions[j]) < 0
+	})
+	result.Issues = append([]RuntimeIssue{}, c.Issues...)
+	sort.Slice(result.Issues, func(i, j int) bool {
+		if result.Issues[i].Code != result.Issues[j].Code {
+			return result.Issues[i].Code < result.Issues[j].Code
+		}
+		return result.Issues[i].Revision < result.Issues[j].Revision
+	})
+	return result
+}
+
+func compareRuntimeRevisionEntries(a, b RuntimeRevisionEntry) int {
+	if !a.Revision.CreatedAt.Equal(b.Revision.CreatedAt) {
+		if a.Revision.CreatedAt.After(b.Revision.CreatedAt) {
+			return -1
+		}
+		return 1
+	}
+	for _, result := range []int{
+		cmp.Compare(a.Revision.Namespace, b.Revision.Namespace),
+		cmp.Compare(a.Revision.Name, b.Revision.Name),
+		cmp.Compare(a.Revision.UID, b.Revision.UID),
+		cmp.Compare(a.Revision.ResourceVersion, b.Revision.ResourceVersion),
+		cmp.Compare(a.Hash, b.Hash),
+		compareRuntimeObjectReferences(a.Source, b.Source),
+		slices.Compare(a.Roles, b.Roles),
+		cmp.Compare(a.Consistency, b.Consistency),
+		cmp.Compare(a.RelationToLive, b.RelationToLive),
+		slices.Compare(a.Issues, b.Issues),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareRuntimeObjectReferences(a, b *RuntimeObjectReference) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	for _, result := range []int{
+		cmp.Compare(a.APIVersion, b.APIVersion),
+		cmp.Compare(a.Kind, b.Kind),
+		cmp.Compare(a.Namespace, b.Namespace),
+		cmp.Compare(a.Name, b.Name),
+		cmp.Compare(a.UID, b.UID),
+		cmp.Compare(a.Generation, b.Generation),
+		cmp.Compare(a.ResourceVersion, b.ResourceVersion),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+// Table returns the deterministic human-readable revision history view.
+func (c RuntimeHistoryContent) Table() report.Table {
+	canonical := c.Canonical()
+	table := report.Table{
+		Headers: []string{
+			"OBSERVATION", "COMPLETENESS", "PAGES", "REVISION", "CREATED", "HASH", "ROLES", "SOURCE",
+			"CONSISTENCY", "RELATION", "REVISION-ISSUES", "REPORT-ISSUES",
+		},
+		Rows: make([][]string, 0, len(canonical.Revisions)),
+	}
+	observation := orDash(string(canonical.Observation))
+	completeness := orDash(string(canonical.Completeness))
+	pages := fmt.Sprintf("%d/%d", canonical.ObservedPages, canonical.RequestedPages)
+	reportIssues := joinRuntimeIssues(canonical.Issues)
+	for _, entry := range canonical.Revisions {
+		table.Rows = append(table.Rows, []string{
+			observation,
+			completeness,
+			pages,
+			orDash(entry.Revision.Name),
+			formatRevisionTime(entry.Revision.CreatedAt),
+			orDash(entry.Hash),
+			joinRevisionRoles(entry.Roles),
+			runtimeReferenceDisplay(entry.Source),
+			orDash(string(entry.Consistency)),
+			orDash(string(entry.RelationToLive)),
+			joinIssueCodes(entry.Issues),
+			reportIssues,
+		})
+	}
+	if len(table.Rows) == 0 {
+		table.Rows = append(table.Rows, []string{
+			observation, completeness, pages, "-", "-", "-", "-", "-", "-", "-", "-", reportIssues,
+		})
+	}
+	return table
+}
+
+func (entry RuntimeRevisionEntry) canonical() RuntimeRevisionEntry {
+	result := entry
+	result.Revision.CreatedAt = entry.Revision.CreatedAt.UTC()
+	result.Source = copyRuntimeObjectReference(entry.Source)
+	result.Roles = append([]RuntimeRevisionRole{}, entry.Roles...)
+	sort.Slice(result.Roles, func(i, j int) bool {
+		if revisionRoleOrder(result.Roles[i]) != revisionRoleOrder(result.Roles[j]) {
+			return revisionRoleOrder(result.Roles[i]) < revisionRoleOrder(result.Roles[j])
+		}
+		return result.Roles[i] < result.Roles[j]
+	})
+	result.Issues = append([]RuntimeIssueCode{}, entry.Issues...)
+	sort.Slice(result.Issues, func(i, j int) bool {
+		return result.Issues[i] < result.Issues[j]
+	})
+	return result
+}
+
+func revisionRoleOrder(role RuntimeRevisionRole) int {
+	switch role {
+	case RuntimeRevisionRoleActive:
+		return 0
+	case RuntimeRevisionRoleRequested:
+		return 1
+	case RuntimeRevisionRoleReported:
+		return 2
+	case RuntimeRevisionRoleHistory:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func formatRevisionTime(createdAt time.Time) string {
+	if createdAt.IsZero() {
+		return "-"
+	}
+	return createdAt.UTC().Format(time.RFC3339)
+}
+
+func joinRevisionRoles(roles []RuntimeRevisionRole) string {
+	values := make([]string, len(roles))
+	for i, role := range roles {
+		values[i] = string(role)
+	}
+	return orDash(strings.Join(values, ","))
+}
+
+func joinIssueCodes(issues []RuntimeIssueCode) string {
+	values := make([]string, len(issues))
+	for i, issue := range issues {
+		values[i] = string(issue)
+	}
+	return orDash(strings.Join(values, ","))
+}

--- a/pkg/cli/report/v1alpha1/runtime_history.go
+++ b/pkg/cli/report/v1alpha1/runtime_history.go
@@ -76,7 +76,6 @@ func compareRuntimeRevisionEntries(a, b RuntimeRevisionEntry) int {
 		cmp.Compare(a.Revision.Namespace, b.Revision.Namespace),
 		cmp.Compare(a.Revision.Name, b.Revision.Name),
 		cmp.Compare(a.Revision.UID, b.Revision.UID),
-		cmp.Compare(a.Revision.ResourceVersion, b.Revision.ResourceVersion),
 		cmp.Compare(a.Hash, b.Hash),
 		compareRuntimeObjectReferences(a.Source, b.Source),
 		slices.Compare(a.Roles, b.Roles),
@@ -108,7 +107,6 @@ func compareRuntimeObjectReferences(a, b *RuntimeObjectReference) int {
 		cmp.Compare(a.Name, b.Name),
 		cmp.Compare(a.UID, b.UID),
 		cmp.Compare(a.Generation, b.Generation),
-		cmp.Compare(a.ResourceVersion, b.ResourceVersion),
 	} {
 		if result != 0 {
 			return result

--- a/pkg/cli/report/v1alpha1/runtime_history_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_history_test.go
@@ -58,7 +58,7 @@ func TestRuntimeHistoryCanonicalIsDeterministicForConflictingEntries(t *testing.
 	source := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
 	base := v1alpha1.RuntimeRevisionEntry{
 		Revision: v1alpha1.RuntimeRevisionReference{
-			Namespace: "ome", Name: "revision", UID: "uid", ResourceVersion: "1", CreatedAt: createdAt,
+			Namespace: "ome", Name: "revision", UID: "uid", CreatedAt: createdAt,
 		},
 		Source: &source, Hash: "aaaaaaaa",
 		Roles:          []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory},
@@ -110,20 +110,6 @@ func TestRuntimeHistoryCanonicalIsDeterministicForConflictingEntries(t *testing.
 				return entry
 			},
 			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) { assert.Equal(t, "a", entry.Revision.UID) },
-		},
-		{
-			name: "revision resource version",
-			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
-				entry.Revision.ResourceVersion = "a"
-				return entry
-			},
-			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
-				entry.Revision.ResourceVersion = "z"
-				return entry
-			},
-			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
-				assert.Equal(t, "a", entry.Revision.ResourceVersion)
-			},
 		},
 		{
 			name: "hash",
@@ -230,11 +216,11 @@ func TestRuntimeHistoryCanonicalOrdersEverySourceIdentityField(t *testing.T) {
 	createdAt := time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)
 	baseSource := v1alpha1.RuntimeObjectReference{
 		APIVersion: "ome.io/v1beta1", Kind: v1alpha1.RuntimeKindServingRuntime,
-		Namespace: "prod", Name: "vllm", UID: "uid", Generation: 2, ResourceVersion: "2",
+		Namespace: "prod", Name: "vllm", UID: "uid", Generation: 2,
 	}
 	baseEntry := v1alpha1.RuntimeRevisionEntry{
 		Revision: v1alpha1.RuntimeRevisionReference{
-			Namespace: "ome", Name: "revision", UID: "uid", ResourceVersion: "1", CreatedAt: createdAt,
+			Namespace: "ome", Name: "revision", UID: "uid", CreatedAt: createdAt,
 		},
 		Hash: "aaaaaaaa", Roles: []v1alpha1.RuntimeRevisionRole{}, Issues: []v1alpha1.RuntimeIssueCode{},
 	}
@@ -274,11 +260,6 @@ func TestRuntimeHistoryCanonicalOrdersEverySourceIdentityField(t *testing.T) {
 			name:  "generation",
 			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Generation = 1 }),
 			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Generation = 3 }),
-		},
-		{
-			name:  "resource version",
-			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.ResourceVersion = "1" }),
-			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.ResourceVersion = "3" }),
 		},
 	}
 

--- a/pkg/cli/report/v1alpha1/runtime_history_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_history_test.go
@@ -1,0 +1,607 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestRuntimeHistoryCanonicalReturnsDeepOrderedUTCCopy(t *testing.T) {
+	content := runtimeHistoryContent()
+	wantOriginal := runtimeHistoryContent()
+	originalRuntime := content.Runtime
+	originalSource := content.Revisions[1].Source
+
+	got := content.Canonical()
+
+	assert.Equal(t, []string{"revision-a", "revision-b", "revision-old"}, revisionNames(got.Revisions))
+	assert.Equal(t, []v1alpha1.RuntimeRevisionRole{
+		v1alpha1.RuntimeRevisionRoleActive,
+		v1alpha1.RuntimeRevisionRoleRequested,
+		v1alpha1.RuntimeRevisionRoleReported,
+		v1alpha1.RuntimeRevisionRoleHistory,
+	}, got.Revisions[0].Roles)
+	assert.Equal(t, []v1alpha1.RuntimeIssueCode{
+		v1alpha1.RuntimeIssueRevisionHashInvalid,
+		v1alpha1.RuntimeIssueRevisionNameMismatch,
+	}, got.Revisions[0].Issues)
+	assert.Equal(t, []v1alpha1.RuntimeIssue{
+		{Code: v1alpha1.RuntimeIssueHistoryTruncated},
+		{Code: v1alpha1.RuntimeIssueRevisionHashCollision, Revision: "revision-b"},
+	}, got.Issues)
+	for _, revision := range got.Revisions {
+		assert.Equal(t, time.UTC, revision.Revision.CreatedAt.Location())
+	}
+
+	require.NotSame(t, originalRuntime, got.Runtime)
+	require.NotSame(t, originalSource, got.Revisions[1].Source)
+	got.Runtime.Name = "returned-runtime"
+	got.Revisions[0].Revision.Name = "returned-revision-identity"
+	got.Revisions[1].Source.Name = "returned-revision-source"
+	got.Revisions[0].Roles[0] = v1alpha1.RuntimeRevisionRole("ReturnedRole")
+	got.Revisions[0].Issues[0] = v1alpha1.RuntimeIssueHistoryUnavailable
+	got.Issues[0].Revision = "returned-history-issue"
+
+	assert.Equal(t, wantOriginal, content)
+}
+
+func TestRuntimeHistoryCanonicalIsDeterministicForConflictingEntries(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)
+	source := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
+	base := v1alpha1.RuntimeRevisionEntry{
+		Revision: v1alpha1.RuntimeRevisionReference{
+			Namespace: "ome", Name: "revision", UID: "uid", ResourceVersion: "1", CreatedAt: createdAt,
+		},
+		Source: &source, Hash: "aaaaaaaa",
+		Roles:          []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory},
+		Consistency:    v1alpha1.RevisionConsistencyConsistent,
+		RelationToLive: v1alpha1.RevisionRelationMatchesLive,
+		Issues:         []v1alpha1.RuntimeIssueCode{v1alpha1.RuntimeIssueRevisionHashInvalid},
+	}
+
+	tests := []struct {
+		name   string
+		early  func(v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry
+		late   func(v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry
+		assert func(*testing.T, v1alpha1.RuntimeRevisionEntry)
+	}{
+		{
+			name: "revision namespace",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.Namespace = "a"
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.Namespace = "z"
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
+				assert.Equal(t, "a", entry.Revision.Namespace)
+			},
+		},
+		{
+			name: "revision name",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.Name = "a"
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.Name = "z"
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) { assert.Equal(t, "a", entry.Revision.Name) },
+		},
+		{
+			name: "revision uid",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.UID = "a"
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.UID = "z"
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) { assert.Equal(t, "a", entry.Revision.UID) },
+		},
+		{
+			name: "revision resource version",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.ResourceVersion = "a"
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Revision.ResourceVersion = "z"
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
+				assert.Equal(t, "a", entry.Revision.ResourceVersion)
+			},
+		},
+		{
+			name: "hash",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Hash = "aaaaaaaa"
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Hash = "zzzzzzzz"
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) { assert.Equal(t, "aaaaaaaa", entry.Hash) },
+		},
+		{
+			name: "source identity",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				sourceCopy := *entry.Source
+				sourceCopy.Name = "a"
+				entry.Source = &sourceCopy
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				sourceCopy := *entry.Source
+				sourceCopy.Name = "z"
+				entry.Source = &sourceCopy
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) { assert.Equal(t, "a", entry.Source.Name) },
+		},
+		{
+			name: "roles",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Roles = []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleActive}
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Roles = []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory}
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
+				assert.Equal(t, []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleActive}, entry.Roles)
+			},
+		},
+		{
+			name: "consistency",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Consistency = v1alpha1.RevisionConsistencyConsistent
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Consistency = v1alpha1.RevisionConsistencyUnknown
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
+				assert.Equal(t, v1alpha1.RevisionConsistencyConsistent, entry.Consistency)
+			},
+		},
+		{
+			name: "relation",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.RelationToLive = v1alpha1.RevisionRelationDiffersFromLive
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.RelationToLive = v1alpha1.RevisionRelationUnknown
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
+				assert.Equal(t, v1alpha1.RevisionRelationDiffersFromLive, entry.RelationToLive)
+			},
+		},
+		{
+			name: "issues",
+			early: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Issues = []v1alpha1.RuntimeIssueCode{v1alpha1.RuntimeIssueRevisionHashInvalid}
+				return entry
+			},
+			late: func(entry v1alpha1.RuntimeRevisionEntry) v1alpha1.RuntimeRevisionEntry {
+				entry.Issues = []v1alpha1.RuntimeIssueCode{v1alpha1.RuntimeIssueRevisionNameMismatch}
+				return entry
+			},
+			assert: func(t *testing.T, entry v1alpha1.RuntimeRevisionEntry) {
+				assert.Equal(t, []v1alpha1.RuntimeIssueCode{v1alpha1.RuntimeIssueRevisionHashInvalid}, entry.Issues)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			early, late := tt.early(base), tt.late(base)
+			forward := (v1alpha1.RuntimeHistoryContent{Revisions: []v1alpha1.RuntimeRevisionEntry{early, late}}).Canonical()
+			reverse := (v1alpha1.RuntimeHistoryContent{Revisions: []v1alpha1.RuntimeRevisionEntry{late, early}}).Canonical()
+
+			require.Len(t, forward.Revisions, 2)
+			require.True(t, slices.EqualFunc(forward.Revisions, reverse.Revisions, func(a, b v1alpha1.RuntimeRevisionEntry) bool {
+				return reflect.DeepEqual(a, b)
+			}), "input order must not affect canonical history")
+			tt.assert(t, forward.Revisions[0])
+		})
+	}
+}
+
+func TestRuntimeHistoryCanonicalOrdersEverySourceIdentityField(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)
+	baseSource := v1alpha1.RuntimeObjectReference{
+		APIVersion: "ome.io/v1beta1", Kind: v1alpha1.RuntimeKindServingRuntime,
+		Namespace: "prod", Name: "vllm", UID: "uid", Generation: 2, ResourceVersion: "2",
+	}
+	baseEntry := v1alpha1.RuntimeRevisionEntry{
+		Revision: v1alpha1.RuntimeRevisionReference{
+			Namespace: "ome", Name: "revision", UID: "uid", ResourceVersion: "1", CreatedAt: createdAt,
+		},
+		Hash: "aaaaaaaa", Roles: []v1alpha1.RuntimeRevisionRole{}, Issues: []v1alpha1.RuntimeIssueCode{},
+	}
+
+	tests := []struct {
+		name  string
+		early *v1alpha1.RuntimeObjectReference
+		late  *v1alpha1.RuntimeObjectReference
+	}{
+		{name: "nil", early: nil, late: runtimeSourceCopy(baseSource, func(*v1alpha1.RuntimeObjectReference) {})},
+		{
+			name:  "api version",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.APIVersion = "a" }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.APIVersion = "z" }),
+		},
+		{
+			name:  "kind",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Kind = v1alpha1.RuntimeKindClusterServingRuntime }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Kind = v1alpha1.RuntimeKindServingRuntime }),
+		},
+		{
+			name:  "namespace",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Namespace = "a" }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Namespace = "z" }),
+		},
+		{
+			name:  "name",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Name = "a" }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Name = "z" }),
+		},
+		{
+			name:  "uid",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.UID = "a" }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.UID = "z" }),
+		},
+		{
+			name:  "generation",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Generation = 1 }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.Generation = 3 }),
+		},
+		{
+			name:  "resource version",
+			early: runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.ResourceVersion = "1" }),
+			late:  runtimeSourceCopy(baseSource, func(source *v1alpha1.RuntimeObjectReference) { source.ResourceVersion = "3" }),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			early, late := baseEntry, baseEntry
+			early.Source, late.Source = tt.early, tt.late
+			forward := (v1alpha1.RuntimeHistoryContent{Revisions: []v1alpha1.RuntimeRevisionEntry{early, late}}).Canonical()
+			reverse := (v1alpha1.RuntimeHistoryContent{Revisions: []v1alpha1.RuntimeRevisionEntry{late, early}}).Canonical()
+
+			require.Len(t, forward.Revisions, 2)
+			assert.True(t, reflect.DeepEqual(forward.Revisions, reverse.Revisions), "input order must not affect source ordering")
+			assert.Equal(t, tt.early, forward.Revisions[0].Source)
+		})
+	}
+}
+
+func TestRuntimeHistoryAllowsUnavailableRuntimeIdentity(t *testing.T) {
+	runtimeField, ok := reflect.TypeOf(v1alpha1.RuntimeHistoryContent{}).FieldByName("Runtime")
+	require.True(t, ok)
+	assert.Equal(t, reflect.Pointer, runtimeField.Type.Kind())
+	assert.Contains(t, runtimeField.Tag.Get("json"), "omitempty")
+
+	reportValue := v1alpha1.NewRuntimeHistoryReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RuntimeHistoryContent{
+			Observation:  v1alpha1.HistoryObservationStateUnavailable,
+			Completeness: v1alpha1.HistoryCompletenessIncomplete,
+			Issues:       []v1alpha1.RuntimeIssue{{Code: v1alpha1.RuntimeIssueHistoryUnavailable}},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatJSON, reportValue))
+	assert.NotContains(t, output.String(), `"runtime"`)
+}
+
+func TestRuntimeHistoryCanonicalNormalizesNilSlices(t *testing.T) {
+	content := v1alpha1.RuntimeHistoryContent{
+		Revisions: []v1alpha1.RuntimeRevisionEntry{{}},
+	}
+
+	got := content.Canonical()
+
+	assert.NotNil(t, got.Revisions)
+	assert.NotNil(t, got.Revisions[0].Roles)
+	assert.NotNil(t, got.Revisions[0].Issues)
+	assert.NotNil(t, got.Issues)
+}
+
+func TestNewRuntimeHistoryReportUsesFixedKindAndUTCClock(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 11, 30, 0, 0, time.FixedZone("test", -7*60*60))
+
+	got := v1alpha1.NewRuntimeHistoryReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RuntimeHistoryContent{},
+		fixedClock{now: now},
+	)
+
+	assert.Equal(t, v1alpha1.RuntimeHistoryReportKind, got.Kind)
+	assert.Equal(t, "2026-08-31T18:30:00Z", got.CollectedAt.Format(time.RFC3339))
+	assert.NotNil(t, got.Content.Revisions)
+	assert.NotNil(t, got.Content.Issues)
+}
+
+func TestRuntimeHistoryTableContract(t *testing.T) {
+	reportValue := v1alpha1.NewRuntimeHistoryReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		runtimeHistoryContent(),
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+
+	assert.Equal(t, report.Table{
+		Headers: []string{
+			"OBSERVATION", "COMPLETENESS", "PAGES", "REVISION", "CREATED", "HASH", "ROLES", "SOURCE",
+			"CONSISTENCY", "RELATION", "REVISION-ISSUES", "REPORT-ISSUES",
+		},
+		Rows: [][]string{
+			{"Partial", "Incomplete", "2/3", "revision-a", "2026-08-31T18:20:00Z", "aaaaaaaa", "Active,Requested,Reported,History", "ServingRuntime/prod/vllm", "Inconsistent", "MatchesLive", "RevisionHashInvalid,RevisionNameMismatch", "HistoryTruncated,RevisionHashCollision(revision-b)"},
+			{"Partial", "Incomplete", "2/3", "revision-b", "2026-08-31T18:20:00Z", "bbbbbbbb", "History", "ServingRuntime/prod/vllm", "Inconsistent", "DiffersFromLive", "RevisionSourceMismatch", "HistoryTruncated,RevisionHashCollision(revision-b)"},
+			{"Partial", "Incomplete", "2/3", "revision-old", "2026-08-31T18:10:00Z", "-", "-", "-", "Unknown", "Unknown", "-", "HistoryTruncated,RevisionHashCollision(revision-b)"},
+		},
+	}, reportValue.Table())
+
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatTable, reportValue))
+	assert.Equal(t,
+		"OBSERVATION   COMPLETENESS   PAGES   REVISION       CREATED                HASH       ROLES                               SOURCE                     CONSISTENCY    RELATION          REVISION-ISSUES                            REPORT-ISSUES\n"+
+			"Partial       Incomplete     2/3     revision-a     2026-08-31T18:20:00Z   aaaaaaaa   Active,Requested,Reported,History   ServingRuntime/prod/vllm   Inconsistent   MatchesLive       RevisionHashInvalid,RevisionNameMismatch   HistoryTruncated,RevisionHashCollision(revision-b)\n"+
+			"Partial       Incomplete     2/3     revision-b     2026-08-31T18:20:00Z   bbbbbbbb   History                             ServingRuntime/prod/vllm   Inconsistent   DiffersFromLive   RevisionSourceMismatch                     HistoryTruncated,RevisionHashCollision(revision-b)\n"+
+			"Partial       Incomplete     2/3     revision-old   2026-08-31T18:10:00Z   -          -                                   -                          Unknown        Unknown           -                                          HistoryTruncated,RevisionHashCollision(revision-b)\n",
+		output.String())
+}
+
+func TestRuntimeHistoryEmptyFormsHaveDiagnosticSummaryRow(t *testing.T) {
+	tests := []struct {
+		content v1alpha1.RuntimeHistoryContent
+		want    []string
+	}{
+		{
+			content: v1alpha1.RuntimeHistoryContent{
+				Observation: v1alpha1.HistoryObservationStateNotRequested, Completeness: v1alpha1.HistoryCompletenessNotRequested,
+			},
+			want: []string{"NotRequested", "NotRequested", "0/0", "-", "-", "-", "-", "-", "-", "-", "-", "-"},
+		},
+		{
+			content: v1alpha1.RuntimeHistoryContent{
+				Observation: v1alpha1.HistoryObservationStateComplete, Completeness: v1alpha1.HistoryCompletenessRetentionBounded,
+				RequestedPages: 1, ObservedPages: 1,
+			},
+			want: []string{"Complete", "RetentionBounded", "1/1", "-", "-", "-", "-", "-", "-", "-", "-", "-"},
+		},
+		{
+			content: v1alpha1.RuntimeHistoryContent{
+				Observation:    v1alpha1.HistoryObservationStateUnavailable,
+				Completeness:   v1alpha1.HistoryCompletenessIncomplete,
+				RequestedPages: 1,
+				Issues:         []v1alpha1.RuntimeIssue{{Code: v1alpha1.RuntimeIssueHistoryUnavailable}},
+			},
+			want: []string{"Unavailable", "Incomplete", "0/1", "-", "-", "-", "-", "-", "-", "-", "-", "HistoryUnavailable"},
+		},
+	}
+	for _, tt := range tests {
+		canonical := tt.content.Canonical()
+		assert.NotNil(t, canonical.Revisions)
+		assert.Equal(t, [][]string{tt.want}, canonical.Table().Rows)
+	}
+}
+
+func TestRuntimeHistoryMachineOutputContract(t *testing.T) {
+	reportValue := v1alpha1.NewRuntimeHistoryReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		runtimeHistoryMachineContent(),
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+	tests := []struct {
+		name   string
+		format report.Format
+		want   string
+	}{
+		{
+			name:   "json",
+			format: report.FormatJSON,
+			want: "{\n" +
+				`  "apiVersion": "cli.ome.io/v1alpha1",` + "\n" +
+				`  "kind": "RuntimeHistoryReport",` + "\n" +
+				`  "metadata": {` + "\n" +
+				`    "namespace": "prod",` + "\n" +
+				`    "name": "chat"` + "\n" +
+				"  },\n" +
+				`  "collectedAt": "2026-08-31T18:30:00Z",` + "\n" +
+				`  "sources": [],` + "\n" +
+				`  "content": {` + "\n" +
+				`    "runtime": {` + "\n" +
+				`      "apiVersion": "ome.io/v1beta1",` + "\n" +
+				`      "kind": "ServingRuntime",` + "\n" +
+				`      "namespace": "prod",` + "\n" +
+				`      "name": "vllm"` + "\n" +
+				"    },\n" +
+				`    "observation": "Complete",` + "\n" +
+				`    "completeness": "RetentionBounded",` + "\n" +
+				`    "requestedPages": 2,` + "\n" +
+				`    "observedPages": 2,` + "\n" +
+				`    "revisions": [` + "\n" +
+				"      {\n" +
+				`        "revision": {` + "\n" +
+				`          "namespace": "ome",` + "\n" +
+				`          "name": "revision-a",` + "\n" +
+				`          "createdAt": "2026-08-31T18:20:00Z"` + "\n" +
+				"        },\n" +
+				`        "source": {` + "\n" +
+				`          "apiVersion": "ome.io/v1beta1",` + "\n" +
+				`          "kind": "ServingRuntime",` + "\n" +
+				`          "namespace": "prod",` + "\n" +
+				`          "name": "vllm"` + "\n" +
+				"        },\n" +
+				`        "hash": "aaaaaaaa",` + "\n" +
+				`        "roles": [` + "\n" +
+				`          "Active",` + "\n" +
+				`          "History"` + "\n" +
+				"        ],\n" +
+				`        "consistency": "Consistent",` + "\n" +
+				`        "relationToLive": "MatchesLive",` + "\n" +
+				`        "issues": []` + "\n" +
+				"      }\n" +
+				"    ],\n" +
+				`    "issues": []` + "\n" +
+				"  },\n" +
+				`  "warnings": []` + "\n" +
+				"}\n",
+		},
+		{
+			name:   "yaml",
+			format: report.FormatYAML,
+			want: "apiVersion: cli.ome.io/v1alpha1\n" +
+				"collectedAt: \"2026-08-31T18:30:00Z\"\n" +
+				"content:\n" +
+				"  completeness: RetentionBounded\n" +
+				"  issues: []\n" +
+				"  observation: Complete\n" +
+				"  observedPages: 2\n" +
+				"  requestedPages: 2\n" +
+				"  revisions:\n" +
+				"  - consistency: Consistent\n" +
+				"    hash: aaaaaaaa\n" +
+				"    issues: []\n" +
+				"    relationToLive: MatchesLive\n" +
+				"    revision:\n" +
+				"      createdAt: \"2026-08-31T18:20:00Z\"\n" +
+				"      name: revision-a\n" +
+				"      namespace: ome\n" +
+				"    roles:\n" +
+				"    - Active\n" +
+				"    - History\n" +
+				"    source:\n" +
+				"      apiVersion: ome.io/v1beta1\n" +
+				"      kind: ServingRuntime\n" +
+				"      name: vllm\n" +
+				"      namespace: prod\n" +
+				"  runtime:\n" +
+				"    apiVersion: ome.io/v1beta1\n" +
+				"    kind: ServingRuntime\n" +
+				"    name: vllm\n" +
+				"    namespace: prod\n" +
+				"kind: RuntimeHistoryReport\n" +
+				"metadata:\n" +
+				"  name: chat\n" +
+				"  namespace: prod\n" +
+				"sources: []\n" +
+				"warnings: []\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, report.Write(&output, tt.format, reportValue))
+			assert.Equal(t, tt.want, output.String())
+		})
+	}
+}
+
+func TestRuntimeHistorySchemaIsStrictlyAllowlisted(t *testing.T) {
+	assertRuntimeReportSchema(t, reflect.TypeOf(v1alpha1.RuntimeEnvelope[v1alpha1.RuntimeHistoryContent]{}), map[reflect.Type]bool{})
+}
+
+func runtimeHistoryContent() v1alpha1.RuntimeHistoryContent {
+	location := time.FixedZone("test", -7*60*60)
+	newest := time.Date(2026, time.August, 31, 11, 20, 0, 0, location)
+	older := time.Date(2026, time.August, 31, 11, 10, 0, 0, location)
+	source := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
+	return v1alpha1.RuntimeHistoryContent{
+		Runtime:        &source,
+		Observation:    v1alpha1.HistoryObservationStatePartial,
+		Completeness:   v1alpha1.HistoryCompletenessIncomplete,
+		RequestedPages: 3,
+		ObservedPages:  2,
+		Revisions: []v1alpha1.RuntimeRevisionEntry{
+			{
+				Revision:    v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-old", CreatedAt: older},
+				Consistency: v1alpha1.RevisionConsistencyUnknown, RelationToLive: v1alpha1.RevisionRelationUnknown,
+			},
+			{
+				Revision: v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-b", CreatedAt: newest},
+				Source:   &source, Hash: "bbbbbbbb", Roles: []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory},
+				Consistency: v1alpha1.RevisionConsistencyInconsistent, RelationToLive: v1alpha1.RevisionRelationDiffersFromLive,
+				Issues: []v1alpha1.RuntimeIssueCode{v1alpha1.RuntimeIssueRevisionSourceMismatch},
+			},
+			{
+				Revision: v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-a", CreatedAt: newest},
+				Source:   &source, Hash: "aaaaaaaa",
+				Roles: []v1alpha1.RuntimeRevisionRole{
+					v1alpha1.RuntimeRevisionRoleHistory, v1alpha1.RuntimeRevisionRoleReported,
+					v1alpha1.RuntimeRevisionRoleRequested, v1alpha1.RuntimeRevisionRoleActive,
+				},
+				Consistency: v1alpha1.RevisionConsistencyInconsistent, RelationToLive: v1alpha1.RevisionRelationMatchesLive,
+				Issues: []v1alpha1.RuntimeIssueCode{
+					v1alpha1.RuntimeIssueRevisionNameMismatch, v1alpha1.RuntimeIssueRevisionHashInvalid,
+				},
+			},
+		},
+		Issues: []v1alpha1.RuntimeIssue{
+			{Code: v1alpha1.RuntimeIssueRevisionHashCollision, Revision: "revision-b"},
+			{Code: v1alpha1.RuntimeIssueHistoryTruncated},
+		},
+	}
+}
+
+func runtimeHistoryMachineContent() v1alpha1.RuntimeHistoryContent {
+	source := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
+	return v1alpha1.RuntimeHistoryContent{
+		Runtime:        &source,
+		Observation:    v1alpha1.HistoryObservationStateComplete,
+		Completeness:   v1alpha1.HistoryCompletenessRetentionBounded,
+		RequestedPages: 2,
+		ObservedPages:  2,
+		Revisions: []v1alpha1.RuntimeRevisionEntry{{
+			Revision: v1alpha1.RuntimeRevisionReference{
+				Namespace: "ome", Name: "revision-a", CreatedAt: time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC),
+			},
+			Source: &source, Hash: "aaaaaaaa",
+			Roles:          []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory, v1alpha1.RuntimeRevisionRoleActive},
+			Consistency:    v1alpha1.RevisionConsistencyConsistent,
+			RelationToLive: v1alpha1.RevisionRelationMatchesLive,
+			Issues:         nil,
+		}},
+		Issues: nil,
+	}
+}
+
+func revisionNames(revisions []v1alpha1.RuntimeRevisionEntry) []string {
+	result := make([]string, 0, len(revisions))
+	for _, revision := range revisions {
+		result = append(result, revision.Revision.Name)
+	}
+	return result
+}
+
+func runtimeSourceCopy(
+	source v1alpha1.RuntimeObjectReference,
+	mutate func(*v1alpha1.RuntimeObjectReference),
+) *v1alpha1.RuntimeObjectReference {
+	mutate(&source)
+	return &source
+}

--- a/pkg/cli/report/v1alpha1/testdata/hostile_runtime_content/hostile.go
+++ b/pkg/cli/report/v1alpha1/testdata/hostile_runtime_content/hostile.go
@@ -1,0 +1,21 @@
+package hostile_runtime_content
+
+import (
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+type hostileContent struct {
+	v1alpha1.RuntimeEffectiveContent
+	ResourceVersion string `json:"resourceVersion"`
+}
+
+func (content hostileContent) Canonical() hostileContent {
+	return content
+}
+
+func (hostileContent) Table() report.Table {
+	return report.Table{}
+}
+
+var _ = v1alpha1.RuntimeEnvelope[hostileContent]{}


### PR DESCRIPTION
## What this PR does

Adds the two versioned, allowlisted report contracts that upcoming
`kubectl ome runtime effective` and `kubectl ome runtime history` commands
will render:

- `RuntimeEffectiveReport` compares the declared runtime, live runtime,
  controller-selected revision, deployment modes, pin state, drift, and status
  freshness.
- `RuntimeHistoryReport` records the bounded ControllerRevision window,
  requested/reported/active roles, source identity, consistency, and relation
  to the live runtime.

The contracts use concrete Go types only. They contain no maps, raw
extensions, runtime specs, pod templates, images, commands, environment
variables, Secrets, arbitrary labels or annotations, raw errors or messages,
or synchronization-token values. Canonicalization returns defensive copies,
normalizes empty collections to `[]`, converts timestamps to UTC, and makes
table, JSON, and YAML ordering deterministic.

History reports omit the runtime field when selection cannot establish a
runtime identity, instead of fabricating an empty object. Conflicting
same-name revision observations use complete identity and evidence
tie-breakers, so API return order cannot change rendered output.

No command is wired in this contract PR, so current `kubectl ome` output does
not change. The collector/projection and command PRs will consume these exact
schemas. For a representative managed pin, the table renderer produces this
exact output:

```text
VIEW     STATE       REASON   RUNTIME                            REVISION                       HASH       COMPONENT   MODE            MODE-SOURCE   PIN          PIN-STATE   SYNC           STATUS    DRIFT                           LIVE-RELATION   ISSUES
Live     Available   -        ServingRuntime/prod/team-runtime   -                              eeeeeeee   engine      OMENative       ServiceSpec   ManagedPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Different       -
Active   Available   -        ServingRuntime/prod/team-runtime   r-prod-team-runtime-aaaaaaaa   aaaaaaaa   engine      RawDeployment   Default       ManagedPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Different       -
```

The same effective report renders as exact automation-safe JSON:

```json
{
  "apiVersion": "cli.ome.io/v1alpha1",
  "kind": "RuntimeEffectiveReport",
  "metadata": {
    "namespace": "prod",
    "name": "chat"
  },
  "collectedAt": "2026-08-31T18:30:00Z",
  "sources": [],
  "content": {
    "selection": {
      "source": "Explicit",
      "runtime": {
        "apiVersion": "ome.io/v1beta1",
        "kind": "ServingRuntime",
        "namespace": "prod",
        "name": "team-runtime"
      }
    },
    "inheritance": {
      "state": "Observed",
      "sources": [
        {
          "apiVersion": "ome.io/v1beta1",
          "kind": "ServingRuntime",
          "namespace": "prod",
          "name": "team-runtime"
        }
      ]
    },
    "pin": {
      "mode": "ManagedPin",
      "state": "Resolved",
      "reportedRevision": "r-prod-team-runtime-aaaaaaaa",
      "status": {
        "generation": 9,
        "observedGeneration": 9,
        "freshness": "Current"
      },
      "reportedDrift": {
        "state": "ReportedTrue",
        "cause": "RevisionMismatch"
      },
      "syncState": "Acknowledged"
    },
    "live": {
      "state": "Available",
      "origin": "LiveRuntime",
      "source": {
        "apiVersion": "ome.io/v1beta1",
        "kind": "ServingRuntime",
        "namespace": "prod",
        "name": "team-runtime"
      },
      "hash": "eeeeeeee",
      "components": [
        {
          "type": "engine",
          "deploymentMode": "OMENative",
          "deploymentModeSource": "ServiceSpec"
        }
      ]
    },
    "active": {
      "state": "Available",
      "origin": "ControllerRevision",
      "source": {
        "apiVersion": "ome.io/v1beta1",
        "kind": "ServingRuntime",
        "namespace": "prod",
        "name": "team-runtime"
      },
      "revision": {
        "namespace": "ome",
        "name": "r-prod-team-runtime-aaaaaaaa",
        "createdAt": "2026-08-30T16:00:00Z"
      },
      "hash": "aaaaaaaa",
      "components": [
        {
          "type": "engine",
          "deploymentMode": "RawDeployment",
          "deploymentModeSource": "Default"
        }
      ]
    },
    "liveToActive": "Different",
    "issues": []
  },
  "warnings": []
}
```

History uses the same typed envelope and renders this exact YAML shape:

```yaml
apiVersion: cli.ome.io/v1alpha1
collectedAt: "2026-08-31T18:30:00Z"
content:
  completeness: RetentionBounded
  issues: []
  observation: Complete
  observedPages: 1
  requestedPages: 1
  revisions:
  - consistency: Consistent
    hash: aaaaaaaa
    issues: []
    relationToLive: DiffersFromLive
    revision:
      createdAt: "2026-08-30T16:00:00Z"
      name: r-prod-team-runtime-aaaaaaaa
      namespace: ome
    roles:
    - Active
    - Reported
    - History
    source:
      apiVersion: ome.io/v1beta1
      kind: ServingRuntime
      name: team-runtime
      namespace: prod
  runtime:
    apiVersion: ome.io/v1beta1
    kind: ServingRuntime
    name: team-runtime
    namespace: prod
kind: RuntimeHistoryReport
metadata:
  name: chat
  namespace: prod
sources: []
warnings: []
```

## Why we need it

Runtime operations now need to explain inherited configuration, OMENative and
other component deployment modes, manual runtime pins, drift, and retained
revision history without serializing credential-bearing runtime or pod specs.
One reviewed schema prevents each command from inventing incompatible fields,
ordering, redaction, and partial-data semantics.

Fixes # — N/A; tracked by OEP-0011.1 runtime diagnostics.

## How to test

```shell
go test -count=1 ./cmd/kubectl-ome ./pkg/cli/...
go test -race -count=1 ./pkg/cli/...
go vet ./cmd/kubectl-ome ./pkg/cli/...
go build ./cmd/kubectl-ome
```

The report packages have 96.4% and 94.2% statement coverage. Exact-output
tests pin table, JSON, and YAML; additional tests cover closed enum spellings,
strict schema redaction, forbidden-field negative fixtures, UTC timestamps,
nil normalization, stable sorting, defensive copying, an external compile-time
envelope-escape canary, missing runtime identity, unavailable configurations,
and control-character-safe table cells.
Linux, Darwin, and Windows cross-compiles pass for amd64 and arm64 with
`CGO_ENABLED=0`.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (the complete report and output contracts are documented
  above; no repository documentation changes are needed for this internal
  contract PR)
- [ ] `make test` passes locally

The submitted commit passes the full scoped CLI suite, scoped race detector,
vet, host build, and six cross-compiles. Required repository CI remains the
authoritative full-suite gate.
