### PR TITLE
[Core] Add runtime pin provenance

### DIFF
--- a/pkg/cli/effective/runtime_pin.go
+++ b/pkg/cli/effective/runtime_pin.go
@@ -1,0 +1,728 @@
+package effective
+
+import (
+	"context"
+	"errors"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+// ErrActiveRuntimeUnavailable indicates that controller evidence does not
+// select an active runtime configuration.
+var ErrActiveRuntimeUnavailable = errors.New("active runtime configuration is unavailable")
+
+// ErrActiveRuntimeInconsistent indicates that the selected configuration is
+// controller-readable but fails the stronger consistency contract.
+var ErrActiveRuntimeInconsistent = errors.New("active runtime configuration is not consistency-safe")
+
+type liveRuntimeResolver interface {
+	ResolveLive(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error)
+}
+
+type revisionNamespace interface {
+	Get(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error)
+	List(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error)
+}
+
+type revisionNamespaceGetter func(string) revisionNamespace
+
+type typedRevisionGetter struct {
+	getter appstyped.ControllerRevisionsGetter
+}
+
+func (g typedRevisionGetter) namespace(namespace string) revisionNamespace {
+	return g.getter.ControllerRevisions(namespace)
+}
+
+// ConfigurationOrigin identifies the snapshot used to form an active
+// configuration.
+type ConfigurationOrigin string
+
+const (
+	ConfigurationOriginLiveRuntime        ConfigurationOrigin = "LiveRuntime"
+	ConfigurationOriginControllerRevision ConfigurationOrigin = "ControllerRevision"
+)
+
+// RuntimePinMode describes whether controller intent selects live runtime
+// content, a managed status pin, or an explicit requested pin.
+type RuntimePinMode string
+
+const (
+	RuntimePinModeAutoSync    RuntimePinMode = "AutoSync"
+	RuntimePinModeManagedPin  RuntimePinMode = "ManagedPin"
+	RuntimePinModeExplicitPin RuntimePinMode = "ExplicitPin"
+	RuntimePinModeInvalidPin  RuntimePinMode = "InvalidPin"
+)
+
+// RuntimePinState summarizes the controller-usable outcome of pin resolution.
+type RuntimePinState string
+
+const (
+	RuntimePinStateNotApplicable           RuntimePinState = "NotApplicable"
+	RuntimePinStateAwaitingPin             RuntimePinState = "AwaitingPin"
+	RuntimePinStateResolved                RuntimePinState = "Resolved"
+	RuntimePinStateDesiredReportedMismatch RuntimePinState = "DesiredReportedMismatch"
+	RuntimePinStateRevisionMissing         RuntimePinState = "RevisionMissing"
+	RuntimePinStateRevisionInvalid         RuntimePinState = "RevisionInvalid"
+	RuntimePinStateRevisionDisabled        RuntimePinState = "RevisionDisabled"
+	RuntimePinStateUnavailable             RuntimePinState = "Unavailable"
+	RuntimePinStateInvalidIntent           RuntimePinState = "InvalidIntent"
+)
+
+// StatusFreshness compares status.observedGeneration with object generation.
+type StatusFreshness string
+
+const (
+	StatusFreshnessCurrent      StatusFreshness = "Current"
+	StatusFreshnessStale        StatusFreshness = "Stale"
+	StatusFreshnessInconsistent StatusFreshness = "Inconsistent"
+	StatusFreshnessUnknown      StatusFreshness = "Unknown"
+)
+
+// SyncTokenState reports the relationship between private sync-token values
+// without exposing either value.
+type SyncTokenState string
+
+const (
+	SyncTokenStateAbsent       SyncTokenState = "Absent"
+	SyncTokenStateAcknowledged SyncTokenState = "Acknowledged"
+	SyncTokenStatePending      SyncTokenState = "Pending"
+	SyncTokenStateStatusOnly   SyncTokenState = "StatusOnly"
+)
+
+// RuntimeDriftState is the bounded state of the RuntimeDrifted condition.
+type RuntimeDriftState string
+
+const (
+	RuntimeDriftStateNotReported     RuntimeDriftState = "NotReported"
+	RuntimeDriftStateReportedTrue    RuntimeDriftState = "ReportedTrue"
+	RuntimeDriftStateReportedFalse   RuntimeDriftState = "ReportedFalse"
+	RuntimeDriftStateReportedUnknown RuntimeDriftState = "ReportedUnknown"
+	RuntimeDriftStateMalformed       RuntimeDriftState = "Malformed"
+)
+
+// RuntimeDriftReason is the allowlisted reason for reported runtime drift.
+type RuntimeDriftReason string
+
+const (
+	RuntimeDriftReasonRevisionMismatch     RuntimeDriftReason = "RevisionMismatch"
+	RuntimeDriftReasonRevisionMissing      RuntimeDriftReason = "RevisionMissing"
+	RuntimeDriftReasonSourceRuntimeMissing RuntimeDriftReason = "SourceRuntimeMissing"
+	RuntimeDriftReasonRuntimeMismatch      RuntimeDriftReason = "RuntimeMismatch"
+	RuntimeDriftReasonPinAdvanced          RuntimeDriftReason = "PinAdvanced"
+	RuntimeDriftReasonOther                RuntimeDriftReason = "Other"
+)
+
+// RuntimeHashRelation compares recomputed runtime content hashes.
+type RuntimeHashRelation string
+
+const (
+	RuntimeHashRelationUnknown   RuntimeHashRelation = "Unknown"
+	RuntimeHashRelationEqual     RuntimeHashRelation = "Equal"
+	RuntimeHashRelationDifferent RuntimeHashRelation = "Different"
+	RuntimeHashRelationAmbiguous RuntimeHashRelation = "Ambiguous"
+)
+
+// LiveRuntimeAvailability is the bounded outcome of independent live runtime
+// resolution. Unavailable includes hard read failures and incomplete snapshots.
+type LiveRuntimeAvailability string
+
+const (
+	LiveRuntimeAvailable   LiveRuntimeAvailability = "Available"
+	LiveRuntimeNotFound    LiveRuntimeAvailability = "NotFound"
+	LiveRuntimeDisabled    LiveRuntimeAvailability = "Disabled"
+	LiveRuntimeUnavailable LiveRuntimeAvailability = "Unavailable"
+)
+
+// RevisionConsistencyState summarizes the revision writer-contract checks.
+type RevisionConsistencyState string
+
+const (
+	RevisionConsistencyConsistent   RevisionConsistencyState = "Consistent"
+	RevisionConsistencyInconsistent RevisionConsistencyState = "Inconsistent"
+	RevisionConsistencyUnknown      RevisionConsistencyState = "Unknown"
+)
+
+// RevisionConsistencyCode identifies a bounded consistency or collection
+// anomaly without exposing raw revision content.
+type RevisionConsistencyCode string
+
+const (
+	RevisionConsistencyCreatedBy            RevisionConsistencyCode = "CreatedBy"
+	RevisionConsistencySourceName           RevisionConsistencyCode = "SourceName"
+	RevisionConsistencySourceKind           RevisionConsistencyCode = "SourceKind"
+	RevisionConsistencySourceNamespace      RevisionConsistencyCode = "SourceNamespace"
+	RevisionConsistencyHashLabelInvalid     RevisionConsistencyCode = "HashLabelInvalid"
+	RevisionConsistencyHashLabelMismatch    RevisionConsistencyCode = "HashLabelMismatch"
+	RevisionConsistencyNameHash             RevisionConsistencyCode = "NameHash"
+	RevisionConsistencyOrdinal              RevisionConsistencyCode = "Ordinal"
+	RevisionConsistencyPayloadCanonicality  RevisionConsistencyCode = "PayloadCanonicality"
+	RevisionConsistencyUnexpectedDataObject RevisionConsistencyCode = "UnexpectedDataObject"
+	RevisionConsistencyMalformedPayload     RevisionConsistencyCode = "MalformedPayload"
+	RevisionConsistencyReturnedIdentity     RevisionConsistencyCode = "ReturnedIdentity"
+	RevisionConsistencyDuplicateIdentity    RevisionConsistencyCode = "DuplicateIdentity"
+	RevisionConsistencyConflictingIdentity  RevisionConsistencyCode = "ConflictingIdentity"
+	RevisionConsistencyDuplicateContentHash RevisionConsistencyCode = "DuplicateContentHash"
+	RevisionConsistencyShortHashCollision   RevisionConsistencyCode = "ShortHashCollision"
+)
+
+// RuntimeRevisionRole records why a revision observation was collected.
+type RuntimeRevisionRole string
+
+const (
+	RuntimeRevisionRoleRequested RuntimeRevisionRole = "Requested"
+	RuntimeRevisionRoleReported  RuntimeRevisionRole = "Reported"
+	RuntimeRevisionRoleActive    RuntimeRevisionRole = "Active"
+	RuntimeRevisionRoleHistory   RuntimeRevisionRole = "History"
+)
+
+// RuntimeSourceIssueCode classifies a bounded evidence-source failure.
+type RuntimeSourceIssueCode string
+
+const (
+	RuntimeSourceIssueLiveNotFound       RuntimeSourceIssueCode = "LiveNotFound"
+	RuntimeSourceIssueLiveDisabled       RuntimeSourceIssueCode = "LiveDisabled"
+	RuntimeSourceIssueLiveUnavailable    RuntimeSourceIssueCode = "LiveUnavailable"
+	RuntimeSourceIssueRevisionNotFound   RuntimeSourceIssueCode = "RevisionNotFound"
+	RuntimeSourceIssueRevisionGetFailed  RuntimeSourceIssueCode = "RevisionGetFailed"
+	RuntimeSourceIssueRevisionListFailed RuntimeSourceIssueCode = "RevisionListFailed"
+)
+
+// RuntimeSourceIssue retains a diagnostic cause for errors.Is/errors.As while
+// exposing only a fixed code and fixed error text.
+type RuntimeSourceIssue struct {
+	Code         RuntimeSourceIssueCode
+	RevisionName string
+	cause        error
+}
+
+// Error returns fixed redacted text for the issue code.
+func (i RuntimeSourceIssue) Error() string {
+	switch i.Code {
+	case RuntimeSourceIssueLiveNotFound:
+		return "live runtime was not found"
+	case RuntimeSourceIssueLiveDisabled:
+		return "live runtime is disabled"
+	case RuntimeSourceIssueLiveUnavailable:
+		return "live runtime evidence is unavailable"
+	case RuntimeSourceIssueRevisionNotFound:
+		return "runtime revision was not found"
+	case RuntimeSourceIssueRevisionGetFailed:
+		return "runtime revision evidence read failed"
+	case RuntimeSourceIssueRevisionListFailed:
+		return "runtime revision history read failed"
+	default:
+		return "runtime source evidence is unavailable"
+	}
+}
+
+// Unwrap preserves the diagnostic cause for errors.Is and errors.As.
+func (i RuntimeSourceIssue) Unwrap() error { return i.cause }
+
+// GoString returns fixed redacted text for %#v formatting.
+func (RuntimeSourceIssue) GoString() string { return "<effective.RuntimeSourceIssue redacted>" }
+
+// RuntimeResolveOptions controls optional bounded evidence collection.
+type RuntimeResolveOptions struct {
+	IncludeHistory bool
+}
+
+// ActiveConfiguration is the controller-selected configuration. spec is kept
+// private because it may contain credentials and arbitrary pod configuration.
+type ActiveConfiguration struct {
+	Origin            ConfigurationOrigin
+	RuntimeName       string
+	RuntimeKind       string
+	RuntimeNamespace  string
+	RevisionName      string
+	RevisionShortHash string
+	components        []EffectiveComponent
+	Consistency       RevisionConsistencyState
+	spec              *v1beta1.ServingRuntimeSpec
+}
+
+// MarshalJSON prevents accidental serialization of private runtime content.
+func (ActiveConfiguration) MarshalJSON() ([]byte, error) { return nil, ErrUnsafeRuntimeSerialization }
+
+// MarshalYAML prevents accidental serialization of private runtime content.
+func (ActiveConfiguration) MarshalYAML() (any, error) { return nil, ErrUnsafeRuntimeSerialization }
+
+// String returns a fixed redacted representation.
+func (ActiveConfiguration) String() string { return "<effective.ActiveConfiguration redacted>" }
+
+// GoString returns a fixed redacted representation for %#v formatting.
+func (ActiveConfiguration) GoString() string { return "<effective.ActiveConfiguration redacted>" }
+
+// RuntimeRevisionObservation exposes allowlisted identity and consistency
+// provenance while retaining decoded content and raw hashes privately.
+type RuntimeRevisionObservation struct {
+	Name              string
+	Namespace         string
+	UID               string
+	ResourceVersion   string
+	SourceName        string
+	SourceKind        string
+	SourceNamespace   string
+	ShortHash         string
+	CreationTimestamp metav1.Time
+	Ordinal           int64
+	roles             []RuntimeRevisionRole
+	Available         bool
+	Consistency       RevisionConsistencyState
+	consistencyCodes  []RevisionConsistencyCode
+	RelationToLive    RuntimeHashRelation
+	Disabled          bool
+	spec              *v1beta1.ServingRuntimeSpec
+	fullHash          string
+	computedShortHash string
+	rawShortHash      string
+	expectedName      string
+	expectedNamespace string
+	objectFingerprint string
+	objectReturned    bool
+	usable            bool
+	readError         error
+	notFound          bool
+}
+
+// MarshalJSON prevents accidental serialization of private revision content.
+func (RuntimeRevisionObservation) MarshalJSON() ([]byte, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// MarshalYAML prevents accidental serialization of private revision content.
+func (RuntimeRevisionObservation) MarshalYAML() (any, error) {
+	return nil, ErrUnsafeRuntimeSerialization
+}
+
+// String returns a fixed redacted representation.
+func (RuntimeRevisionObservation) String() string {
+	return "<effective.RuntimeRevisionObservation redacted>"
+}
+
+// GoString returns a fixed redacted representation for %#v formatting.
+func (RuntimeRevisionObservation) GoString() string {
+	return "<effective.RuntimeRevisionObservation redacted>"
+}
+
+// InferenceServiceIdentity binds collected evidence to the exact primary
+// object snapshot that requested it.
+type InferenceServiceIdentity struct {
+	Name      string
+	Namespace string
+	UID       string
+}
+
+type inferenceServiceBinding struct {
+	identity        InferenceServiceIdentity
+	resourceVersion string
+}
+
+// RuntimeState keeps unsafe resolution snapshots internal to the effective
+// layer while exposing bounded provenance for allowlisted report projection.
+type RuntimeState struct {
+	Generation              int64
+	ObservedGeneration      int64
+	RuntimeName             string
+	RuntimeKind             string
+	RuntimeNamespace        string
+	DeclaredSourceKind      string
+	DeclaredSourceNamespace string
+	SelectionSource         RuntimeSelectionSource
+	PinMode                 RuntimePinMode
+	PinState                RuntimePinState
+	RequestedRevisionName   string
+	ReportedRevisionName    string
+	ActiveRevisionName      string
+	StatusFreshness         StatusFreshness
+	SyncTokenState          SyncTokenState
+	DriftState              RuntimeDriftState
+	DriftReason             RuntimeDriftReason
+	LiveToActive            RuntimeHashRelation
+	LiveShortHash           string
+	live                    *LiveConfiguration
+	active                  *ActiveConfiguration
+	revisions               []RuntimeRevisionObservation
+	issues                  []RuntimeSourceIssue
+	HistoryRequested        bool
+	HistoryPages            int
+	HistoryPageLimit        int
+	HistoryRequestedPages   int
+	HistoryObservedPages    int
+	HistoryComplete         bool
+	HistoryTruncated        bool
+	historyNamespace        string
+	liveAvailability        liveAvailability
+	inferenceService        inferenceServiceBinding
+}
+
+type liveAvailability uint8
+
+const (
+	liveUnreadable liveAvailability = iota
+	liveAvailable
+	liveNotFound
+	liveDisabled
+)
+
+// MarshalJSON prevents accidental serialization of the aggregate unsafe state.
+func (RuntimeState) MarshalJSON() ([]byte, error) { return nil, ErrUnsafeRuntimeSerialization }
+
+// MarshalYAML prevents accidental serialization of the aggregate unsafe state.
+func (RuntimeState) MarshalYAML() (any, error) { return nil, ErrUnsafeRuntimeSerialization }
+
+// String returns a fixed redacted representation.
+func (RuntimeState) String() string { return "<effective.RuntimeState redacted>" }
+
+// GoString returns a fixed redacted representation for %#v formatting.
+func (RuntimeState) GoString() string { return "<effective.RuntimeState redacted>" }
+
+// RuntimePinResolver collects live and revision evidence without changing
+// Kubernetes state.
+type RuntimePinResolver struct {
+	revisions    revisionNamespaceGetter
+	live         liveRuntimeResolver
+	omeNamespace string
+	limits       paging.Limits
+}
+
+// NewRuntimePinResolver constructs a bounded runtime pin provenance resolver.
+func NewRuntimePinResolver(revisions appstyped.ControllerRevisionsGetter, live *RuntimeResolver, omeNamespace string, limits paging.Limits) (*RuntimePinResolver, error) {
+	if revisions == nil {
+		return nil, errors.New("ControllerRevision client must not be nil")
+	}
+	if live == nil {
+		return nil, errors.New("live runtime resolver must not be nil")
+	}
+	return newRuntimePinResolver(typedRevisionGetter{getter: revisions}.namespace, live, omeNamespace, limits)
+}
+
+func newRuntimePinResolver(revisions revisionNamespaceGetter, live liveRuntimeResolver, omeNamespace string, limits paging.Limits) (*RuntimePinResolver, error) {
+	if revisions == nil {
+		return nil, errors.New("ControllerRevision client must not be nil")
+	}
+	if live == nil {
+		return nil, errors.New("live runtime resolver must not be nil")
+	}
+	if omeNamespace == "" {
+		return nil, errors.New("OME namespace must not be empty")
+	}
+	if limits.PageSize <= 0 || limits.MaxItems <= 0 || limits.MaxPages <= 0 || limits.RequestTimeout <= 0 {
+		return nil, errors.New("revision paging limits are invalid")
+	}
+	return &RuntimePinResolver{revisions: revisions, live: live, omeNamespace: omeNamespace, limits: limits}, nil
+}
+
+// Resolve independently collects live, exact pin, and optional history
+// evidence and returns a defensive-access state envelope.
+func (r *RuntimePinResolver) Resolve(ctx context.Context, isvc *v1beta1.InferenceService, options RuntimeResolveOptions) (*RuntimeState, error) {
+	if r == nil || r.revisions == nil || r.live == nil {
+		return nil, errors.New("runtime pin resolver is not configured")
+	}
+	if ctx == nil {
+		return nil, errors.New("context must not be nil")
+	}
+	if isvc == nil {
+		return nil, errors.New("InferenceService must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	binding := inferenceServiceBinding{
+		identity: InferenceServiceIdentity{
+			Name: isvc.Name, Namespace: isvc.Namespace, UID: string(isvc.UID),
+		},
+		resourceVersion: isvc.ResourceVersion,
+	}
+
+	mode, declaredKind, declaredNamespace := runtimePinIntent(isvc)
+	liveCtx, cancelLive := context.WithTimeout(ctx, r.limits.RequestTimeout)
+	live, liveErr := r.live.ResolveLive(liveCtx, isvc)
+	cancelLive()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	state := &RuntimeState{
+		Generation: isvc.Generation, ObservedGeneration: isvc.Status.ObservedGeneration,
+		PinMode: mode, PinState: RuntimePinStateNotApplicable,
+		DeclaredSourceKind: declaredKind, DeclaredSourceNamespace: declaredNamespace,
+		SelectionSource: RuntimeSelected, LiveToActive: RuntimeHashRelationUnknown,
+		live: live, HistoryRequested: false, HistoryComplete: false,
+		inferenceService: binding,
+	}
+	state.StatusFreshness = deriveStatusFreshness(state.Generation, state.ObservedGeneration)
+	state.SyncTokenState = deriveSyncTokenState(
+		isvc.Annotations[constants.RuntimeSyncAnnotationKey], isvc.Status.LastRuntimeSyncToken,
+	)
+	state.DriftState, state.DriftReason = deriveRuntimeDrift(isvc.Status.Conditions)
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+		state.RuntimeName = isvc.Spec.Runtime.Name
+		state.SelectionSource = RuntimeExplicit
+	}
+	state.liveAvailability = classifyLiveAvailability(live, liveErr)
+	if state.liveAvailability == liveUnreadable && liveErr == nil {
+		liveErr = errors.New("live runtime snapshot is incomplete")
+	}
+	if liveErr != nil {
+		code := RuntimeSourceIssueLiveUnavailable
+		switch state.liveAvailability {
+		case liveNotFound:
+			code = RuntimeSourceIssueLiveNotFound
+		case liveDisabled:
+			code = RuntimeSourceIssueLiveDisabled
+		}
+		state.issues = append(state.issues, RuntimeSourceIssue{Code: code, cause: liveErr})
+	}
+	if live != nil {
+		state.RuntimeName = live.Runtime.Name
+		state.RuntimeKind = live.Runtime.Kind
+		state.RuntimeNamespace = live.Runtime.Namespace
+		state.SelectionSource = live.Runtime.SelectionSource
+		if live.Runtime.spec != nil {
+			_, state.LiveShortHash, _ = runtimerevision.Hash(live.Runtime.spec)
+		}
+	}
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Revision != nil {
+		state.RequestedRevisionName = *isvc.Spec.Runtime.Revision
+	}
+	state.ReportedRevisionName = isvc.Status.PinnedRevisionName
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+		if err := r.collectExactRevision(ctx, state, state.RequestedRevisionName, RuntimeRevisionRoleRequested); err != nil {
+			return nil, err
+		}
+		if err := r.collectExactRevision(ctx, state, state.ReportedRevisionName, RuntimeRevisionRoleReported); err != nil {
+			return nil, err
+		}
+	}
+	r.selectActive(isvc, state)
+	if err := r.collectHistory(ctx, state, options); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func runtimePinIntent(isvc *v1beta1.InferenceService) (RuntimePinMode, string, string) {
+	if isvc == nil || isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name == "" {
+		return RuntimePinModeAutoSync, "", ""
+	}
+	ref := isvc.Spec.Runtime
+	if !validDeclaredRuntimeKind(ref.Kind) {
+		if runtimeAutoSyncEnabled(ref) {
+			return RuntimePinModeAutoSync, "", ""
+		}
+		return RuntimePinModeInvalidPin, "", ""
+	}
+	kind := runtimeselector.KindClusterServingRuntime
+	namespace := ""
+	if ref.Kind != nil && *ref.Kind == runtimeselector.KindServingRuntime {
+		kind = runtimeselector.KindServingRuntime
+		namespace = isvc.Namespace
+	}
+	if runtimeAutoSyncEnabled(ref) {
+		return RuntimePinModeAutoSync, kind, namespace
+	}
+	if ref.Revision != nil && *ref.Revision != "" {
+		return RuntimePinModeExplicitPin, kind, namespace
+	}
+	return RuntimePinModeManagedPin, kind, namespace
+}
+
+func (r *RuntimePinResolver) selectActive(isvc *v1beta1.InferenceService, state *RuntimeState) {
+	if state.liveAvailability == liveUnreadable {
+		state.PinState = RuntimePinStateUnavailable
+		return
+	}
+	switch state.PinMode {
+	case RuntimePinModeAutoSync:
+		if state.liveAvailability == liveAvailable {
+			state.PinState = RuntimePinStateNotApplicable
+			state.active = activeFromLive(state.live)
+			state.LiveToActive = RuntimeHashRelationEqual
+		} else {
+			state.PinState = RuntimePinStateUnavailable
+		}
+	case RuntimePinModeInvalidPin:
+		state.PinState = RuntimePinStateInvalidIntent
+	case RuntimePinModeManagedPin:
+		if state.ReportedRevisionName == "" {
+			if state.liveAvailability == liveAvailable {
+				state.PinState = RuntimePinStateAwaitingPin
+				state.active = activeFromLive(state.live)
+				state.LiveToActive = RuntimeHashRelationEqual
+			} else {
+				state.PinState = RuntimePinStateUnavailable
+			}
+			return
+		}
+		observation := findRevisionObservation(state.revisions, state.ReportedRevisionName)
+		if observation == nil {
+			state.PinState = RuntimePinStateRevisionInvalid
+			return
+		}
+		if observation.notFound {
+			state.PinState = RuntimePinStateRevisionMissing
+			return
+		}
+		if observation.readError != nil {
+			state.PinState = RuntimePinStateUnavailable
+			return
+		}
+		if !observation.Available || observation.spec == nil {
+			state.PinState = RuntimePinStateRevisionInvalid
+			return
+		}
+		state.PinState = RuntimePinStateResolved
+		state.activateRevision(isvc, observation)
+	case RuntimePinModeExplicitPin:
+		observation := findRevisionObservation(state.revisions, state.RequestedRevisionName)
+		if observation == nil {
+			state.PinState = RuntimePinStateRevisionInvalid
+			return
+		}
+		if observation.notFound {
+			state.PinState = RuntimePinStateRevisionMissing
+			return
+		}
+		if observation.readError != nil {
+			state.PinState = RuntimePinStateUnavailable
+			return
+		}
+		if !observation.Available || observation.spec == nil || observation.SourceName != state.RuntimeName {
+			state.PinState = RuntimePinStateRevisionInvalid
+			return
+		}
+		state.PinState = RuntimePinStateResolved
+		if state.ReportedRevisionName != "" && state.ReportedRevisionName != state.RequestedRevisionName {
+			state.PinState = RuntimePinStateDesiredReportedMismatch
+		}
+		state.activateRevision(isvc, observation)
+	}
+}
+
+func findRevisionObservation(observations []RuntimeRevisionObservation, name string) *RuntimeRevisionObservation {
+	for i := range observations {
+		if observations[i].expectedName == name {
+			return &observations[i]
+		}
+	}
+	return nil
+}
+
+func (s *RuntimeState) activateRevision(isvc *v1beta1.InferenceService, observation *RuntimeRevisionObservation) {
+	if observation.spec.IsDisabled() {
+		s.PinState = RuntimePinStateRevisionDisabled
+		return
+	}
+	components, err := MergeEffectiveComponents(isvc, observation.spec)
+	if err != nil {
+		s.PinState = RuntimePinStateRevisionInvalid
+		return
+	}
+	revisionName := observation.Name
+	if observation.expectedName != "" {
+		revisionName = observation.expectedName
+	}
+	s.ActiveRevisionName = revisionName
+	s.active = &ActiveConfiguration{
+		Origin:      ConfigurationOriginControllerRevision,
+		RuntimeName: s.RuntimeName, RuntimeKind: s.DeclaredSourceKind,
+		RuntimeNamespace: s.DeclaredSourceNamespace, RevisionName: revisionName,
+		RevisionShortHash: observation.ShortHash, components: components,
+		Consistency: observation.Consistency, spec: observation.spec.DeepCopy(),
+	}
+	observation.roles = appendRole(observation.roles, RuntimeRevisionRoleActive)
+	if s.live != nil && s.live.Runtime.spec != nil {
+		liveFull, liveShort, _ := runtimerevision.Hash(s.live.Runtime.spec)
+		activeFull, activeShort, _ := runtimerevision.Hash(observation.spec)
+		s.LiveToActive = compareRuntimeHashes(liveFull, liveShort, activeFull, activeShort)
+	}
+}
+
+func compareRuntimeHashes(leftFull, leftShort, rightFull, rightShort string) RuntimeHashRelation {
+	if leftFull == "" || rightFull == "" {
+		return RuntimeHashRelationUnknown
+	}
+	if leftFull == rightFull {
+		return RuntimeHashRelationEqual
+	}
+	if leftShort == rightShort {
+		return RuntimeHashRelationAmbiguous
+	}
+	return RuntimeHashRelationDifferent
+}
+
+func appendRole(roles []RuntimeRevisionRole, role RuntimeRevisionRole) []RuntimeRevisionRole {
+	for _, existing := range roles {
+		if existing == role {
+			return roles
+		}
+	}
+	return append(roles, role)
+}
+
+func (r *RuntimePinResolver) collectExactRevision(ctx context.Context, state *RuntimeState, name string, role RuntimeRevisionRole) error {
+	if name == "" {
+		return nil
+	}
+	for i := range state.revisions {
+		if state.revisions[i].expectedName == name {
+			state.revisions[i].roles = appendRole(state.revisions[i].roles, role)
+			return nil
+		}
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, r.limits.RequestTimeout)
+	revision, err := r.revisions(r.omeNamespace).Get(requestCtx, name, metav1.GetOptions{})
+	cancel()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if err != nil {
+		observation := RuntimeRevisionObservation{
+			roles: []RuntimeRevisionRole{role}, Available: false,
+			Consistency: RevisionConsistencyUnknown, expectedName: name,
+			expectedNamespace: r.omeNamespace, readError: err,
+		}
+		code := RuntimeSourceIssueRevisionGetFailed
+		if apierrors.IsNotFound(err) {
+			observation.notFound = true
+			code = RuntimeSourceIssueRevisionNotFound
+		}
+		state.revisions = append(state.revisions, observation)
+		state.issues = append(state.issues, RuntimeSourceIssue{Code: code, RevisionName: name, cause: err})
+		return nil
+	}
+	observation := inspectRuntimeRevision(
+		revision, r.omeNamespace, name, state.RuntimeName,
+		state.DeclaredSourceKind, state.DeclaredSourceNamespace,
+	)
+	observation.roles = []RuntimeRevisionRole{role}
+	state.revisions = append(state.revisions, observation)
+	return nil
+}
+
+func activeFromLive(live *LiveConfiguration) *ActiveConfiguration {
+	if live == nil || live.Runtime.spec == nil {
+		return nil
+	}
+	return &ActiveConfiguration{
+		Origin:           ConfigurationOriginLiveRuntime,
+		RuntimeName:      live.Runtime.Name,
+		RuntimeKind:      live.Runtime.Kind,
+		RuntimeNamespace: live.Runtime.Namespace,
+		components:       cloneEffectiveComponents(live.Components),
+		Consistency:      RevisionConsistencyUnknown,
+		spec:             live.Runtime.spec.DeepCopy(),
+	}
+}

--- a/pkg/cli/effective/runtime_pin.go
+++ b/pkg/cli/effective/runtime_pin.go
@@ -314,8 +314,8 @@ func (RuntimeRevisionObservation) GoString() string {
 	return "<effective.RuntimeRevisionObservation redacted>"
 }
 
-// InferenceServiceIdentity binds collected evidence to the exact primary
-// object snapshot that requested it.
+// InferenceServiceIdentity is the safe primary object identity associated with
+// collected evidence. Exact snapshot metadata remains private to RuntimeState.
 type InferenceServiceIdentity struct {
 	Name      string
 	Namespace string
@@ -524,10 +524,10 @@ func runtimePinIntent(isvc *v1beta1.InferenceService) (RuntimePinMode, string, s
 		}
 		return RuntimePinModeInvalidPin, "", ""
 	}
-	kind := runtimeselector.KindClusterServingRuntime
+	kind := string(runtimerevision.KindClusterServingRuntime)
 	namespace := ""
 	if ref.Kind != nil && *ref.Kind == runtimeselector.KindServingRuntime {
-		kind = runtimeselector.KindServingRuntime
+		kind = string(runtimerevision.KindServingRuntime)
 		namespace = isvc.Namespace
 	}
 	if runtimeAutoSyncEnabled(ref) {
@@ -540,7 +540,7 @@ func runtimePinIntent(isvc *v1beta1.InferenceService) (RuntimePinMode, string, s
 }
 
 func (r *RuntimePinResolver) selectActive(isvc *v1beta1.InferenceService, state *RuntimeState) {
-	if state.liveAvailability == liveUnreadable {
+	if state.liveAvailability == liveUnreadable || state.liveAvailability == liveDisabled {
 		state.PinState = RuntimePinStateUnavailable
 		return
 	}
@@ -688,6 +688,9 @@ func (r *RuntimePinResolver) collectExactRevision(ctx context.Context, state *Ru
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return ctxErr
 	}
+	if err == nil && revision == nil {
+		err = errors.New("runtime revision read returned an empty response")
+	}
 	if err != nil {
 		observation := RuntimeRevisionObservation{
 			roles: []RuntimeRevisionRole{role}, Available: false,
@@ -705,7 +708,7 @@ func (r *RuntimePinResolver) collectExactRevision(ctx context.Context, state *Ru
 	}
 	observation := inspectRuntimeRevision(
 		revision, r.omeNamespace, name, state.RuntimeName,
-		state.DeclaredSourceKind, state.DeclaredSourceNamespace,
+		runtimerevision.SourceKind(state.DeclaredSourceKind), state.DeclaredSourceNamespace,
 	)
 	observation.roles = []RuntimeRevisionRole{role}
 	state.revisions = append(state.revisions, observation)

--- a/pkg/cli/effective/runtime_pin_history.go
+++ b/pkg/cli/effective/runtime_pin_history.go
@@ -1,0 +1,276 @@
+package effective
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+)
+
+func (r *RuntimePinResolver) collectHistory(
+	ctx context.Context,
+	state *RuntimeState,
+	options RuntimeResolveOptions,
+) error {
+	state.HistoryRequested = options.IncludeHistory
+	state.HistoryPageLimit = r.limits.MaxPages
+	if !options.IncludeHistory {
+		state.HistoryComplete = false
+		finalizeRevisionEvidence(state)
+		return nil
+	}
+	state.HistoryComplete = false
+	if state.RuntimeName == "" {
+		finalizeRevisionEvidence(state)
+		return nil
+	}
+	state.historyNamespace = r.omeNamespace
+
+	base := metav1.ListOptions{LabelSelector: labels.Set{
+		constants.RuntimeRevisionOfLabelKey: state.RuntimeName,
+	}.AsSelector().String()}
+	requestedPages := 0
+	observedPages := 0
+	result, err := paging.ListBounded(ctx, base, r.limits, func(
+		requestCtx context.Context,
+		options metav1.ListOptions,
+	) (paging.Page[appsv1.ControllerRevision], error) {
+		requestedPages++
+		list, err := r.revisions(r.omeNamespace).List(requestCtx, options)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return paging.Page[appsv1.ControllerRevision]{}, ctxErr
+			}
+			return paging.Page[appsv1.ControllerRevision]{}, err
+		}
+		if list == nil {
+			return paging.Page[appsv1.ControllerRevision]{}, errors.New("runtime revision history returned an empty response")
+		}
+		observedPages++
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return paging.Page[appsv1.ControllerRevision]{}, ctxErr
+		}
+		return paging.Page[appsv1.ControllerRevision]{Items: list.Items, Continue: list.Continue}, nil
+	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	state.HistoryPages = result.Pages
+	state.HistoryRequestedPages = requestedPages
+	state.HistoryObservedPages = observedPages
+	state.HistoryTruncated = result.Truncated
+	state.HistoryComplete = err == nil && !result.Truncated
+	historyObservations := make([]RuntimeRevisionObservation, 0, len(result.Items))
+	for i := range result.Items {
+		revision := result.Items[i].DeepCopy()
+		observation := inspectRuntimeRevision(
+			revision, r.omeNamespace, "", state.RuntimeName,
+			state.DeclaredSourceKind, state.DeclaredSourceNamespace,
+		)
+		observation.roles = []RuntimeRevisionRole{RuntimeRevisionRoleHistory}
+		historyObservations = append(historyObservations, observation)
+	}
+	sortRuntimeRevisionObservations(historyObservations)
+	for i := range historyObservations {
+		mergeHistoryObservation(state, historyObservations[i])
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		state.issues = append(state.issues, RuntimeSourceIssue{
+			Code: RuntimeSourceIssueRevisionListFailed, cause: err,
+		})
+	}
+	finalizeRevisionEvidence(state)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return nil
+}
+
+func mergeHistoryObservation(state *RuntimeState, history RuntimeRevisionObservation) {
+	for i := range state.revisions {
+		exact := &state.revisions[i]
+		if exact.expectedName == "" || exact.expectedName != history.Name ||
+			!exact.objectReturned || !history.objectReturned ||
+			exact.Name != history.Name || exact.Namespace != history.Namespace ||
+			exact.objectFingerprint == "" || exact.objectFingerprint != history.objectFingerprint {
+			continue
+		}
+		historyAlreadyMerged := false
+		for _, role := range exact.roles {
+			if role == RuntimeRevisionRoleHistory {
+				historyAlreadyMerged = true
+				break
+			}
+		}
+		if historyAlreadyMerged {
+			continue
+		}
+		for _, role := range history.roles {
+			exact.roles = appendRole(exact.roles, role)
+		}
+		return
+	}
+	state.revisions = append(state.revisions, history)
+}
+
+func finalizeRevisionEvidence(state *RuntimeState) {
+	var liveFullHash, liveShortHash string
+	if state.live != nil && state.live.Runtime.spec != nil {
+		var err error
+		liveFullHash, liveShortHash, err = runtimerevision.Hash(state.live.Runtime.spec)
+		if err != nil {
+			liveFullHash, liveShortHash = "", ""
+		}
+	}
+	for i := range state.revisions {
+		setObservationLiveRelation(&state.revisions[i], liveFullHash, liveShortHash)
+	}
+	classifyRevisionCollectionAnomalies(state.revisions)
+	sortRuntimeRevisionObservations(state.revisions)
+	if state.active == nil || state.ActiveRevisionName == "" {
+		return
+	}
+	for i := range state.revisions {
+		if state.revisions[i].expectedName == state.ActiveRevisionName {
+			state.active.Consistency = state.revisions[i].Consistency
+			return
+		}
+	}
+}
+
+func classifyRevisionCollectionAnomalies(observations []RuntimeRevisionObservation) {
+	identities := make(map[string][]int)
+	fullHashes := make(map[string][]int)
+	shortHashes := make(map[string][]int)
+	for i := range observations {
+		observation := &observations[i]
+		if observation.objectReturned {
+			key := observation.Namespace + "\x00" + observation.Name
+			identities[key] = append(identities[key], i)
+		}
+		if observation.fullHash != "" {
+			fullHashes[observation.fullHash] = append(fullHashes[observation.fullHash], i)
+		}
+		if observation.computedShortHash != "" && observation.fullHash != "" {
+			shortHashes[observation.computedShortHash] = append(shortHashes[observation.computedShortHash], i)
+		}
+	}
+	for _, indexes := range identities {
+		if len(indexes) < 2 {
+			continue
+		}
+		fingerprints := make(map[string][]int)
+		unknownFingerprints := 0
+		for _, index := range indexes {
+			fingerprint := observations[index].objectFingerprint
+			if fingerprint == "" {
+				unknownFingerprints++
+				continue
+			}
+			fingerprints[fingerprint] = append(fingerprints[fingerprint], index)
+		}
+		for _, duplicateIndexes := range fingerprints {
+			if len(duplicateIndexes) < 2 {
+				continue
+			}
+			for _, index := range duplicateIndexes {
+				addObservationConsistencyCode(&observations[index], RevisionConsistencyDuplicateIdentity)
+			}
+		}
+		if len(fingerprints)+unknownFingerprints > 1 {
+			for _, index := range indexes {
+				addObservationConsistencyCode(&observations[index], RevisionConsistencyConflictingIdentity)
+			}
+		}
+	}
+	for _, indexes := range fullHashes {
+		if len(indexes) < 2 {
+			continue
+		}
+		for _, index := range indexes {
+			addObservationConsistencyCode(&observations[index], RevisionConsistencyDuplicateContentHash)
+		}
+	}
+	for _, indexes := range shortHashes {
+		if len(indexes) < 2 {
+			continue
+		}
+		uniqueFullHashes := make(map[string]struct{})
+		for _, index := range indexes {
+			uniqueFullHashes[observations[index].fullHash] = struct{}{}
+		}
+		if len(uniqueFullHashes) < 2 {
+			continue
+		}
+		for _, index := range indexes {
+			addObservationConsistencyCode(&observations[index], RevisionConsistencyShortHashCollision)
+		}
+	}
+}
+
+func addObservationConsistencyCode(observation *RuntimeRevisionObservation, code RevisionConsistencyCode) {
+	for _, existing := range observation.consistencyCodes {
+		if existing == code {
+			return
+		}
+	}
+	observation.consistencyCodes = append(observation.consistencyCodes, code)
+	observation.Consistency = RevisionConsistencyInconsistent
+	sortConsistencyCodes(observation.consistencyCodes)
+}
+
+func setObservationLiveRelation(observation *RuntimeRevisionObservation, liveFullHash, liveShortHash string) {
+	if observation == nil {
+		return
+	}
+	if liveFullHash == "" || observation.fullHash == "" {
+		observation.RelationToLive = RuntimeHashRelationUnknown
+		return
+	}
+	observation.RelationToLive = compareRuntimeHashes(
+		liveFullHash, liveShortHash, observation.fullHash, observation.computedShortHash,
+	)
+}
+
+func sortRuntimeRevisionObservations(observations []RuntimeRevisionObservation) {
+	sort.SliceStable(observations, func(i, j int) bool {
+		left := &observations[i]
+		right := &observations[j]
+		if !left.CreationTimestamp.Time.Equal(right.CreationTimestamp.Time) {
+			return left.CreationTimestamp.Time.After(right.CreationTimestamp.Time)
+		}
+		values := [...][2]string{
+			{left.Name, right.Name},
+			{left.Namespace, right.Namespace},
+			{left.expectedName, right.expectedName},
+			{left.fullHash, right.fullHash},
+			{left.computedShortHash, right.computedShortHash},
+			{left.objectFingerprint, right.objectFingerprint},
+			{left.UID, right.UID},
+			{left.ResourceVersion, right.ResourceVersion},
+			{left.SourceName, right.SourceName},
+			{left.SourceKind, right.SourceKind},
+			{left.SourceNamespace, right.SourceNamespace},
+			{left.rawShortHash, right.rawShortHash},
+		}
+		for _, pair := range values {
+			if pair[0] != pair[1] {
+				return pair[0] < pair[1]
+			}
+		}
+		if left.Ordinal != right.Ordinal {
+			return left.Ordinal < right.Ordinal
+		}
+		return false
+	})
+}

--- a/pkg/cli/effective/runtime_pin_history.go
+++ b/pkg/cli/effective/runtime_pin_history.go
@@ -40,10 +40,10 @@ func (r *RuntimePinResolver) collectHistory(
 	observedPages := 0
 	result, err := paging.ListBounded(ctx, base, r.limits, func(
 		requestCtx context.Context,
-		options metav1.ListOptions,
+		listOptions metav1.ListOptions,
 	) (paging.Page[appsv1.ControllerRevision], error) {
 		requestedPages++
-		list, err := r.revisions(r.omeNamespace).List(requestCtx, options)
+		list, err := r.revisions(r.omeNamespace).List(requestCtx, listOptions)
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return paging.Page[appsv1.ControllerRevision]{}, ctxErr
@@ -72,7 +72,7 @@ func (r *RuntimePinResolver) collectHistory(
 		revision := result.Items[i].DeepCopy()
 		observation := inspectRuntimeRevision(
 			revision, r.omeNamespace, "", state.RuntimeName,
-			state.DeclaredSourceKind, state.DeclaredSourceNamespace,
+			runtimerevision.SourceKind(state.DeclaredSourceKind), state.DeclaredSourceNamespace,
 		)
 		observation.roles = []RuntimeRevisionRole{RuntimeRevisionRoleHistory}
 		historyObservations = append(historyObservations, observation)

--- a/pkg/cli/effective/runtime_pin_history_test.go
+++ b/pkg/cli/effective/runtime_pin_history_test.go
@@ -1,0 +1,830 @@
+package effective
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+func TestResolveHistoryUsesRuntimeNameOnlySelectorUnionsExactReadsAndSorts(t *testing.T) {
+	newer := revisionFixture(t, runtimeselector.KindServingRuntime, "other-scope", "runtime", runtimeSpecFixture("newer"))
+	newer.CreationTimestamp = metav1.NewTime(time.Unix(200, 0))
+	older := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("older"))
+	older.CreationTimestamp = metav1.NewTime(time.Unix(100, 0))
+	autoSync := false
+	var listOptions []metav1.ListOptions
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{
+				get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+					return older.DeepCopy(), nil
+				},
+				list: func(_ context.Context, options metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					listOptions = append(listOptions, options)
+					switch options.Continue {
+					case "":
+						return &appsv1.ControllerRevisionList{
+							Items:    []appsv1.ControllerRevision{*older.DeepCopy()},
+							ListMeta: metav1.ListMeta{Continue: "next"},
+						}, nil
+					case "next":
+						return &appsv1.ControllerRevisionList{Items: []appsv1.ControllerRevision{*newer.DeepCopy()}}, nil
+					default:
+						return nil, errors.New("unexpected continue token")
+					}
+				},
+			}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			live := livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false)
+			live.Runtime.spec = runtimeSpecFixture("live")
+			return live, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, "")
+	isvc.Status.PinnedRevisionName = older.Name
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{IncludeHistory: true})
+
+	require.NoError(t, err)
+	require.Len(t, listOptions, 2)
+	for _, options := range listOptions {
+		assert.Equal(t, constants.RuntimeRevisionOfLabelKey+"=runtime", options.LabelSelector)
+		assert.Empty(t, options.FieldSelector)
+	}
+	assert.True(t, state.HistoryRequested)
+	assert.True(t, state.HistoryComplete)
+	assert.Equal(t, testPinLimits.MaxPages, state.HistoryPageLimit)
+	assert.Equal(t, 2, state.HistoryRequestedPages)
+	assert.Equal(t, 2, state.HistoryObservedPages)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 2)
+	assert.Equal(t, []string{newer.Name, older.Name}, []string{observations[0].Name, observations[1].Name})
+	assert.Contains(t, observations[0].ConsistencyCodes(), RevisionConsistencySourceKind)
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleReported, RuntimeRevisionRoleActive, RuntimeRevisionRoleHistory}, observations[1].Roles())
+	assert.Equal(t, RuntimeHashRelationDifferent, observations[0].RelationToLive)
+}
+
+func TestResolveHistoryRetainsSuccessfulPrefixAfterLaterFailure(t *testing.T) {
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("one"))
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, "", errors.New("denied"))
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{list: func(_ context.Context, options metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+				if options.Continue == "" {
+					return &appsv1.ControllerRevisionList{
+						Items:    []appsv1.ControllerRevision{*revision.DeepCopy()},
+						ListMeta: metav1.ListMeta{Continue: "next"},
+					}, nil
+				}
+				return nil, forbidden
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+
+	state, err := resolver.Resolve(context.Background(), pinISVC("runtime", nil, ""), RuntimeResolveOptions{IncludeHistory: true})
+
+	require.NoError(t, err)
+	assert.False(t, state.HistoryComplete)
+	assert.False(t, state.HistoryTruncated)
+	assert.Equal(t, 2, state.HistoryRequestedPages)
+	assert.Equal(t, 1, state.HistoryObservedPages)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 1)
+	assert.Equal(t, revision.Name, observations[0].Name)
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, "runtime revision history read failed", issues[0].Error())
+	assert.ErrorIs(t, issues[0], forbidden)
+}
+
+func TestResolveHistoryNilSuccessfulListResponseIsBounded(t *testing.T) {
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+				return nil, nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+
+	state, err := resolver.Resolve(
+		context.Background(), pinISVC("runtime", nil, ""), RuntimeResolveOptions{IncludeHistory: true},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, state.HistoryComplete)
+	assert.Equal(t, 1, state.HistoryRequestedPages)
+	assert.Zero(t, state.HistoryObservedPages)
+	assert.Empty(t, state.RevisionObservations())
+	assert.Equal(t, "ome", state.HistoryNamespace())
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, RuntimeSourceIssueRevisionListFailed, issues[0].Code)
+	assert.Equal(t, "runtime revision history read failed", issues[0].Error())
+	assert.ErrorContains(t, errors.Unwrap(issues[0]), "empty response")
+}
+
+func TestResolveHistoryReportsTruncationAndNonadvancingTokens(t *testing.T) {
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("one"))
+	t.Run("truncated", func(t *testing.T) {
+		limits := testPinLimits
+		limits.MaxItems = 1
+		resolver, err := newRuntimePinResolver(
+			func(string) revisionNamespace {
+				return revisionNamespaceStub{list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					return &appsv1.ControllerRevisionList{
+						Items:    []appsv1.ControllerRevision{*revision.DeepCopy(), *revision.DeepCopy()},
+						ListMeta: metav1.ListMeta{Continue: "more"},
+					}, nil
+				}}
+			},
+			liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+				return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+			}), "ome", limits,
+		)
+		require.NoError(t, err)
+		state, err := resolver.Resolve(context.Background(), pinISVC("runtime", nil, ""), RuntimeResolveOptions{IncludeHistory: true})
+		require.NoError(t, err)
+		assert.True(t, state.HistoryTruncated)
+		assert.False(t, state.HistoryComplete)
+	})
+
+	t.Run("nonadvancing", func(t *testing.T) {
+		resolver, err := newRuntimePinResolver(
+			func(string) revisionNamespace {
+				return revisionNamespaceStub{list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					return &appsv1.ControllerRevisionList{
+						Items:    []appsv1.ControllerRevision{*revision.DeepCopy()},
+						ListMeta: metav1.ListMeta{Continue: "same"},
+					}, nil
+				}}
+			},
+			liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+				return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+			}), "ome", testPinLimits,
+		)
+		require.NoError(t, err)
+		state, err := resolver.Resolve(context.Background(), pinISVC("runtime", nil, ""), RuntimeResolveOptions{IncludeHistory: true})
+		require.NoError(t, err)
+		assert.False(t, state.HistoryComplete)
+		assert.Equal(t, 2, state.HistoryRequestedPages)
+		assert.Equal(t, 2, state.HistoryObservedPages)
+		issues := state.SourceIssues()
+		require.Len(t, issues, 1)
+		assert.ErrorContains(t, errors.Unwrap(issues[0]), "continue token did not advance")
+	})
+}
+
+func TestResolveHistoryKeepsExactEvidenceDistinctByRequestIdentity(t *testing.T) {
+	autoSync := false
+	requestedA := "requested-a"
+	returnedB := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("b"))
+	reportedB := returnedB.Name
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{
+				get: func(_ context.Context, _ string, _ metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+					return returnedB.DeepCopy(), nil
+				},
+				list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					return &appsv1.ControllerRevisionList{Items: []appsv1.ControllerRevision{*returnedB.DeepCopy()}}, nil
+				},
+			}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, requestedA)
+	isvc.Status.PinnedRevisionName = reportedB
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{IncludeHistory: true})
+
+	require.NoError(t, err)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 2)
+	byExpected := make(map[string]RuntimeRevisionObservation, len(observations))
+	for _, observation := range observations {
+		byExpected[observation.ExpectedName()] = observation
+	}
+	assert.Equal(t, returnedB.Name, byExpected[requestedA].ReturnedName())
+	assert.Equal(t, "ome", byExpected[requestedA].ExpectedNamespace())
+	assert.Equal(t, "ome", byExpected[requestedA].ReturnedNamespace())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleRequested, RuntimeRevisionRoleActive}, byExpected[requestedA].Roles())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleReported, RuntimeRevisionRoleHistory}, byExpected[reportedB].Roles())
+	for _, observation := range observations {
+		assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+		assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateContentHash)
+	}
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, RevisionConsistencyInconsistent, active.Consistency)
+	_, err = state.RequireConsistentActive()
+	assert.ErrorIs(t, err, ErrActiveRuntimeInconsistent)
+}
+
+func TestResolveHistoryMergesOnlyFirstDuplicateIntoExactEvidence(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{
+				get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+					return revision.DeepCopy(), nil
+				},
+				list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					return &appsv1.ControllerRevisionList{Items: []appsv1.ControllerRevision{
+						*revision.DeepCopy(), *revision.DeepCopy(),
+					}}, nil
+				},
+			}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+
+	state, err := resolver.Resolve(
+		context.Background(), pinISVC("runtime", &autoSync, revision.Name),
+		RuntimeResolveOptions{IncludeHistory: true},
+	)
+
+	require.NoError(t, err)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 2)
+	var exact, duplicate *RuntimeRevisionObservation
+	for i := range observations {
+		if observations[i].ExpectedName() == revision.Name {
+			exact = &observations[i]
+		} else {
+			duplicate = &observations[i]
+		}
+	}
+	require.NotNil(t, exact)
+	require.NotNil(t, duplicate)
+	assert.Equal(t, []RuntimeRevisionRole{
+		RuntimeRevisionRoleRequested, RuntimeRevisionRoleActive, RuntimeRevisionRoleHistory,
+	}, exact.Roles())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleHistory}, duplicate.Roles())
+	for _, observation := range observations {
+		assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+		assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateContentHash)
+	}
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, RevisionConsistencyInconsistent, active.Consistency)
+	_, err = state.RequireConsistentActive()
+	assert.ErrorIs(t, err, ErrActiveRuntimeInconsistent)
+}
+
+func TestResolveHistoryDuplicateAbsorptionIsPermutationInvariant(t *testing.T) {
+	autoSync := false
+	exact := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	exact.UID = types.UID("revision-uid")
+	exact.ResourceVersion = "1"
+	createdAt := time.Unix(100, 123).UTC()
+	exact.CreationTimestamp = metav1.NewTime(createdAt)
+	rv2 := exact.DeepCopy()
+	rv2.ResourceVersion = "2"
+	rv2.Annotations[constants.RuntimeRevisionGCEligibleSinceKey] = "2026-01-01T00:00:00Z"
+	rv2.OwnerReferences = []metav1.OwnerReference{{Name: "owner-two", UID: types.UID("owner-two")}}
+	rv3 := exact.DeepCopy()
+	rv3.ResourceVersion = "3"
+	rv3.Annotations[constants.RuntimeRevisionGCEligibleSinceKey] = "2026-02-01T00:00:00Z"
+	rv3.Finalizers = []string{"example.com/three"}
+
+	resolve := func(t *testing.T, items ...*appsv1.ControllerRevision) *RuntimeState {
+		t.Helper()
+		listed := make([]appsv1.ControllerRevision, len(items))
+		for i := range items {
+			listed[i] = *items[i].DeepCopy()
+		}
+		resolver, err := newRuntimePinResolver(
+			func(string) revisionNamespace {
+				return revisionNamespaceStub{
+					get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+						return exact.DeepCopy(), nil
+					},
+					list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+						return &appsv1.ControllerRevisionList{Items: listed}, nil
+					},
+				}
+			},
+			liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+				return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+			}),
+			"ome", testPinLimits,
+		)
+		require.NoError(t, err)
+		state, err := resolver.Resolve(
+			context.Background(), pinISVC("runtime", &autoSync, exact.Name),
+			RuntimeResolveOptions{IncludeHistory: true},
+		)
+		require.NoError(t, err)
+		return state
+	}
+
+	type observationView struct {
+		Name, Namespace, UID, ResourceVersion   string
+		SourceName, SourceKind, SourceNamespace string
+		ShortHash                               string
+		CreationTimestamp                       metav1.Time
+		Ordinal                                 int64
+		Roles                                   []RuntimeRevisionRole
+		Available                               bool
+		Consistency                             RevisionConsistencyState
+		Codes                                   []RevisionConsistencyCode
+		RelationToLive                          RuntimeHashRelation
+		Disabled                                bool
+		ObjectReturned                          bool
+		ExpectedName, ExpectedNamespace         string
+		ReturnedName, ReturnedNamespace         string
+	}
+	type stateView struct {
+		Generation, ObservedGeneration              int64
+		RuntimeName, RuntimeKind, RuntimeNamespace  string
+		DeclaredSourceKind, DeclaredSourceNamespace string
+		SelectionSource                             RuntimeSelectionSource
+		PinMode                                     RuntimePinMode
+		PinState                                    RuntimePinState
+		RequestedRevisionName                       string
+		ReportedRevisionName                        string
+		ActiveRevisionName                          string
+		StatusFreshness                             StatusFreshness
+		SyncTokenState                              SyncTokenState
+		DriftState                                  RuntimeDriftState
+		DriftReason                                 RuntimeDriftReason
+		LiveToActive                                RuntimeHashRelation
+		LiveShortHash                               string
+		HistoryRequested                            bool
+		HistoryPages                                int
+		HistoryPageLimit                            int
+		HistoryRequestedPages                       int
+		HistoryObservedPages                        int
+		HistoryComplete                             bool
+		HistoryTruncated                            bool
+		LiveAvailability                            LiveRuntimeAvailability
+		Live                                        *LiveConfiguration
+		Active                                      *ActiveConfiguration
+		ConsistentActiveError                       string
+		SourceIssues                                []RuntimeSourceIssue
+		Observations                                []observationView
+	}
+	view := func(t *testing.T, state *RuntimeState) stateView {
+		t.Helper()
+		active, err := state.RequireActive()
+		require.NoError(t, err)
+		_, consistentErr := state.RequireConsistentActive()
+		require.Error(t, consistentErr)
+		observations := state.RevisionObservations()
+		result := stateView{
+			Generation: state.Generation, ObservedGeneration: state.ObservedGeneration,
+			RuntimeName: state.RuntimeName, RuntimeKind: state.RuntimeKind, RuntimeNamespace: state.RuntimeNamespace,
+			DeclaredSourceKind: state.DeclaredSourceKind, DeclaredSourceNamespace: state.DeclaredSourceNamespace,
+			SelectionSource: state.SelectionSource,
+			PinMode:         state.PinMode, PinState: state.PinState,
+			RequestedRevisionName: state.RequestedRevisionName,
+			ReportedRevisionName:  state.ReportedRevisionName,
+			ActiveRevisionName:    state.ActiveRevisionName,
+			StatusFreshness:       state.StatusFreshness, SyncTokenState: state.SyncTokenState,
+			DriftState: state.DriftState, DriftReason: state.DriftReason,
+			LiveToActive: state.LiveToActive, LiveShortHash: state.LiveShortHash,
+			HistoryRequested: state.HistoryRequested, HistoryPages: state.HistoryPages,
+			HistoryPageLimit:      state.HistoryPageLimit,
+			HistoryRequestedPages: state.HistoryRequestedPages, HistoryObservedPages: state.HistoryObservedPages,
+			HistoryComplete: state.HistoryComplete, HistoryTruncated: state.HistoryTruncated,
+			LiveAvailability: state.LiveAvailability(), Live: state.LiveConfiguration(), Active: active,
+			ConsistentActiveError: consistentErr.Error(), SourceIssues: state.SourceIssues(),
+			Observations: make([]observationView, len(observations)),
+		}
+		for i := range observations {
+			result.Observations[i] = observationView{
+				Name: observations[i].Name, Namespace: observations[i].Namespace, UID: observations[i].UID,
+				ResourceVersion: observations[i].ResourceVersion,
+				SourceName:      observations[i].SourceName, SourceKind: observations[i].SourceKind,
+				SourceNamespace: observations[i].SourceNamespace, ShortHash: observations[i].ShortHash,
+				CreationTimestamp: observations[i].CreationTimestamp, Ordinal: observations[i].Ordinal,
+				Roles: observations[i].Roles(), Available: observations[i].Available,
+				Consistency: observations[i].Consistency, Codes: observations[i].ConsistencyCodes(),
+				RelationToLive: observations[i].RelationToLive, Disabled: observations[i].Disabled,
+				ObjectReturned: observations[i].ObjectReturned(),
+				ExpectedName:   observations[i].ExpectedName(), ExpectedNamespace: observations[i].ExpectedNamespace(),
+				ReturnedName: observations[i].ReturnedName(), ReturnedNamespace: observations[i].ReturnedNamespace(),
+			}
+		}
+		return result
+	}
+
+	assertPermutationInvariant := func(t *testing.T, first, second *appsv1.ControllerRevision) []*RuntimeState {
+		t.Helper()
+		forward := resolve(t, first, second)
+		reverse := resolve(t, second, first)
+
+		assert.Equal(t, view(t, forward), view(t, reverse))
+		for _, state := range []*RuntimeState{forward, reverse} {
+			require.Len(t, state.RevisionObservations(), 2)
+			_, err := state.RequireConsistentActive()
+			assert.ErrorIs(t, err, ErrActiveRuntimeInconsistent)
+			for _, observation := range state.RevisionObservations() {
+				assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+				assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateContentHash)
+			}
+		}
+		return []*RuntimeState{forward, reverse}
+	}
+
+	t.Run("resource version tie break", func(t *testing.T) {
+		assertPermutationInvariant(t, rv2, rv3)
+	})
+
+	t.Run("same instant timestamp representations", func(t *testing.T) {
+		utc := exact.DeepCopy()
+		utc.ResourceVersion = "2"
+		utc.CreationTimestamp = metav1.NewTime(createdAt)
+		zoned := exact.DeepCopy()
+		zoned.ResourceVersion = "2"
+		zoned.CreationTimestamp = metav1.NewTime(createdAt.In(time.FixedZone("same-instant", 2*60*60)))
+		wantUTC := utc.DeepCopy()
+		wantZoned := zoned.DeepCopy()
+
+		states := assertPermutationInvariant(t, utc, zoned)
+
+		for _, state := range states {
+			for _, observation := range state.RevisionObservations() {
+				assert.Equal(t, time.UTC, observation.CreationTimestamp.Location())
+				assert.Equal(t, createdAt, observation.CreationTimestamp.Time)
+			}
+		}
+		assert.Equal(t, wantUTC, utc, "resolution must not mutate the UTC caller object")
+		assert.Equal(t, wantZoned, zoned, "resolution must not mutate the fixed-zone caller object")
+		assert.Equal(t, "same-instant", zoned.CreationTimestamp.Location().String())
+	})
+}
+
+func TestResolveHistoryFingerprintUsesOnlyWriterContractEvidence(t *testing.T) {
+	autoSync := false
+	resolve := func(t *testing.T, exact, listed *appsv1.ControllerRevision) *RuntimeState {
+		t.Helper()
+		resolver, err := newRuntimePinResolver(
+			func(string) revisionNamespace {
+				return revisionNamespaceStub{
+					get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+						return exact.DeepCopy(), nil
+					},
+					list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+						return &appsv1.ControllerRevisionList{Items: []appsv1.ControllerRevision{*listed.DeepCopy()}}, nil
+					},
+				}
+			},
+			liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+				return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+			}),
+			"ome", testPinLimits,
+		)
+		require.NoError(t, err)
+		state, err := resolver.Resolve(
+			context.Background(), pinISVC("runtime", &autoSync, exact.Name),
+			RuntimeResolveOptions{IncludeHistory: true},
+		)
+		require.NoError(t, err)
+		return state
+	}
+
+	t.Run("mutable metadata does not split one revision", func(t *testing.T) {
+		exact := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+		exact.UID = types.UID("revision-uid")
+		createdAt := time.Unix(100, 123).UTC()
+		exact.CreationTimestamp = metav1.NewTime(createdAt)
+		exact.ResourceVersion = "1"
+		exact.Annotations[constants.RuntimeRevisionGCEligibleSinceKey] = "2026-01-01T00:00:00Z"
+		exact.Annotations["example.com/mutable"] = "first"
+		exact.Finalizers = []string{"example.com/first"}
+		exact.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "ome.io/v1beta1", Kind: "InferenceService", Name: "first", UID: types.UID("owner-first"),
+		}}
+		exact.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "first"}}
+		listed := exact.DeepCopy()
+		listed.CreationTimestamp = metav1.NewTime(createdAt.In(time.FixedZone("same-instant", 2*60*60)))
+		listed.ResourceVersion = "2"
+		listed.Annotations[constants.RuntimeRevisionGCEligibleSinceKey] = "2026-02-01T00:00:00Z"
+		listed.Annotations["example.com/mutable"] = "second"
+		listed.Finalizers = []string{"example.com/second"}
+		listed.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "ome.io/v1beta1", Kind: "InferenceService", Name: "second", UID: types.UID("owner-second"),
+		}}
+		listed.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "second"}}
+		deletionTime := metav1.NewTime(time.Unix(200, 0))
+		gracePeriod := int64(30)
+		listed.DeletionTimestamp = &deletionTime
+		listed.DeletionGracePeriodSeconds = &gracePeriod
+
+		state := resolve(t, exact, listed)
+
+		observations := state.RevisionObservations()
+		require.Len(t, observations, 1)
+		assert.Equal(t, []RuntimeRevisionRole{
+			RuntimeRevisionRoleRequested, RuntimeRevisionRoleActive, RuntimeRevisionRoleHistory,
+		}, observations[0].Roles())
+		assert.NotContains(t, observations[0].ConsistencyCodes(), RevisionConsistencyConflictingIdentity)
+	})
+
+	t.Run("writer identity and content differences remain conflicts", func(t *testing.T) {
+		mutations := []struct {
+			name   string
+			mutate func(*appsv1.ControllerRevision)
+		}{
+			{name: "uid", mutate: func(revision *appsv1.ControllerRevision) {
+				revision.UID = types.UID("replacement-uid")
+			}},
+			{name: "creation timestamp", mutate: func(revision *appsv1.ControllerRevision) {
+				revision.CreationTimestamp = metav1.NewTime(time.Unix(101, 123).UTC())
+			}},
+			{name: "missing creation timestamp", mutate: func(revision *appsv1.ControllerRevision) {
+				revision.CreationTimestamp = metav1.Time{}
+			}},
+			{name: "writer label", mutate: func(revision *appsv1.ControllerRevision) {
+				revision.Labels[constants.RuntimeRevisionHashLabelKey] = "deadbeef"
+			}},
+			{name: "arbitrary label", mutate: func(revision *appsv1.ControllerRevision) {
+				revision.Labels["example.com/immutable"] = "added"
+			}},
+			{name: "data", mutate: func(revision *appsv1.ControllerRevision) {
+				revision.Data.Raw = []byte(`{}`)
+			}},
+		}
+		for _, mutation := range mutations {
+			t.Run(mutation.name, func(t *testing.T) {
+				exact := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+				exact.UID = types.UID("revision-uid")
+				exact.CreationTimestamp = metav1.NewTime(time.Unix(100, 123).UTC())
+				listed := exact.DeepCopy()
+				mutation.mutate(listed)
+
+				state := resolve(t, exact, listed)
+
+				observations := state.RevisionObservations()
+				require.Len(t, observations, 2)
+				for _, observation := range observations {
+					assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyConflictingIdentity)
+				}
+				_, err := state.RequireConsistentActive()
+				assert.ErrorIs(t, err, ErrActiveRuntimeInconsistent)
+			})
+		}
+	})
+}
+
+func TestRuntimeRevisionWriterFingerprintMatchesWebhookLabelEquality(t *testing.T) {
+	base := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	base.UID = types.UID("revision-uid")
+	base.CreationTimestamp = metav1.NewTime(time.Unix(100, 123).UTC())
+	tests := []struct {
+		name      string
+		prepare   func(*appsv1.ControllerRevision, *appsv1.ControllerRevision)
+		wantEqual bool
+	}{
+		{
+			name: "nil and empty maps differ",
+			prepare: func(left, right *appsv1.ControllerRevision) {
+				left.Labels = nil
+				right.Labels = map[string]string{}
+			},
+			wantEqual: false,
+		},
+		{
+			name: "equal maps ignore insertion order",
+			prepare: func(left, right *appsv1.ControllerRevision) {
+				entries := [][2]string{
+					{constants.RuntimeRevisionOfLabelKey, "runtime"},
+					{constants.RuntimeRevisionOfKindLabelKey, runtimeselector.KindClusterServingRuntime},
+					{constants.RuntimeRevisionOfNamespaceLabelKey, ""},
+					{constants.RuntimeRevisionHashLabelKey, base.Labels[constants.RuntimeRevisionHashLabelKey]},
+					{"example.com/immutable-a", "one"},
+					{"example.com/immutable-b", "two"},
+				}
+				left.Labels = make(map[string]string, len(entries))
+				right.Labels = make(map[string]string, len(entries))
+				for i := range entries {
+					left.Labels[entries[i][0]] = entries[i][1]
+					rightEntry := entries[len(entries)-1-i]
+					right.Labels[rightEntry[0]] = rightEntry[1]
+				}
+			},
+			wantEqual: true,
+		},
+		{
+			name: "arbitrary label values differ",
+			prepare: func(left, right *appsv1.ControllerRevision) {
+				left.Labels["example.com/immutable"] = "one"
+				right.Labels["example.com/immutable"] = "two"
+			},
+			wantEqual: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left := base.DeepCopy()
+			right := base.DeepCopy()
+			test.prepare(left, right)
+			assert.Equal(t, test.wantEqual, reflect.DeepEqual(left.Labels, right.Labels))
+
+			leftObservation := inspectRuntimeRevision(left, "ome", left.Name, "", "", "")
+			rightObservation := inspectRuntimeRevision(right, "ome", right.Name, "", "", "")
+			assert.Equal(t, test.wantEqual, leftObservation.objectFingerprint == rightObservation.objectFingerprint)
+
+			observations := []RuntimeRevisionObservation{leftObservation, rightObservation}
+			classifyRevisionCollectionAnomalies(observations)
+			for _, observation := range observations {
+				if test.wantEqual {
+					assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+					assert.NotContains(t, observation.ConsistencyCodes(), RevisionConsistencyConflictingIdentity)
+				} else {
+					assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyConflictingIdentity)
+					assert.NotContains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveHistoryPreservesExactFailureAssociation(t *testing.T) {
+	autoSync := false
+	requested := "requested-a"
+	missing := apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, requested)
+	history := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("history"))
+	history.Name = requested
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{
+				get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+					return nil, missing
+				},
+				list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					return &appsv1.ControllerRevisionList{Items: []appsv1.ControllerRevision{*history.DeepCopy()}}, nil
+				},
+			}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, requested)
+	isvc.Status.PinnedRevisionName = requested
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{IncludeHistory: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinStateRevisionMissing, state.PinState)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 2)
+	var exact, listed *RuntimeRevisionObservation
+	for i := range observations {
+		if observations[i].ExpectedName() == requested {
+			exact = &observations[i]
+		} else if observations[i].ReturnedName() == requested {
+			listed = &observations[i]
+		}
+	}
+	require.NotNil(t, exact)
+	require.NotNil(t, listed)
+	assert.False(t, exact.ObjectReturned())
+	assert.True(t, listed.ObjectReturned())
+	assert.Empty(t, exact.ReturnedName())
+	assert.Equal(t, "ome", exact.ExpectedNamespace())
+	assert.Empty(t, exact.ReturnedNamespace())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleRequested, RuntimeRevisionRoleReported}, exact.Roles())
+	assert.Empty(t, listed.ExpectedName())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleHistory}, listed.Roles())
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, requested, issues[0].RevisionName)
+	assert.ErrorIs(t, issues[0], missing)
+}
+
+func TestResolveHistoryPreservesDuplicateAndConflictingListEvidenceDeterministically(t *testing.T) {
+	first := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("first"))
+	second := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("second"))
+	second.Name = first.Name
+
+	resolve := func(t *testing.T, items []appsv1.ControllerRevision) []RuntimeRevisionObservation {
+		t.Helper()
+		resolver, err := newRuntimePinResolver(
+			func(string) revisionNamespace {
+				return revisionNamespaceStub{list: func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+					return &appsv1.ControllerRevisionList{Items: items}, nil
+				}}
+			},
+			liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+				return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+			}),
+			"ome", testPinLimits,
+		)
+		require.NoError(t, err)
+		state, err := resolver.Resolve(context.Background(), pinISVC("runtime", nil, ""), RuntimeResolveOptions{IncludeHistory: true})
+		require.NoError(t, err)
+		return state.RevisionObservations()
+	}
+
+	t.Run("duplicate", func(t *testing.T) {
+		observations := resolve(t, []appsv1.ControllerRevision{*first.DeepCopy(), *first.DeepCopy()})
+		require.Len(t, observations, 2)
+		for _, observation := range observations {
+			assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+			assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyDuplicateContentHash)
+		}
+	})
+
+	t.Run("conflicting", func(t *testing.T) {
+		forward := resolve(t, []appsv1.ControllerRevision{*first.DeepCopy(), *second.DeepCopy()})
+		reverse := resolve(t, []appsv1.ControllerRevision{*second.DeepCopy(), *first.DeepCopy()})
+		require.Len(t, forward, 2)
+		require.Len(t, reverse, 2)
+		codes := func(observations []RuntimeRevisionObservation) [][]RevisionConsistencyCode {
+			result := make([][]RevisionConsistencyCode, len(observations))
+			for i := range observations {
+				result[i] = observations[i].ConsistencyCodes()
+				assert.Contains(t, result[i], RevisionConsistencyConflictingIdentity)
+			}
+			return result
+		}
+		assert.Equal(t, codes(forward), codes(reverse))
+	})
+}
+
+func TestClassifyRevisionCollectionAnomaliesDetectsTrueShortHashCollision(t *testing.T) {
+	observations := []RuntimeRevisionObservation{
+		{Name: "a", Namespace: "ome", objectReturned: true, fullHash: "aaaa", computedShortHash: "deadbeef", Consistency: RevisionConsistencyConsistent},
+		{Name: "b", Namespace: "ome", objectReturned: true, fullHash: "bbbb", computedShortHash: "deadbeef", Consistency: RevisionConsistencyConsistent},
+	}
+
+	classifyRevisionCollectionAnomalies(observations)
+
+	for _, observation := range observations {
+		assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyShortHashCollision)
+		assert.Equal(t, RevisionConsistencyInconsistent, observation.Consistency)
+	}
+}
+
+func TestClassifyRevisionCollectionAnomaliesPreservesDuplicateSubsetWithinConflict(t *testing.T) {
+	observations := []RuntimeRevisionObservation{
+		{Name: "same", Namespace: "ome", objectReturned: true, objectFingerprint: "duplicate", Consistency: RevisionConsistencyConsistent},
+		{Name: "same", Namespace: "ome", objectReturned: true, objectFingerprint: "duplicate", Consistency: RevisionConsistencyConsistent},
+		{Name: "same", Namespace: "ome", objectReturned: true, objectFingerprint: "conflict", Consistency: RevisionConsistencyConsistent},
+	}
+
+	classifyRevisionCollectionAnomalies(observations)
+
+	assert.Contains(t, observations[0].ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+	assert.Contains(t, observations[1].ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+	assert.NotContains(t, observations[2].ConsistencyCodes(), RevisionConsistencyDuplicateIdentity)
+	for _, observation := range observations {
+		assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyConflictingIdentity)
+	}
+}
+
+func TestHistoryObservationOrderingUsesFullHashAsDeterministicTieBreak(t *testing.T) {
+	left := RuntimeRevisionObservation{Name: "same", Namespace: "ome", fullHash: "bbbb"}
+	right := RuntimeRevisionObservation{Name: "same", Namespace: "ome", fullHash: "aaaa"}
+	observations := []RuntimeRevisionObservation{left, right}
+
+	sortRuntimeRevisionObservations(observations)
+
+	fullHashes := []string{observations[0].fullHash, observations[1].fullHash}
+	expected := append([]string{}, fullHashes...)
+	sort.Strings(expected)
+	assert.Equal(t, expected, fullHashes)
+}

--- a/pkg/cli/effective/runtime_pin_revision.go
+++ b/pkg/cli/effective/runtime_pin_revision.go
@@ -20,7 +20,9 @@ import (
 
 func inspectRuntimeRevision(
 	revision *appsv1.ControllerRevision,
-	expectedNamespace, expectedName, runtimeName, sourceKind, sourceNamespace string,
+	expectedNamespace, expectedName, runtimeName string,
+	sourceKind runtimerevision.SourceKind,
+	sourceNamespace string,
 ) RuntimeRevisionObservation {
 	observation := RuntimeRevisionObservation{
 		Available: false, Consistency: RevisionConsistencyUnknown,
@@ -67,7 +69,7 @@ func inspectRuntimeRevision(
 	}
 	observedKindValid := observation.SourceKind == string(runtimerevision.KindClusterServingRuntime) ||
 		observation.SourceKind == string(runtimerevision.KindServingRuntime)
-	if !observedKindValid || (sourceKind != "" && observation.SourceKind != sourceKind) {
+	if !observedKindValid || (sourceKind != "" && observation.SourceKind != string(sourceKind)) {
 		addCode(RevisionConsistencySourceKind)
 	}
 	observedNamespaceValid := (observation.SourceKind == string(runtimerevision.KindClusterServingRuntime) && observation.SourceNamespace == "") ||
@@ -380,9 +382,9 @@ func (s *RuntimeState) LiveAvailability() LiveRuntimeAvailability {
 	}
 }
 
-// InferenceServiceIdentity returns the exact primary object identity whose
-// snapshot produced this runtime evidence. Projection layers must compare all
-// three fields before associating the state with an InferenceService.
+// InferenceServiceIdentity returns the safe primary object identity whose
+// snapshot produced this runtime evidence. Call MatchesInferenceService when
+// exact snapshot validation is required.
 func (s *RuntimeState) InferenceServiceIdentity() InferenceServiceIdentity {
 	if s == nil {
 		return InferenceServiceIdentity{}
@@ -398,6 +400,10 @@ func (s *RuntimeState) MatchesInferenceService(candidate *v1beta1.InferenceServi
 		return false
 	}
 	identity := s.inferenceService.identity
+	if identity.Name == "" || identity.Namespace == "" || identity.UID == "" ||
+		s.inferenceService.resourceVersion == "" {
+		return false
+	}
 	return identity.Name == candidate.Name &&
 		identity.Namespace == candidate.Namespace &&
 		identity.UID == string(candidate.UID) &&

--- a/pkg/cli/effective/runtime_pin_revision.go
+++ b/pkg/cli/effective/runtime_pin_revision.go
@@ -1,0 +1,454 @@
+package effective
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+)
+
+func inspectRuntimeRevision(
+	revision *appsv1.ControllerRevision,
+	expectedNamespace, expectedName, runtimeName, sourceKind, sourceNamespace string,
+) RuntimeRevisionObservation {
+	observation := RuntimeRevisionObservation{
+		Available: false, Consistency: RevisionConsistencyUnknown,
+		expectedName: expectedName, expectedNamespace: expectedNamespace,
+	}
+	if revision == nil {
+		return observation
+	}
+
+	observation.Name = revision.Name
+	observation.Namespace = revision.Namespace
+	observation.UID = string(revision.UID)
+	observation.ResourceVersion = revision.ResourceVersion
+	if revision.CreationTimestamp.Time.IsZero() {
+		observation.CreationTimestamp = metav1.Time{}
+	} else {
+		observation.CreationTimestamp = metav1.NewTime(revision.CreationTimestamp.Time.UTC())
+	}
+	observation.Ordinal = revision.Revision
+	observation.objectReturned = true
+	observation.objectFingerprint = runtimeRevisionWriterFingerprint(revision)
+	observation.SourceName = revision.Labels[constants.RuntimeRevisionOfLabelKey]
+	observation.SourceKind = revision.Labels[constants.RuntimeRevisionOfKindLabelKey]
+	observation.SourceNamespace = revision.Labels[constants.RuntimeRevisionOfNamespaceLabelKey]
+	observation.rawShortHash = revision.Labels[constants.RuntimeRevisionHashLabelKey]
+
+	addCode := func(code RevisionConsistencyCode) {
+		for _, existing := range observation.consistencyCodes {
+			if existing == code {
+				return
+			}
+		}
+		observation.consistencyCodes = append(observation.consistencyCodes, code)
+	}
+	if (expectedName != "" && revision.Name != expectedName) ||
+		(expectedNamespace != "" && revision.Namespace != expectedNamespace) {
+		addCode(RevisionConsistencyReturnedIdentity)
+	}
+	if revision.Annotations[constants.RuntimeRevisionCreatedByKey] != constants.RuntimeRevisionCreatedByOMEValue {
+		addCode(RevisionConsistencyCreatedBy)
+	}
+	if observation.SourceName == "" || (runtimeName != "" && observation.SourceName != runtimeName) {
+		addCode(RevisionConsistencySourceName)
+	}
+	observedKindValid := observation.SourceKind == string(runtimerevision.KindClusterServingRuntime) ||
+		observation.SourceKind == string(runtimerevision.KindServingRuntime)
+	if !observedKindValid || (sourceKind != "" && observation.SourceKind != sourceKind) {
+		addCode(RevisionConsistencySourceKind)
+	}
+	observedNamespaceValid := (observation.SourceKind == string(runtimerevision.KindClusterServingRuntime) && observation.SourceNamespace == "") ||
+		(observation.SourceKind == string(runtimerevision.KindServingRuntime) && observation.SourceNamespace != "")
+	if !observedNamespaceValid || (sourceKind != "" && observation.SourceNamespace != sourceNamespace) {
+		addCode(RevisionConsistencySourceNamespace)
+	}
+	if revision.Revision != 1 {
+		addCode(RevisionConsistencyOrdinal)
+	}
+	if revision.Data.Object != nil {
+		addCode(RevisionConsistencyUnexpectedDataObject)
+	}
+
+	spec := &v1beta1.ServingRuntimeSpec{}
+	if err := json.Unmarshal(revision.Data.Raw, spec); err != nil {
+		addCode(RevisionConsistencyMalformedPayload)
+		observation.Consistency = RevisionConsistencyInconsistent
+		sortConsistencyCodes(observation.consistencyCodes)
+		return observation
+	}
+	observation.usable = true
+	observation.Available = true
+	observation.spec = spec
+	observation.Disabled = spec.IsDisabled()
+	canonical, err := json.Marshal(spec)
+	if err != nil || !bytes.Equal(canonical, revision.Data.Raw) || !strictRuntimeSpecJSON(revision.Data.Raw) {
+		addCode(RevisionConsistencyPayloadCanonicality)
+	}
+	fullHash, shortHash, err := runtimerevision.Hash(spec)
+	if err == nil {
+		observation.fullHash = fullHash
+		observation.computedShortHash = shortHash
+		if !validShortHash(observation.rawShortHash) {
+			addCode(RevisionConsistencyHashLabelInvalid)
+		} else if observation.rawShortHash != shortHash {
+			addCode(RevisionConsistencyHashLabelMismatch)
+		} else {
+			observation.ShortHash = shortHash
+		}
+		if observation.SourceName != "" && observedKindValid && observedNamespaceValid {
+			expectedRevisionName := runtimerevision.Name(
+				runtimerevision.SourceKind(observation.SourceKind), observation.SourceNamespace,
+				observation.SourceName, shortHash,
+			)
+			if revision.Name != expectedRevisionName {
+				addCode(RevisionConsistencyNameHash)
+			}
+		}
+	} else {
+		addCode(RevisionConsistencyHashLabelInvalid)
+	}
+	if len(observation.consistencyCodes) == 0 {
+		observation.Consistency = RevisionConsistencyConsistent
+	} else {
+		observation.Consistency = RevisionConsistencyInconsistent
+		sortConsistencyCodes(observation.consistencyCodes)
+	}
+	return observation
+}
+
+func runtimeRevisionWriterFingerprint(revision *appsv1.ControllerRevision) string {
+	if revision == nil {
+		return ""
+	}
+	digest := sha256.New()
+	var length [8]byte
+	writePart := func(value []byte) {
+		binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+		_, _ = digest.Write(length[:])
+		_, _ = digest.Write(value)
+	}
+	writePresence := func(present bool) {
+		if present {
+			writePart([]byte{1})
+			return
+		}
+		writePart([]byte{0})
+	}
+
+	writePart([]byte(revision.UID))
+	createdAt := revision.CreationTimestamp.Time
+	writePresence(!createdAt.IsZero())
+	if !createdAt.IsZero() {
+		var seconds [8]byte
+		binary.BigEndian.PutUint64(seconds[:], uint64(createdAt.Unix()))
+		writePart(seconds[:])
+		var nanoseconds [4]byte
+		binary.BigEndian.PutUint32(nanoseconds[:], uint32(createdAt.Nanosecond()))
+		writePart(nanoseconds[:])
+	}
+	writePresence(revision.Labels != nil)
+	labelKeys := make([]string, 0, len(revision.Labels))
+	for key := range revision.Labels {
+		labelKeys = append(labelKeys, key)
+	}
+	sort.Strings(labelKeys)
+	var labelCount [8]byte
+	binary.BigEndian.PutUint64(labelCount[:], uint64(len(labelKeys)))
+	writePart(labelCount[:])
+	for _, key := range labelKeys {
+		writePart([]byte(key))
+		writePart([]byte(revision.Labels[key]))
+	}
+	writePresence(revision.Data.Raw != nil)
+	writePart(revision.Data.Raw)
+	if revision.Data.Object == nil {
+		writePresence(false)
+	} else {
+		encoded, err := json.Marshal(revision.Data.Object)
+		if err != nil {
+			return ""
+		}
+		writePresence(true)
+		writePart([]byte(fmt.Sprintf("%T", revision.Data.Object)))
+		writePart(encoded)
+	}
+	var ordinal [8]byte
+	binary.BigEndian.PutUint64(ordinal[:], uint64(revision.Revision))
+	writePart(ordinal[:])
+	createdBy, present := revision.Annotations[constants.RuntimeRevisionCreatedByKey]
+	writePresence(present)
+	writePart([]byte(createdBy))
+	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+func strictRuntimeSpecJSON(raw []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var spec v1beta1.ServingRuntimeSpec
+	if err := decoder.Decode(&spec); err != nil {
+		return false
+	}
+	return errors.Is(decoder.Decode(&struct{}{}), io.EOF)
+}
+
+func validShortHash(hash string) bool {
+	if len(hash) != 8 {
+		return false
+	}
+	for _, character := range hash {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func sortConsistencyCodes(codes []RevisionConsistencyCode) {
+	order := map[RevisionConsistencyCode]int{
+		RevisionConsistencyReturnedIdentity:     0,
+		RevisionConsistencyCreatedBy:            1,
+		RevisionConsistencySourceName:           2,
+		RevisionConsistencySourceKind:           3,
+		RevisionConsistencySourceNamespace:      4,
+		RevisionConsistencyHashLabelInvalid:     5,
+		RevisionConsistencyHashLabelMismatch:    6,
+		RevisionConsistencyNameHash:             7,
+		RevisionConsistencyOrdinal:              8,
+		RevisionConsistencyUnexpectedDataObject: 9,
+		RevisionConsistencyPayloadCanonicality:  10,
+		RevisionConsistencyMalformedPayload:     11,
+		RevisionConsistencyDuplicateIdentity:    12,
+		RevisionConsistencyConflictingIdentity:  13,
+		RevisionConsistencyDuplicateContentHash: 14,
+		RevisionConsistencyShortHashCollision:   15,
+	}
+	sort.SliceStable(codes, func(i, j int) bool { return order[codes[i]] < order[codes[j]] })
+}
+
+// RequireActive returns a defensive copy of the controller-selected active
+// configuration or a fixed error when controller evidence does not select one.
+func (s *RuntimeState) RequireActive() (*ActiveConfiguration, error) {
+	if s == nil || s.active == nil {
+		return nil, ErrActiveRuntimeUnavailable
+	}
+	return cloneActiveConfiguration(s.active), nil
+}
+
+// RequireConsistentActive is the mutation-safety gate. Controller-readable
+// revision data can remain active while failing this stronger writer contract.
+func (s *RuntimeState) RequireConsistentActive() (*ActiveConfiguration, error) {
+	active, err := s.RequireActive()
+	if err != nil {
+		return nil, err
+	}
+	if active.Consistency != RevisionConsistencyConsistent {
+		return nil, ErrActiveRuntimeInconsistent
+	}
+	return active, nil
+}
+
+func cloneActiveConfiguration(active *ActiveConfiguration) *ActiveConfiguration {
+	if active == nil {
+		return nil
+	}
+	cloned := *active
+	cloned.components = cloneEffectiveComponents(active.components)
+	if active.spec != nil {
+		cloned.spec = active.spec.DeepCopy()
+	}
+	return &cloned
+}
+
+// Components returns defensive copies of the merged component summaries and
+// their private typed specs.
+func (a *ActiveConfiguration) Components() []EffectiveComponent {
+	if a == nil {
+		return []EffectiveComponent{}
+	}
+	return cloneEffectiveComponents(a.components)
+}
+
+// Roles returns the deterministic set of evidence roles for this revision.
+func (o RuntimeRevisionObservation) Roles() []RuntimeRevisionRole {
+	return append([]RuntimeRevisionRole{}, o.roles...)
+}
+
+// ConsistencyCodes returns a defensive copy of bounded writer-contract codes.
+func (o RuntimeRevisionObservation) ConsistencyCodes() []RevisionConsistencyCode {
+	return append([]RevisionConsistencyCode{}, o.consistencyCodes...)
+}
+
+// ObjectReturned reports whether the API supplied a ControllerRevision object,
+// including when its payload or returned identity was malformed.
+func (o RuntimeRevisionObservation) ObjectReturned() bool {
+	return o.objectReturned
+}
+
+// ExpectedName returns the exact ControllerRevision GET key associated with
+// this evidence. It is empty for history-only observations.
+func (o RuntimeRevisionObservation) ExpectedName() string {
+	return o.expectedName
+}
+
+// ExpectedNamespace returns the namespace used for the exact GET or bounded
+// history LIST that produced this evidence.
+func (o RuntimeRevisionObservation) ExpectedNamespace() string {
+	return o.expectedNamespace
+}
+
+// ReturnedName returns the metadata.name supplied by the API response. It is
+// empty when an exact GET returned no object.
+func (o RuntimeRevisionObservation) ReturnedName() string {
+	if !o.objectReturned {
+		return ""
+	}
+	return o.Name
+}
+
+// ReturnedNamespace returns metadata.namespace from the API response. It is
+// empty when an exact GET returned no object.
+func (o RuntimeRevisionObservation) ReturnedNamespace() string {
+	if !o.objectReturned {
+		return ""
+	}
+	return o.Namespace
+}
+
+// LiveConfiguration returns a defensive copy of the independently resolved
+// live snapshot, or nil when live evidence was unavailable.
+func (s *RuntimeState) LiveConfiguration() *LiveConfiguration {
+	if s == nil {
+		return nil
+	}
+	return cloneLiveConfiguration(s.live)
+}
+
+// RevisionObservations returns defensive copies of safe revision provenance.
+func (s *RuntimeState) RevisionObservations() []RuntimeRevisionObservation {
+	if s == nil {
+		return []RuntimeRevisionObservation{}
+	}
+	observations := make([]RuntimeRevisionObservation, len(s.revisions))
+	for i := range s.revisions {
+		observations[i] = s.revisions[i]
+		observations[i].roles = s.revisions[i].Roles()
+		observations[i].consistencyCodes = s.revisions[i].ConsistencyCodes()
+		if s.revisions[i].spec != nil {
+			observations[i].spec = s.revisions[i].spec.DeepCopy()
+		}
+	}
+	return observations
+}
+
+// SourceIssues returns fixed-code evidence errors with their causes preserved
+// for errors.Is/errors.As diagnostics.
+func (s *RuntimeState) SourceIssues() []RuntimeSourceIssue {
+	if s == nil {
+		return []RuntimeSourceIssue{}
+	}
+	return append([]RuntimeSourceIssue{}, s.issues...)
+}
+
+// LiveAvailability returns the bounded outcome of independent live runtime
+// resolution without exposing the source error or runtime specification.
+func (s *RuntimeState) LiveAvailability() LiveRuntimeAvailability {
+	if s == nil {
+		return LiveRuntimeUnavailable
+	}
+	switch s.liveAvailability {
+	case liveAvailable:
+		return LiveRuntimeAvailable
+	case liveNotFound:
+		return LiveRuntimeNotFound
+	case liveDisabled:
+		return LiveRuntimeDisabled
+	default:
+		return LiveRuntimeUnavailable
+	}
+}
+
+// InferenceServiceIdentity returns the exact primary object identity whose
+// snapshot produced this runtime evidence. Projection layers must compare all
+// three fields before associating the state with an InferenceService.
+func (s *RuntimeState) InferenceServiceIdentity() InferenceServiceIdentity {
+	if s == nil {
+		return InferenceServiceIdentity{}
+	}
+	return s.inferenceService.identity
+}
+
+// MatchesInferenceService reports whether candidate is the exact Kubernetes
+// object snapshot used for collection. ResourceVersion participates in the
+// comparison but is deliberately never exposed by the state API.
+func (s *RuntimeState) MatchesInferenceService(candidate *v1beta1.InferenceService) bool {
+	if s == nil || candidate == nil {
+		return false
+	}
+	identity := s.inferenceService.identity
+	return identity.Name == candidate.Name &&
+		identity.Namespace == candidate.Namespace &&
+		identity.UID == string(candidate.UID) &&
+		s.inferenceService.resourceVersion == candidate.ResourceVersion
+}
+
+// HistoryNamespace returns the namespace searched for ControllerRevision
+// history. It is empty when no history LIST was attempted.
+func (s *RuntimeState) HistoryNamespace() string {
+	if s == nil {
+		return ""
+	}
+	return s.historyNamespace
+}
+
+func cloneLiveConfiguration(live *LiveConfiguration) *LiveConfiguration {
+	if live == nil {
+		return nil
+	}
+	cloned := *live
+	if live.Model != nil {
+		model := *live.Model
+		if live.Model.spec != nil {
+			model.spec = live.Model.spec.DeepCopy()
+		}
+		cloned.Model = &model
+	}
+	if live.Runtime.spec != nil {
+		cloned.Runtime.spec = live.Runtime.spec.DeepCopy()
+	}
+	cloned.Runtime.DeclaredInheritance.chain = append(
+		[]RuntimeSourceReference{}, live.Runtime.DeclaredInheritance.chain...,
+	)
+	cloned.Components = cloneEffectiveComponents(live.Components)
+	cloned.Advisories = append([]RuntimeAdvisory{}, live.Advisories...)
+	return &cloned
+}
+
+func cloneEffectiveComponents(components []EffectiveComponent) []EffectiveComponent {
+	cloned := make([]EffectiveComponent, len(components))
+	for i := range components {
+		cloned[i] = components[i]
+		if components[i].engine != nil {
+			cloned[i].engine = components[i].engine.DeepCopy()
+		}
+		if components[i].decoder != nil {
+			cloned[i].decoder = components[i].decoder.DeepCopy()
+		}
+		if components[i].router != nil {
+			cloned[i].router = components[i].router.DeepCopy()
+		}
+	}
+	return cloned
+}

--- a/pkg/cli/effective/runtime_pin_revision_test.go
+++ b/pkg/cli/effective/runtime_pin_revision_test.go
@@ -1,0 +1,370 @@
+package effective
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+func TestInspectRuntimeRevisionCanonicalizesCreationTimestampWithoutMutation(t *testing.T) {
+	location := time.FixedZone("same-instant", 2*60*60)
+	tests := []struct {
+		name      string
+		timestamp time.Time
+		want      metav1.Time
+	}{
+		{
+			name:      "nonzero timestamp uses UTC",
+			timestamp: time.Unix(100, 123).In(location),
+			want:      metav1.NewTime(time.Unix(100, 123).UTC()),
+		},
+		{
+			name:      "zero timestamp uses canonical zero",
+			timestamp: time.Time{}.In(location),
+			want:      metav1.Time{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			revision := revisionFixture(
+				t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("v1"),
+			)
+			revision.CreationTimestamp = metav1.NewTime(test.timestamp)
+			before := revision.DeepCopy()
+
+			observation := inspectRuntimeRevision(revision, "ome", revision.Name, "runtime", runtimeselector.KindClusterServingRuntime, "")
+
+			assert.Equal(t, test.want, observation.CreationTimestamp)
+			assert.Equal(t, before, revision, "inspection must not mutate the caller object")
+		})
+	}
+}
+
+func TestInspectRuntimeRevisionChecksWriterContractWithoutChangingReadability(t *testing.T) {
+	base := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("v1"))
+	expectedName := base.Name
+
+	valid := inspectRuntimeRevision(base.DeepCopy(), "ome", expectedName, "runtime", runtimeselector.KindClusterServingRuntime, "")
+	assert.True(t, valid.usable)
+	assert.Equal(t, RevisionConsistencyConsistent, valid.Consistency)
+	assert.Empty(t, valid.ConsistencyCodes())
+
+	tests := []struct {
+		name   string
+		mutate func(*appsv1.ControllerRevision)
+		code   RevisionConsistencyCode
+		usable bool
+	}{
+		{
+			name: "returned name", code: RevisionConsistencyReturnedIdentity, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Name = "returned-other" },
+		},
+		{
+			name: "returned namespace", code: RevisionConsistencyReturnedIdentity, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Namespace = "other" },
+		},
+		{
+			name: "created by", code: RevisionConsistencyCreatedBy, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) {
+				rev.Annotations[constants.RuntimeRevisionCreatedByKey] = "other"
+			},
+		},
+		{
+			name: "source name", code: RevisionConsistencySourceName, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Labels[constants.RuntimeRevisionOfLabelKey] = "other" },
+		},
+		{
+			name: "source kind", code: RevisionConsistencySourceKind, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) {
+				rev.Labels[constants.RuntimeRevisionOfKindLabelKey] = runtimeselector.KindServingRuntime
+			},
+		},
+		{
+			name: "source namespace", code: RevisionConsistencySourceNamespace, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) {
+				rev.Labels[constants.RuntimeRevisionOfNamespaceLabelKey] = "other"
+			},
+		},
+		{
+			name: "hash label invalid", code: RevisionConsistencyHashLabelInvalid, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Labels[constants.RuntimeRevisionHashLabelKey] = "ZZZZZZZZ" },
+		},
+		{
+			name: "hash label mismatch", code: RevisionConsistencyHashLabelMismatch, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Labels[constants.RuntimeRevisionHashLabelKey] = "deadbeef" },
+		},
+		{
+			name: "name hash", code: RevisionConsistencyNameHash, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Name = "cr-runtime-deadbeef" },
+		},
+		{
+			name: "ordinal", code: RevisionConsistencyOrdinal, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Revision = 2 },
+		},
+		{
+			name: "unexpected data object", code: RevisionConsistencyUnexpectedDataObject, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) {
+				rev.Data.Object = &appsv1.ControllerRevision{}
+			},
+		},
+		{
+			name: "noncanonical bytes", code: RevisionConsistencyPayloadCanonicality, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Data.Raw = append(rev.Data.Raw, '\n') },
+		},
+		{
+			name: "unknown field", code: RevisionConsistencyPayloadCanonicality, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Data.Raw = []byte(`{"unknown":1}`) },
+		},
+		{
+			name: "duplicate field", code: RevisionConsistencyPayloadCanonicality, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) {
+				rev.Data.Raw = []byte(`{"disabled":false,"disabled":false}`)
+			},
+		},
+		{
+			name: "null", code: RevisionConsistencyPayloadCanonicality, usable: true,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Data.Raw = []byte(`null`) },
+		},
+		{
+			name: "malformed", code: RevisionConsistencyMalformedPayload, usable: false,
+			mutate: func(rev *appsv1.ControllerRevision) { rev.Data.Raw = []byte(`{`) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			revision := base.DeepCopy()
+			test.mutate(revision)
+			got := inspectRuntimeRevision(revision, "ome", expectedName, "runtime", runtimeselector.KindClusterServingRuntime, "")
+			assert.Equal(t, test.usable, got.usable)
+			assert.Equal(t, RevisionConsistencyInconsistent, got.Consistency)
+			assert.Contains(t, got.ConsistencyCodes(), test.code)
+		})
+	}
+}
+
+func TestInspectRuntimeRevisionValidatesObservedWriterShapeWithoutDeclaredScope(t *testing.T) {
+	base := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("v1"))
+	tests := []struct {
+		name   string
+		mutate func(*appsv1.ControllerRevision)
+		code   RevisionConsistencyCode
+	}{
+		{name: "empty source name", code: RevisionConsistencySourceName, mutate: func(rev *appsv1.ControllerRevision) {
+			rev.Labels[constants.RuntimeRevisionOfLabelKey] = ""
+		}},
+		{name: "unknown source kind", code: RevisionConsistencySourceKind, mutate: func(rev *appsv1.ControllerRevision) {
+			rev.Labels[constants.RuntimeRevisionOfKindLabelKey] = "Bogus"
+		}},
+		{name: "cluster source with namespace", code: RevisionConsistencySourceNamespace, mutate: func(rev *appsv1.ControllerRevision) {
+			rev.Labels[constants.RuntimeRevisionOfNamespaceLabelKey] = "unexpected"
+		}},
+		{name: "namespaced source without namespace", code: RevisionConsistencySourceNamespace, mutate: func(rev *appsv1.ControllerRevision) {
+			rev.Labels[constants.RuntimeRevisionOfKindLabelKey] = runtimeselector.KindServingRuntime
+			rev.Labels[constants.RuntimeRevisionOfNamespaceLabelKey] = ""
+		}},
+		{name: "observed labels imply another name", code: RevisionConsistencyNameHash, mutate: func(rev *appsv1.ControllerRevision) {
+			rev.Labels[constants.RuntimeRevisionOfLabelKey] = "other-runtime"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			revision := base.DeepCopy()
+			test.mutate(revision)
+			got := inspectRuntimeRevision(revision, "ome", revision.Name, "", "", "")
+			assert.Contains(t, got.ConsistencyCodes(), test.code)
+		})
+	}
+}
+
+func TestRevisionShortHashIsVerifiedAndRelationsUseRecomputedHash(t *testing.T) {
+	live := livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false)
+	live.Runtime.spec = runtimeSpecFixture("live")
+	liveFull, liveShort, err := runtimerevision.Hash(live.Runtime.spec)
+	require.NoError(t, err)
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("different"))
+	revision.Labels[constants.RuntimeRevisionHashLabelKey] = liveShort
+
+	observation := inspectRuntimeRevision(
+		revision, "ome", revision.Name, "runtime", runtimeselector.KindClusterServingRuntime, "",
+	)
+	setObservationLiveRelation(&observation, liveFull, liveShort)
+
+	assert.Empty(t, observation.ShortHash, "mismatched raw label must not become public provenance")
+	assert.Contains(t, observation.ConsistencyCodes(), RevisionConsistencyHashLabelMismatch)
+	assert.Equal(t, RuntimeHashRelationDifferent, observation.RelationToLive)
+
+	valid := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("valid"))
+	verified := inspectRuntimeRevision(valid, "ome", valid.Name, "runtime", runtimeselector.KindClusterServingRuntime, "")
+	assert.Equal(t, valid.Labels[constants.RuntimeRevisionHashLabelKey], verified.ShortHash)
+}
+
+func TestResolveManagedPinKeepsInconsistentReadableRevisionActiveButBlocksConsistencyGate(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("v1"))
+	revision.Annotations[constants.RuntimeRevisionCreatedByKey] = "unexpected-writer"
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, "")
+	isvc.Status.PinnedRevisionName = revision.Name
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	require.NoError(t, err)
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, RevisionConsistencyInconsistent, active.Consistency)
+	_, err = state.RequireConsistentActive()
+	assert.EqualError(t, err, "active runtime configuration is not consistency-safe")
+}
+
+func TestResolveExplicitPinRejectsWrongRuntimeOfWithoutFallingBack(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "other-runtime", runtimeSpecFixture("other"))
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, revision.Name)
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinStateRevisionInvalid, state.PinState)
+	_, err = state.RequireActive()
+	assert.EqualError(t, err, "active runtime configuration is unavailable")
+}
+
+func TestRevisionEvidenceExposesSafeAssociationDisabledStateAndIssueKey(t *testing.T) {
+	autoSync := false
+	disabled := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", &v1beta1.ServingRuntimeSpec{Disabled: ptrBool(true)})
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return disabled.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, disabled.Name)
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	require.NoError(t, err)
+	observation := state.RevisionObservations()[0]
+	assert.Equal(t, disabled.Name, observation.ExpectedName())
+	assert.Equal(t, disabled.Name, observation.ReturnedName())
+	assert.True(t, observation.Disabled)
+
+	missingName := "missing-revision"
+	missing := apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, missingName)
+	missingResolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return nil, missing
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	state, err = missingResolver.Resolve(context.Background(), pinISVC("runtime", &autoSync, missingName), RuntimeResolveOptions{})
+	require.NoError(t, err)
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, missingName, issues[0].RevisionName)
+}
+
+func TestMalformedRevisionStillExposesReturnedIdentity(t *testing.T) {
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("bad"))
+	revision.Data.Raw = []byte(`{`)
+
+	observation := inspectRuntimeRevision(
+		revision, "ome", revision.Name, "runtime", runtimeselector.KindClusterServingRuntime, "",
+	)
+
+	assert.False(t, observation.Available)
+	assert.True(t, observation.ObjectReturned())
+	assert.Equal(t, revision.Name, observation.ExpectedName())
+	assert.Equal(t, revision.Name, observation.ReturnedName())
+	assert.Equal(t, "ome", observation.ExpectedNamespace())
+	assert.Equal(t, "ome", observation.ReturnedNamespace())
+}
+
+func FuzzInspectRuntimeRevisionPayload(f *testing.F) {
+	canonical, err := json.Marshal(runtimeSpecFixture("canonical"))
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, seed := range [][]byte{
+		canonical,
+		[]byte(`{}`),
+		[]byte(`null`),
+		[]byte(`{"unknown":1}`),
+		[]byte(`{"disabled":false,"disabled":true}`),
+		[]byte(`{`),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		revision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "revision", Namespace: "ome",
+				Labels: map[string]string{
+					constants.RuntimeRevisionOfLabelKey:          "runtime",
+					constants.RuntimeRevisionOfKindLabelKey:      runtimeselector.KindClusterServingRuntime,
+					constants.RuntimeRevisionOfNamespaceLabelKey: "",
+					constants.RuntimeRevisionHashLabelKey:        "deadbeef",
+				},
+				Annotations: map[string]string{
+					constants.RuntimeRevisionCreatedByKey: constants.RuntimeRevisionCreatedByOMEValue,
+				},
+			},
+			Data: runtimeRaw(string(raw)), Revision: 1,
+		}
+		observation := inspectRuntimeRevision(
+			revision, "ome", "revision", "runtime", runtimeselector.KindClusterServingRuntime, "",
+		)
+		assert.Equal(t, "revision", observation.ReturnedName())
+		assert.Equal(t, "ome", observation.ReturnedNamespace())
+		_, marshalErr := json.Marshal(observation)
+		assert.True(t, errors.Is(marshalErr, ErrUnsafeRuntimeSerialization))
+		assert.Equal(t, "<effective.RuntimeRevisionObservation redacted>", observation.String())
+	})
+}

--- a/pkg/cli/effective/runtime_pin_revision_test.go
+++ b/pkg/cli/effective/runtime_pin_revision_test.go
@@ -310,6 +310,42 @@ func TestRevisionEvidenceExposesSafeAssociationDisabledStateAndIssueKey(t *testi
 	assert.Equal(t, missingName, issues[0].RevisionName)
 }
 
+func TestResolveNilExactRevisionResponseIsUnavailable(t *testing.T) {
+	autoSync := false
+	const revisionName = "empty-revision-response"
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return nil, nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, "")
+	isvc.Status.PinnedRevisionName = revisionName
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinStateUnavailable, state.PinState)
+	_, err = state.RequireActive()
+	assert.ErrorIs(t, err, ErrActiveRuntimeUnavailable)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 1)
+	assert.False(t, observations[0].ObjectReturned())
+	assert.Equal(t, revisionName, observations[0].ExpectedName())
+	assert.Equal(t, "ome", observations[0].ExpectedNamespace())
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, RuntimeSourceIssueRevisionGetFailed, issues[0].Code)
+	assert.Equal(t, revisionName, issues[0].RevisionName)
+	assert.ErrorContains(t, errors.Unwrap(issues[0]), "empty response")
+}
+
 func TestMalformedRevisionStillExposesReturnedIdentity(t *testing.T) {
 	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("bad"))
 	revision.Data.Raw = []byte(`{`)

--- a/pkg/cli/effective/runtime_pin_safety_test.go
+++ b/pkg/cli/effective/runtime_pin_safety_test.go
@@ -93,6 +93,7 @@ func TestRuntimeStateBindsCollectedInferenceServiceIdentity(t *testing.T) {
 	assert.Equal(t, want, state.InferenceServiceIdentity())
 	assert.Equal(t, InferenceServiceIdentity{}, (*RuntimeState)(nil).InferenceServiceIdentity())
 	assert.True(t, state.MatchesInferenceService(isvc.DeepCopy()))
+	assert.False(t, (&RuntimeState{}).MatchesInferenceService(&v1beta1.InferenceService{}))
 	assert.False(t, state.MatchesInferenceService(nil))
 	assert.False(t, (*RuntimeState)(nil).MatchesInferenceService(isvc))
 

--- a/pkg/cli/effective/runtime_pin_safety_test.go
+++ b/pkg/cli/effective/runtime_pin_safety_test.go
@@ -1,0 +1,168 @@
+package effective
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+type runtimeSourceCauseCanary struct {
+	Text string
+}
+
+func (e runtimeSourceCauseCanary) Error() string { return e.Text }
+
+func TestRuntimeStateAccessorsReturnDefensiveCopies(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			live := livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false)
+			live.Runtime.spec = runtimeSpecFixture("live")
+			return live, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, revision.Name)
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	require.NoError(t, err)
+
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	components := active.Components()
+	require.NotEmpty(t, components)
+	components[0].engine.Runner.Image = "mutated"
+	again, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, "pin", again.Components()[0].engine.Runner.Image)
+
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 1)
+	roles := observations[0].Roles()
+	roles[0] = RuntimeRevisionRoleHistory
+	observations[0].spec.EngineConfig.Runner.Image = "mutated"
+	againObservations := state.RevisionObservations()
+	assert.Equal(t, RuntimeRevisionRoleRequested, againObservations[0].Roles()[0])
+	assert.Equal(t, "pin", againObservations[0].spec.EngineConfig.Runner.Image)
+
+	live := state.LiveConfiguration()
+	require.NotNil(t, live)
+	live.Runtime.spec.EngineConfig.Runner.Image = "mutated"
+	assert.Equal(t, "live", state.LiveConfiguration().Runtime.spec.EngineConfig.Runner.Image)
+}
+
+func TestRuntimeStateBindsCollectedInferenceServiceIdentity(t *testing.T) {
+	autoSync := true
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace { return revisionNamespaceStub{} },
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, "")
+	isvc.UID = "inference-service-uid"
+	isvc.ResourceVersion = "17"
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	require.NoError(t, err)
+
+	want := InferenceServiceIdentity{
+		Name: "chat", Namespace: "workloads", UID: "inference-service-uid",
+	}
+	assert.Equal(t, want, state.InferenceServiceIdentity())
+	assert.Equal(t, InferenceServiceIdentity{}, (*RuntimeState)(nil).InferenceServiceIdentity())
+	assert.True(t, state.MatchesInferenceService(isvc.DeepCopy()))
+	assert.False(t, state.MatchesInferenceService(nil))
+	assert.False(t, (*RuntimeState)(nil).MatchesInferenceService(isvc))
+
+	mutations := []func(*v1beta1.InferenceService){
+		func(candidate *v1beta1.InferenceService) { candidate.Name = "other" },
+		func(candidate *v1beta1.InferenceService) { candidate.Namespace = "other" },
+		func(candidate *v1beta1.InferenceService) { candidate.UID = "other" },
+		func(candidate *v1beta1.InferenceService) { candidate.ResourceVersion = "18" },
+	}
+	for _, mutate := range mutations {
+		candidate := isvc.DeepCopy()
+		mutate(candidate)
+		assert.False(t, state.MatchesInferenceService(candidate))
+	}
+}
+
+func TestUnsafeRuntimePinTypesRejectJSONAndYAMLSerialization(t *testing.T) {
+	values := []any{
+		RuntimeState{},
+		ActiveConfiguration{spec: runtimeSpecFixture("secret")},
+		RuntimeRevisionObservation{spec: runtimeSpecFixture("secret")},
+	}
+	for _, value := range values {
+		_, err := json.Marshal(value)
+		assert.ErrorIs(t, err, ErrUnsafeRuntimeSerialization)
+		_, err = sigsyaml.Marshal(value)
+		assert.True(t, errors.Is(err, ErrUnsafeRuntimeSerialization), "%T: %v", value, err)
+	}
+}
+
+func TestRequireActiveUsesStableSentinelErrors(t *testing.T) {
+	_, err := (*RuntimeState)(nil).RequireActive()
+	assert.ErrorIs(t, err, ErrActiveRuntimeUnavailable)
+
+	state := &RuntimeState{active: &ActiveConfiguration{Consistency: RevisionConsistencyUnknown}}
+	_, err = state.RequireConsistentActive()
+	assert.ErrorIs(t, err, ErrActiveRuntimeInconsistent)
+}
+
+func TestRuntimePinTypesHaveFixedRedactedStringFormatting(t *testing.T) {
+	const sentinel = "redaction-canary-do-not-emit"
+	values := []struct {
+		value any
+		want  string
+	}{
+		{RuntimeState{RuntimeName: sentinel}, "<effective.RuntimeState redacted>"},
+		{ActiveConfiguration{RuntimeName: sentinel, spec: runtimeSpecFixture(sentinel)}, "<effective.ActiveConfiguration redacted>"},
+		{RuntimeRevisionObservation{SourceName: sentinel, spec: runtimeSpecFixture(sentinel)}, "<effective.RuntimeRevisionObservation redacted>"},
+	}
+	for _, test := range values {
+		got := fmt.Sprintf("%v|%+v|%#v", test.value, test.value, test.value)
+		assert.NotContains(t, got, sentinel)
+		assert.Equal(t, strings.Join([]string{test.want, test.want, test.want}, "|"), got)
+	}
+}
+
+func TestRuntimeSourceIssueFormattingNeverExposesCause(t *testing.T) {
+	const sentinel = "runtime-source-cause-redaction-canary"
+	cause := runtimeSourceCauseCanary{Text: sentinel}
+	issue := RuntimeSourceIssue{
+		Code: RuntimeSourceIssueRevisionGetFailed, RevisionName: "safe-revision", cause: cause,
+	}
+
+	formatted := fmt.Sprintf("%v|%+v|%#v", issue, issue, issue)
+
+	assert.NotContains(t, formatted, sentinel)
+	assert.Equal(t,
+		"runtime revision evidence read failed|runtime revision evidence read failed|<effective.RuntimeSourceIssue redacted>",
+		formatted,
+	)
+	assert.Equal(t, "runtime revision evidence read failed", issue.Error())
+	assert.ErrorIs(t, issue, cause)
+}

--- a/pkg/cli/effective/runtime_pin_state.go
+++ b/pkg/cli/effective/runtime_pin_state.go
@@ -1,0 +1,94 @@
+package effective
+
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	knapis "knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+func classifyLiveAvailability(live *LiveConfiguration, err error) liveAvailability {
+	if err == nil && live != nil && live.Runtime.spec != nil {
+		return liveAvailable
+	}
+	var notFound *runtimeselector.RuntimeNotFoundError
+	if errors.As(err, &notFound) {
+		return liveNotFound
+	}
+	var disabled *runtimeselector.RuntimeDisabledError
+	if errors.As(err, &disabled) {
+		return liveDisabled
+	}
+	return liveUnreadable
+}
+
+func deriveStatusFreshness(generation, observedGeneration int64) StatusFreshness {
+	if observedGeneration == 0 {
+		return StatusFreshnessUnknown
+	}
+	if observedGeneration == generation {
+		return StatusFreshnessCurrent
+	}
+	if observedGeneration < generation {
+		return StatusFreshnessStale
+	}
+	return StatusFreshnessInconsistent
+}
+
+func deriveSyncTokenState(annotation, status string) SyncTokenState {
+	switch {
+	case annotation == "" && status == "":
+		return SyncTokenStateAbsent
+	case annotation == "":
+		return SyncTokenStateStatusOnly
+	case annotation == status:
+		return SyncTokenStateAcknowledged
+	default:
+		return SyncTokenStatePending
+	}
+}
+
+func deriveRuntimeDrift[T ~[]knapis.Condition](conditions T) (RuntimeDriftState, RuntimeDriftReason) {
+	found := false
+	var drift knapis.Condition
+	for _, condition := range conditions {
+		if string(condition.Type) != constants.RuntimeDriftedConditionType {
+			continue
+		}
+		if found {
+			return RuntimeDriftStateMalformed, ""
+		}
+		found = true
+		drift = condition
+	}
+	if !found {
+		return RuntimeDriftStateNotReported, ""
+	}
+	reason := classifyRuntimeDriftReason(drift.Reason)
+	switch drift.Status {
+	case corev1.ConditionTrue:
+		return RuntimeDriftStateReportedTrue, reason
+	case corev1.ConditionFalse:
+		return RuntimeDriftStateReportedFalse, reason
+	case corev1.ConditionUnknown:
+		return RuntimeDriftStateReportedUnknown, reason
+	default:
+		return RuntimeDriftStateMalformed, reason
+	}
+}
+
+func classifyRuntimeDriftReason(reason string) RuntimeDriftReason {
+	switch RuntimeDriftReason(reason) {
+	case RuntimeDriftReasonRevisionMismatch,
+		RuntimeDriftReasonRevisionMissing,
+		RuntimeDriftReasonSourceRuntimeMissing,
+		RuntimeDriftReasonRuntimeMismatch,
+		RuntimeDriftReasonPinAdvanced:
+		return RuntimeDriftReason(reason)
+	default:
+		return RuntimeDriftReasonOther
+	}
+}

--- a/pkg/cli/effective/runtime_pin_state_test.go
+++ b/pkg/cli/effective/runtime_pin_state_test.go
@@ -1,0 +1,284 @@
+package effective
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	knapis "knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+func TestResolvePinRemainsActiveWhenLiveSourceIsMissingOrDisabled(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	tests := []struct {
+		name             string
+		liveErr          error
+		wantAvailability LiveRuntimeAvailability
+	}{
+		{
+			name: "not found",
+			liveErr: &runtimeselector.RuntimeNotFoundError{
+				RuntimeName: "runtime", Namespace: "workloads",
+			},
+			wantAvailability: LiveRuntimeNotFound,
+		},
+		{
+			name:             "disabled",
+			liveErr:          &runtimeselector.RuntimeDisabledError{RuntimeName: "runtime", IsCluster: true},
+			wantAvailability: LiveRuntimeDisabled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver, err := newRuntimePinResolver(
+				func(string) revisionNamespace {
+					return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+						return revision.DeepCopy(), nil
+					}}
+				},
+				liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+					return nil, test.liveErr
+				}),
+				"ome", testPinLimits,
+			)
+			require.NoError(t, err)
+			isvc := pinISVC("runtime", &autoSync, "")
+			isvc.Status.PinnedRevisionName = revision.Name
+
+			state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantAvailability, state.LiveAvailability())
+			assert.Equal(t, RuntimePinStateResolved, state.PinState)
+			active, err := state.RequireActive()
+			require.NoError(t, err)
+			assert.Equal(t, revision.Name, active.RevisionName)
+		})
+	}
+}
+
+func TestResolveHardLiveFailureCollectsExactPinButDoesNotLabelItActive(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	liveCause := errors.New("credential-bearing upstream failure")
+	var getCalls int
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				getCalls++
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return nil, liveCause
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, revision.Name)
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, getCalls)
+	assert.Equal(t, LiveRuntimeUnavailable, state.LiveAvailability())
+	assert.Equal(t, RuntimePinStateUnavailable, state.PinState)
+	_, err = state.RequireActive()
+	assert.EqualError(t, err, "active runtime configuration is unavailable")
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, "live runtime evidence is unavailable", issues[0].Error())
+	assert.ErrorIs(t, issues[0], liveCause)
+}
+
+func TestResolveRevisionFailureStates(t *testing.T) {
+	autoSync := false
+	disabled := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", &v1beta1.ServingRuntimeSpec{Disabled: ptrBool(true)})
+	malformed := disabled.DeepCopy()
+	malformed.Name = "malformed"
+	malformed.Data.Raw = []byte(`{`)
+	missingErr := apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, "missing")
+	tests := []struct {
+		name     string
+		revision string
+		get      func() (*appsv1.ControllerRevision, error)
+		want     RuntimePinState
+	}{
+		{name: "missing", revision: "missing", get: func() (*appsv1.ControllerRevision, error) { return nil, missingErr }, want: RuntimePinStateRevisionMissing},
+		{name: "malformed", revision: malformed.Name, get: func() (*appsv1.ControllerRevision, error) { return malformed.DeepCopy(), nil }, want: RuntimePinStateRevisionInvalid},
+		{name: "disabled", revision: disabled.Name, get: func() (*appsv1.ControllerRevision, error) { return disabled.DeepCopy(), nil }, want: RuntimePinStateRevisionDisabled},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver, err := newRuntimePinResolver(
+				func(string) revisionNamespace {
+					return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+						return test.get()
+					}}
+				},
+				liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+					return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+				}),
+				"ome", testPinLimits,
+			)
+			require.NoError(t, err)
+			isvc := pinISVC("runtime", &autoSync, test.revision)
+
+			state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, test.want, state.PinState)
+			_, err = state.RequireActive()
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestResolveBoundsExactGetAndPreservesTimeoutCause(t *testing.T) {
+	limits := testPinLimits
+	limits.RequestTimeout = 5 * time.Millisecond
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(ctx context.Context, _ string, _ metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", limits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", nil, "")
+	isvc.Status.PinnedRevisionName = "retained"
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, ConfigurationOriginLiveRuntime, active.Origin)
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, "runtime revision evidence read failed", issues[0].Error())
+	assert.ErrorIs(t, issues[0], context.DeadlineExceeded)
+}
+
+func TestResolveParentCancellationIsTopLevel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace { return revisionNamespaceStub{} },
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(ctx, pinISVC("runtime", nil, ""), RuntimeResolveOptions{})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResolveChecksParentCancellationAfterSuccessfulExactGet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				cancel()
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(ctx, pinISVC("runtime", &autoSync, revision.Name), RuntimeResolveOptions{})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResolveInitializesSafeDefaultsAndMarksLiveActiveEqual(t *testing.T) {
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace { return revisionNamespaceStub{} },
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			live := livePinFixture("selected", runtimeselector.KindClusterServingRuntime, "", false)
+			live.Runtime.SelectionSource = RuntimeSelected
+			return live, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("selected", nil, "")
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeSelected, state.SelectionSource)
+	assert.Equal(t, LiveRuntimeAvailable, state.LiveAvailability())
+	assert.Equal(t, RuntimeHashRelationEqual, state.LiveToActive)
+
+	hardResolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace { return revisionNamespaceStub{} },
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return nil, errors.New("unreadable")
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	empty := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads"}}
+	state, err = hardResolver.Resolve(context.Background(), empty, RuntimeResolveOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, RuntimeSelected, state.SelectionSource)
+	assert.Equal(t, RuntimeHashRelationUnknown, state.LiveToActive)
+}
+
+func TestDerivedRuntimeStates(t *testing.T) {
+	assert.Equal(t, StatusFreshnessUnknown, deriveStatusFreshness(3, 0))
+	assert.Equal(t, StatusFreshnessCurrent, deriveStatusFreshness(3, 3))
+	assert.Equal(t, StatusFreshnessStale, deriveStatusFreshness(3, 2))
+	assert.Equal(t, StatusFreshnessInconsistent, deriveStatusFreshness(3, 4))
+
+	assert.Equal(t, SyncTokenStateAbsent, deriveSyncTokenState("", ""))
+	assert.Equal(t, SyncTokenStateStatusOnly, deriveSyncTokenState("", "old"))
+	assert.Equal(t, SyncTokenStateAcknowledged, deriveSyncTokenState("same", "same"))
+	assert.Equal(t, SyncTokenStatePending, deriveSyncTokenState("new", "old"))
+
+	state, reason := deriveRuntimeDrift(knapis.Conditions(nil))
+	assert.Equal(t, RuntimeDriftStateNotReported, state)
+	assert.Empty(t, reason)
+	state, reason = deriveRuntimeDrift([]knapis.Condition{{
+		Type: knapis.ConditionType(constants.RuntimeDriftedConditionType), Status: corev1.ConditionTrue, Reason: "RevisionMismatch",
+	}})
+	assert.Equal(t, RuntimeDriftStateReportedTrue, state)
+	assert.Equal(t, RuntimeDriftReasonRevisionMismatch, reason)
+	state, reason = deriveRuntimeDrift([]knapis.Condition{{
+		Type: knapis.ConditionType(constants.RuntimeDriftedConditionType), Status: corev1.ConditionUnknown, Reason: "secret-reason",
+	}})
+	assert.Equal(t, RuntimeDriftStateReportedUnknown, state)
+	assert.Equal(t, RuntimeDriftReasonOther, reason)
+	state, _ = deriveRuntimeDrift([]knapis.Condition{{
+		Type: knapis.ConditionType(constants.RuntimeDriftedConditionType), Status: corev1.ConditionStatus("bogus"),
+	}})
+	assert.Equal(t, RuntimeDriftStateMalformed, state)
+
+	assert.Equal(t, RuntimeHashRelationAmbiguous, compareRuntimeHashes("aaaa", "deadbeef", "bbbb", "deadbeef"))
+}
+
+func ptrBool(value bool) *bool { return &value }

--- a/pkg/cli/effective/runtime_pin_state_test.go
+++ b/pkg/cli/effective/runtime_pin_state_test.go
@@ -20,54 +20,64 @@ import (
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 )
 
-func TestResolvePinRemainsActiveWhenLiveSourceIsMissingOrDisabled(t *testing.T) {
+func TestResolvePinRemainsActiveWhenLiveSourceIsMissing(t *testing.T) {
 	autoSync := false
 	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
-	tests := []struct {
-		name             string
-		liveErr          error
-		wantAvailability LiveRuntimeAvailability
-	}{
-		{
-			name: "not found",
-			liveErr: &runtimeselector.RuntimeNotFoundError{
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return nil, &runtimeselector.RuntimeNotFoundError{
 				RuntimeName: "runtime", Namespace: "workloads",
-			},
-			wantAvailability: LiveRuntimeNotFound,
-		},
-		{
-			name:             "disabled",
-			liveErr:          &runtimeselector.RuntimeDisabledError{RuntimeName: "runtime", IsCluster: true},
-			wantAvailability: LiveRuntimeDisabled,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			resolver, err := newRuntimePinResolver(
-				func(string) revisionNamespace {
-					return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
-						return revision.DeepCopy(), nil
-					}}
-				},
-				liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
-					return nil, test.liveErr
-				}),
-				"ome", testPinLimits,
-			)
-			require.NoError(t, err)
-			isvc := pinISVC("runtime", &autoSync, "")
-			isvc.Status.PinnedRevisionName = revision.Name
+			}
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, "")
+	isvc.Status.PinnedRevisionName = revision.Name
 
-			state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
 
-			require.NoError(t, err)
-			assert.Equal(t, test.wantAvailability, state.LiveAvailability())
-			assert.Equal(t, RuntimePinStateResolved, state.PinState)
-			active, err := state.RequireActive()
-			require.NoError(t, err)
-			assert.Equal(t, revision.Name, active.RevisionName)
-		})
-	}
+	require.NoError(t, err)
+	assert.Equal(t, LiveRuntimeNotFound, state.LiveAvailability())
+	assert.Equal(t, RuntimePinStateResolved, state.PinState)
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, revision.Name, active.RevisionName)
+}
+
+func TestResolveDisabledLiveSourceCollectsPinButDoesNotLabelItActive(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("pin"))
+	var getCalls int
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				getCalls++
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return nil, &runtimeselector.RuntimeDisabledError{RuntimeName: "runtime", IsCluster: true}
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, "")
+	isvc.Status.PinnedRevisionName = revision.Name
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, getCalls)
+	assert.Equal(t, LiveRuntimeDisabled, state.LiveAvailability())
+	assert.Equal(t, RuntimePinStateUnavailable, state.PinState)
+	_, err = state.RequireActive()
+	assert.ErrorIs(t, err, ErrActiveRuntimeUnavailable)
 }
 
 func TestResolveHardLiveFailureCollectsExactPinButDoesNotLabelItActive(t *testing.T) {

--- a/pkg/cli/effective/runtime_pin_test.go
+++ b/pkg/cli/effective/runtime_pin_test.go
@@ -1,0 +1,402 @@
+package effective
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+var testPinLimits = paging.Limits{
+	PageSize: 2, MaxItems: 10, MaxPages: 5, RequestTimeout: time.Second,
+}
+
+func runtimeRaw(raw string) runtime.RawExtension { return runtime.RawExtension{Raw: []byte(raw)} }
+
+func runtimeSpecFixture(marker string) *v1beta1.ServingRuntimeSpec {
+	return &v1beta1.ServingRuntimeSpec{
+		EngineConfig: &v1beta1.EngineSpec{Runner: &v1beta1.RunnerSpec{
+			Container: corev1.Container{Name: "runner", Image: marker},
+		}},
+		ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{
+			NodeSelector: map[string]string{"version": marker},
+		},
+	}
+}
+
+func revisionFixture(t *testing.T, kind, sourceNamespace, runtimeName string, spec *v1beta1.ServingRuntimeSpec) *appsv1.ControllerRevision {
+	t.Helper()
+	full, short, err := runtimerevision.Hash(spec)
+	require.NoError(t, err)
+	assert.Len(t, full, 64)
+	raw, err := json.Marshal(spec)
+	require.NoError(t, err)
+	name := runtimerevision.Name(runtimerevision.SourceKind(kind), sourceNamespace, runtimeName, short)
+	return &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "ome",
+			Labels: map[string]string{
+				constants.RuntimeRevisionOfLabelKey:          runtimeName,
+				constants.RuntimeRevisionOfKindLabelKey:      kind,
+				constants.RuntimeRevisionOfNamespaceLabelKey: sourceNamespace,
+				constants.RuntimeRevisionHashLabelKey:        short,
+			},
+			Annotations: map[string]string{
+				constants.RuntimeRevisionCreatedByKey: constants.RuntimeRevisionCreatedByOMEValue,
+			},
+		},
+		Data: runtime.RawExtension{Raw: raw}, Revision: 1,
+	}
+}
+
+type liveRuntimeResolverFunc func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error)
+
+func (f liveRuntimeResolverFunc) ResolveLive(ctx context.Context, isvc *v1beta1.InferenceService) (*LiveConfiguration, error) {
+	return f(ctx, isvc)
+}
+
+func TestResolveManagedPinUsesDeclaredClusterSourceDespiteNamespacedLiveFallback(t *testing.T) {
+	autoSync := false
+	spec := runtimeSpecFixture("managed")
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "same-name", spec)
+	resolver, err := newRuntimePinResolver(
+		func(namespace string) revisionNamespace {
+			assert.Equal(t, "ome", namespace)
+			return revisionNamespaceStub{get: func(_ context.Context, name string, _ metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				assert.Equal(t, revision.Name, name)
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("same-name", runtimeselector.KindServingRuntime, "workloads", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("same-name", &autoSync, "")
+	isvc.Status.PinnedRevisionName = revision.Name
+
+	got, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinModeManagedPin, got.PinMode)
+	assert.Equal(t, RuntimePinStateResolved, got.PinState)
+	assert.Equal(t, runtimeselector.KindClusterServingRuntime, got.DeclaredSourceKind)
+	assert.Empty(t, got.DeclaredSourceNamespace)
+	active, err := got.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, ConfigurationOriginControllerRevision, active.Origin)
+	assert.Equal(t, revision.Name, got.ActiveRevisionName)
+}
+
+func TestResolveExplicitPinGetsRequestedThenReportedAndNeverFallsBack(t *testing.T) {
+	autoSync := false
+	liveSpec := runtimeSpecFixture("live")
+	requestedSpec := runtimeSpecFixture("requested")
+	reportedSpec := runtimeSpecFixture("reported")
+	requested := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", requestedSpec)
+	reported := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", reportedSpec)
+	byName := map[string]*appsv1.ControllerRevision{requested.Name: requested, reported.Name: reported}
+	var gets []string
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(_ context.Context, name string, _ metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				gets = append(gets, name)
+				return byName[name].DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			live := livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false)
+			live.Runtime.spec = liveSpec
+			return live, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, requested.Name)
+	isvc.Status.PinnedRevisionName = reported.Name
+
+	got, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{requested.Name, reported.Name}, gets)
+	assert.Equal(t, RuntimePinModeExplicitPin, got.PinMode)
+	assert.Equal(t, RuntimePinStateDesiredReportedMismatch, got.PinState)
+	assert.Equal(t, requested.Name, got.ActiveRevisionName)
+	active, err := got.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, requested.Name, active.RevisionName)
+	assert.Equal(t, RuntimeHashRelationDifferent, got.LiveToActive)
+}
+
+func TestResolveDeduplicatesEqualRequestedAndReportedRevision(t *testing.T) {
+	autoSync := false
+	revision := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("same"))
+	var gets int
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				gets++
+				return revision.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, revision.Name)
+	isvc.Status.PinnedRevisionName = revision.Name
+
+	got, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, gets)
+	observations := got.RevisionObservations()
+	require.Len(t, observations, 1)
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleRequested, RuntimeRevisionRoleReported, RuntimeRevisionRoleActive}, observations[0].Roles())
+}
+
+func TestResolveDeduplicatesByExpectedNameWhenServerReturnsMismatchedIdentity(t *testing.T) {
+	autoSync := false
+	expectedName := "requested-name"
+	returned := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("same"))
+	returned.Name = "returned-other"
+	var gets int
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				gets++
+				return returned.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, expectedName)
+	isvc.Status.PinnedRevisionName = expectedName
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, gets)
+	assert.Equal(t, RuntimePinStateResolved, state.PinState)
+	active, err := state.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, expectedName, active.RevisionName)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 1)
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleRequested, RuntimeRevisionRoleReported, RuntimeRevisionRoleActive}, observations[0].Roles())
+}
+
+func TestResolveDoesNotDedupeReturnedNameAgainstDifferentExactRequestKey(t *testing.T) {
+	autoSync := false
+	requestedA := "requested-a"
+	returnedB := revisionFixture(t, runtimeselector.KindClusterServingRuntime, "", "runtime", runtimeSpecFixture("b"))
+	reportedB := returnedB.Name
+	var gets []string
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(_ context.Context, name string, _ metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				gets = append(gets, name)
+				return returnedB.DeepCopy(), nil
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return livePinFixture("runtime", runtimeselector.KindClusterServingRuntime, "", false), nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("runtime", &autoSync, requestedA)
+	isvc.Status.PinnedRevisionName = reportedB
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{requestedA, reportedB}, gets)
+	assert.Equal(t, RuntimePinStateDesiredReportedMismatch, state.PinState)
+	assert.Equal(t, requestedA, state.ActiveRevisionName)
+	observations := state.RevisionObservations()
+	require.Len(t, observations, 2)
+	byExpected := make(map[string]RuntimeRevisionObservation, len(observations))
+	for _, observation := range observations {
+		byExpected[observation.ExpectedName()] = observation
+	}
+	assert.Equal(t, returnedB.Name, byExpected[requestedA].ReturnedName())
+	assert.Equal(t, returnedB.Name, byExpected[reportedB].ReturnedName())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleRequested, RuntimeRevisionRoleActive}, byExpected[requestedA].Roles())
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleReported}, byExpected[reportedB].Roles())
+}
+
+func TestResolveNilLiveSpecIsBoundedUnavailable(t *testing.T) {
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace { return revisionNamespaceStub{} },
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return &LiveConfiguration{Runtime: RuntimeResolution{Name: "runtime"}}, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+
+	state, err := resolver.Resolve(context.Background(), pinISVC("runtime", nil, ""), RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinStateUnavailable, state.PinState)
+	_, err = state.RequireActive()
+	assert.Error(t, err)
+	issues := state.SourceIssues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, RuntimeSourceIssueLiveUnavailable, issues[0].Code)
+}
+
+func TestResolveEmptyRuntimeNameDoesNotReadRetainedPinAgainstSelectedRuntime(t *testing.T) {
+	var revisionCalls int
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{get: func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+				revisionCalls++
+				return nil, errors.New("must not read retained pin")
+			}}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			live := livePinFixture("selected-runtime", runtimeselector.KindClusterServingRuntime, "", false)
+			live.Runtime.SelectionSource = RuntimeSelected
+			return live, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("", ptr.To(false), "")
+	isvc.Status.PinnedRevisionName = "retained-old-pin"
+
+	state, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinModeAutoSync, state.PinMode)
+	assert.Equal(t, RuntimePinStateNotApplicable, state.PinState)
+	assert.Equal(t, "retained-old-pin", state.ReportedRevisionName)
+	assert.Zero(t, revisionCalls)
+	assert.Empty(t, state.RevisionObservations())
+}
+
+type revisionNamespaceStub struct {
+	get  func(context.Context, string, metav1.GetOptions) (*appsv1.ControllerRevision, error)
+	list func(context.Context, metav1.ListOptions) (*appsv1.ControllerRevisionList, error)
+}
+
+func (s revisionNamespaceStub) Get(ctx context.Context, name string, opts metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+	if s.get == nil {
+		return nil, errors.New("unexpected revision GET")
+	}
+	return s.get(ctx, name, opts)
+}
+
+func (s revisionNamespaceStub) List(ctx context.Context, opts metav1.ListOptions) (*appsv1.ControllerRevisionList, error) {
+	if s.list == nil {
+		return nil, errors.New("unexpected revision LIST")
+	}
+	return s.list(ctx, opts)
+}
+
+func livePinFixture(name, kind, namespace string, disabled bool) *LiveConfiguration {
+	spec := &v1beta1.ServingRuntimeSpec{Disabled: ptr.To(disabled)}
+	return &LiveConfiguration{Runtime: RuntimeResolution{
+		Name: name, Kind: kind, Namespace: namespace, SelectionSource: RuntimeExplicit, spec: spec,
+	}}
+}
+
+func pinISVC(name string, autoSync *bool, revision string) *v1beta1.InferenceService {
+	ref := &v1beta1.ServingRuntimeRef{Name: name, AutoSync: autoSync}
+	if revision != "" {
+		ref.Revision = ptr.To(revision)
+	}
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "workloads", Generation: 3},
+		Spec:       v1beta1.InferenceServiceSpec{Runtime: ref, Engine: &v1beta1.EngineSpec{}},
+	}
+}
+
+func TestNewRuntimePinResolverRejectsInvalidDependencies(t *testing.T) {
+	validLive := &RuntimeResolver{}
+	validRevisions := k8sfake.NewSimpleClientset().AppsV1()
+
+	_, err := NewRuntimePinResolver(nil, validLive, "ome", testPinLimits)
+	assert.EqualError(t, err, "ControllerRevision client must not be nil")
+
+	_, err = NewRuntimePinResolver(validRevisions, nil, "ome", testPinLimits)
+	assert.EqualError(t, err, "live runtime resolver must not be nil")
+
+	_, err = NewRuntimePinResolver(validRevisions, validLive, "", testPinLimits)
+	assert.EqualError(t, err, "OME namespace must not be empty")
+
+	invalidLimits := testPinLimits
+	invalidLimits.RequestTimeout = 0
+	_, err = NewRuntimePinResolver(validRevisions, validLive, "ome", invalidLimits)
+	assert.EqualError(t, err, "revision paging limits are invalid")
+}
+
+func TestResolveAutoSyncUsesLiveAndRetainsStatusPinAsInactiveEvidence(t *testing.T) {
+	var revisionCalls int
+	live := livePinFixture("team-runtime", runtimeselector.KindClusterServingRuntime, "", false)
+	resolver, err := newRuntimePinResolver(
+		func(string) revisionNamespace {
+			return revisionNamespaceStub{
+				get: func(_ context.Context, name string, _ metav1.GetOptions) (*appsv1.ControllerRevision, error) {
+					revisionCalls++
+					return &appsv1.ControllerRevision{
+						ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ome"},
+						Data:       runtimeRaw(`{}`), Revision: 1,
+					}, nil
+				},
+			}
+		},
+		liveRuntimeResolverFunc(func(context.Context, *v1beta1.InferenceService) (*LiveConfiguration, error) {
+			return live, nil
+		}),
+		"ome", testPinLimits,
+	)
+	require.NoError(t, err)
+	isvc := pinISVC("team-runtime", nil, "")
+	isvc.Status.PinnedRevisionName = "stale-status-pin"
+
+	got, err := resolver.Resolve(context.Background(), isvc, RuntimeResolveOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, RuntimePinModeAutoSync, got.PinMode)
+	assert.Equal(t, RuntimePinStateNotApplicable, got.PinState)
+	assert.Equal(t, runtimeselector.KindClusterServingRuntime, got.DeclaredSourceKind)
+	assert.Empty(t, got.DeclaredSourceNamespace)
+	assert.Empty(t, got.RequestedRevisionName)
+	assert.Equal(t, "stale-status-pin", got.ReportedRevisionName)
+	assert.Empty(t, got.ActiveRevisionName)
+	active, err := got.RequireActive()
+	require.NoError(t, err)
+	assert.Equal(t, ConfigurationOriginLiveRuntime, active.Origin)
+	observations := got.RevisionObservations()
+	require.Len(t, observations, 1)
+	assert.Equal(t, []RuntimeRevisionRole{RuntimeRevisionRoleReported}, observations[0].Roles())
+	assert.Equal(t, 1, revisionCalls)
+	assert.False(t, got.HistoryRequested)
+	assert.False(t, got.HistoryComplete)
+}


### PR DESCRIPTION
## What this PR does

Adds the read-only, controller-faithful evidence collector that future
`kubectl ome runtime effective` and `kubectl ome runtime history` commands need
to explain runtime pins, rollback targets, drift, and retained revisions.

The collector resolves three evidence streams independently:

- the current live ServingRuntime or ClusterServingRuntime;
- exact GETs for the explicitly requested and controller-reported
  ControllerRevisions; and
- an optional, bounded ControllerRevision history LIST selected only by
  `ome.io/runtime-of=<runtime-name>`.

It then exposes closed, typed states for:

- `AutoSync`, `ManagedPin`, `ExplicitPin`, and invalid pin intent;
- awaiting, resolved, mismatched, missing, invalid, disabled, and unavailable
  pin outcomes;
- status freshness, synchronization relationship, reported drift, and
  live-to-active hash relationship;
- requested, reported, active, and history revision roles; and
- consistent, inconsistent, and unknown revision evidence with bounded issue
  codes for identity, source, payload, hash, duplicate, conflict, and collision
  anomalies.

The implementation follows the controller rather than guessing from one API
object. Explicit revision intent takes precedence over status. Managed pins use
the reported pinned revision. Exact revision reads survive partial or forbidden
history collection. A hard live-runtime read failure, including a disabled
source, blocks active-configuration selection. Only a not-found live source can
leave an enabled retained pin active, matching the controller's recovery path.

Safety is part of the API contract:

- runtime specs, pod configuration, images, commands, environment values,
  Secrets, raw ControllerRevision data, and synchronization-token values stay
  behind private fields and serialization guards;
- source-issue text and Go formatting are fixed and redacted; retained causes
  remain available only through `Unwrap`/`errors.Is`/`errors.As` and are never
  rendered or serialized by safe CLI output;
- public short hashes are emitted only after recomputation and verification;
- every state is bound to the InferenceService name, namespace, UID, and a
  privately retained resource version whose snapshot produced it, preventing
  cross-object or cross-snapshot report association without exposing the
  resource version;
- `%v`, `%+v`, and `%#v` formatting cannot expose retained error causes;
- direct JSON/YAML serialization of internal runtime state fails closed; and
- returned live, active, revision, role, issue, and component data is
  defensively copied.

No command is wired in this foundation PR, so current user-visible CLI output
does not change. The exact relevant section of `kubectl ome runtime --help`
remains:

```text
Available Commands:
  explain     Explain which serving runtimes match a model and why
```

In particular, this PR does **not** add `runtime effective` or
`runtime history`, and it prints no new table, JSON, or YAML by itself. After
the projection and command-wiring PRs consume this collector and the report
contract from #821, the representative effective table is designed to be:

```text
VIEW     STATE       REASON   RUNTIME                            REVISION                       HASH       COMPONENT   MODE            MODE-SOURCE   PIN          PIN-STATE   SYNC           STATUS    DRIFT                           LIVE-RELATION   ISSUES
Live     Available   -        ServingRuntime/prod/team-runtime   -                              eeeeeeee   engine      OMENative       ServiceSpec   ManagedPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Different       -
Active   Available   -        ServingRuntime/prod/team-runtime   r-prod-team-runtime-aaaaaaaa   aaaaaaaa   engine      RawDeployment   Default       ManagedPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Different       -
```

That future output is shown here to make the operational purpose concrete; it
is not claimed as current stdout from this PR.

## Why we need it

OME can now retain a controller-selected runtime snapshot while the live
runtime changes, disappears, becomes disabled, or differs intentionally during
an explicit rollback. Looking only at the live runtime can therefore tell an
operator the wrong configuration. The CLI needs one bounded evidence model that
can answer:

- which runtime and revision were declared, requested, reported, and active;
- whether the controller is awaiting its first managed pin;
- whether live and active content match, differ, or have an ambiguous short
  hash collision;
- whether retained revision metadata follows the OME writer contract; and
- whether history is complete, retention-bounded, partial, unavailable, or
  truncated.

This is also the safe base for later mutation commands. `RequireActive`
describes controller-usable content, while `RequireConsistentActive` separately
blocks mutation when duplicate, conflicting, malformed, or otherwise
inconsistent evidence exists. The collector deliberately uses
`Consistent`/`Inconsistent` terminology and makes no cryptographic trust claim.

Fixes: N/A; tracked by OEP-0011.1 runtime diagnostics.

## How to test

```shell
go test -count=1 ./cmd/kubectl-ome/... ./pkg/cli/...
go test -race -count=1 ./cmd/kubectl-ome/... ./pkg/cli/...
go vet ./cmd/kubectl-ome/... ./pkg/cli/...
go test -cover -count=1 ./pkg/cli/effective
```

The effective package has 89.4% statement coverage. The submitted commit also
passes `CGO_ENABLED=0` cross-compilation for Linux, Darwin, and Windows on both
amd64 and arm64.

Focused tests cover:

- explicit, managed, auto-sync, empty-name, invalid-kind, stale-status, and
  requested/reported mismatch paths;
- live available, missing, disabled, and hard-error behavior independent of
  exact revision collection;
- malformed, noncanonical, disabled, mismatched, duplicate, conflicting, and
  colliding ControllerRevision evidence;
- complete, partial, forbidden, truncated, nonadvancing-token, nil GET/LIST,
  and cancellation-aware bounded history, including the exact searched
  namespace when an empty or failed LIST returns no revisions;
- deterministic union and ordering across API permutations, including mutable
  metadata, full immutable label maps, and canonical UTC creation timestamps;
- exact InferenceService name/namespace/UID binding for downstream projection;
- defensive-copy and serialization guards; and
- serialization and formatting redaction canaries for runtime specs, decoded
  revision observations, internal runtime state, and retained raw error causes.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (N/A: this is an internal collector; repository user
  documentation will land with the command that exposes it)
- [ ] `make test` passes locally

The scoped CLI suite, race detector, vet, coverage run, host build, and six
cross-compiles pass locally. Required repository CI remains the authoritative
full-suite gate.
