### PR TITLE
[Core] Add runtime report projection

### DIFF
--- a/pkg/cli/report/v1alpha1/runtime_common.go
+++ b/pkg/cli/report/v1alpha1/runtime_common.go
@@ -230,7 +230,11 @@ const (
 	RuntimeIssueRevisionIdentityMismatch      RuntimeIssueCode = "RevisionIdentityMismatch"
 	RuntimeIssueRevisionDisabled              RuntimeIssueCode = "RevisionDisabled"
 	RuntimeIssueDuplicateRevision             RuntimeIssueCode = "DuplicateRevision"
+	RuntimeIssueConflictingRevision           RuntimeIssueCode = "ConflictingRevision"
+	RuntimeIssueDuplicateRevisionContent      RuntimeIssueCode = "DuplicateRevisionContent"
 	RuntimeIssueRevisionHashCollision         RuntimeIssueCode = "RevisionHashCollision"
+	RuntimeIssueRevisionNotFound              RuntimeIssueCode = "RevisionNotFound"
+	RuntimeIssueRevisionUnavailable           RuntimeIssueCode = "RevisionUnavailable"
 	RuntimeIssueReportedDriftConflict         RuntimeIssueCode = "ReportedDriftConflict"
 	RuntimeIssueHistoryUnavailable            RuntimeIssueCode = "HistoryUnavailable"
 	RuntimeIssueHistoryTruncated              RuntimeIssueCode = "HistoryTruncated"
@@ -358,10 +362,10 @@ type RuntimeObjectReference struct {
 
 // RuntimeRevisionReference is an allowlisted ControllerRevision identity.
 type RuntimeRevisionReference struct {
-	Namespace string    `json:"namespace"`
-	Name      string    `json:"name"`
-	UID       string    `json:"uid,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
+	Namespace string     `json:"namespace"`
+	Name      string     `json:"name"`
+	UID       string     `json:"uid,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 }
 
 // RuntimeComponent summarizes one runtime component's deployment mode.

--- a/pkg/cli/report/v1alpha1/runtime_common_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_common_test.go
@@ -2,6 +2,7 @@ package v1alpha1_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -97,6 +98,13 @@ func TestRuntimeReportEnumValuesAreStable(t *testing.T) {
 		{"completeness not requested", string(v1alpha1.HistoryCompletenessNotRequested), "NotRequested"},
 		{"completeness retention", string(v1alpha1.HistoryCompletenessRetentionBounded), "RetentionBounded"},
 		{"completeness incomplete", string(v1alpha1.HistoryCompletenessIncomplete), "Incomplete"},
+		{"unavailable cycle", string(v1alpha1.UnavailableCycle), "Cycle"},
+		{"unavailable max depth", string(v1alpha1.UnavailableMaxDepthExceeded), "MaxDepthExceeded"},
+		{"unavailable disabled", string(v1alpha1.UnavailableDisabled), "Disabled"},
+		{"issue revision not found", string(v1alpha1.RuntimeIssueRevisionNotFound), "RevisionNotFound"},
+		{"issue revision unavailable", string(v1alpha1.RuntimeIssueRevisionUnavailable), "RevisionUnavailable"},
+		{"issue conflicting revision", string(v1alpha1.RuntimeIssueConflictingRevision), "ConflictingRevision"},
+		{"issue duplicate revision content", string(v1alpha1.RuntimeIssueDuplicateRevisionContent), "DuplicateRevisionContent"},
 	}
 
 	for _, tt := range tests {
@@ -341,7 +349,8 @@ func TestRuntimeIssueCodesUseBoundedIdentifiers(t *testing.T) {
 		"RevisionSourceMismatch", "RevisionHashInvalid", "RevisionPayloadMalformed",
 		"RevisionHashMismatch", "RevisionNameMismatch", "RevisionOrdinalUnexpected",
 		"RevisionPayloadNonCanonical", "RevisionDataObjectPresent", "RevisionIdentityMismatch",
-		"RevisionDisabled", "DuplicateRevision", "RevisionHashCollision", "ReportedDriftConflict",
+		"RevisionDisabled", "DuplicateRevision", "ConflictingRevision", "DuplicateRevisionContent",
+		"RevisionHashCollision", "RevisionNotFound", "RevisionUnavailable", "ReportedDriftConflict",
 		"HistoryUnavailable", "HistoryTruncated",
 	}
 	got := []string{
@@ -355,11 +364,31 @@ func TestRuntimeIssueCodesUseBoundedIdentifiers(t *testing.T) {
 		string(v1alpha1.RuntimeIssueRevisionNameMismatch), string(v1alpha1.RuntimeIssueRevisionOrdinalUnexpected),
 		string(v1alpha1.RuntimeIssueRevisionPayloadNonCanonical), string(v1alpha1.RuntimeIssueRevisionDataObjectPresent),
 		string(v1alpha1.RuntimeIssueRevisionIdentityMismatch), string(v1alpha1.RuntimeIssueRevisionDisabled),
-		string(v1alpha1.RuntimeIssueDuplicateRevision), string(v1alpha1.RuntimeIssueRevisionHashCollision),
+		string(v1alpha1.RuntimeIssueDuplicateRevision), string(v1alpha1.RuntimeIssueConflictingRevision),
+		string(v1alpha1.RuntimeIssueDuplicateRevisionContent), string(v1alpha1.RuntimeIssueRevisionHashCollision),
+		string(v1alpha1.RuntimeIssueRevisionNotFound), string(v1alpha1.RuntimeIssueRevisionUnavailable),
 		string(v1alpha1.RuntimeIssueReportedDriftConflict), string(v1alpha1.RuntimeIssueHistoryUnavailable),
 		string(v1alpha1.RuntimeIssueHistoryTruncated),
 	}
 	assert.Equal(t, want, got)
+}
+
+func TestRuntimeRevisionReferenceOmitsUnknownCreationTime(t *testing.T) {
+	encoded, err := json.Marshal(v1alpha1.RuntimeRevisionReference{
+		Namespace: "ome-system",
+		Name:      "expected-revision",
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"namespace":"ome-system","name":"expected-revision"}`, string(encoded))
+	typeOfReference := reflect.TypeOf(v1alpha1.RuntimeRevisionReference{})
+	createdAt, found := typeOfReference.FieldByName("CreatedAt")
+	require.True(t, found)
+	assert.Equal(t, reflect.Pointer, createdAt.Type.Kind())
+}
+
+func runtimeReportTime(value time.Time) *time.Time {
+	return &value
 }
 
 func assertRuntimeReportSchema(t *testing.T, typ reflect.Type, seen map[reflect.Type]bool) {

--- a/pkg/cli/report/v1alpha1/runtime_effective.go
+++ b/pkg/cli/report/v1alpha1/runtime_effective.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"sort"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/ome/pkg/cli/report"
 )
@@ -119,7 +120,7 @@ func (c RuntimeConfiguration) canonical() RuntimeConfiguration {
 	result.Source = copyRuntimeObjectReference(c.Source)
 	if c.Revision != nil {
 		revision := *c.Revision
-		revision.CreatedAt = revision.CreatedAt.UTC()
+		revision.CreatedAt = canonicalTimePointer(revision.CreatedAt)
 		result.Revision = &revision
 	}
 	result.Components = append([]RuntimeComponent{}, c.Components...)
@@ -137,6 +138,14 @@ func (c RuntimeConfiguration) canonical() RuntimeConfiguration {
 		return a.DeploymentModeSource < b.DeploymentModeSource
 	})
 	return result
+}
+
+func canonicalTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	utc := value.UTC()
+	return &utc
 }
 
 func copyRuntimeObjectReference(source *RuntimeObjectReference) *RuntimeObjectReference {

--- a/pkg/cli/report/v1alpha1/runtime_effective_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_effective_test.go
@@ -343,7 +343,7 @@ func runtimeEffectiveContent() v1alpha1.RuntimeEffectiveContent {
 			State: v1alpha1.ConfigurationStateAvailable, Origin: v1alpha1.ConfigurationOriginControllerRevision,
 			Source: &active,
 			Revision: &v1alpha1.RuntimeRevisionReference{
-				Namespace: "ome", Name: "revision-a", CreatedAt: time.Date(2026, time.August, 31, 11, 0, 0, 0, time.FixedZone("test", -7*60*60)),
+				Namespace: "ome", Name: "revision-a", CreatedAt: runtimeReportTime(time.Date(2026, time.August, 31, 11, 0, 0, 0, time.FixedZone("test", -7*60*60))),
 			},
 			Hash: "aabbccdd",
 			Components: []v1alpha1.RuntimeComponent{

--- a/pkg/cli/report/v1alpha1/runtime_history.go
+++ b/pkg/cli/report/v1alpha1/runtime_history.go
@@ -66,11 +66,8 @@ func (c RuntimeHistoryContent) Canonical() RuntimeHistoryContent {
 }
 
 func compareRuntimeRevisionEntries(a, b RuntimeRevisionEntry) int {
-	if !a.Revision.CreatedAt.Equal(b.Revision.CreatedAt) {
-		if a.Revision.CreatedAt.After(b.Revision.CreatedAt) {
-			return -1
-		}
-		return 1
+	if result := compareOptionalTimesNewestFirst(a.Revision.CreatedAt, b.Revision.CreatedAt); result != 0 {
+		return result
 	}
 	for _, result := range []int{
 		cmp.Compare(a.Revision.Namespace, b.Revision.Namespace),
@@ -155,7 +152,7 @@ func (c RuntimeHistoryContent) Table() report.Table {
 
 func (entry RuntimeRevisionEntry) canonical() RuntimeRevisionEntry {
 	result := entry
-	result.Revision.CreatedAt = entry.Revision.CreatedAt.UTC()
+	result.Revision.CreatedAt = canonicalTimePointer(entry.Revision.CreatedAt)
 	result.Source = copyRuntimeObjectReference(entry.Source)
 	result.Roles = append([]RuntimeRevisionRole{}, entry.Roles...)
 	sort.Slice(result.Roles, func(i, j int) bool {
@@ -186,11 +183,30 @@ func revisionRoleOrder(role RuntimeRevisionRole) int {
 	}
 }
 
-func formatRevisionTime(createdAt time.Time) string {
-	if createdAt.IsZero() {
+func formatRevisionTime(createdAt *time.Time) string {
+	if createdAt == nil || createdAt.IsZero() {
 		return "-"
 	}
 	return createdAt.UTC().Format(time.RFC3339)
+}
+
+func compareOptionalTimesNewestFirst(a, b *time.Time) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return 1
+	}
+	if b == nil {
+		return -1
+	}
+	if a.Equal(*b) {
+		return 0
+	}
+	if a.After(*b) {
+		return -1
+	}
+	return 1
 }
 
 func joinRevisionRoles(roles []RuntimeRevisionRole) string {

--- a/pkg/cli/report/v1alpha1/runtime_history_test.go
+++ b/pkg/cli/report/v1alpha1/runtime_history_test.go
@@ -58,7 +58,7 @@ func TestRuntimeHistoryCanonicalIsDeterministicForConflictingEntries(t *testing.
 	source := runtimeObject(v1alpha1.RuntimeKindServingRuntime, "prod", "vllm")
 	base := v1alpha1.RuntimeRevisionEntry{
 		Revision: v1alpha1.RuntimeRevisionReference{
-			Namespace: "ome", Name: "revision", UID: "uid", CreatedAt: createdAt,
+			Namespace: "ome", Name: "revision", UID: "uid", CreatedAt: runtimeReportTime(createdAt),
 		},
 		Source: &source, Hash: "aaaaaaaa",
 		Roles:          []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory},
@@ -220,7 +220,7 @@ func TestRuntimeHistoryCanonicalOrdersEverySourceIdentityField(t *testing.T) {
 	}
 	baseEntry := v1alpha1.RuntimeRevisionEntry{
 		Revision: v1alpha1.RuntimeRevisionReference{
-			Namespace: "ome", Name: "revision", UID: "uid", CreatedAt: createdAt,
+			Namespace: "ome", Name: "revision", UID: "uid", CreatedAt: runtimeReportTime(createdAt),
 		},
 		Hash: "aaaaaaaa", Roles: []v1alpha1.RuntimeRevisionRole{}, Issues: []v1alpha1.RuntimeIssueCode{},
 	}
@@ -520,17 +520,17 @@ func runtimeHistoryContent() v1alpha1.RuntimeHistoryContent {
 		ObservedPages:  2,
 		Revisions: []v1alpha1.RuntimeRevisionEntry{
 			{
-				Revision:    v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-old", CreatedAt: older},
+				Revision:    v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-old", CreatedAt: runtimeReportTime(older)},
 				Consistency: v1alpha1.RevisionConsistencyUnknown, RelationToLive: v1alpha1.RevisionRelationUnknown,
 			},
 			{
-				Revision: v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-b", CreatedAt: newest},
+				Revision: v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-b", CreatedAt: runtimeReportTime(newest)},
 				Source:   &source, Hash: "bbbbbbbb", Roles: []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory},
 				Consistency: v1alpha1.RevisionConsistencyInconsistent, RelationToLive: v1alpha1.RevisionRelationDiffersFromLive,
 				Issues: []v1alpha1.RuntimeIssueCode{v1alpha1.RuntimeIssueRevisionSourceMismatch},
 			},
 			{
-				Revision: v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-a", CreatedAt: newest},
+				Revision: v1alpha1.RuntimeRevisionReference{Namespace: "ome", Name: "revision-a", CreatedAt: runtimeReportTime(newest)},
 				Source:   &source, Hash: "aaaaaaaa",
 				Roles: []v1alpha1.RuntimeRevisionRole{
 					v1alpha1.RuntimeRevisionRoleHistory, v1alpha1.RuntimeRevisionRoleReported,
@@ -559,7 +559,7 @@ func runtimeHistoryMachineContent() v1alpha1.RuntimeHistoryContent {
 		ObservedPages:  2,
 		Revisions: []v1alpha1.RuntimeRevisionEntry{{
 			Revision: v1alpha1.RuntimeRevisionReference{
-				Namespace: "ome", Name: "revision-a", CreatedAt: time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC),
+				Namespace: "ome", Name: "revision-a", CreatedAt: runtimeReportTime(time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)),
 			},
 			Source: &source, Hash: "aaaaaaaa",
 			Roles:          []v1alpha1.RuntimeRevisionRole{v1alpha1.RuntimeRevisionRoleHistory, v1alpha1.RuntimeRevisionRoleActive},

--- a/pkg/cli/report/v1alpha1/types.go
+++ b/pkg/cli/report/v1alpha1/types.go
@@ -64,6 +64,9 @@ const (
 	UnavailableMalformedPayload UnavailableReason = "MalformedPayload"
 	UnavailableNotConfigured    UnavailableReason = "NotConfigured"
 	UnavailableUnreadable       UnavailableReason = "Unreadable"
+	UnavailableCycle            UnavailableReason = "Cycle"
+	UnavailableMaxDepthExceeded UnavailableReason = "MaxDepthExceeded"
+	UnavailableDisabled         UnavailableReason = "Disabled"
 )
 
 // SourceReference identifies one typed source used to build a report.

--- a/pkg/cli/runtimeprojection/diagnostics.go
+++ b/pkg/cli/runtimeprojection/diagnostics.go
@@ -1,0 +1,172 @@
+package runtimeprojection
+
+import (
+	"sort"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func projectEffectiveDiagnostics(
+	isvc *v1beta1.InferenceService,
+	state *effective.RuntimeState,
+	live *effective.LiveConfiguration,
+	inheritance reportv1alpha1.RuntimeInheritance,
+	active reportv1alpha1.RuntimeConfiguration,
+) ([]reportv1alpha1.RuntimeIssue, []reportv1alpha1.RuntimeSourceReference, []reportv1alpha1.RuntimeWarning, bool) {
+	issues := []reportv1alpha1.RuntimeIssue{}
+	warnings := []reportv1alpha1.RuntimeWarning{}
+	sources := projectBaseSources(isvc, live)
+
+	if inheritance.State == reportv1alpha1.InheritanceStateUnavailable {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable})
+	}
+	switch state.StatusFreshness {
+	case effective.StatusFreshnessCurrent:
+	case effective.StatusFreshnessUnknown:
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusUnobserved})
+	case effective.StatusFreshnessStale:
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusStale})
+		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence})
+	case effective.StatusFreshnessInconsistent:
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusInvalid})
+		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence})
+	default:
+		return nil, nil, nil, false
+	}
+	if state.DriftState == effective.RuntimeDriftStateMalformed {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueReportedDriftConflict})
+	}
+
+	if live != nil {
+		for _, advisory := range live.Advisories {
+			switch advisory.Code {
+			case effective.RuntimeAdvisoryDeclaredCompatibilityMismatch:
+				issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueDeclaredCompatibilityMismatch})
+			case effective.RuntimeAdvisoryInvalidDeclaredKind:
+				issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind})
+			default:
+				return nil, nil, nil, false
+			}
+		}
+	}
+
+	if state.PinState == effective.RuntimePinStateAwaitingPin {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueActiveRevisionUnreported})
+	}
+	if active.State == reportv1alpha1.ConfigurationStateUnavailable {
+		switch state.PinMode {
+		case effective.RuntimePinModeManagedPin, effective.RuntimePinModeExplicitPin, effective.RuntimePinModeInvalidPin:
+			issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueActiveRevisionUnavailable})
+		}
+	}
+
+	observations := state.RevisionObservations()
+	for _, observation := range observations {
+		if !isEffectiveObservation(observation) {
+			continue
+		}
+		revisionName := observation.ExpectedName()
+		if revisionName == "" {
+			revisionName = observation.ReturnedName()
+		}
+		for _, code := range observation.ConsistencyCodes() {
+			if historyOnlyConsistencyCode(code) {
+				continue
+			}
+			issueCode, ok := mapConsistencyIssue(code)
+			if !ok {
+				return nil, nil, nil, false
+			}
+			issues = append(issues, reportv1alpha1.RuntimeIssue{Code: issueCode, Revision: revisionName})
+		}
+		if observation.Disabled {
+			issues = append(issues, reportv1alpha1.RuntimeIssue{
+				Code: reportv1alpha1.RuntimeIssueRevisionDisabled, Revision: revisionName,
+			})
+		}
+		if observation.ObjectReturned() {
+			sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+				Kind: "ControllerRevision", Namespace: observation.ReturnedNamespace(), Name: observation.ReturnedName(),
+				UID: observation.UID, Evidence: reportv1alpha1.EvidenceObserved,
+			})
+			continue
+		}
+		if reason, found := failedRevisionReason(state.SourceIssues(), observation.ExpectedName()); found {
+			sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+				Kind: "ControllerRevision", Namespace: observation.ExpectedNamespace(), Name: observation.ExpectedName(),
+				Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: reason,
+			})
+		}
+	}
+
+	for _, sourceIssue := range state.SourceIssues() {
+		if sourceIssue.Code == effective.RuntimeSourceIssueRevisionListFailed {
+			continue
+		}
+		issue, _, ok := projectSourceIssue(sourceIssue)
+		if !ok {
+			return nil, nil, nil, false
+		}
+		issues = append(issues, issue)
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable},
+		)
+	}
+
+	if live == nil && state.RuntimeName != "" {
+		kind := state.DeclaredSourceKind
+		namespace := state.DeclaredSourceNamespace
+		if kind == "" {
+			kind = state.RuntimeKind
+			namespace = state.RuntimeNamespace
+		}
+		if !safeRuntimeSourceKind(kind) {
+			return nil, nil, nil, false
+		}
+		sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+			Kind: kind, Namespace: namespace, Name: state.RuntimeName,
+			Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: liveUnavailableReason(state),
+		})
+	}
+
+	issues = deduplicateIssues(issues)
+	warnings = deduplicateWarnings(warnings)
+	sources = deduplicateSources(sources)
+	return issues, sources, warnings, true
+}
+
+func isEffectiveObservation(observation effective.RuntimeRevisionObservation) bool {
+	roles := observation.Roles()
+	return hasRevisionRole(roles, effective.RuntimeRevisionRoleActive) ||
+		hasRevisionRole(roles, effective.RuntimeRevisionRoleRequested) ||
+		hasRevisionRole(roles, effective.RuntimeRevisionRoleReported)
+}
+
+func historyOnlyConsistencyCode(code effective.RevisionConsistencyCode) bool {
+	switch code {
+	case effective.RevisionConsistencyDuplicateIdentity,
+		effective.RevisionConsistencyConflictingIdentity,
+		effective.RevisionConsistencyDuplicateContentHash,
+		effective.RevisionConsistencyShortHashCollision:
+		return true
+	default:
+		return false
+	}
+}
+
+func safeRuntimeSourceKind(kind string) bool {
+	_, ok := mapRuntimeKind(kind)
+	return ok && kind != ""
+}
+
+func sortRuntimeIssues(values []reportv1alpha1.RuntimeIssue) {
+	sort.Slice(values, func(i, j int) bool {
+		if values[i].Code != values[j].Code {
+			return values[i].Code < values[j].Code
+		}
+		return values[i].Revision < values[j].Revision
+	})
+}

--- a/pkg/cli/runtimeprojection/diagnostics.go
+++ b/pkg/cli/runtimeprojection/diagnostics.go
@@ -1,8 +1,6 @@
 package runtimeprojection
 
 import (
-	"sort"
-
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/effective"
 	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
@@ -14,24 +12,42 @@ func projectEffectiveDiagnostics(
 	live *effective.LiveConfiguration,
 	inheritance reportv1alpha1.RuntimeInheritance,
 	active reportv1alpha1.RuntimeConfiguration,
+	notConfigured bool,
 ) ([]reportv1alpha1.RuntimeIssue, []reportv1alpha1.RuntimeSourceReference, []reportv1alpha1.RuntimeWarning, bool) {
 	issues := []reportv1alpha1.RuntimeIssue{}
 	warnings := []reportv1alpha1.RuntimeWarning{}
 	sources := projectBaseSources(isvc, live)
+	invalidDeclaredKind := invalidDeclaredRuntimeKind(isvc)
+	if invalidDeclaredKind {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind})
+	}
 
 	if inheritance.State == reportv1alpha1.InheritanceStateUnavailable {
 		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable})
+		if live != nil {
+			warnings = append(warnings,
+				reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+				reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable},
+			)
+		}
 	}
 	switch state.StatusFreshness {
 	case effective.StatusFreshnessCurrent:
 	case effective.StatusFreshnessUnknown:
 		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusUnobserved})
+		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData})
 	case effective.StatusFreshnessStale:
 		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusStale})
-		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence})
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence},
+		)
 	case effective.StatusFreshnessInconsistent:
 		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusInvalid})
-		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence})
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence},
+		)
 	default:
 		return nil, nil, nil, false
 	}
@@ -45,7 +61,9 @@ func projectEffectiveDiagnostics(
 			case effective.RuntimeAdvisoryDeclaredCompatibilityMismatch:
 				issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueDeclaredCompatibilityMismatch})
 			case effective.RuntimeAdvisoryInvalidDeclaredKind:
-				issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind})
+				if !invalidDeclaredKind {
+					return nil, nil, nil, false
+				}
 			default:
 				return nil, nil, nil, false
 			}
@@ -57,7 +75,7 @@ func projectEffectiveDiagnostics(
 	}
 	if active.State == reportv1alpha1.ConfigurationStateUnavailable {
 		switch state.PinMode {
-		case effective.RuntimePinModeManagedPin, effective.RuntimePinModeExplicitPin, effective.RuntimePinModeInvalidPin:
+		case effective.RuntimePinModeManagedPin, effective.RuntimePinModeExplicitPin:
 			issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueActiveRevisionUnavailable})
 		}
 	}
@@ -67,14 +85,14 @@ func projectEffectiveDiagnostics(
 		if !isEffectiveObservation(observation) {
 			continue
 		}
+		if observation.ObjectReturned() && !validReturnedRevisionIdentity(observation) {
+			return nil, nil, nil, false
+		}
 		revisionName := observation.ExpectedName()
 		if revisionName == "" {
 			revisionName = observation.ReturnedName()
 		}
 		for _, code := range observation.ConsistencyCodes() {
-			if historyOnlyConsistencyCode(code) {
-				continue
-			}
 			issueCode, ok := mapConsistencyIssue(code)
 			if !ok {
 				return nil, nil, nil, false
@@ -102,6 +120,9 @@ func projectEffectiveDiagnostics(
 	}
 
 	for _, sourceIssue := range state.SourceIssues() {
+		if notConfigured && liveSourceIssue(sourceIssue.Code) {
+			continue
+		}
 		if sourceIssue.Code == effective.RuntimeSourceIssueRevisionListFailed {
 			continue
 		}
@@ -117,25 +138,47 @@ func projectEffectiveDiagnostics(
 	}
 
 	if live == nil && state.RuntimeName != "" {
-		kind := state.DeclaredSourceKind
-		namespace := state.DeclaredSourceNamespace
-		if kind == "" {
-			kind = state.RuntimeKind
-			namespace = state.RuntimeNamespace
+		source, valid := unavailableLiveSource(state)
+		if !valid {
+			if !invalidDeclaredKind {
+				return nil, nil, nil, false
+			}
+		} else {
+			sources = append(sources, source)
 		}
-		if !safeRuntimeSourceKind(kind) {
-			return nil, nil, nil, false
-		}
-		sources = append(sources, reportv1alpha1.RuntimeSourceReference{
-			Kind: kind, Namespace: namespace, Name: state.RuntimeName,
-			Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: liveUnavailableReason(state),
-		})
 	}
 
 	issues = deduplicateIssues(issues)
 	warnings = deduplicateWarnings(warnings)
 	sources = deduplicateSources(sources)
 	return issues, sources, warnings, true
+}
+
+func unavailableLiveSource(state *effective.RuntimeState) (reportv1alpha1.RuntimeSourceReference, bool) {
+	kind := state.DeclaredSourceKind
+	namespace := state.DeclaredSourceNamespace
+	if kind == "" {
+		kind = state.RuntimeKind
+		namespace = state.RuntimeNamespace
+	}
+	if !safeRuntimeSourceKind(kind) || state.RuntimeName == "" {
+		return reportv1alpha1.RuntimeSourceReference{}, false
+	}
+	return reportv1alpha1.RuntimeSourceReference{
+		Kind: kind, Namespace: namespace, Name: state.RuntimeName,
+		Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: liveUnavailableReason(state),
+	}, true
+}
+
+func liveSourceIssue(code effective.RuntimeSourceIssueCode) bool {
+	switch code {
+	case effective.RuntimeSourceIssueLiveNotFound,
+		effective.RuntimeSourceIssueLiveDisabled,
+		effective.RuntimeSourceIssueLiveUnavailable:
+		return true
+	default:
+		return false
+	}
 }
 
 func isEffectiveObservation(observation effective.RuntimeRevisionObservation) bool {
@@ -145,28 +188,7 @@ func isEffectiveObservation(observation effective.RuntimeRevisionObservation) bo
 		hasRevisionRole(roles, effective.RuntimeRevisionRoleReported)
 }
 
-func historyOnlyConsistencyCode(code effective.RevisionConsistencyCode) bool {
-	switch code {
-	case effective.RevisionConsistencyDuplicateIdentity,
-		effective.RevisionConsistencyConflictingIdentity,
-		effective.RevisionConsistencyDuplicateContentHash,
-		effective.RevisionConsistencyShortHashCollision:
-		return true
-	default:
-		return false
-	}
-}
-
 func safeRuntimeSourceKind(kind string) bool {
 	_, ok := mapRuntimeKind(kind)
 	return ok && kind != ""
-}
-
-func sortRuntimeIssues(values []reportv1alpha1.RuntimeIssue) {
-	sort.Slice(values, func(i, j int) bool {
-		if values[i].Code != values[j].Code {
-			return values[i].Code < values[j].Code
-		}
-		return values[i].Revision < values[j].Revision
-	})
 }

--- a/pkg/cli/runtimeprojection/effective_diagnostics_test.go
+++ b/pkg/cli/runtimeprojection/effective_diagnostics_test.go
@@ -1,20 +1,31 @@
 package runtimeprojection
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
+	k8stesting "k8s.io/client-go/testing"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/effective"
 	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/cli/report"
 	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
 )
 
 func TestProjectEffectiveSurfacesBoundedStatusDiagnostics(t *testing.T) {
@@ -29,17 +40,22 @@ func TestProjectEffectiveSurfacesBoundedStatusDiagnostics(t *testing.T) {
 	}{
 		{
 			name: "unobserved", observed: 0, freshness: effective.StatusFreshnessUnknown,
-			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusUnobserved}},
+			wantIssues:   []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusUnobserved}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{{Code: reportv1alpha1.WarningPartialData}},
 		},
 		{
 			name: "stale", observed: 6, freshness: effective.StatusFreshnessStale,
-			wantIssues:   []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusStale}},
-			wantWarnings: []reportv1alpha1.RuntimeWarning{{Code: reportv1alpha1.WarningStaleEvidence}},
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusStale}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningStaleEvidence},
+			},
 		},
 		{
 			name: "invalid", observed: 8, freshness: effective.StatusFreshnessInconsistent,
-			wantIssues:   []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusInvalid}},
-			wantWarnings: []reportv1alpha1.RuntimeWarning{{Code: reportv1alpha1.WarningStaleEvidence}},
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusInvalid}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningStaleEvidence},
+			},
 		},
 		{
 			name: "malformed drift", observed: 7, freshness: effective.StatusFreshnessCurrent,
@@ -57,6 +73,7 @@ func TestProjectEffectiveSurfacesBoundedStatusDiagnostics(t *testing.T) {
 			state.StatusFreshness = test.freshness
 			if test.drift != "" {
 				state.DriftState = test.drift
+				setMalformedProjectionDrift(isvcCopy)
 			}
 			if test.wantWarnings == nil {
 				test.wantWarnings = []reportv1alpha1.RuntimeWarning{}
@@ -113,6 +130,912 @@ func TestProjectEffectiveMapsMissingAndDisabledLiveRuntimeAsEvidence(t *testing.
 	}
 }
 
+func TestProjectionRejectsFabricatedActualScopeWithoutLiveSnapshot(t *testing.T) {
+	isvc, baseState := resolveUnavailableLiveFixture(t, nil)
+	tests := []struct {
+		name   string
+		mutate func(*effective.RuntimeState)
+	}{
+		{
+			name: "actual kind without live object",
+			mutate: func(state *effective.RuntimeState) {
+				state.RuntimeKind = "ServingRuntime"
+			},
+		},
+		{
+			name: "actual namespace without live object",
+			mutate: func(state *effective.RuntimeState) {
+				state.RuntimeNamespace = "workloads"
+			},
+		},
+		{
+			name: "live hash without live object",
+			mutate: func(state *effective.RuntimeState) {
+				state.LiveShortHash = "deadbeef"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := *baseState
+			test.mutate(&state)
+
+			_, err := ProjectEffective(isvc, &state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			_, err = ProjectHistory(isvc, &state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
+func TestProjectEffectiveRetainsLiveIdentityWhenInheritanceEvidenceIsUnavailable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-runtime", UID: "runtime-uid", Generation: 5,
+			Annotations: map[string]string{constants.RuntimeInheritFromAnnotationKey: "missing-parent"},
+		},
+		Spec: *projectionRuntimeSpec("private.registry/live:secret"),
+	}
+	runtimeObject.Spec.SupportedModelFormats = []v1beta1.SupportedModelFormat{{
+		ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 10}, AutoSelect: pointerTo(true),
+	}}
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "workloads", UID: "model-uid", Generation: 2},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: "pytorch"}},
+	}
+	liveClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(model, runtimeObject).Build()
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model: &v1beta1.ModelRef{Name: model.Name}, Engine: &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset().AppsV1(), effective.NewRuntimeResolver(liveClient), "ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+	require.Equal(t, effective.LiveRuntimeAvailable, state.LiveAvailability())
+	require.NotNil(t, state.LiveConfiguration())
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.InheritanceStateUnavailable, reportValue.Content.Inheritance.State)
+	assert.Equal(t, reportv1alpha1.UnavailableNotFound, reportValue.Content.Inheritance.UnavailableReason)
+	assert.Equal(t, reportv1alpha1.ConfigurationStateAvailable, reportValue.Content.Live.State)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable,
+	})
+	assert.Equal(t, []reportv1alpha1.RuntimeWarning{
+		{Code: reportv1alpha1.WarningPartialData},
+		{Code: reportv1alpha1.WarningSourceUnavailable},
+	}, reportValue.Warnings)
+	assert.Contains(t, reportValue.Sources, reportv1alpha1.RuntimeSourceReference{
+		Kind: "ClusterServingRuntime", Name: runtimeObject.Name,
+		Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+	})
+}
+
+func TestProjectEffectiveProjectsOnlyTheExpectedActiveRevisionIdentity(t *testing.T) {
+	isvc, state, activeRevision, _ := resolveHistoryProjectionFixture(t)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	require.NotNil(t, reportValue.Content.Active.Revision)
+	activeCreatedAt := activeRevision.CreationTimestamp.Time.UTC()
+	assert.Equal(t, &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: "ome-system", Name: activeRevision.Name, UID: "active-uid", CreatedAt: &activeCreatedAt,
+	}, reportValue.Content.Active.Revision)
+	assert.Equal(t, reportv1alpha1.ConfigurationOriginControllerRevision, reportValue.Content.Active.Origin)
+	assert.Equal(t, activeRevision.Labels[constants.RuntimeRevisionHashLabelKey], reportValue.Content.Active.Hash)
+	assert.Empty(t, reportValue.Content.Issues)
+	var revisionSources []reportv1alpha1.RuntimeSourceReference
+	for _, source := range reportValue.Sources {
+		if source.Kind == "ControllerRevision" {
+			revisionSources = append(revisionSources, source)
+		}
+	}
+	assert.Equal(t, []reportv1alpha1.RuntimeSourceReference{{
+		Kind: "ControllerRevision", Namespace: "ome-system", Name: activeRevision.Name, UID: "active-uid",
+		Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+	}}, revisionSources, "history-only revisions must not leak into the effective report")
+}
+
+func TestProjectEffectiveSeparatesExpectedActiveKeyFromMismatchedReturnedIdentity(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	returned := projectionRevision(t, "returned-uid", "gpu-runtime", liveSpec)
+	returned.Name = "returned-other-revision"
+	returned.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 31, 19, 0, 0, 0, time.UTC))
+	clientset := k8sfake.NewSimpleClientset(returned.DeepCopy())
+	clientset.PrependReactor("get", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, returned.DeepCopy(), nil
+	})
+	expectedName := "expected-revision"
+	isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, expectedName, nil)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: "ome-system", Name: expectedName,
+	}, reportValue.Content.Active.Revision)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueRevisionIdentityMismatch, Revision: expectedName,
+	})
+	assert.Contains(t, reportValue.Sources, reportv1alpha1.RuntimeSourceReference{
+		Kind: "ControllerRevision", Namespace: "ome-system", Name: returned.Name, UID: "returned-uid",
+		Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+	})
+}
+
+func TestProjectEffectivePreservesDeclaredPinScopeAcrossNamespacedLiveFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	runtimeObject := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-name", Namespace: "workloads", UID: "namespaced-uid", Generation: 4},
+		Spec:       *projectionRuntimeSpec("private.registry/namespaced:secret"),
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeObject).Build()
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset().AppsV1(), effective.NewRuntimeResolver(client), "ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(context.Background(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RuntimeKindServingRuntime, reportValue.Content.Selection.Runtime.Kind)
+	assert.Equal(t, "workloads", reportValue.Content.Selection.Runtime.Namespace)
+	assert.Equal(t, "namespaced-uid", reportValue.Content.Selection.Runtime.UID)
+	assert.Equal(t, reportv1alpha1.RuntimeKindServingRuntime, reportValue.Content.Live.Source.Kind)
+	assert.Equal(t, "workloads", reportValue.Content.Live.Source.Namespace)
+	assert.Equal(t, "ClusterServingRuntime", state.DeclaredSourceKind)
+}
+
+func TestProjectEffectiveDistinguishesNotConfiguredFromFailedAutoSelection(t *testing.T) {
+	tests := []struct {
+		name         string
+		model        *v1beta1.BaseModel
+		modelRef     *v1beta1.ModelRef
+		wantReason   reportv1alpha1.UnavailableReason
+		wantIssues   []reportv1alpha1.RuntimeIssue
+		wantWarnings []reportv1alpha1.RuntimeWarning
+	}{
+		{
+			name: "no runtime or model configured", wantReason: reportv1alpha1.UnavailableNotConfigured,
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable}},
+		},
+		{
+			name: "configured model has no selectable runtime",
+			model: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "workloads", UID: "model-uid", Generation: 2},
+			},
+			modelRef:   &v1beta1.ModelRef{Name: "model"},
+			wantReason: reportv1alpha1.UnavailableUnreadable,
+			wantIssues: []reportv1alpha1.RuntimeIssue{
+				{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable},
+				{Code: reportv1alpha1.RuntimeIssueLiveRuntimeUnavailable},
+			},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData},
+				{Code: reportv1alpha1.WarningSourceUnavailable},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1beta1.AddToScheme(scheme))
+			builder := ctrlclientfake.NewClientBuilder().WithScheme(scheme)
+			if test.model != nil {
+				builder = builder.WithObjects(test.model)
+			}
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+					ResourceVersion: "secret-isvc-resource-version",
+				},
+				Spec: v1beta1.InferenceServiceSpec{Model: test.modelRef, Engine: &v1beta1.EngineSpec{}},
+			}
+			isvc.Status.ObservedGeneration = 7
+			resolver, err := effective.NewRuntimePinResolver(
+				k8sfake.NewSimpleClientset().AppsV1(), effective.NewRuntimeResolver(builder.Build()), "ome-system",
+				paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+			)
+			require.NoError(t, err)
+			state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+			require.NoError(t, err)
+
+			reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			assert.Nil(t, reportValue.Content.Selection.Runtime)
+			assert.Equal(t, test.wantReason, reportValue.Content.Inheritance.UnavailableReason)
+			assert.Equal(t, test.wantReason, reportValue.Content.Live.UnavailableReason)
+			assert.Equal(t, test.wantReason, reportValue.Content.Active.UnavailableReason)
+			assert.Equal(t, test.wantIssues, reportValue.Content.Issues)
+			if test.wantWarnings == nil {
+				test.wantWarnings = []reportv1alpha1.RuntimeWarning{}
+			}
+			assert.Equal(t, test.wantWarnings, reportValue.Warnings)
+		})
+	}
+}
+
+func TestProjectEffectiveClassifiesLiveReadFailuresWithoutCopyingErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantReason reportv1alpha1.UnavailableReason
+	}{
+		{
+			name: "forbidden",
+			err: apierrors.NewForbidden(
+				schema.GroupResource{Group: v1beta1.SchemeGroupVersion.Group, Resource: "clusterservingruntimes"},
+				"gpu-runtime", errors.New("secret-forbidden-cause"),
+			),
+			wantReason: reportv1alpha1.UnavailableForbidden,
+		},
+		{
+			name: "unsupported api",
+			err: &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: v1beta1.SchemeGroupVersion.Group, Kind: "ClusterServingRuntime"},
+				SearchedVersions: []string{"secret-version"},
+			},
+			wantReason: reportv1alpha1.UnavailableUnsupportedAPI,
+		},
+		{name: "unreadable", err: errors.New("secret-unreadable-cause"), wantReason: reportv1alpha1.UnavailableUnreadable},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1beta1.AddToScheme(scheme))
+			base := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+			client := projectionGetErrorClient{Client: base, err: test.err}
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+					ResourceVersion: "secret-isvc-resource-version",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "gpu-runtime"}, Engine: &v1beta1.EngineSpec{},
+				},
+			}
+			isvc.Status.ObservedGeneration = 7
+			resolver, err := effective.NewRuntimePinResolver(
+				k8sfake.NewSimpleClientset().AppsV1(), effective.NewRuntimeResolver(client), "ome-system",
+				paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+			)
+			require.NoError(t, err)
+			state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+			require.NoError(t, err)
+
+			reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantReason, reportValue.Content.Live.UnavailableReason)
+			assert.Equal(t, test.wantReason, reportValue.Content.Inheritance.UnavailableReason)
+			assert.NotContains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable})
+		})
+	}
+}
+
+func TestProjectEffectiveProjectsFailedExpectedRevisionWithoutFabricatedMetadata(t *testing.T) {
+	tests := []struct {
+		name       string
+		reactor    func(k8stesting.Action) (bool, runtime.Object, error)
+		wantReason reportv1alpha1.UnavailableReason
+		wantIssue  reportv1alpha1.RuntimeIssueCode
+	}{
+		{
+			name: "not found",
+			reactor: func(action k8stesting.Action) (bool, runtime.Object, error) {
+				get := action.(k8stesting.GetAction)
+				return true, nil, apierrors.NewNotFound(
+					schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, get.GetName(),
+				)
+			},
+			wantReason: reportv1alpha1.UnavailableNotFound,
+			wantIssue:  reportv1alpha1.RuntimeIssueRevisionNotFound,
+		},
+		{
+			name: "forbidden",
+			reactor: func(action k8stesting.Action) (bool, runtime.Object, error) {
+				get := action.(k8stesting.GetAction)
+				return true, nil, apierrors.NewForbidden(
+					schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
+					get.GetName(), errors.New("secret-revision-denial"),
+				)
+			},
+			wantReason: reportv1alpha1.UnavailableForbidden,
+			wantIssue:  reportv1alpha1.RuntimeIssueRevisionUnavailable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientset := k8sfake.NewSimpleClientset()
+			clientset.PrependReactor("get", "controllerrevisions", test.reactor)
+			liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+			expected := "expected-revision"
+			isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, expected, nil)
+
+			reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.ConfigurationStateUnavailable, reportValue.Content.Active.State)
+			assert.Equal(t, test.wantReason, reportValue.Content.Active.UnavailableReason)
+			assert.Equal(t, &reportv1alpha1.RuntimeRevisionReference{
+				Namespace: "ome-system", Name: expected,
+			}, reportValue.Content.Active.Revision)
+			assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+				Code: reportv1alpha1.RuntimeIssueActiveRevisionUnavailable,
+			})
+			assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+				Code: test.wantIssue, Revision: expected,
+			})
+			assert.Contains(t, reportValue.Sources, reportv1alpha1.RuntimeSourceReference{
+				Kind: "ControllerRevision", Namespace: "ome-system", Name: expected,
+				Evidence: reportv1alpha1.EvidenceUnavailable, CollectedAt: projectionTestClock.Now(),
+				UnavailableReason: test.wantReason,
+			})
+		})
+	}
+}
+
+func TestProjectEffectiveClassifiesNilRevisionGetAsUnavailable(t *testing.T) {
+	base := k8sfake.NewSimpleClientset().AppsV1()
+	revisions := nilGetRevisionsGetter{delegate: base}
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	expected := "expected-revision"
+	isvc, state := resolveProjectionWithRevisionGetter(t, revisions, liveSpec, expected, nil)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, effective.RuntimePinStateUnavailable, state.PinState)
+	assert.Equal(t, reportv1alpha1.UnavailableUnreadable, reportValue.Content.Active.UnavailableReason)
+	assert.Equal(t, &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: "ome-system", Name: expected,
+	}, reportValue.Content.Active.Revision)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueRevisionUnavailable, Revision: expected,
+	})
+	assert.Contains(t, reportValue.Sources, reportv1alpha1.RuntimeSourceReference{
+		Kind: "ControllerRevision", Namespace: "ome-system", Name: expected,
+		Evidence: reportv1alpha1.EvidenceUnavailable, CollectedAt: projectionTestClock.Now(),
+		UnavailableReason: reportv1alpha1.UnavailableUnreadable,
+	})
+}
+
+type nilGetRevisionsGetter struct {
+	delegate appstyped.ControllerRevisionsGetter
+}
+
+func (getter nilGetRevisionsGetter) ControllerRevisions(namespace string) appstyped.ControllerRevisionInterface {
+	return nilGetRevisionInterface{ControllerRevisionInterface: getter.delegate.ControllerRevisions(namespace)}
+}
+
+type nilGetRevisionInterface struct {
+	appstyped.ControllerRevisionInterface
+}
+
+func (client nilGetRevisionInterface) Get(
+	context.Context,
+	string,
+	metav1.GetOptions,
+) (*appsv1.ControllerRevision, error) {
+	return nil, nil
+}
+
+func TestProjectEffectiveDoesNotActivateRetainedPinWhenLiveRuntimeIsDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-runtime", UID: "disabled-runtime-uid", Generation: 5},
+		Spec:       v1beta1.ServingRuntimeSpec{Disabled: pointerTo(true)},
+	}
+	liveClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeObject).Build()
+	revision := projectionRevision(t, "retained-uid", runtimeObject.Name, projectionRuntimeSpec("private.registry/retained:secret"))
+	autoSync := false
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name, AutoSync: &autoSync},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.PinnedRevisionName = revision.Name
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset(revision.DeepCopy()).AppsV1(), effective.NewRuntimeResolver(liveClient), "ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, effective.RuntimePinStateUnavailable, state.PinState)
+	_, err = state.RequireActive()
+	require.ErrorIs(t, err, effective.ErrActiveRuntimeUnavailable)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.UnavailableDisabled, reportValue.Content.Live.UnavailableReason)
+	assert.Equal(t, reportv1alpha1.UnavailableDisabled, reportValue.Content.Active.UnavailableReason)
+	assert.Equal(t, &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: "ome-system", Name: revision.Name, UID: "retained-uid",
+	}, reportValue.Content.Active.Revision)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueActiveRevisionUnavailable,
+	})
+}
+
+func TestProjectionRejectsRevisionPinStatesWhenLiveReadPreemptsPinResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		liveClient func(*testing.T) ctrlclient.Client
+		explicit   bool
+		wantMode   effective.RuntimePinMode
+	}{
+		{
+			name: "managed pin with disabled live", liveClient: disabledProjectionRuntimeClient,
+			wantMode: effective.RuntimePinModeManagedPin,
+		},
+		{
+			name: "managed pin with unreadable live", liveClient: unreadableProjectionRuntimeClient,
+			wantMode: effective.RuntimePinModeManagedPin,
+		},
+		{
+			name: "explicit pin with disabled live", liveClient: disabledProjectionRuntimeClient,
+			explicit: true, wantMode: effective.RuntimePinModeExplicitPin,
+		},
+		{
+			name: "explicit pin with unreadable live", liveClient: unreadableProjectionRuntimeClient,
+			explicit: true, wantMode: effective.RuntimePinModeExplicitPin,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			autoSync := false
+			revision := projectionRevision(
+				t, "revision-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/revision:secret"),
+			)
+			runtimeReference := &v1beta1.ServingRuntimeRef{Name: "gpu-runtime", AutoSync: &autoSync}
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+					ResourceVersion: "secret-isvc-resource-version",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: runtimeReference, Engine: &v1beta1.EngineSpec{},
+				},
+			}
+			isvc.Status.ObservedGeneration = 7
+			if test.explicit {
+				runtimeReference.Revision = pointerTo(revision.Name)
+			} else {
+				isvc.Status.PinnedRevisionName = revision.Name
+			}
+			resolver, err := effective.NewRuntimePinResolver(
+				k8sfake.NewSimpleClientset(revision.DeepCopy()).AppsV1(),
+				effective.NewRuntimeResolver(test.liveClient(t)),
+				"ome-system",
+				paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+			)
+			require.NoError(t, err)
+			state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+			require.NoError(t, err)
+			require.Equal(t, test.wantMode, state.PinMode)
+			require.Equal(t, effective.RuntimePinStateUnavailable, state.PinState)
+			_, err = state.RequireActive()
+			require.ErrorIs(t, err, effective.ErrActiveRuntimeUnavailable)
+			_, err = ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			_, err = ProjectHistory(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+
+			for _, forgedState := range []effective.RuntimePinState{
+				effective.RuntimePinStateRevisionMissing,
+				effective.RuntimePinStateRevisionInvalid,
+				effective.RuntimePinStateRevisionDisabled,
+			} {
+				contradictory := *state
+				contradictory.PinState = forgedState
+				_, err = ProjectEffective(isvc, &contradictory, projectionTestClock)
+				require.ErrorIs(t, err, ErrInvalidEvidence, "pin state %s", forgedState)
+				assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+				_, err = ProjectHistory(isvc, &contradictory, projectionTestClock)
+				require.ErrorIs(t, err, ErrInvalidEvidence, "pin state %s", forgedState)
+				assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestProjectEffectiveRetainsVerifiedPinWhenLiveRuntimeIsMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	liveClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+	revision := projectionRevision(
+		t, "retained-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/retained:secret"),
+	)
+	revision.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 31, 19, 0, 0, 0, time.UTC))
+	autoSync := false
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "gpu-runtime", AutoSync: &autoSync},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.PinnedRevisionName = revision.Name
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset(revision.DeepCopy()).AppsV1(), effective.NewRuntimeResolver(liveClient), "ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, effective.RuntimePinStateResolved, state.PinState)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.UnavailableNotFound, reportValue.Content.Live.UnavailableReason)
+	assert.Equal(t, reportv1alpha1.ConfigurationStateAvailable, reportValue.Content.Active.State)
+	assert.Equal(t, reportv1alpha1.ConfigurationOriginControllerRevision, reportValue.Content.Active.Origin)
+	assert.Equal(t, reportv1alpha1.RuntimeHashRelationUnknown, reportValue.Content.LiveToActive)
+	createdAt := revision.CreationTimestamp.Time.UTC()
+	assert.Equal(t, &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: "ome-system", Name: revision.Name, UID: "retained-uid", CreatedAt: &createdAt,
+	}, reportValue.Content.Active.Revision)
+	assert.Equal(t, revision.Labels[constants.RuntimeRevisionHashLabelKey], reportValue.Content.Active.Hash)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueLiveRuntimeUnavailable,
+	})
+}
+
+func TestProjectEffectiveProjectsManagedAwaitingPin(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	isvc, state := resolveProjectionWithRevisionClient(t, k8sfake.NewSimpleClientset(), liveSpec, "", nil)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RuntimePinModeManagedPin, reportValue.Content.Pin.Mode)
+	assert.Equal(t, reportv1alpha1.RuntimePinStateAwaitingPin, reportValue.Content.Pin.State)
+	assert.Equal(t, reportv1alpha1.ConfigurationOriginLiveRuntime, reportValue.Content.Active.Origin)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueActiveRevisionUnreported,
+	})
+}
+
+func TestProjectEffectiveProjectsExplicitDesiredReportedMismatchWithoutInventingDrift(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	requested := projectionRevision(t, "requested-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/requested:secret"))
+	reported := projectionRevision(t, "reported-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/reported:secret"))
+	requestedName := requested.Name
+	isvc, state := resolveProjectionWithRevisionClient(
+		t, k8sfake.NewSimpleClientset(requested.DeepCopy(), reported.DeepCopy()),
+		liveSpec, reported.Name, &requestedName,
+	)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RuntimePinModeExplicitPin, reportValue.Content.Pin.Mode)
+	assert.Equal(t, reportv1alpha1.RuntimePinStateDesiredReportedMismatch, reportValue.Content.Pin.State)
+	assert.Equal(t, requested.Name, reportValue.Content.Pin.RequestedRevision)
+	assert.Equal(t, reported.Name, reportValue.Content.Pin.ReportedRevision)
+	require.NotNil(t, reportValue.Content.Active.Revision)
+	assert.Equal(t, requested.Name, reportValue.Content.Active.Revision.Name)
+	assert.Equal(t, reportv1alpha1.RuntimeHashRelationDifferent, reportValue.Content.LiveToActive)
+	assert.NotContains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueReportedDriftConflict,
+	})
+}
+
+func TestProjectionRejectsRevisionRelationContradictingVerifiedShortHashes(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	revision := projectionRevision(
+		t, "revision-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/revision:secret"),
+	)
+	isvc, state := resolveProjectionWithRevisionClient(
+		t, k8sfake.NewSimpleClientset(revision.DeepCopy()), liveSpec, revision.Name, nil,
+	)
+	require.NotEqual(t, state.LiveShortHash, revision.Labels[constants.RuntimeRevisionHashLabelKey])
+	require.Equal(t, effective.RuntimeHashRelationDifferent, state.LiveToActive)
+
+	state.LiveToActive = effective.RuntimeHashRelationEqual
+	_, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+}
+
+func TestProjectEffectiveProjectsInvalidAndDisabledRevisionEvidence(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	disabledSpec := projectionRuntimeSpec("private.registry/disabled:secret")
+	disabledSpec.Disabled = pointerTo(true)
+	disabled := projectionRevision(t, "disabled-uid", "gpu-runtime", disabledSpec)
+	malformed := projectionRevision(t, "malformed-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/malformed:secret"))
+	malformed.Data.Raw = []byte(`{"private":"secret-malformed-payload"`)
+	tests := []struct {
+		name       string
+		revision   *appsv1.ControllerRevision
+		wantState  reportv1alpha1.RuntimePinState
+		wantReason reportv1alpha1.UnavailableReason
+		wantIssue  reportv1alpha1.RuntimeIssueCode
+	}{
+		{
+			name: "disabled", revision: disabled, wantState: reportv1alpha1.RuntimePinStateRevisionDisabled,
+			wantReason: reportv1alpha1.UnavailableDisabled, wantIssue: reportv1alpha1.RuntimeIssueRevisionDisabled,
+		},
+		{
+			name: "malformed", revision: malformed, wantState: reportv1alpha1.RuntimePinStateRevisionInvalid,
+			wantReason: reportv1alpha1.UnavailableMalformedPayload, wantIssue: reportv1alpha1.RuntimeIssueRevisionPayloadMalformed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc, state := resolveProjectionWithRevisionClient(
+				t, k8sfake.NewSimpleClientset(test.revision.DeepCopy()), liveSpec, test.revision.Name, nil,
+			)
+
+			reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantState, reportValue.Content.Pin.State)
+			assert.Equal(t, reportv1alpha1.ConfigurationStateUnavailable, reportValue.Content.Active.State)
+			assert.Equal(t, test.wantReason, reportValue.Content.Active.UnavailableReason)
+			assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+				Code: test.wantIssue, Revision: test.revision.Name,
+			})
+		})
+	}
+}
+
+func TestProjectEffectiveProjectsInvalidPinIntentWithoutEchoingDeclaredKind(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-runtime", UID: "runtime-uid", Generation: 5},
+		Spec:       *projectionRuntimeSpec("private.registry/live:secret"),
+	}
+	liveClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeObject).Build()
+	autoSync := false
+	hostileKind := "secret-unsupported-runtime-kind"
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{
+				Name: runtimeObject.Name, Kind: &hostileKind, AutoSync: &autoSync,
+			},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset().AppsV1(), effective.NewRuntimeResolver(liveClient), "ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RuntimePinModeInvalidPin, reportValue.Content.Pin.Mode)
+	assert.Equal(t, reportv1alpha1.RuntimePinStateInvalidIntent, reportValue.Content.Pin.State)
+	assert.Equal(t, reportv1alpha1.ConfigurationStateUnavailable, reportValue.Content.Active.State)
+	assert.Equal(t, reportv1alpha1.UnavailableMalformedPayload, reportValue.Content.Active.UnavailableReason)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind,
+	})
+	assert.NotContains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueActiveRevisionUnavailable,
+	})
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		assert.NotContains(t, renderProjectionDocument(t, format, reportValue), hostileKind)
+	}
+}
+
+func TestProjectionSafelyReportsInvalidDeclaredKindWhenLiveIsUnavailable(t *testing.T) {
+	autoSync := false
+	tests := []struct {
+		name         string
+		kind         string
+		liveClient   func(*testing.T) ctrlclient.Client
+		wantPinState reportv1alpha1.RuntimePinState
+		wantReason   reportv1alpha1.UnavailableReason
+	}{
+		{
+			name: "empty kind with missing live runtime", kind: "",
+			liveClient: func(t *testing.T) ctrlclient.Client {
+				return ctrlclientfake.NewClientBuilder().WithScheme(projectionRuntimeScheme(t)).Build()
+			},
+			wantPinState: reportv1alpha1.RuntimePinStateInvalidIntent,
+			wantReason:   reportv1alpha1.UnavailableNotFound,
+		},
+		{
+			name: "unsupported kind with missing live runtime", kind: "secret-unsupported-kind",
+			liveClient: func(t *testing.T) ctrlclient.Client {
+				return ctrlclientfake.NewClientBuilder().WithScheme(projectionRuntimeScheme(t)).Build()
+			},
+			wantPinState: reportv1alpha1.RuntimePinStateInvalidIntent,
+			wantReason:   reportv1alpha1.UnavailableNotFound,
+		},
+		{
+			name: "empty kind with disabled live runtime", kind: "",
+			liveClient:   disabledProjectionRuntimeClient,
+			wantPinState: reportv1alpha1.RuntimePinStateUnavailable,
+			wantReason:   reportv1alpha1.UnavailableDisabled,
+		},
+		{
+			name: "unsupported kind with disabled live runtime", kind: "secret-unsupported-kind",
+			liveClient:   disabledProjectionRuntimeClient,
+			wantPinState: reportv1alpha1.RuntimePinStateUnavailable,
+			wantReason:   reportv1alpha1.UnavailableDisabled,
+		},
+		{
+			name: "empty kind with unreadable live runtime", kind: "",
+			liveClient:   unreadableProjectionRuntimeClient,
+			wantPinState: reportv1alpha1.RuntimePinStateUnavailable,
+			wantReason:   reportv1alpha1.UnavailableUnreadable,
+		},
+		{
+			name: "unsupported kind with unreadable live runtime", kind: "secret-unsupported-kind",
+			liveClient:   unreadableProjectionRuntimeClient,
+			wantPinState: reportv1alpha1.RuntimePinStateUnavailable,
+			wantReason:   reportv1alpha1.UnavailableUnreadable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+					ResourceVersion: "secret-isvc-resource-version",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name: "gpu-runtime", Kind: &test.kind, AutoSync: &autoSync,
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			}
+			isvc.Status.ObservedGeneration = 7
+			resolver, err := effective.NewRuntimePinResolver(
+				k8sfake.NewSimpleClientset().AppsV1(),
+				effective.NewRuntimeResolver(test.liveClient(t)),
+				"ome-system",
+				paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+			)
+			require.NoError(t, err)
+			state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+			require.NoError(t, err)
+
+			effectiveReport, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			historyReport, err := ProjectHistory(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.wantPinState, effectiveReport.Content.Pin.State)
+			require.NotNil(t, effectiveReport.Content.Selection.Runtime)
+			assert.Equal(t, "gpu-runtime", effectiveReport.Content.Selection.Runtime.Name)
+			assert.Equal(t, reportv1alpha1.RuntimeKindUnknown, effectiveReport.Content.Selection.Runtime.Kind)
+			assert.Nil(t, effectiveReport.Content.Live.Source)
+			assert.Nil(t, effectiveReport.Content.Active.Source)
+			assert.Equal(t, test.wantReason, effectiveReport.Content.Live.UnavailableReason)
+			assert.Contains(t, effectiveReport.Content.Issues, reportv1alpha1.RuntimeIssue{
+				Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind,
+			})
+			assert.Equal(t, effectiveReport.Content.Selection.Runtime, historyReport.Content.Runtime)
+			assert.Contains(t, historyReport.Content.Issues, reportv1alpha1.RuntimeIssue{
+				Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind,
+			})
+			for _, source := range append(effectiveReport.Sources, historyReport.Sources...) {
+				assert.NotEqual(t, "gpu-runtime", source.Name, "unobserved runtime scope must not be fabricated")
+			}
+			for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+				if test.kind != "" {
+					assert.NotContains(t, renderProjectionDocument(t, format, effectiveReport), test.kind)
+					assert.NotContains(t, renderProjectionDocument(t, format, historyReport), test.kind)
+				}
+			}
+
+			contradictory := *state
+			if state.PinState == effective.RuntimePinStateInvalidIntent {
+				contradictory.PinState = effective.RuntimePinStateUnavailable
+			} else {
+				contradictory.PinState = effective.RuntimePinStateInvalidIntent
+			}
+			_, err = ProjectEffective(isvc, &contradictory, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			_, err = ProjectHistory(isvc, &contradictory, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
+func projectionRuntimeScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	return scheme
+}
+
+func disabledProjectionRuntimeClient(t *testing.T) ctrlclient.Client {
+	t.Helper()
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-runtime"},
+		Spec:       *projectionRuntimeSpec("private.registry/disabled:secret"),
+	}
+	runtimeObject.Spec.Disabled = pointerTo(true)
+	return ctrlclientfake.NewClientBuilder().WithScheme(projectionRuntimeScheme(t)).WithObjects(runtimeObject).Build()
+}
+
+func unreadableProjectionRuntimeClient(t *testing.T) ctrlclient.Client {
+	t.Helper()
+	return projectionGetErrorClient{
+		Client: ctrlclientfake.NewClientBuilder().WithScheme(projectionRuntimeScheme(t)).Build(),
+		err:    errors.New("secret-live-read-failure"),
+	}
+}
+
+type projectionGetErrorClient struct {
+	ctrlclient.Client
+	err error
+}
+
+func (client projectionGetErrorClient) Get(
+	context.Context,
+	ctrlclient.ObjectKey,
+	ctrlclient.Object,
+	...ctrlclient.GetOption,
+) error {
+	return client.err
+}
+
 func resolveUnavailableLiveFixture(
 	t *testing.T,
 	runtimeObject *v1beta1.ClusterServingRuntime,
@@ -127,6 +1050,7 @@ func resolveUnavailableLiveFixture(
 	isvc := &v1beta1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
 		},
 		Spec: v1beta1.InferenceServiceSpec{
 			Runtime: &v1beta1.ServingRuntimeRef{Name: "gpu-runtime"},

--- a/pkg/cli/runtimeprojection/effective_diagnostics_test.go
+++ b/pkg/cli/runtimeprojection/effective_diagnostics_test.go
@@ -1,0 +1,147 @@
+package runtimeprojection
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestProjectEffectiveSurfacesBoundedStatusDiagnostics(t *testing.T) {
+	isvc, baseState := resolveLiveProjectionFixture(t)
+	tests := []struct {
+		name         string
+		observed     int64
+		freshness    effective.StatusFreshness
+		drift        effective.RuntimeDriftState
+		wantIssues   []reportv1alpha1.RuntimeIssue
+		wantWarnings []reportv1alpha1.RuntimeWarning
+	}{
+		{
+			name: "unobserved", observed: 0, freshness: effective.StatusFreshnessUnknown,
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusUnobserved}},
+		},
+		{
+			name: "stale", observed: 6, freshness: effective.StatusFreshnessStale,
+			wantIssues:   []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusStale}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{{Code: reportv1alpha1.WarningStaleEvidence}},
+		},
+		{
+			name: "invalid", observed: 8, freshness: effective.StatusFreshnessInconsistent,
+			wantIssues:   []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueStatusInvalid}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{{Code: reportv1alpha1.WarningStaleEvidence}},
+		},
+		{
+			name: "malformed drift", observed: 7, freshness: effective.StatusFreshnessCurrent,
+			drift:      effective.RuntimeDriftStateMalformed,
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueReportedDriftConflict}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := *baseState
+			isvcCopy := isvc.DeepCopy()
+			isvcCopy.Status.ObservedGeneration = test.observed
+			state.ObservedGeneration = test.observed
+			state.StatusFreshness = test.freshness
+			if test.drift != "" {
+				state.DriftState = test.drift
+			}
+			if test.wantWarnings == nil {
+				test.wantWarnings = []reportv1alpha1.RuntimeWarning{}
+			}
+
+			reportValue, err := ProjectEffective(isvcCopy, &state, projectionTestClock)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantIssues, reportValue.Content.Issues)
+			assert.Equal(t, test.wantWarnings, reportValue.Warnings)
+		})
+	}
+}
+
+func TestProjectEffectiveMapsMissingAndDisabledLiveRuntimeAsEvidence(t *testing.T) {
+	tests := []struct {
+		name       string
+		runtime    *v1beta1.ClusterServingRuntime
+		wantReason reportv1alpha1.UnavailableReason
+	}{
+		{name: "missing", wantReason: reportv1alpha1.UnavailableNotFound},
+		{
+			name: "disabled",
+			runtime: &v1beta1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-runtime", UID: "disabled-runtime-uid", Generation: 4},
+				Spec:       v1beta1.ServingRuntimeSpec{Disabled: pointerTo(true)},
+			},
+			wantReason: reportv1alpha1.UnavailableDisabled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc, state := resolveUnavailableLiveFixture(t, test.runtime)
+
+			reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RuntimeKindClusterServingRuntime, reportValue.Content.Selection.Runtime.Kind)
+			assert.Equal(t, test.wantReason, reportValue.Content.Inheritance.UnavailableReason)
+			assert.Equal(t, test.wantReason, reportValue.Content.Live.UnavailableReason)
+			assert.Equal(t, test.wantReason, reportValue.Content.Active.UnavailableReason)
+			assert.Equal(t, []reportv1alpha1.RuntimeIssue{
+				{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable},
+				{Code: reportv1alpha1.RuntimeIssueLiveRuntimeUnavailable},
+			}, reportValue.Content.Issues)
+			assert.Equal(t, []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData},
+				{Code: reportv1alpha1.WarningSourceUnavailable},
+			}, reportValue.Warnings)
+			require.Len(t, reportValue.Sources, 2)
+			assert.Equal(t, reportv1alpha1.EvidenceUnavailable, reportValue.Sources[0].Evidence)
+			assert.Equal(t, test.wantReason, reportValue.Sources[0].UnavailableReason)
+			assert.Equal(t, "gpu-runtime", reportValue.Sources[0].Name)
+		})
+	}
+}
+
+func resolveUnavailableLiveFixture(
+	t *testing.T,
+	runtimeObject *v1beta1.ClusterServingRuntime,
+) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	builder := ctrlclientfake.NewClientBuilder().WithScheme(scheme)
+	if runtimeObject != nil {
+		builder = builder.WithObjects(runtimeObject)
+	}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "gpu-runtime"},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset().AppsV1(),
+		effective.NewRuntimeResolver(builder.Build()),
+		"ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+	return isvc, state
+}

--- a/pkg/cli/runtimeprojection/history.go
+++ b/pkg/cli/runtimeprojection/history.go
@@ -1,0 +1,418 @@
+package runtimeprojection
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+// ProjectHistory projects bounded runtime revision evidence into the safe,
+// versioned history report contract.
+func ProjectHistory(
+	isvc *v1beta1.InferenceService,
+	state *effective.RuntimeState,
+	clock reportv1alpha1.Clock,
+) (reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent], error) {
+	if !validInputs(isvc, state) {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+	live := state.LiveConfiguration()
+	if !validStateEvidence(state, live) {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+	_, runtimeIdentity, ok := projectInheritance(state, live)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+	observation, completeness, ok := projectHistoryCollectionState(state)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+
+	revisions := state.RevisionObservations()
+	entries := make([]reportv1alpha1.RuntimeRevisionEntry, 0, len(revisions))
+	for i := range revisions {
+		if !revisions[i].ObjectReturned() {
+			continue
+		}
+		entry, valid := projectRevisionEntry(revisions[i])
+		if !valid {
+			return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+		}
+		entries = append(entries, entry)
+	}
+
+	issues, sources, warnings, ok := projectHistoryDiagnostics(isvc, state, live, revisions)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+	content := reportv1alpha1.RuntimeHistoryContent{
+		Runtime:        copyRuntimeReference(runtimeIdentity),
+		Observation:    observation,
+		Completeness:   completeness,
+		RequestedPages: state.HistoryRequestedPages,
+		ObservedPages:  state.HistoryObservedPages,
+		Revisions:      entries,
+		Issues:         issues,
+	}
+	reportValue := reportv1alpha1.NewRuntimeHistoryReport(
+		reportv1alpha1.Metadata{Namespace: isvc.Namespace, Name: isvc.Name}, content, clock,
+	)
+	reportValue.Sources = sources
+	reportValue.Warnings = warnings
+	return reportValue.Canonical(), nil
+}
+
+func projectHistoryCollectionState(
+	state *effective.RuntimeState,
+) (reportv1alpha1.HistoryObservationState, reportv1alpha1.HistoryCompleteness, bool) {
+	if state.HistoryRequestedPages < 0 || state.HistoryObservedPages < 0 ||
+		state.HistoryObservedPages > state.HistoryRequestedPages {
+		return "", "", false
+	}
+	if !state.HistoryRequested {
+		if state.HistoryComplete || state.HistoryTruncated ||
+			state.HistoryRequestedPages != 0 || state.HistoryObservedPages != 0 {
+			return "", "", false
+		}
+		return reportv1alpha1.HistoryObservationStateNotRequested,
+			reportv1alpha1.HistoryCompletenessNotRequested, true
+	}
+	if state.HistoryComplete {
+		if state.HistoryTruncated {
+			return "", "", false
+		}
+		return reportv1alpha1.HistoryObservationStateComplete,
+			reportv1alpha1.HistoryCompletenessRetentionBounded, true
+	}
+	if state.HistoryObservedPages > 0 || state.HistoryTruncated {
+		return reportv1alpha1.HistoryObservationStatePartial,
+			reportv1alpha1.HistoryCompletenessIncomplete, true
+	}
+	return reportv1alpha1.HistoryObservationStateUnavailable,
+		reportv1alpha1.HistoryCompletenessIncomplete, true
+}
+
+func projectRevisionEntry(
+	observation effective.RuntimeRevisionObservation,
+) (reportv1alpha1.RuntimeRevisionEntry, bool) {
+	if !validVerifiedShortHash(observation.ShortHash) {
+		return reportv1alpha1.RuntimeRevisionEntry{}, false
+	}
+	roles := observation.Roles()
+	projectedRoles := make([]reportv1alpha1.RuntimeRevisionRole, len(roles))
+	for i := range roles {
+		role, ok := mapRevisionRole(roles[i])
+		if !ok {
+			return reportv1alpha1.RuntimeRevisionEntry{}, false
+		}
+		projectedRoles[i] = role
+	}
+	consistency, ok := mapRevisionConsistency(observation.Consistency)
+	if !ok {
+		return reportv1alpha1.RuntimeRevisionEntry{}, false
+	}
+	relation, ok := mapRevisionRelation(observation.RelationToLive)
+	if !ok {
+		return reportv1alpha1.RuntimeRevisionEntry{}, false
+	}
+	issues, ok := projectConsistencyIssues(observation.ConsistencyCodes(), observation.Disabled)
+	if !ok {
+		return reportv1alpha1.RuntimeRevisionEntry{}, false
+	}
+	var createdAt *time.Time
+	if !observation.CreationTimestamp.IsZero() {
+		utc := observation.CreationTimestamp.Time.UTC()
+		createdAt = &utc
+	}
+	var source *reportv1alpha1.RuntimeObjectReference
+	if observation.SourceName != "" {
+		kind, known := mapRuntimeKind(observation.SourceKind)
+		if !known {
+			kind = reportv1alpha1.RuntimeKindUnknown
+		}
+		source = &reportv1alpha1.RuntimeObjectReference{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       kind,
+			Namespace:  observation.SourceNamespace,
+			Name:       observation.SourceName,
+		}
+	}
+	return reportv1alpha1.RuntimeRevisionEntry{
+		Revision: reportv1alpha1.RuntimeRevisionReference{
+			Namespace: observation.ReturnedNamespace(),
+			Name:      observation.ReturnedName(),
+			UID:       observation.UID,
+			CreatedAt: createdAt,
+		},
+		Source:         source,
+		Hash:           observation.ShortHash,
+		Roles:          projectedRoles,
+		Consistency:    consistency,
+		RelationToLive: relation,
+		Issues:         issues,
+	}, true
+}
+
+func mapRevisionRole(value effective.RuntimeRevisionRole) (reportv1alpha1.RuntimeRevisionRole, bool) {
+	switch value {
+	case effective.RuntimeRevisionRoleRequested:
+		return reportv1alpha1.RuntimeRevisionRoleRequested, true
+	case effective.RuntimeRevisionRoleReported:
+		return reportv1alpha1.RuntimeRevisionRoleReported, true
+	case effective.RuntimeRevisionRoleActive:
+		return reportv1alpha1.RuntimeRevisionRoleActive, true
+	case effective.RuntimeRevisionRoleHistory:
+		return reportv1alpha1.RuntimeRevisionRoleHistory, true
+	default:
+		return "", false
+	}
+}
+
+func mapRevisionConsistency(value effective.RevisionConsistencyState) (reportv1alpha1.RevisionConsistency, bool) {
+	switch value {
+	case effective.RevisionConsistencyConsistent:
+		return reportv1alpha1.RevisionConsistencyConsistent, true
+	case effective.RevisionConsistencyInconsistent:
+		return reportv1alpha1.RevisionConsistencyInconsistent, true
+	case effective.RevisionConsistencyUnknown:
+		return reportv1alpha1.RevisionConsistencyUnknown, true
+	default:
+		return "", false
+	}
+}
+
+func mapRevisionRelation(value effective.RuntimeHashRelation) (reportv1alpha1.RevisionRelation, bool) {
+	switch value {
+	case effective.RuntimeHashRelationUnknown:
+		return reportv1alpha1.RevisionRelationUnknown, true
+	case effective.RuntimeHashRelationEqual:
+		return reportv1alpha1.RevisionRelationMatchesLive, true
+	case effective.RuntimeHashRelationDifferent:
+		return reportv1alpha1.RevisionRelationDiffersFromLive, true
+	case effective.RuntimeHashRelationAmbiguous:
+		return reportv1alpha1.RevisionRelationAmbiguous, true
+	default:
+		return "", false
+	}
+}
+
+func projectConsistencyIssues(
+	codes []effective.RevisionConsistencyCode,
+	disabled bool,
+) ([]reportv1alpha1.RuntimeIssueCode, bool) {
+	issues := make([]reportv1alpha1.RuntimeIssueCode, 0, len(codes)+1)
+	for _, code := range codes {
+		issue, ok := mapConsistencyIssue(code)
+		if !ok {
+			return nil, false
+		}
+		issues = append(issues, issue)
+	}
+	if disabled {
+		issues = append(issues, reportv1alpha1.RuntimeIssueRevisionDisabled)
+	}
+	sort.Slice(issues, func(i, j int) bool { return issues[i] < issues[j] })
+	issues = deduplicateIssueCodes(issues)
+	return issues, true
+}
+
+func mapConsistencyIssue(value effective.RevisionConsistencyCode) (reportv1alpha1.RuntimeIssueCode, bool) {
+	switch value {
+	case effective.RevisionConsistencyCreatedBy:
+		return reportv1alpha1.RuntimeIssueRevisionNotOMEManaged, true
+	case effective.RevisionConsistencySourceName,
+		effective.RevisionConsistencySourceKind,
+		effective.RevisionConsistencySourceNamespace:
+		return reportv1alpha1.RuntimeIssueRevisionSourceMismatch, true
+	case effective.RevisionConsistencyHashLabelInvalid:
+		return reportv1alpha1.RuntimeIssueRevisionHashInvalid, true
+	case effective.RevisionConsistencyHashLabelMismatch:
+		return reportv1alpha1.RuntimeIssueRevisionHashMismatch, true
+	case effective.RevisionConsistencyNameHash:
+		return reportv1alpha1.RuntimeIssueRevisionNameMismatch, true
+	case effective.RevisionConsistencyOrdinal:
+		return reportv1alpha1.RuntimeIssueRevisionOrdinalUnexpected, true
+	case effective.RevisionConsistencyPayloadCanonicality:
+		return reportv1alpha1.RuntimeIssueRevisionPayloadNonCanonical, true
+	case effective.RevisionConsistencyUnexpectedDataObject:
+		return reportv1alpha1.RuntimeIssueRevisionDataObjectPresent, true
+	case effective.RevisionConsistencyMalformedPayload:
+		return reportv1alpha1.RuntimeIssueRevisionPayloadMalformed, true
+	case effective.RevisionConsistencyReturnedIdentity:
+		return reportv1alpha1.RuntimeIssueRevisionIdentityMismatch, true
+	case effective.RevisionConsistencyDuplicateIdentity:
+		return reportv1alpha1.RuntimeIssueDuplicateRevision, true
+	case effective.RevisionConsistencyConflictingIdentity:
+		return reportv1alpha1.RuntimeIssueConflictingRevision, true
+	case effective.RevisionConsistencyDuplicateContentHash:
+		return reportv1alpha1.RuntimeIssueDuplicateRevisionContent, true
+	case effective.RevisionConsistencyShortHashCollision:
+		return reportv1alpha1.RuntimeIssueRevisionHashCollision, true
+	default:
+		return "", false
+	}
+}
+
+func projectHistoryDiagnostics(
+	isvc *v1beta1.InferenceService,
+	state *effective.RuntimeState,
+	live *effective.LiveConfiguration,
+	observations []effective.RuntimeRevisionObservation,
+) ([]reportv1alpha1.RuntimeIssue, []reportv1alpha1.RuntimeSourceReference, []reportv1alpha1.RuntimeWarning, bool) {
+	issues := []reportv1alpha1.RuntimeIssue{}
+	sources := projectBaseSources(isvc, live)
+	warnings := []reportv1alpha1.RuntimeWarning{}
+
+	for _, observation := range observations {
+		if observation.ObjectReturned() {
+			sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+				Kind: "ControllerRevision", Namespace: observation.ReturnedNamespace(), Name: observation.ReturnedName(),
+				UID: observation.UID, Evidence: reportv1alpha1.EvidenceObserved,
+			})
+			continue
+		}
+		reason, found := failedRevisionReason(state.SourceIssues(), observation.ExpectedName())
+		if found {
+			sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+				Kind: "ControllerRevision", Namespace: observation.ExpectedNamespace(), Name: observation.ExpectedName(),
+				Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: reason,
+			})
+		}
+	}
+
+	for _, sourceIssue := range state.SourceIssues() {
+		issue, reason, valid := projectSourceIssue(sourceIssue)
+		if !valid {
+			return nil, nil, nil, false
+		}
+		issues = append(issues, issue)
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable},
+		)
+		if sourceIssue.Code == effective.RuntimeSourceIssueRevisionListFailed {
+			sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+				Kind: "ControllerRevisionList", Name: state.RuntimeName,
+				Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: reason,
+			})
+		}
+	}
+	if state.HistoryRequested && !state.HistoryComplete && !state.HistoryTruncated {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable})
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable},
+		)
+	}
+	if state.HistoryTruncated {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueHistoryTruncated})
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningTruncated},
+		)
+	}
+	issues = deduplicateIssues(issues)
+	warnings = deduplicateWarnings(warnings)
+	return issues, deduplicateSources(sources), warnings, true
+}
+
+func projectSourceIssue(
+	issue effective.RuntimeSourceIssue,
+) (reportv1alpha1.RuntimeIssue, reportv1alpha1.UnavailableReason, bool) {
+	switch issue.Code {
+	case effective.RuntimeSourceIssueLiveNotFound:
+		return reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueLiveRuntimeUnavailable},
+			reportv1alpha1.UnavailableNotFound, true
+	case effective.RuntimeSourceIssueLiveDisabled:
+		return reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueLiveRuntimeUnavailable},
+			reportv1alpha1.UnavailableDisabled, true
+	case effective.RuntimeSourceIssueLiveUnavailable:
+		return reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueLiveRuntimeUnavailable},
+			classifySourceError(errors.Unwrap(issue)), true
+	case effective.RuntimeSourceIssueRevisionNotFound:
+		return reportv1alpha1.RuntimeIssue{
+			Code: reportv1alpha1.RuntimeIssueRevisionNotFound, Revision: issue.RevisionName,
+		}, reportv1alpha1.UnavailableNotFound, true
+	case effective.RuntimeSourceIssueRevisionGetFailed:
+		return reportv1alpha1.RuntimeIssue{
+			Code: reportv1alpha1.RuntimeIssueRevisionUnavailable, Revision: issue.RevisionName,
+		}, classifySourceError(errors.Unwrap(issue)), true
+	case effective.RuntimeSourceIssueRevisionListFailed:
+		return reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable},
+			classifySourceError(errors.Unwrap(issue)), true
+	default:
+		return reportv1alpha1.RuntimeIssue{}, "", false
+	}
+}
+
+func classifySourceError(err error) reportv1alpha1.UnavailableReason {
+	switch {
+	case apierrors.IsNotFound(err):
+		return reportv1alpha1.UnavailableNotFound
+	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+		return reportv1alpha1.UnavailableForbidden
+	case meta.IsNoMatchError(err):
+		return reportv1alpha1.UnavailableUnsupportedAPI
+	default:
+		return reportv1alpha1.UnavailableUnreadable
+	}
+}
+
+func failedRevisionReason(
+	issues []effective.RuntimeSourceIssue,
+	revisionName string,
+) (reportv1alpha1.UnavailableReason, bool) {
+	for _, issue := range issues {
+		if issue.RevisionName != revisionName {
+			continue
+		}
+		_, reason, ok := projectSourceIssue(issue)
+		return reason, ok
+	}
+	return "", false
+}
+
+func deduplicateIssueCodes(values []reportv1alpha1.RuntimeIssueCode) []reportv1alpha1.RuntimeIssueCode {
+	result := make([]reportv1alpha1.RuntimeIssueCode, 0, len(values))
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func deduplicateIssues(values []reportv1alpha1.RuntimeIssue) []reportv1alpha1.RuntimeIssue {
+	sort.Slice(values, func(i, j int) bool {
+		if values[i].Code != values[j].Code {
+			return values[i].Code < values[j].Code
+		}
+		return values[i].Revision < values[j].Revision
+	})
+	result := make([]reportv1alpha1.RuntimeIssue, 0, len(values))
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func deduplicateWarnings(values []reportv1alpha1.RuntimeWarning) []reportv1alpha1.RuntimeWarning {
+	sort.Slice(values, func(i, j int) bool { return values[i].Code < values[j].Code })
+	result := make([]reportv1alpha1.RuntimeWarning, 0, len(values))
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/pkg/cli/runtimeprojection/history.go
+++ b/pkg/cli/runtimeprojection/history.go
@@ -27,8 +27,16 @@ func ProjectHistory(
 	if !validStateEvidence(state, live) {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
 	}
-	_, runtimeIdentity, ok := projectInheritance(state, live)
+	notConfigured := noRuntimeConfigurationDeclared(isvc)
+	_, runtimeIdentity, ok := projectInheritance(state, live, notConfigured)
 	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+	if _, valid := projectLiveConfiguration(state, live, runtimeIdentity, notConfigured); !valid {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
+	}
+	activeConfiguration, valid := projectActiveConfiguration(state, runtimeIdentity, notConfigured)
+	if !valid || !validPinConfiguration(state, activeConfiguration) {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
 	}
 	observation, completeness, ok := projectHistoryCollectionState(state)
@@ -49,7 +57,7 @@ func ProjectHistory(
 		entries = append(entries, entry)
 	}
 
-	issues, sources, warnings, ok := projectHistoryDiagnostics(isvc, state, live, revisions)
+	issues, sources, warnings, ok := projectHistoryDiagnostics(isvc, state, live, revisions, notConfigured)
 	if !ok {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]{}, ErrInvalidEvidence
 	}
@@ -73,22 +81,14 @@ func ProjectHistory(
 func projectHistoryCollectionState(
 	state *effective.RuntimeState,
 ) (reportv1alpha1.HistoryObservationState, reportv1alpha1.HistoryCompleteness, bool) {
-	if state.HistoryRequestedPages < 0 || state.HistoryObservedPages < 0 ||
-		state.HistoryObservedPages > state.HistoryRequestedPages {
+	if !validHistoryCollectionEvidence(state) {
 		return "", "", false
 	}
 	if !state.HistoryRequested {
-		if state.HistoryComplete || state.HistoryTruncated ||
-			state.HistoryRequestedPages != 0 || state.HistoryObservedPages != 0 {
-			return "", "", false
-		}
 		return reportv1alpha1.HistoryObservationStateNotRequested,
 			reportv1alpha1.HistoryCompletenessNotRequested, true
 	}
 	if state.HistoryComplete {
-		if state.HistoryTruncated {
-			return "", "", false
-		}
 		return reportv1alpha1.HistoryObservationStateComplete,
 			reportv1alpha1.HistoryCompletenessRetentionBounded, true
 	}
@@ -100,9 +100,61 @@ func projectHistoryCollectionState(
 		reportv1alpha1.HistoryCompletenessIncomplete, true
 }
 
+func validHistoryCollectionEvidence(state *effective.RuntimeState) bool {
+	if state == nil || state.HistoryPageLimit <= 0 || state.HistoryPages < 0 ||
+		state.HistoryRequestedPages < 0 || state.HistoryObservedPages < 0 ||
+		state.HistoryPages != state.HistoryRequestedPages ||
+		state.HistoryRequestedPages > state.HistoryPageLimit ||
+		state.HistoryObservedPages > state.HistoryRequestedPages {
+		return false
+	}
+
+	listFailures := 0
+	for _, issue := range state.SourceIssues() {
+		if issue.Code != effective.RuntimeSourceIssueRevisionListFailed {
+			continue
+		}
+		if issue.RevisionName != "" {
+			return false
+		}
+		listFailures++
+	}
+	if listFailures > 1 {
+		return false
+	}
+
+	if !state.HistoryRequested {
+		return !state.HistoryComplete && !state.HistoryTruncated &&
+			state.HistoryPages == 0 && state.HistoryNamespace() == "" && listFailures == 0
+	}
+	if state.RuntimeName == "" {
+		return !state.HistoryComplete && !state.HistoryTruncated &&
+			state.HistoryPages == 0 && state.HistoryNamespace() == "" && listFailures == 0
+	}
+	if state.HistoryNamespace() == "" || state.HistoryRequestedPages == 0 {
+		return false
+	}
+	if state.HistoryComplete {
+		return !state.HistoryTruncated &&
+			state.HistoryObservedPages == state.HistoryRequestedPages && listFailures == 0
+	}
+	if state.HistoryTruncated {
+		return state.HistoryObservedPages == state.HistoryRequestedPages && listFailures == 0
+	}
+	if listFailures != 1 {
+		return false
+	}
+	failedBeforeObservation := state.HistoryRequestedPages-state.HistoryObservedPages == 1
+	failedAfterObservation := state.HistoryRequestedPages == state.HistoryObservedPages
+	return failedBeforeObservation || failedAfterObservation
+}
+
 func projectRevisionEntry(
 	observation effective.RuntimeRevisionObservation,
 ) (reportv1alpha1.RuntimeRevisionEntry, bool) {
+	if !observation.ObjectReturned() || !validReturnedRevisionIdentity(observation) {
+		return reportv1alpha1.RuntimeRevisionEntry{}, false
+	}
 	if !validVerifiedShortHash(observation.ShortHash) {
 		return reportv1alpha1.RuntimeRevisionEntry{}, false
 	}
@@ -159,6 +211,10 @@ func projectRevisionEntry(
 		RelationToLive: relation,
 		Issues:         issues,
 	}, true
+}
+
+func validReturnedRevisionIdentity(observation effective.RuntimeRevisionObservation) bool {
+	return observation.ReturnedName() != "" && observation.ReturnedNamespace() != ""
 }
 
 func mapRevisionRole(value effective.RuntimeRevisionRole) (reportv1alpha1.RuntimeRevisionRole, bool) {
@@ -266,10 +322,61 @@ func projectHistoryDiagnostics(
 	state *effective.RuntimeState,
 	live *effective.LiveConfiguration,
 	observations []effective.RuntimeRevisionObservation,
+	notConfigured bool,
 ) ([]reportv1alpha1.RuntimeIssue, []reportv1alpha1.RuntimeSourceReference, []reportv1alpha1.RuntimeWarning, bool) {
 	issues := []reportv1alpha1.RuntimeIssue{}
 	sources := projectBaseSources(isvc, live)
 	warnings := []reportv1alpha1.RuntimeWarning{}
+	invalidDeclaredKind := invalidDeclaredRuntimeKind(isvc)
+	if invalidDeclaredKind {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInvalidDeclaredKind})
+	}
+	switch state.StatusFreshness {
+	case effective.StatusFreshnessCurrent:
+	case effective.StatusFreshnessUnknown:
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusUnobserved})
+		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData})
+	case effective.StatusFreshnessStale:
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusStale})
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence},
+		)
+	case effective.StatusFreshnessInconsistent:
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueStatusInvalid})
+		warnings = append(warnings,
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningStaleEvidence},
+		)
+	default:
+		return nil, nil, nil, false
+	}
+	if state.DriftState == effective.RuntimeDriftStateMalformed {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueReportedDriftConflict})
+	}
+	if live == nil || live.Runtime.DeclaredInheritance.State() == effective.InheritanceUnavailable {
+		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable})
+		if live != nil {
+			warnings = append(warnings,
+				reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
+				reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable},
+			)
+		}
+	}
+	if live != nil {
+		for _, advisory := range live.Advisories {
+			switch advisory.Code {
+			case effective.RuntimeAdvisoryDeclaredCompatibilityMismatch:
+				issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueDeclaredCompatibilityMismatch})
+			case effective.RuntimeAdvisoryInvalidDeclaredKind:
+				if !invalidDeclaredKind {
+					return nil, nil, nil, false
+				}
+			default:
+				return nil, nil, nil, false
+			}
+		}
+	}
 
 	for _, observation := range observations {
 		if observation.ObjectReturned() {
@@ -289,6 +396,9 @@ func projectHistoryDiagnostics(
 	}
 
 	for _, sourceIssue := range state.SourceIssues() {
+		if notConfigured && liveSourceIssue(sourceIssue.Code) {
+			continue
+		}
 		issue, reason, valid := projectSourceIssue(sourceIssue)
 		if !valid {
 			return nil, nil, nil, false
@@ -300,17 +410,24 @@ func projectHistoryDiagnostics(
 		)
 		if sourceIssue.Code == effective.RuntimeSourceIssueRevisionListFailed {
 			sources = append(sources, reportv1alpha1.RuntimeSourceReference{
-				Kind: "ControllerRevisionList", Name: state.RuntimeName,
+				Kind: "ControllerRevisionList", Namespace: state.HistoryNamespace(), Name: state.RuntimeName,
 				Evidence: reportv1alpha1.EvidenceUnavailable, UnavailableReason: reason,
 			})
 		}
 	}
+	if live == nil && state.RuntimeName != "" {
+		source, valid := unavailableLiveSource(state)
+		if !valid {
+			if !invalidDeclaredKind {
+				return nil, nil, nil, false
+			}
+		} else {
+			sources = append(sources, source)
+		}
+	}
 	if state.HistoryRequested && !state.HistoryComplete && !state.HistoryTruncated {
 		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable})
-		warnings = append(warnings,
-			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData},
-			reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable},
-		)
+		warnings = append(warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData})
 	}
 	if state.HistoryTruncated {
 		issues = append(issues, reportv1alpha1.RuntimeIssue{Code: reportv1alpha1.RuntimeIssueHistoryTruncated})

--- a/pkg/cli/runtimeprojection/history_test.go
+++ b/pkg/cli/runtimeprojection/history_test.go
@@ -2,6 +2,8 @@ package runtimeprojection
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,10 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
+	k8stesting "k8s.io/client-go/testing"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -117,51 +123,66 @@ func TestProjectHistoryMapsCompleteRetentionBoundedEvidence(t *testing.T) {
 }
 
 func TestProjectHistoryMapsCollectionStateWithoutInventingCompleteness(t *testing.T) {
-	isvc, baseState := resolveLiveProjectionFixture(t)
 	tests := []struct {
 		name             string
-		requested        bool
-		complete         bool
-		truncated        bool
-		requestedPages   int
-		observedPages    int
+		resolve          func(*testing.T) (*v1beta1.InferenceService, *effective.RuntimeState)
 		wantObservation  reportv1alpha1.HistoryObservationState
 		wantCompleteness reportv1alpha1.HistoryCompleteness
+		wantRequested    int
+		wantObserved     int
 		wantIssues       []reportv1alpha1.RuntimeIssue
 		wantWarnings     []reportv1alpha1.RuntimeWarning
 	}{
 		{
-			name: "not requested", wantObservation: reportv1alpha1.HistoryObservationStateNotRequested,
+			name: "not requested", resolve: resolveLiveProjectionFixture,
+			wantObservation:  reportv1alpha1.HistoryObservationStateNotRequested,
 			wantCompleteness: reportv1alpha1.HistoryCompletenessNotRequested,
 		},
 		{
-			name: "complete is retention bounded", requested: true, complete: true, requestedPages: 2, observedPages: 2,
+			name: "complete is retention bounded", resolve: resolveCompleteHistoryCollectionFixture,
 			wantObservation:  reportv1alpha1.HistoryObservationStateComplete,
 			wantCompleteness: reportv1alpha1.HistoryCompletenessRetentionBounded,
+			wantRequested:    1, wantObserved: 1,
 		},
 		{
-			name: "partial after one page", requested: true, requestedPages: 2, observedPages: 1,
+			name: "partial after one page", resolve: resolvePartialHistoryCollectionFixture,
 			wantObservation:  reportv1alpha1.HistoryObservationStatePartial,
 			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
-			wantIssues:       []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}},
+			wantRequested:    2, wantObserved: 1,
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}},
 			wantWarnings: []reportv1alpha1.RuntimeWarning{
-				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningSourceUnavailable},
+				{Code: reportv1alpha1.WarningPartialData},
+				{Code: reportv1alpha1.WarningSourceUnavailable},
 			},
 		},
 		{
-			name: "unavailable before first page", requested: true, requestedPages: 1,
+			name: "partial after nonadvancing token", resolve: resolveNonadvancingHistoryCollectionFixture,
+			wantObservation:  reportv1alpha1.HistoryObservationStatePartial,
+			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
+			wantRequested:    2, wantObserved: 2,
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData},
+				{Code: reportv1alpha1.WarningSourceUnavailable},
+			},
+		},
+		{
+			name: "unavailable before first page", resolve: resolveUnavailableHistoryCollectionFixture,
 			wantObservation:  reportv1alpha1.HistoryObservationStateUnavailable,
 			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
+			wantRequested:    1,
 			wantIssues:       []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}},
 			wantWarnings: []reportv1alpha1.RuntimeWarning{
-				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningSourceUnavailable},
+				{Code: reportv1alpha1.WarningPartialData},
+				{Code: reportv1alpha1.WarningSourceUnavailable},
 			},
 		},
 		{
-			name: "truncated", requested: true, truncated: true, requestedPages: 2, observedPages: 2,
+			name: "truncated", resolve: resolveTruncatedHistoryCollectionFixture,
 			wantObservation:  reportv1alpha1.HistoryObservationStatePartial,
 			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
-			wantIssues:       []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryTruncated}},
+			wantRequested:    2, wantObserved: 2,
+			wantIssues: []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryTruncated}},
 			wantWarnings: []reportv1alpha1.RuntimeWarning{
 				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningTruncated},
 			},
@@ -170,14 +191,9 @@ func TestProjectHistoryMapsCollectionStateWithoutInventingCompleteness(t *testin
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			state := *baseState
-			state.HistoryRequested = test.requested
-			state.HistoryComplete = test.complete
-			state.HistoryTruncated = test.truncated
-			state.HistoryRequestedPages = test.requestedPages
-			state.HistoryObservedPages = test.observedPages
+			isvc, state := test.resolve(t)
 
-			reportValue, err := ProjectHistory(isvc, &state, projectionTestClock)
+			reportValue, err := ProjectHistory(isvc, state, projectionTestClock)
 			require.NoError(t, err)
 			if test.wantIssues == nil {
 				test.wantIssues = []reportv1alpha1.RuntimeIssue{}
@@ -187,12 +203,587 @@ func TestProjectHistoryMapsCollectionStateWithoutInventingCompleteness(t *testin
 			}
 			assert.Equal(t, test.wantObservation, reportValue.Content.Observation)
 			assert.Equal(t, test.wantCompleteness, reportValue.Content.Completeness)
-			assert.Equal(t, test.requestedPages, reportValue.Content.RequestedPages)
-			assert.Equal(t, test.observedPages, reportValue.Content.ObservedPages)
+			assert.Equal(t, test.wantRequested, reportValue.Content.RequestedPages)
+			assert.Equal(t, test.wantObserved, reportValue.Content.ObservedPages)
 			assert.Equal(t, test.wantIssues, reportValue.Content.Issues)
 			assert.Equal(t, test.wantWarnings, reportValue.Warnings)
 		})
 	}
+}
+
+func resolveCompleteHistoryCollectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	return resolveProjectionWithRevisionClient(
+		t, k8sfake.NewSimpleClientset(), projectionRuntimeSpec("private.registry/live:secret"), "", nil,
+	)
+}
+
+func resolvePartialHistoryCollectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	clientset := k8sfake.NewSimpleClientset()
+	calls := 0
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		if calls == 1 {
+			return true, &appsv1.ControllerRevisionList{ListMeta: metav1.ListMeta{Continue: "next"}}, nil
+		}
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
+			"gpu-runtime",
+			errors.New("secret-list-denial"),
+		)
+	})
+	return resolveProjectionWithRevisionClient(
+		t, clientset, projectionRuntimeSpec("private.registry/live:secret"), "", nil,
+	)
+}
+
+func resolveUnavailableHistoryCollectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	clientset := k8sfake.NewSimpleClientset()
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
+			"gpu-runtime",
+			errors.New("secret-list-denial"),
+		)
+	})
+	return resolveProjectionWithRevisionClient(
+		t, clientset, projectionRuntimeSpec("private.registry/live:secret"), "", nil,
+	)
+}
+
+func resolveNonadvancingHistoryCollectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	clientset := k8sfake.NewSimpleClientset()
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &appsv1.ControllerRevisionList{ListMeta: metav1.ListMeta{Continue: "same"}}, nil
+	})
+	return resolveProjectionWithRevisionClient(
+		t, clientset, projectionRuntimeSpec("private.registry/live:secret"), "", nil,
+	)
+}
+
+func resolveTruncatedHistoryCollectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	clientset := k8sfake.NewSimpleClientset()
+	calls := 0
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		return true, &appsv1.ControllerRevisionList{
+			ListMeta: metav1.ListMeta{Continue: fmt.Sprintf("page-%d", calls)},
+		}, nil
+	})
+	return resolveProjectionWithRevisionClient(
+		t, clientset, projectionRuntimeSpec("private.registry/live:secret"), "", nil,
+	)
+}
+
+func TestProjectHistoryReportsRequestedHistoryWithoutRuntimeAsUnavailableNotFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+	}
+	isvc.Status.ObservedGeneration = 7
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset().AppsV1(),
+		effective.NewRuntimeResolver(ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()),
+		"ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{IncludeHistory: true})
+	require.NoError(t, err)
+
+	reportValue, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Nil(t, reportValue.Content.Runtime)
+	assert.Equal(t, reportv1alpha1.HistoryObservationStateUnavailable, reportValue.Content.Observation)
+	assert.Equal(t, reportv1alpha1.HistoryCompletenessIncomplete, reportValue.Content.Completeness)
+	assert.Zero(t, reportValue.Content.RequestedPages)
+	assert.Zero(t, reportValue.Content.ObservedPages)
+	assert.Equal(t, []reportv1alpha1.RuntimeIssue{
+		{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable},
+		{Code: reportv1alpha1.RuntimeIssueInheritanceUnavailable},
+	}, reportValue.Content.Issues)
+	assert.Equal(t, []reportv1alpha1.RuntimeWarning{{Code: reportv1alpha1.WarningPartialData}}, reportValue.Warnings)
+	assert.NotContains(t, reportValue.Warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable})
+	assert.Equal(t, []reportv1alpha1.RuntimeSourceReference{{
+		Kind: "InferenceService", Namespace: "workloads", Name: "chat", UID: "isvc-uid", Generation: 7,
+		Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+	}}, reportValue.Sources)
+}
+
+func TestProjectionRejectsImpossibleCollectionCounters(t *testing.T) {
+	isvc, baseState := resolveLiveProjectionFixture(t)
+	tests := []struct {
+		name   string
+		mutate func(*effective.RuntimeState)
+	}{
+		{"negative requested", func(state *effective.RuntimeState) { state.HistoryRequestedPages = -1 }},
+		{"negative observed", func(state *effective.RuntimeState) { state.HistoryObservedPages = -1 }},
+		{"observed exceeds requested", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryRequestedPages = 1
+			state.HistoryObservedPages = 2
+		}},
+		{"not requested with page", func(state *effective.RuntimeState) { state.HistoryRequestedPages = 1 }},
+		{"not requested complete", func(state *effective.RuntimeState) { state.HistoryComplete = true }},
+		{"not requested truncated", func(state *effective.RuntimeState) { state.HistoryTruncated = true }},
+		{"complete and truncated", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryComplete = true
+			state.HistoryTruncated = true
+			state.HistoryRequestedPages = 1
+			state.HistoryObservedPages = 1
+		}},
+		{"complete with no request", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryComplete = true
+		}},
+		{"complete page mismatch", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryComplete = true
+			state.HistoryRequestedPages = 2
+			state.HistoryObservedPages = 1
+		}},
+		{"incomplete failure without failed request", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryRequestedPages = 1
+			state.HistoryObservedPages = 1
+		}},
+		{"truncated without page", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryTruncated = true
+		}},
+		{"truncated page mismatch", func(state *effective.RuntimeState) {
+			state.HistoryRequested = true
+			state.HistoryTruncated = true
+			state.HistoryRequestedPages = 2
+			state.HistoryObservedPages = 1
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := *baseState
+			test.mutate(&state)
+
+			_, err := ProjectEffective(isvc, &state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			_, err = ProjectHistory(isvc, &state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
+func TestProjectionRejectsCollectorCollectionContradictions(t *testing.T) {
+	tests := []struct {
+		name    string
+		resolve func(*testing.T) (*v1beta1.InferenceService, *effective.RuntimeState)
+		mutate  func(*effective.RuntimeState)
+	}{
+		{
+			name: "history pages differ from requested pages", resolve: resolveCompleteHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) { state.HistoryPages++ },
+		},
+		{
+			name: "history pages are negative", resolve: resolveCompleteHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) { state.HistoryPages = -1 },
+		},
+		{
+			name: "requests exceed collector page limit", resolve: resolveCompleteHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) {
+				state.HistoryPages = state.HistoryPageLimit + 1
+				state.HistoryRequestedPages = state.HistoryPages
+				state.HistoryObservedPages = state.HistoryPages
+			},
+		},
+		{
+			name: "collector page limit is absent", resolve: resolveCompleteHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) { state.HistoryPageLimit = 0 },
+		},
+		{
+			name: "not requested carries a collector page", resolve: resolveLiveProjectionFixture,
+			mutate: func(state *effective.RuntimeState) { state.HistoryPages = 1 },
+		},
+		{
+			name: "failure counters have no list failure", resolve: resolveCompleteHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) {
+				state.HistoryComplete = false
+				state.HistoryPages = 2
+				state.HistoryRequestedPages = 2
+				state.HistoryObservedPages = 1
+			},
+		},
+		{
+			name: "list failure claims complete", resolve: resolveUnavailableHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) {
+				state.HistoryComplete = true
+				state.HistoryObservedPages = state.HistoryRequestedPages
+			},
+		},
+		{
+			name: "list failure claims truncation", resolve: resolveUnavailableHistoryCollectionFixture,
+			mutate: func(state *effective.RuntimeState) {
+				state.HistoryTruncated = true
+				state.HistoryObservedPages = state.HistoryRequestedPages
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc, state := test.resolve(t)
+			test.mutate(state)
+
+			_, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			_, err = ProjectHistory(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
+func TestProjectHistoryCarriesGlobalBoundedDiagnostics(t *testing.T) {
+	isvc, baseState := resolveLiveProjectionFixture(t)
+	state := *baseState
+	isvc = isvc.DeepCopy()
+	isvc.Status.ObservedGeneration = 6
+	state.ObservedGeneration = 6
+	state.StatusFreshness = effective.StatusFreshnessStale
+	state.DriftState = effective.RuntimeDriftStateMalformed
+	setMalformedProjectionDrift(isvc)
+
+	reportValue, err := ProjectHistory(isvc, &state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, []reportv1alpha1.RuntimeIssue{
+		{Code: reportv1alpha1.RuntimeIssueReportedDriftConflict},
+		{Code: reportv1alpha1.RuntimeIssueStatusStale},
+	}, reportValue.Content.Issues)
+	assert.Equal(t, []reportv1alpha1.RuntimeWarning{
+		{Code: reportv1alpha1.WarningPartialData},
+		{Code: reportv1alpha1.WarningStaleEvidence},
+	}, reportValue.Warnings)
+}
+
+func TestProjectHistoryCarriesUnavailableLiveRuntimeSourceIdentity(t *testing.T) {
+	isvc, state := resolveUnavailableLiveFixture(t, nil)
+
+	reportValue, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, &reportv1alpha1.RuntimeObjectReference{
+		APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: reportv1alpha1.RuntimeKindClusterServingRuntime,
+		Name: "gpu-runtime",
+	}, reportValue.Content.Runtime)
+	assert.Contains(t, reportValue.Sources, reportv1alpha1.RuntimeSourceReference{
+		Kind: "ClusterServingRuntime", Name: "gpu-runtime", Evidence: reportv1alpha1.EvidenceUnavailable,
+		CollectedAt: projectionTestClock.Now(), UnavailableReason: reportv1alpha1.UnavailableNotFound,
+	})
+}
+
+func TestProjectHistoryRejectsUnknownAggregateEnumsEvenWhenNotRendered(t *testing.T) {
+	isvc, baseState := resolveLiveProjectionFixture(t)
+	mutations := []func(*effective.RuntimeState){
+		func(state *effective.RuntimeState) {
+			state.SelectionSource = effective.RuntimeSelectionSource("secret")
+		},
+		func(state *effective.RuntimeState) { state.PinMode = effective.RuntimePinMode("secret") },
+		func(state *effective.RuntimeState) { state.PinState = effective.RuntimePinState("secret") },
+		func(state *effective.RuntimeState) { state.StatusFreshness = effective.StatusFreshness("secret") },
+		func(state *effective.RuntimeState) { state.SyncTokenState = effective.SyncTokenState("secret") },
+		func(state *effective.RuntimeState) { state.DriftState = effective.RuntimeDriftState("secret") },
+		func(state *effective.RuntimeState) { state.DriftReason = effective.RuntimeDriftReason("secret") },
+		func(state *effective.RuntimeState) { state.LiveToActive = effective.RuntimeHashRelation("secret") },
+	}
+
+	for index, mutate := range mutations {
+		state := *baseState
+		mutate(&state)
+
+		_, err := ProjectHistory(isvc, &state, projectionTestClock)
+		require.ErrorIs(t, err, ErrInvalidEvidence, "mutation %d", index)
+		assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		assert.NotContains(t, err.Error(), "secret")
+	}
+}
+
+func TestProjectHistoryRejectsKnownButImpossiblePinConfiguration(t *testing.T) {
+	isvc, state := resolveLiveProjectionFixture(t)
+	state.PinState = effective.RuntimePinStateUnavailable
+
+	_, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+}
+
+func TestProjectHistoryRetainsExactEvidenceWhenHistoryListFails(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	activeRevision := projectionRevision(t, "active-uid", "gpu-runtime", liveSpec)
+	activeRevision.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 31, 19, 0, 0, 0, time.UTC))
+	clientset := k8sfake.NewSimpleClientset(activeRevision.DeepCopy())
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
+			"gpu-runtime",
+			errors.New("secret-list-denial"),
+		)
+	})
+	isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, activeRevision.Name, nil)
+
+	reportValue, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.HistoryObservationStateUnavailable, reportValue.Content.Observation)
+	assert.Equal(t, 1, reportValue.Content.RequestedPages)
+	assert.Zero(t, reportValue.Content.ObservedPages)
+	require.Len(t, reportValue.Content.Revisions, 1, "the successful exact GET must survive LIST failure")
+	assert.Equal(t, activeRevision.Name, reportValue.Content.Revisions[0].Revision.Name)
+	assert.Equal(t, []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}}, reportValue.Content.Issues)
+	assert.Equal(t, []reportv1alpha1.RuntimeWarning{
+		{Code: reportv1alpha1.WarningPartialData},
+		{Code: reportv1alpha1.WarningSourceUnavailable},
+	}, reportValue.Warnings)
+	assert.Contains(t, reportValue.Sources, reportv1alpha1.RuntimeSourceReference{
+		Kind: "ControllerRevisionList", Namespace: "ome-system", Name: "gpu-runtime",
+		Evidence: reportv1alpha1.EvidenceUnavailable, CollectedAt: projectionTestClock.Now(),
+		UnavailableReason: reportv1alpha1.UnavailableForbidden,
+	})
+}
+
+func TestProjectHistoryKeepsFailedExactKeySeparateFromSameNameListObject(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	historyRevision := projectionRevision(t, "history-uid", "gpu-runtime", liveSpec)
+	historyRevision.Name = "expected-revision"
+	clientset := k8sfake.NewSimpleClientset(historyRevision.DeepCopy())
+	clientset.PrependReactor("get", "controllerrevisions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get := action.(k8stesting.GetAction)
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, get.GetName(),
+		)
+	})
+	requested := historyRevision.Name
+	isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, "", &requested)
+
+	reportValue, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	require.Len(t, reportValue.Content.Revisions, 1)
+	assert.Equal(t, historyRevision.Name, reportValue.Content.Revisions[0].Revision.Name)
+	assert.Equal(t, []reportv1alpha1.RuntimeRevisionRole{reportv1alpha1.RuntimeRevisionRoleHistory}, reportValue.Content.Revisions[0].Roles)
+	assert.Contains(t, reportValue.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueRevisionNotFound, Revision: requested,
+	})
+	var observed, unavailable int
+	for _, source := range reportValue.Sources {
+		if source.Kind != "ControllerRevision" || source.Name != requested {
+			continue
+		}
+		switch source.Evidence {
+		case reportv1alpha1.EvidenceObserved:
+			observed++
+		case reportv1alpha1.EvidenceUnavailable:
+			unavailable++
+			assert.Equal(t, reportv1alpha1.UnavailableNotFound, source.UnavailableReason)
+		}
+	}
+	assert.Equal(t, 1, observed)
+	assert.Equal(t, 1, unavailable)
+}
+
+func TestProjectionRejectsReturnedRevisionWithoutRequiredIdentity(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	tests := []struct {
+		name   string
+		mutate func(*appsv1.ControllerRevision)
+	}{
+		{name: "empty returned name", mutate: func(revision *appsv1.ControllerRevision) { revision.Name = "" }},
+		{name: "empty returned namespace", mutate: func(revision *appsv1.ControllerRevision) { revision.Namespace = "" }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			returned := projectionRevision(t, "returned-uid", "gpu-runtime", liveSpec)
+			test.mutate(returned)
+			clientset := k8sfake.NewSimpleClientset()
+			clientset.PrependReactor("get", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, returned.DeepCopy(), nil
+			})
+			clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &appsv1.ControllerRevisionList{
+					Items: []appsv1.ControllerRevision{*returned.DeepCopy()},
+				}, nil
+			})
+			expected := "expected-revision"
+			isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, expected, nil)
+
+			_, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			_, err = ProjectHistory(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
+func TestProjectionKeepsJoinedActiveHistoryAnomaliesInEffectiveReport(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	revision := projectionRevision(t, "revision-uid", "gpu-runtime", liveSpec)
+	clientset := k8sfake.NewSimpleClientset(revision.DeepCopy())
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &appsv1.ControllerRevisionList{
+			Items: []appsv1.ControllerRevision{*revision.DeepCopy(), *revision.DeepCopy()},
+		}, nil
+	})
+	isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, revision.Name, nil)
+
+	effectiveReport, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	historyReport, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, []reportv1alpha1.RuntimeIssue{
+		{Code: reportv1alpha1.RuntimeIssueDuplicateRevision, Revision: revision.Name},
+		{Code: reportv1alpha1.RuntimeIssueDuplicateRevisionContent, Revision: revision.Name},
+	}, effectiveReport.Content.Issues, "anomalies joined to exact active evidence must remain visible")
+	require.Len(t, historyReport.Content.Revisions, 2)
+	for _, entry := range historyReport.Content.Revisions {
+		assert.Equal(t, []reportv1alpha1.RuntimeIssueCode{
+			reportv1alpha1.RuntimeIssueDuplicateRevision,
+			reportv1alpha1.RuntimeIssueDuplicateRevisionContent,
+		}, entry.Issues)
+	}
+	var revisionSources int
+	for _, source := range historyReport.Sources {
+		if source.Kind == "ControllerRevision" && source.Name == revision.Name {
+			revisionSources++
+		}
+	}
+	assert.Equal(t, 1, revisionSources, "identical source provenance must be deduplicated")
+}
+
+func TestProjectionKeepsJoinedActiveHistoryConflictsInEffectiveReport(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	exact := projectionRevision(t, "exact-revision-uid", "gpu-runtime", liveSpec)
+	listed := exact.DeepCopy()
+	listed.UID = "conflicting-list-uid"
+	clientset := k8sfake.NewSimpleClientset(exact.DeepCopy())
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &appsv1.ControllerRevisionList{Items: []appsv1.ControllerRevision{*listed}}, nil
+	})
+	isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, exact.Name, nil)
+
+	effectiveReport, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Contains(t, effectiveReport.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueConflictingRevision, Revision: exact.Name,
+	})
+	assert.Contains(t, effectiveReport.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueDuplicateRevisionContent, Revision: exact.Name,
+	})
+	assert.NotContains(t, effectiveReport.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueDuplicateRevision, Revision: exact.Name,
+	})
+}
+
+func TestProjectionSuppressesExclusivelyHistoryAnomaliesFromEffectiveReport(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	active := projectionRevision(t, "active-revision-uid", "gpu-runtime", liveSpec)
+	older := projectionRevision(
+		t, "older-revision-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/older:secret"),
+	)
+	clientset := k8sfake.NewSimpleClientset(active.DeepCopy())
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &appsv1.ControllerRevisionList{
+			Items: []appsv1.ControllerRevision{*older.DeepCopy(), *older.DeepCopy()},
+		}, nil
+	})
+	isvc, state := resolveProjectionWithRevisionClient(t, clientset, liveSpec, active.Name, nil)
+
+	effectiveReport, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	historyReport, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	assert.Empty(t, effectiveReport.Content.Issues)
+	var olderEntries []reportv1alpha1.RuntimeRevisionEntry
+	for _, entry := range historyReport.Content.Revisions {
+		if entry.Revision.Name != older.Name {
+			continue
+		}
+		olderEntries = append(olderEntries, entry)
+	}
+	require.Len(t, olderEntries, 2)
+	for _, entry := range olderEntries {
+		assert.Equal(t, []reportv1alpha1.RuntimeIssueCode{
+			reportv1alpha1.RuntimeIssueDuplicateRevision,
+			reportv1alpha1.RuntimeIssueDuplicateRevisionContent,
+		}, entry.Issues)
+	}
+}
+
+func resolveProjectionWithRevisionClient(
+	t *testing.T,
+	clientset *k8sfake.Clientset,
+	liveSpec *v1beta1.ServingRuntimeSpec,
+	reportedRevision string,
+	requestedRevision *string,
+) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	return resolveProjectionWithRevisionGetter(t, clientset.AppsV1(), liveSpec, reportedRevision, requestedRevision)
+}
+
+func resolveProjectionWithRevisionGetter(
+	t *testing.T,
+	revisions appstyped.ControllerRevisionsGetter,
+	liveSpec *v1beta1.ServingRuntimeSpec,
+	reportedRevision string,
+	requestedRevision *string,
+) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-runtime", UID: "runtime-uid", Generation: 5},
+		Spec:       *liveSpec.DeepCopy(),
+	}
+	liveClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeObject).Build()
+	autoSync := false
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{
+				Name: "gpu-runtime", AutoSync: &autoSync, Revision: requestedRevision,
+			},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.PinnedRevisionName = reportedRevision
+	resolver, err := effective.NewRuntimePinResolver(
+		revisions, effective.NewRuntimeResolver(liveClient), "ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{IncludeHistory: true})
+	require.NoError(t, err)
+	return isvc, state
 }
 
 func resolveHistoryProjectionFixture(t *testing.T) (
@@ -218,6 +809,7 @@ func resolveHistoryProjectionFixture(t *testing.T) (
 	isvc := &v1beta1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "secret-isvc-resource-version",
 		},
 		Spec: v1beta1.InferenceServiceSpec{
 			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name, AutoSync: &autoSync},

--- a/pkg/cli/runtimeprojection/history_test.go
+++ b/pkg/cli/runtimeprojection/history_test.go
@@ -1,0 +1,281 @@
+package runtimeprojection
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+func TestProjectHistoryRejectsNilInputsWithFixedSentinel(t *testing.T) {
+	isvc := &v1beta1.InferenceService{}
+	state := &effective.RuntimeState{}
+
+	_, err := ProjectHistory(nil, state, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+
+	_, err = ProjectHistory(isvc, nil, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+}
+
+func TestProjectHistoryMapsCompleteRetentionBoundedEvidence(t *testing.T) {
+	isvc, state, activeRevision, olderRevision := resolveHistoryProjectionFixture(t)
+
+	reportValue, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	activeCreatedAt := activeRevision.CreationTimestamp.Time.UTC()
+	olderCreatedAt := olderRevision.CreationTimestamp.Time.UTC()
+	assert.Equal(t, reportv1alpha1.RuntimeHistoryContent{
+		Runtime: &reportv1alpha1.RuntimeObjectReference{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       reportv1alpha1.RuntimeKindClusterServingRuntime,
+			Name:       "gpu-runtime",
+			UID:        "runtime-uid",
+			Generation: 5,
+		},
+		Observation:    reportv1alpha1.HistoryObservationStateComplete,
+		Completeness:   reportv1alpha1.HistoryCompletenessRetentionBounded,
+		RequestedPages: 1,
+		ObservedPages:  1,
+		Revisions: []reportv1alpha1.RuntimeRevisionEntry{
+			{
+				Revision: reportv1alpha1.RuntimeRevisionReference{
+					Namespace: "ome-system", Name: activeRevision.Name, UID: "active-uid", CreatedAt: &activeCreatedAt,
+				},
+				Source: &reportv1alpha1.RuntimeObjectReference{
+					APIVersion: v1beta1.SchemeGroupVersion.String(),
+					Kind:       reportv1alpha1.RuntimeKindClusterServingRuntime,
+					Name:       "gpu-runtime",
+				},
+				Hash: activeRevision.Labels[constants.RuntimeRevisionHashLabelKey],
+				Roles: []reportv1alpha1.RuntimeRevisionRole{
+					reportv1alpha1.RuntimeRevisionRoleActive,
+					reportv1alpha1.RuntimeRevisionRoleReported,
+					reportv1alpha1.RuntimeRevisionRoleHistory,
+				},
+				Consistency:    reportv1alpha1.RevisionConsistencyConsistent,
+				RelationToLive: reportv1alpha1.RevisionRelationMatchesLive,
+				Issues:         []reportv1alpha1.RuntimeIssueCode{},
+			},
+			{
+				Revision: reportv1alpha1.RuntimeRevisionReference{
+					Namespace: "ome-system", Name: olderRevision.Name, UID: "older-uid", CreatedAt: &olderCreatedAt,
+				},
+				Source: &reportv1alpha1.RuntimeObjectReference{
+					APIVersion: v1beta1.SchemeGroupVersion.String(),
+					Kind:       reportv1alpha1.RuntimeKindClusterServingRuntime,
+					Name:       "gpu-runtime",
+				},
+				Hash:           olderRevision.Labels[constants.RuntimeRevisionHashLabelKey],
+				Roles:          []reportv1alpha1.RuntimeRevisionRole{reportv1alpha1.RuntimeRevisionRoleHistory},
+				Consistency:    reportv1alpha1.RevisionConsistencyConsistent,
+				RelationToLive: reportv1alpha1.RevisionRelationDiffersFromLive,
+				Issues:         []reportv1alpha1.RuntimeIssueCode{},
+			},
+		},
+		Issues: []reportv1alpha1.RuntimeIssue{},
+	}, reportValue.Content)
+	assert.Equal(t, []reportv1alpha1.RuntimeSourceReference{
+		{
+			Kind: "ClusterServingRuntime", Name: "gpu-runtime", UID: "runtime-uid", Generation: 5,
+			Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+		{
+			Kind: "ControllerRevision", Namespace: "ome-system", Name: activeRevision.Name, UID: "active-uid",
+			Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+		{
+			Kind: "ControllerRevision", Namespace: "ome-system", Name: olderRevision.Name, UID: "older-uid",
+			Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+		{
+			Kind: "InferenceService", Namespace: "workloads", Name: "chat", UID: "isvc-uid", Generation: 7,
+			Evidence: reportv1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+	}, reportValue.Sources)
+	assert.Empty(t, reportValue.Warnings)
+}
+
+func TestProjectHistoryMapsCollectionStateWithoutInventingCompleteness(t *testing.T) {
+	isvc, baseState := resolveLiveProjectionFixture(t)
+	tests := []struct {
+		name             string
+		requested        bool
+		complete         bool
+		truncated        bool
+		requestedPages   int
+		observedPages    int
+		wantObservation  reportv1alpha1.HistoryObservationState
+		wantCompleteness reportv1alpha1.HistoryCompleteness
+		wantIssues       []reportv1alpha1.RuntimeIssue
+		wantWarnings     []reportv1alpha1.RuntimeWarning
+	}{
+		{
+			name: "not requested", wantObservation: reportv1alpha1.HistoryObservationStateNotRequested,
+			wantCompleteness: reportv1alpha1.HistoryCompletenessNotRequested,
+		},
+		{
+			name: "complete is retention bounded", requested: true, complete: true, requestedPages: 2, observedPages: 2,
+			wantObservation:  reportv1alpha1.HistoryObservationStateComplete,
+			wantCompleteness: reportv1alpha1.HistoryCompletenessRetentionBounded,
+		},
+		{
+			name: "partial after one page", requested: true, requestedPages: 2, observedPages: 1,
+			wantObservation:  reportv1alpha1.HistoryObservationStatePartial,
+			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
+			wantIssues:       []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningSourceUnavailable},
+			},
+		},
+		{
+			name: "unavailable before first page", requested: true, requestedPages: 1,
+			wantObservation:  reportv1alpha1.HistoryObservationStateUnavailable,
+			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
+			wantIssues:       []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryUnavailable}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningSourceUnavailable},
+			},
+		},
+		{
+			name: "truncated", requested: true, truncated: true, requestedPages: 2, observedPages: 2,
+			wantObservation:  reportv1alpha1.HistoryObservationStatePartial,
+			wantCompleteness: reportv1alpha1.HistoryCompletenessIncomplete,
+			wantIssues:       []reportv1alpha1.RuntimeIssue{{Code: reportv1alpha1.RuntimeIssueHistoryTruncated}},
+			wantWarnings: []reportv1alpha1.RuntimeWarning{
+				{Code: reportv1alpha1.WarningPartialData}, {Code: reportv1alpha1.WarningTruncated},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := *baseState
+			state.HistoryRequested = test.requested
+			state.HistoryComplete = test.complete
+			state.HistoryTruncated = test.truncated
+			state.HistoryRequestedPages = test.requestedPages
+			state.HistoryObservedPages = test.observedPages
+
+			reportValue, err := ProjectHistory(isvc, &state, projectionTestClock)
+			require.NoError(t, err)
+			if test.wantIssues == nil {
+				test.wantIssues = []reportv1alpha1.RuntimeIssue{}
+			}
+			if test.wantWarnings == nil {
+				test.wantWarnings = []reportv1alpha1.RuntimeWarning{}
+			}
+			assert.Equal(t, test.wantObservation, reportValue.Content.Observation)
+			assert.Equal(t, test.wantCompleteness, reportValue.Content.Completeness)
+			assert.Equal(t, test.requestedPages, reportValue.Content.RequestedPages)
+			assert.Equal(t, test.observedPages, reportValue.Content.ObservedPages)
+			assert.Equal(t, test.wantIssues, reportValue.Content.Issues)
+			assert.Equal(t, test.wantWarnings, reportValue.Warnings)
+		})
+	}
+}
+
+func resolveHistoryProjectionFixture(t *testing.T) (
+	*v1beta1.InferenceService,
+	*effective.RuntimeState,
+	*appsv1.ControllerRevision,
+	*appsv1.ControllerRevision,
+) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-runtime", UID: "runtime-uid", Generation: 5},
+		Spec:       *liveSpec.DeepCopy(),
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeObject).Build()
+	activeRevision := projectionRevision(t, "active-uid", "gpu-runtime", liveSpec)
+	activeRevision.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 31, 19, 0, 0, 0, time.UTC))
+	olderRevision := projectionRevision(t, "older-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/older:secret"))
+	olderRevision.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 30, 19, 0, 0, 0, time.UTC))
+	autoSync := false
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name, AutoSync: &autoSync},
+			Engine:  &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.PinnedRevisionName = activeRevision.Name
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset(activeRevision.DeepCopy(), olderRevision.DeepCopy()).AppsV1(),
+		effective.NewRuntimeResolver(client),
+		"ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{IncludeHistory: true})
+	require.NoError(t, err)
+	return isvc, state, activeRevision, olderRevision
+}
+
+func projectionRuntimeSpec(image string) *v1beta1.ServingRuntimeSpec {
+	return &v1beta1.ServingRuntimeSpec{
+		EngineConfig: &v1beta1.EngineSpec{Runner: &v1beta1.RunnerSpec{
+			Container: corev1.Container{
+				Name: "runner", Image: image, Command: []string{"secret-command"},
+				Env: []corev1.EnvVar{{Name: "SECRET_ENV", Value: "secret-value"}},
+			},
+		}},
+	}
+}
+
+func projectionRevision(
+	t *testing.T,
+	uid, runtimeName string,
+	spec *v1beta1.ServingRuntimeSpec,
+) *appsv1.ControllerRevision {
+	t.Helper()
+	_, shortHash, err := runtimerevision.Hash(spec)
+	require.NoError(t, err)
+	raw, err := json.Marshal(spec)
+	require.NoError(t, err)
+	name := runtimerevision.Name(runtimerevision.KindClusterServingRuntime, "", runtimeName, shortHash)
+	return &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "ome-system", UID: typesUID(uid),
+			Labels: map[string]string{
+				constants.RuntimeRevisionOfLabelKey:          runtimeName,
+				constants.RuntimeRevisionOfKindLabelKey:      runtimeselector.KindClusterServingRuntime,
+				constants.RuntimeRevisionOfNamespaceLabelKey: "",
+				constants.RuntimeRevisionHashLabelKey:        shortHash,
+			},
+			Annotations: map[string]string{
+				constants.RuntimeRevisionCreatedByKey: constants.RuntimeRevisionCreatedByOMEValue,
+			},
+		},
+		Data:     runtime.RawExtension{Raw: raw},
+		Revision: 1,
+	}
+}
+
+func typesUID(value string) types.UID { return types.UID(value) }

--- a/pkg/cli/runtimeprojection/mapping_test.go
+++ b/pkg/cli/runtimeprojection/mapping_test.go
@@ -17,10 +17,11 @@ import (
 )
 
 type enumMappingCase struct {
-	name string
-	got  string
-	ok   bool
-	want string
+	name  string
+	got   string
+	ok    bool
+	want  string
+	valid bool
 }
 
 func TestClosedRuntimeEnumMappings(t *testing.T) {
@@ -104,7 +105,7 @@ func TestClosedRuntimeEnumMappings(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want != "", test.ok)
+			assert.Equal(t, test.valid, test.ok)
 			assert.Equal(t, test.want, test.got)
 		})
 	}
@@ -460,14 +461,11 @@ func inheritanceReasonMapping(name string, input effective.InheritanceUnavailabl
 }
 
 func enumMapping(name, got string, ok bool, want string) enumMappingCase {
-	return enumMappingCase{name, got, ok, want}
+	return enumMappingCase{name: name, got: got, ok: ok, want: want, valid: want != ""}
 }
 
 func enumMappingAllowEmpty(name, got string, ok bool, want string) enumMappingCase {
 	result := enumMapping(name, got, ok, want)
-	if ok {
-		result.want = "<valid-empty>"
-		result.got = "<valid-empty>"
-	}
+	result.valid = true
 	return result
 }

--- a/pkg/cli/runtimeprojection/mapping_test.go
+++ b/pkg/cli/runtimeprojection/mapping_test.go
@@ -1,9 +1,13 @@
 package runtimeprojection
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/effective"
@@ -182,6 +186,197 @@ func TestRevisionEvidenceMappingsAreExhaustive(t *testing.T) {
 		got, ok := mapConsistencyIssue(test.input)
 		assert.Equal(t, test.valid, ok)
 		assert.Equal(t, test.want, got)
+	}
+}
+
+func TestProjectConsistencyIssuesDeduplicatesCollapsedCodes(t *testing.T) {
+	issues, ok := projectConsistencyIssues([]effective.RevisionConsistencyCode{
+		effective.RevisionConsistencySourceNamespace,
+		effective.RevisionConsistencySourceName,
+		effective.RevisionConsistencySourceKind,
+		effective.RevisionConsistencySourceName,
+	}, true)
+
+	assert.True(t, ok)
+	assert.Equal(t, []reportv1alpha1.RuntimeIssueCode{
+		reportv1alpha1.RuntimeIssueRevisionDisabled,
+		reportv1alpha1.RuntimeIssueRevisionSourceMismatch,
+	}, issues)
+}
+
+func TestLiveEvidenceShapeRequiresSnapshotAvailabilityAgreement(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability effective.LiveRuntimeAvailability
+		livePresent  bool
+		want         bool
+	}{
+		{name: "available snapshot", availability: effective.LiveRuntimeAvailable, livePresent: true, want: true},
+		{name: "missing snapshot", availability: effective.LiveRuntimeNotFound, want: true},
+		{name: "disabled snapshot", availability: effective.LiveRuntimeDisabled, want: true},
+		{name: "unreadable snapshot", availability: effective.LiveRuntimeUnavailable, want: true},
+		{name: "available without snapshot", availability: effective.LiveRuntimeAvailable},
+		{name: "missing with snapshot", availability: effective.LiveRuntimeNotFound, livePresent: true},
+		{name: "disabled with snapshot", availability: effective.LiveRuntimeDisabled, livePresent: true},
+		{name: "unreadable with snapshot", availability: effective.LiveRuntimeUnavailable, livePresent: true},
+		{name: "unknown availability", availability: effective.LiveRuntimeAvailability("hostile")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, validLiveEvidenceShape(test.availability, test.livePresent))
+		})
+	}
+}
+
+func TestOperationalErrorClassificationUsesOnlyBoundedReasons(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want reportv1alpha1.UnavailableReason
+	}{
+		{
+			name: "not found",
+			err:  apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "controllerrevisions"}, "secret-name"),
+			want: reportv1alpha1.UnavailableNotFound,
+		},
+		{
+			name: "forbidden",
+			err: apierrors.NewForbidden(
+				schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
+				"secret-name", errors.New("secret-cause"),
+			),
+			want: reportv1alpha1.UnavailableForbidden,
+		},
+		{name: "unauthorized", err: apierrors.NewUnauthorized("secret-cause"), want: reportv1alpha1.UnavailableForbidden},
+		{
+			name: "unsupported api",
+			err: &meta.NoKindMatchError{
+				GroupKind: schema.GroupKind{Group: "secret-group", Kind: "secret-kind"},
+			},
+			want: reportv1alpha1.UnavailableUnsupportedAPI,
+		},
+		{name: "unreadable", err: errors.New("secret-cause"), want: reportv1alpha1.UnavailableUnreadable},
+		{name: "empty error", want: reportv1alpha1.UnavailableUnreadable},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, classifySourceError(test.err))
+		})
+	}
+}
+
+func TestLiveUnavailableReasonMappingIsBounded(t *testing.T) {
+	tests := []struct {
+		input effective.LiveRuntimeAvailability
+		want  reportv1alpha1.UnavailableReason
+	}{
+		{effective.LiveRuntimeNotFound, reportv1alpha1.UnavailableNotFound},
+		{effective.LiveRuntimeDisabled, reportv1alpha1.UnavailableDisabled},
+		{effective.LiveRuntimeUnavailable, reportv1alpha1.UnavailableUnreadable},
+		{effective.LiveRuntimeAvailable, reportv1alpha1.UnavailableUnreadable},
+		{effective.LiveRuntimeAvailability("hostile"), reportv1alpha1.UnavailableUnreadable},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, mapLiveUnavailableReason(test.input))
+	}
+	issue, reason, ok := projectSourceIssue(effective.RuntimeSourceIssue{
+		Code: effective.RuntimeSourceIssueCode("hostile"), RevisionName: "secret-revision",
+	})
+	assert.False(t, ok)
+	assert.Empty(t, issue)
+	assert.Empty(t, reason)
+}
+
+func TestProjectionInvariantHelpersFailClosed(t *testing.T) {
+	for _, value := range []effective.RuntimePinState{
+		effective.RuntimePinStateRevisionMissing,
+		effective.RuntimePinStateRevisionInvalid,
+		effective.RuntimePinStateRevisionDisabled,
+		effective.RuntimePinStateUnavailable,
+	} {
+		assert.True(t, failedRevisionPinState(value))
+	}
+	assert.False(t, failedRevisionPinState(effective.RuntimePinStateResolved))
+	assert.False(t, failedRevisionPinState(effective.RuntimePinState("hostile")))
+
+	for _, value := range []effective.RuntimeSourceIssueCode{
+		effective.RuntimeSourceIssueLiveNotFound,
+		effective.RuntimeSourceIssueLiveDisabled,
+		effective.RuntimeSourceIssueLiveUnavailable,
+	} {
+		assert.True(t, liveSourceIssue(value))
+	}
+	assert.False(t, liveSourceIssue(effective.RuntimeSourceIssueRevisionNotFound))
+	assert.False(t, liveSourceIssue(effective.RuntimeSourceIssueCode("hostile")))
+
+	assert.True(t, validVerifiedShortHash(""))
+	assert.True(t, validVerifiedShortHash("0123abcd"))
+	assert.False(t, validVerifiedShortHash("0123abc"))
+	assert.False(t, validVerifiedShortHash("0123abcD"))
+	assert.False(t, validVerifiedShortHash("0123abcg"))
+
+	validSource, ok := unavailableLiveSource(&effective.RuntimeState{
+		RuntimeName: "runtime", DeclaredSourceKind: runtimeselector.KindServingRuntime,
+		DeclaredSourceNamespace: "workloads",
+	})
+	assert.True(t, ok)
+	assert.Equal(t, "runtime", validSource.Name)
+	assert.Equal(t, "workloads", validSource.Namespace)
+	assert.Equal(t, reportv1alpha1.UnavailableUnreadable, validSource.UnavailableReason)
+	fallbackSource, ok := unavailableLiveSource(&effective.RuntimeState{
+		RuntimeName: "runtime", RuntimeKind: runtimeselector.KindClusterServingRuntime,
+	})
+	assert.True(t, ok)
+	assert.Equal(t, runtimeselector.KindClusterServingRuntime, fallbackSource.Kind)
+	_, ok = unavailableLiveSource(&effective.RuntimeState{RuntimeName: "runtime", RuntimeKind: "hostile"})
+	assert.False(t, ok)
+	_, ok = unavailableLiveSource(&effective.RuntimeState{RuntimeKind: runtimeselector.KindClusterServingRuntime})
+	assert.False(t, ok)
+
+	left := &reportv1alpha1.RuntimeObjectReference{
+		APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: reportv1alpha1.RuntimeKindServingRuntime,
+		Namespace: "workloads", Name: "runtime",
+	}
+	right := *left
+	assert.True(t, sameRuntimeReference(nil, nil))
+	assert.False(t, sameRuntimeReference(left, nil))
+	assert.False(t, sameRuntimeReference(nil, left))
+	assert.True(t, sameRuntimeReference(left, &right))
+	right.Name = "other"
+	assert.False(t, sameRuntimeReference(left, &right))
+}
+
+func TestProjectComponentsRejectsUnknownFieldsWithoutPartialOutput(t *testing.T) {
+	valid := effective.EffectiveComponent{
+		Type: v1beta1.EngineComponent, DeploymentMode: constants.OMENative,
+		DeploymentModeSource: effective.DeploymentModeServiceSpec,
+	}
+	components, ok := projectComponents([]effective.EffectiveComponent{
+		valid,
+		{
+			Type: v1beta1.DecoderComponent, DeploymentMode: constants.MultiNode,
+			DeploymentModeSource: effective.DeploymentModeLeaderWorkerShape,
+		},
+		{
+			Type: v1beta1.RouterComponent, DeploymentMode: constants.RawDeployment,
+			DeploymentModeSource: effective.DeploymentModeComponentAnnotation,
+		},
+	})
+	assert.True(t, ok)
+	assert.Len(t, components, 3)
+
+	tests := []effective.EffectiveComponent{
+		{Type: v1beta1.ComponentType("hostile"), DeploymentMode: constants.OMENative, DeploymentModeSource: effective.DeploymentModeDefault},
+		{Type: v1beta1.EngineComponent, DeploymentMode: constants.DeploymentModeType("hostile"), DeploymentModeSource: effective.DeploymentModeDefault},
+		{Type: v1beta1.EngineComponent, DeploymentMode: constants.OMENative, DeploymentModeSource: effective.ComponentDeploymentModeSource("hostile")},
+	}
+	for _, test := range tests {
+		components, ok := projectComponents([]effective.EffectiveComponent{valid, test})
+		assert.False(t, ok)
+		assert.Nil(t, components)
 	}
 }
 

--- a/pkg/cli/runtimeprojection/mapping_test.go
+++ b/pkg/cli/runtimeprojection/mapping_test.go
@@ -16,13 +16,15 @@ import (
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 )
 
+type enumMappingCase struct {
+	name string
+	got  string
+	ok   bool
+	want string
+}
+
 func TestClosedRuntimeEnumMappings(t *testing.T) {
-	tests := []struct {
-		name string
-		got  string
-		ok   bool
-		want string
-	}{
+	tests := []enumMappingCase{
 		selectionMapping("selection explicit", effective.RuntimeExplicit, reportv1alpha1.RuntimeSelectionSourceExplicit),
 		selectionMapping("selection selected", effective.RuntimeSelected, reportv1alpha1.RuntimeSelectionSourceSelected),
 		selectionMapping("selection unknown", effective.RuntimeSelectionSource("hostile"), ""),
@@ -380,87 +382,46 @@ func TestProjectComponentsRejectsUnknownFieldsWithoutPartialOutput(t *testing.T)
 	}
 }
 
-func selectionMapping(name string, input effective.RuntimeSelectionSource, want reportv1alpha1.RuntimeSelectionSource) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func selectionMapping(
+	name string,
+	input effective.RuntimeSelectionSource,
+	want reportv1alpha1.RuntimeSelectionSource,
+) enumMappingCase {
 	got, ok := mapSelectionSource(input)
-	return struct {
-		name string
-		got  string
-		ok   bool
-		want string
-	}{name, string(got), ok, string(want)}
+	return enumMapping(name, string(got), ok, string(want))
 }
 
-func runtimeKindMapping(name, input string, want reportv1alpha1.RuntimeKind) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func runtimeKindMapping(name, input string, want reportv1alpha1.RuntimeKind) enumMappingCase {
 	got, ok := mapRuntimeKind(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func pinModeMapping(name string, input effective.RuntimePinMode, want reportv1alpha1.RuntimePinMode) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func pinModeMapping(name string, input effective.RuntimePinMode, want reportv1alpha1.RuntimePinMode) enumMappingCase {
 	got, ok := mapPinMode(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func pinStateMapping(name string, input effective.RuntimePinState, want reportv1alpha1.RuntimePinState) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func pinStateMapping(name string, input effective.RuntimePinState, want reportv1alpha1.RuntimePinState) enumMappingCase {
 	got, ok := mapPinState(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func freshnessMapping(name string, input effective.StatusFreshness, want reportv1alpha1.StatusFreshness) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func freshnessMapping(name string, input effective.StatusFreshness, want reportv1alpha1.StatusFreshness) enumMappingCase {
 	got, ok := mapFreshness(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func syncMapping(name string, input effective.SyncTokenState, want reportv1alpha1.RuntimeSyncState) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func syncMapping(name string, input effective.SyncTokenState, want reportv1alpha1.RuntimeSyncState) enumMappingCase {
 	got, ok := mapSyncState(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func driftStateMapping(name string, input effective.RuntimeDriftState, want reportv1alpha1.DriftConditionState) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func driftStateMapping(name string, input effective.RuntimeDriftState, want reportv1alpha1.DriftConditionState) enumMappingCase {
 	got, ok := mapDriftState(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func driftCauseMapping(name string, input effective.RuntimeDriftReason, want reportv1alpha1.RuntimeDriftCause) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func driftCauseMapping(name string, input effective.RuntimeDriftReason, want reportv1alpha1.RuntimeDriftCause) enumMappingCase {
 	got, ok := mapDriftCause(input)
 	if input == "" && want == "" {
 		return enumMappingAllowEmpty(name, string(got), ok, string(want))
@@ -468,86 +429,41 @@ func driftCauseMapping(name string, input effective.RuntimeDriftReason, want rep
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func hashMapping(name string, input effective.RuntimeHashRelation, want reportv1alpha1.RuntimeHashRelation) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func hashMapping(name string, input effective.RuntimeHashRelation, want reportv1alpha1.RuntimeHashRelation) enumMappingCase {
 	got, ok := mapHashRelation(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func originMapping(name string, input effective.ConfigurationOrigin, want reportv1alpha1.ConfigurationOrigin) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func originMapping(name string, input effective.ConfigurationOrigin, want reportv1alpha1.ConfigurationOrigin) enumMappingCase {
 	got, ok := mapConfigurationOrigin(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func componentMapping(name string, input v1beta1.ComponentType, want reportv1alpha1.RuntimeComponentType) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func componentMapping(name string, input v1beta1.ComponentType, want reportv1alpha1.RuntimeComponentType) enumMappingCase {
 	got, ok := mapComponentType(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func modeMapping(name string, input constants.DeploymentModeType, want reportv1alpha1.DeploymentMode) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func modeMapping(name string, input constants.DeploymentModeType, want reportv1alpha1.DeploymentMode) enumMappingCase {
 	got, ok := mapDeploymentMode(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func modeSourceMapping(name string, input effective.ComponentDeploymentModeSource, want reportv1alpha1.DeploymentModeSource) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func modeSourceMapping(name string, input effective.ComponentDeploymentModeSource, want reportv1alpha1.DeploymentModeSource) enumMappingCase {
 	got, ok := mapDeploymentModeSource(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func inheritanceReasonMapping(name string, input effective.InheritanceUnavailableReason, want reportv1alpha1.UnavailableReason) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func inheritanceReasonMapping(name string, input effective.InheritanceUnavailableReason, want reportv1alpha1.UnavailableReason) enumMappingCase {
 	got, ok := mapInheritanceUnavailableReason(input)
 	return enumMapping(name, string(got), ok, string(want))
 }
 
-func enumMapping(name, got string, ok bool, want string) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
-	return struct {
-		name string
-		got  string
-		ok   bool
-		want string
-	}{name, got, ok, want}
+func enumMapping(name, got string, ok bool, want string) enumMappingCase {
+	return enumMappingCase{name, got, ok, want}
 }
 
-func enumMappingAllowEmpty(name, got string, ok bool, want string) struct {
-	name string
-	got  string
-	ok   bool
-	want string
-} {
+func enumMappingAllowEmpty(name, got string, ok bool, want string) enumMappingCase {
 	result := enumMapping(name, got, ok, want)
 	if ok {
 		result.want = "<valid-empty>"

--- a/pkg/cli/runtimeprojection/mapping_test.go
+++ b/pkg/cli/runtimeprojection/mapping_test.go
@@ -1,0 +1,362 @@
+package runtimeprojection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+func TestClosedRuntimeEnumMappings(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		ok   bool
+		want string
+	}{
+		selectionMapping("selection explicit", effective.RuntimeExplicit, reportv1alpha1.RuntimeSelectionSourceExplicit),
+		selectionMapping("selection selected", effective.RuntimeSelected, reportv1alpha1.RuntimeSelectionSourceSelected),
+		selectionMapping("selection unknown", effective.RuntimeSelectionSource("hostile"), ""),
+		runtimeKindMapping("runtime kind namespaced", runtimeselector.KindServingRuntime, reportv1alpha1.RuntimeKindServingRuntime),
+		runtimeKindMapping("runtime kind cluster", runtimeselector.KindClusterServingRuntime, reportv1alpha1.RuntimeKindClusterServingRuntime),
+		runtimeKindMapping("runtime kind absent", "", reportv1alpha1.RuntimeKindUnknown),
+		runtimeKindMapping("runtime kind hostile", "hostile-secret-kind", ""),
+		pinModeMapping("pin auto", effective.RuntimePinModeAutoSync, reportv1alpha1.RuntimePinModeAutoSync),
+		pinModeMapping("pin managed", effective.RuntimePinModeManagedPin, reportv1alpha1.RuntimePinModeManagedPin),
+		pinModeMapping("pin explicit", effective.RuntimePinModeExplicitPin, reportv1alpha1.RuntimePinModeExplicitPin),
+		pinModeMapping("pin invalid", effective.RuntimePinModeInvalidPin, reportv1alpha1.RuntimePinModeInvalidPin),
+		pinModeMapping("pin unknown", effective.RuntimePinMode("hostile"), ""),
+		pinStateMapping("pin state not applicable", effective.RuntimePinStateNotApplicable, reportv1alpha1.RuntimePinStateNotApplicable),
+		pinStateMapping("pin state awaiting", effective.RuntimePinStateAwaitingPin, reportv1alpha1.RuntimePinStateAwaitingPin),
+		pinStateMapping("pin state resolved", effective.RuntimePinStateResolved, reportv1alpha1.RuntimePinStateResolved),
+		pinStateMapping("pin state mismatch", effective.RuntimePinStateDesiredReportedMismatch, reportv1alpha1.RuntimePinStateDesiredReportedMismatch),
+		pinStateMapping("pin state missing", effective.RuntimePinStateRevisionMissing, reportv1alpha1.RuntimePinStateRevisionMissing),
+		pinStateMapping("pin state invalid revision", effective.RuntimePinStateRevisionInvalid, reportv1alpha1.RuntimePinStateRevisionInvalid),
+		pinStateMapping("pin state disabled", effective.RuntimePinStateRevisionDisabled, reportv1alpha1.RuntimePinStateRevisionDisabled),
+		pinStateMapping("pin state unavailable", effective.RuntimePinStateUnavailable, reportv1alpha1.RuntimePinStateUnavailable),
+		pinStateMapping("pin state invalid intent", effective.RuntimePinStateInvalidIntent, reportv1alpha1.RuntimePinStateInvalidIntent),
+		pinStateMapping("pin state unknown", effective.RuntimePinState("hostile"), ""),
+		freshnessMapping("freshness current", effective.StatusFreshnessCurrent, reportv1alpha1.StatusFreshnessCurrent),
+		freshnessMapping("freshness stale", effective.StatusFreshnessStale, reportv1alpha1.StatusFreshnessStale),
+		freshnessMapping("freshness unknown", effective.StatusFreshnessUnknown, reportv1alpha1.StatusFreshnessUnobserved),
+		freshnessMapping("freshness inconsistent", effective.StatusFreshnessInconsistent, reportv1alpha1.StatusFreshnessInvalid),
+		freshnessMapping("freshness hostile", effective.StatusFreshness("hostile"), ""),
+		syncMapping("sync absent", effective.SyncTokenStateAbsent, reportv1alpha1.RuntimeSyncStateAbsent),
+		syncMapping("sync acknowledged", effective.SyncTokenStateAcknowledged, reportv1alpha1.RuntimeSyncStateAcknowledged),
+		syncMapping("sync pending", effective.SyncTokenStatePending, reportv1alpha1.RuntimeSyncStatePending),
+		syncMapping("sync status only", effective.SyncTokenStateStatusOnly, reportv1alpha1.RuntimeSyncStateStatusOnly),
+		syncMapping("sync hostile", effective.SyncTokenState("hostile"), ""),
+		driftStateMapping("drift absent", effective.RuntimeDriftStateNotReported, reportv1alpha1.DriftConditionStateNotReported),
+		driftStateMapping("drift true", effective.RuntimeDriftStateReportedTrue, reportv1alpha1.DriftConditionStateReportedTrue),
+		driftStateMapping("drift false", effective.RuntimeDriftStateReportedFalse, reportv1alpha1.DriftConditionStateReportedFalse),
+		driftStateMapping("drift unknown", effective.RuntimeDriftStateReportedUnknown, reportv1alpha1.DriftConditionStateReportedUnknown),
+		driftStateMapping("drift malformed", effective.RuntimeDriftStateMalformed, reportv1alpha1.DriftConditionStateMalformed),
+		driftStateMapping("drift hostile", effective.RuntimeDriftState("hostile"), ""),
+		driftCauseMapping("drift cause omitted", "", ""),
+		driftCauseMapping("drift cause revision mismatch", effective.RuntimeDriftReasonRevisionMismatch, reportv1alpha1.RuntimeDriftCauseRevisionMismatch),
+		driftCauseMapping("drift cause revision missing", effective.RuntimeDriftReasonRevisionMissing, reportv1alpha1.RuntimeDriftCauseRevisionMissing),
+		driftCauseMapping("drift cause source missing", effective.RuntimeDriftReasonSourceRuntimeMissing, reportv1alpha1.RuntimeDriftCauseSourceRuntimeMissing),
+		driftCauseMapping("drift cause runtime mismatch", effective.RuntimeDriftReasonRuntimeMismatch, reportv1alpha1.RuntimeDriftCauseRuntimeMismatch),
+		driftCauseMapping("drift cause pin advanced", effective.RuntimeDriftReasonPinAdvanced, reportv1alpha1.RuntimeDriftCausePinAdvanced),
+		driftCauseMapping("drift cause other", effective.RuntimeDriftReasonOther, reportv1alpha1.RuntimeDriftCauseOther),
+		driftCauseMapping("drift cause hostile", effective.RuntimeDriftReason("hostile-secret-reason"), ""),
+		hashMapping("hash unknown", effective.RuntimeHashRelationUnknown, reportv1alpha1.RuntimeHashRelationUnknown),
+		hashMapping("hash equal", effective.RuntimeHashRelationEqual, reportv1alpha1.RuntimeHashRelationEqual),
+		hashMapping("hash different", effective.RuntimeHashRelationDifferent, reportv1alpha1.RuntimeHashRelationDifferent),
+		hashMapping("hash ambiguous", effective.RuntimeHashRelationAmbiguous, reportv1alpha1.RuntimeHashRelationAmbiguous),
+		hashMapping("hash hostile", effective.RuntimeHashRelation("hostile"), ""),
+		originMapping("origin live", effective.ConfigurationOriginLiveRuntime, reportv1alpha1.ConfigurationOriginLiveRuntime),
+		originMapping("origin revision", effective.ConfigurationOriginControllerRevision, reportv1alpha1.ConfigurationOriginControllerRevision),
+		originMapping("origin hostile", effective.ConfigurationOrigin("hostile"), ""),
+		componentMapping("component engine", v1beta1.EngineComponent, reportv1alpha1.RuntimeComponentEngine),
+		componentMapping("component decoder", v1beta1.DecoderComponent, reportv1alpha1.RuntimeComponentDecoder),
+		componentMapping("component router", v1beta1.RouterComponent, reportv1alpha1.RuntimeComponentRouter),
+		componentMapping("component hostile", v1beta1.ComponentType("hostile"), ""),
+		modeMapping("mode raw", constants.RawDeployment, reportv1alpha1.DeploymentModeRawDeployment),
+		modeMapping("mode multi", constants.MultiNode, reportv1alpha1.DeploymentModeMultiNode),
+		modeMapping("mode virtual", constants.VirtualDeployment, reportv1alpha1.DeploymentModeVirtualDeployment),
+		modeMapping("mode native", constants.OMENative, reportv1alpha1.DeploymentModeOMENative),
+		modeMapping("mode hostile", constants.DeploymentModeType("hostile"), ""),
+		modeSourceMapping("mode source annotation", effective.DeploymentModeComponentAnnotation, reportv1alpha1.DeploymentModeSourceComponentAnnotation),
+		modeSourceMapping("mode source service", effective.DeploymentModeServiceSpec, reportv1alpha1.DeploymentModeSourceServiceSpec),
+		modeSourceMapping("mode source shape", effective.DeploymentModeLeaderWorkerShape, reportv1alpha1.DeploymentModeSourceLeaderWorkerShape),
+		modeSourceMapping("mode source default", effective.DeploymentModeDefault, reportv1alpha1.DeploymentModeSourceDefault),
+		modeSourceMapping("mode source hostile", effective.ComponentDeploymentModeSource("hostile"), ""),
+		inheritanceReasonMapping("inheritance not found", effective.InheritanceNotFound, reportv1alpha1.UnavailableNotFound),
+		inheritanceReasonMapping("inheritance forbidden", effective.InheritanceForbidden, reportv1alpha1.UnavailableForbidden),
+		inheritanceReasonMapping("inheritance cycle", effective.InheritanceCycle, reportv1alpha1.UnavailableCycle),
+		inheritanceReasonMapping("inheritance max depth", effective.InheritanceMaxDepthExceeded, reportv1alpha1.UnavailableMaxDepthExceeded),
+		inheritanceReasonMapping("inheritance malformed", effective.InheritanceMalformed, reportv1alpha1.UnavailableMalformedPayload),
+		inheritanceReasonMapping("inheritance unreadable", effective.InheritanceUnreadable, reportv1alpha1.UnavailableUnreadable),
+		inheritanceReasonMapping("inheritance hostile", effective.InheritanceUnavailableReason("hostile"), ""),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want != "", test.ok)
+			assert.Equal(t, test.want, test.got)
+		})
+	}
+}
+
+func TestRevisionEvidenceMappingsAreExhaustive(t *testing.T) {
+	roleTests := []struct {
+		input effective.RuntimeRevisionRole
+		want  reportv1alpha1.RuntimeRevisionRole
+		valid bool
+	}{
+		{effective.RuntimeRevisionRoleRequested, reportv1alpha1.RuntimeRevisionRoleRequested, true},
+		{effective.RuntimeRevisionRoleReported, reportv1alpha1.RuntimeRevisionRoleReported, true},
+		{effective.RuntimeRevisionRoleActive, reportv1alpha1.RuntimeRevisionRoleActive, true},
+		{effective.RuntimeRevisionRoleHistory, reportv1alpha1.RuntimeRevisionRoleHistory, true},
+		{effective.RuntimeRevisionRole("hostile"), "", false},
+	}
+	for _, test := range roleTests {
+		got, ok := mapRevisionRole(test.input)
+		assert.Equal(t, test.valid, ok)
+		assert.Equal(t, test.want, got)
+	}
+
+	consistencyTests := []struct {
+		input effective.RevisionConsistencyState
+		want  reportv1alpha1.RevisionConsistency
+		valid bool
+	}{
+		{effective.RevisionConsistencyConsistent, reportv1alpha1.RevisionConsistencyConsistent, true},
+		{effective.RevisionConsistencyInconsistent, reportv1alpha1.RevisionConsistencyInconsistent, true},
+		{effective.RevisionConsistencyUnknown, reportv1alpha1.RevisionConsistencyUnknown, true},
+		{effective.RevisionConsistencyState("hostile"), "", false},
+	}
+	for _, test := range consistencyTests {
+		got, ok := mapRevisionConsistency(test.input)
+		assert.Equal(t, test.valid, ok)
+		assert.Equal(t, test.want, got)
+	}
+
+	relationTests := []struct {
+		input effective.RuntimeHashRelation
+		want  reportv1alpha1.RevisionRelation
+		valid bool
+	}{
+		{effective.RuntimeHashRelationUnknown, reportv1alpha1.RevisionRelationUnknown, true},
+		{effective.RuntimeHashRelationEqual, reportv1alpha1.RevisionRelationMatchesLive, true},
+		{effective.RuntimeHashRelationDifferent, reportv1alpha1.RevisionRelationDiffersFromLive, true},
+		{effective.RuntimeHashRelationAmbiguous, reportv1alpha1.RevisionRelationAmbiguous, true},
+		{effective.RuntimeHashRelation("hostile"), "", false},
+	}
+	for _, test := range relationTests {
+		got, ok := mapRevisionRelation(test.input)
+		assert.Equal(t, test.valid, ok)
+		assert.Equal(t, test.want, got)
+	}
+
+	issueTests := []struct {
+		input effective.RevisionConsistencyCode
+		want  reportv1alpha1.RuntimeIssueCode
+		valid bool
+	}{
+		{effective.RevisionConsistencyCreatedBy, reportv1alpha1.RuntimeIssueRevisionNotOMEManaged, true},
+		{effective.RevisionConsistencySourceName, reportv1alpha1.RuntimeIssueRevisionSourceMismatch, true},
+		{effective.RevisionConsistencySourceKind, reportv1alpha1.RuntimeIssueRevisionSourceMismatch, true},
+		{effective.RevisionConsistencySourceNamespace, reportv1alpha1.RuntimeIssueRevisionSourceMismatch, true},
+		{effective.RevisionConsistencyHashLabelInvalid, reportv1alpha1.RuntimeIssueRevisionHashInvalid, true},
+		{effective.RevisionConsistencyHashLabelMismatch, reportv1alpha1.RuntimeIssueRevisionHashMismatch, true},
+		{effective.RevisionConsistencyNameHash, reportv1alpha1.RuntimeIssueRevisionNameMismatch, true},
+		{effective.RevisionConsistencyOrdinal, reportv1alpha1.RuntimeIssueRevisionOrdinalUnexpected, true},
+		{effective.RevisionConsistencyPayloadCanonicality, reportv1alpha1.RuntimeIssueRevisionPayloadNonCanonical, true},
+		{effective.RevisionConsistencyUnexpectedDataObject, reportv1alpha1.RuntimeIssueRevisionDataObjectPresent, true},
+		{effective.RevisionConsistencyMalformedPayload, reportv1alpha1.RuntimeIssueRevisionPayloadMalformed, true},
+		{effective.RevisionConsistencyReturnedIdentity, reportv1alpha1.RuntimeIssueRevisionIdentityMismatch, true},
+		{effective.RevisionConsistencyDuplicateIdentity, reportv1alpha1.RuntimeIssueDuplicateRevision, true},
+		{effective.RevisionConsistencyConflictingIdentity, reportv1alpha1.RuntimeIssueConflictingRevision, true},
+		{effective.RevisionConsistencyDuplicateContentHash, reportv1alpha1.RuntimeIssueDuplicateRevisionContent, true},
+		{effective.RevisionConsistencyShortHashCollision, reportv1alpha1.RuntimeIssueRevisionHashCollision, true},
+		{effective.RevisionConsistencyCode("hostile"), "", false},
+	}
+	for _, test := range issueTests {
+		got, ok := mapConsistencyIssue(test.input)
+		assert.Equal(t, test.valid, ok)
+		assert.Equal(t, test.want, got)
+	}
+}
+
+func selectionMapping(name string, input effective.RuntimeSelectionSource, want reportv1alpha1.RuntimeSelectionSource) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapSelectionSource(input)
+	return struct {
+		name string
+		got  string
+		ok   bool
+		want string
+	}{name, string(got), ok, string(want)}
+}
+
+func runtimeKindMapping(name, input string, want reportv1alpha1.RuntimeKind) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapRuntimeKind(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func pinModeMapping(name string, input effective.RuntimePinMode, want reportv1alpha1.RuntimePinMode) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapPinMode(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func pinStateMapping(name string, input effective.RuntimePinState, want reportv1alpha1.RuntimePinState) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapPinState(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func freshnessMapping(name string, input effective.StatusFreshness, want reportv1alpha1.StatusFreshness) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapFreshness(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func syncMapping(name string, input effective.SyncTokenState, want reportv1alpha1.RuntimeSyncState) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapSyncState(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func driftStateMapping(name string, input effective.RuntimeDriftState, want reportv1alpha1.DriftConditionState) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapDriftState(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func driftCauseMapping(name string, input effective.RuntimeDriftReason, want reportv1alpha1.RuntimeDriftCause) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapDriftCause(input)
+	if input == "" && want == "" {
+		return enumMappingAllowEmpty(name, string(got), ok, string(want))
+	}
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func hashMapping(name string, input effective.RuntimeHashRelation, want reportv1alpha1.RuntimeHashRelation) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapHashRelation(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func originMapping(name string, input effective.ConfigurationOrigin, want reportv1alpha1.ConfigurationOrigin) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapConfigurationOrigin(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func componentMapping(name string, input v1beta1.ComponentType, want reportv1alpha1.RuntimeComponentType) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapComponentType(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func modeMapping(name string, input constants.DeploymentModeType, want reportv1alpha1.DeploymentMode) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapDeploymentMode(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func modeSourceMapping(name string, input effective.ComponentDeploymentModeSource, want reportv1alpha1.DeploymentModeSource) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapDeploymentModeSource(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func inheritanceReasonMapping(name string, input effective.InheritanceUnavailableReason, want reportv1alpha1.UnavailableReason) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	got, ok := mapInheritanceUnavailableReason(input)
+	return enumMapping(name, string(got), ok, string(want))
+}
+
+func enumMapping(name, got string, ok bool, want string) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	return struct {
+		name string
+		got  string
+		ok   bool
+		want string
+	}{name, got, ok, want}
+}
+
+func enumMappingAllowEmpty(name, got string, ok bool, want string) struct {
+	name string
+	got  string
+	ok   bool
+	want string
+} {
+	result := enumMapping(name, got, ok, want)
+	if ok {
+		result.want = "<valid-empty>"
+		result.got = "<valid-empty>"
+	}
+	return result
+}

--- a/pkg/cli/runtimeprojection/projection.go
+++ b/pkg/cli/runtimeprojection/projection.go
@@ -26,6 +26,9 @@ func ProjectEffective(
 	if !validInputs(isvc, state) {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
 	}
+	if !validHistoryCollectionEvidence(state) {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
 
 	selectionSource, ok := mapSelectionSource(state.SelectionSource)
 	if !ok {
@@ -64,7 +67,8 @@ func ProjectEffective(
 	if !validStateEvidence(state, live) {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
 	}
-	inheritance, runtimeIdentity, ok := projectInheritance(state, live)
+	notConfigured := noRuntimeConfigurationDeclared(isvc)
+	inheritance, runtimeIdentity, ok := projectInheritance(state, live, notConfigured)
 	if !ok {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
 	}
@@ -73,16 +77,21 @@ func ProjectEffective(
 		selectionRuntime = nil
 	}
 
-	liveConfiguration, ok := projectLiveConfiguration(state, live, runtimeIdentity)
+	liveConfiguration, ok := projectLiveConfiguration(state, live, runtimeIdentity, notConfigured)
 	if !ok {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
 	}
-	activeConfiguration, ok := projectActiveConfiguration(state, runtimeIdentity)
+	activeConfiguration, ok := projectActiveConfiguration(state, runtimeIdentity, notConfigured)
 	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	if !validPinConfiguration(state, activeConfiguration) {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
 	}
 
-	issues, sources, warnings, ok := projectEffectiveDiagnostics(isvc, state, live, inheritance, activeConfiguration)
+	issues, sources, warnings, ok := projectEffectiveDiagnostics(
+		isvc, state, live, inheritance, activeConfiguration, notConfigured,
+	)
 	if !ok {
 		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
 	}
@@ -115,11 +124,133 @@ func ProjectEffective(
 	return reportValue.Canonical(), nil
 }
 
+func noRuntimeConfigurationDeclared(isvc *v1beta1.InferenceService) bool {
+	if isvc == nil {
+		return false
+	}
+	runtimeAbsent := isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name == ""
+	modelAbsent := isvc.Spec.Model == nil || isvc.Spec.Model.Name == ""
+	return runtimeAbsent && modelAbsent
+}
+
+func invalidDeclaredRuntimeKind(isvc *v1beta1.InferenceService) bool {
+	if isvc == nil || isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name == "" ||
+		isvc.Spec.Runtime.Kind == nil {
+		return false
+	}
+	kind := *isvc.Spec.Runtime.Kind
+	return kind != runtimeselector.KindServingRuntime && kind != runtimeselector.KindClusterServingRuntime
+}
+
+func validPinConfiguration(
+	state *effective.RuntimeState,
+	active reportv1alpha1.RuntimeConfiguration,
+) bool {
+	available := active.State == reportv1alpha1.ConfigurationStateAvailable
+	if !validConfigurationRelation(state, active, available) {
+		return false
+	}
+	if state.LiveAvailability() == effective.LiveRuntimeDisabled ||
+		state.LiveAvailability() == effective.LiveRuntimeUnavailable {
+		return state.PinState == effective.RuntimePinStateUnavailable && !available
+	}
+	switch state.PinMode {
+	case effective.RuntimePinModeAutoSync:
+		if state.LiveAvailability() == effective.LiveRuntimeAvailable {
+			return state.PinState == effective.RuntimePinStateNotApplicable && available &&
+				active.Origin == reportv1alpha1.ConfigurationOriginLiveRuntime
+		}
+		return state.PinState == effective.RuntimePinStateUnavailable && !available
+	case effective.RuntimePinModeInvalidPin:
+		return state.PinState == effective.RuntimePinStateInvalidIntent && !available
+	case effective.RuntimePinModeManagedPin:
+		if state.ReportedRevisionName == "" {
+			if state.LiveAvailability() == effective.LiveRuntimeAvailable {
+				return state.PinState == effective.RuntimePinStateAwaitingPin && available &&
+					active.Origin == reportv1alpha1.ConfigurationOriginLiveRuntime
+			}
+			return state.PinState == effective.RuntimePinStateUnavailable && !available
+		}
+		if state.PinState == effective.RuntimePinStateResolved {
+			return available && active.Origin == reportv1alpha1.ConfigurationOriginControllerRevision
+		}
+		return !available && failedRevisionPinState(state.PinState)
+	case effective.RuntimePinModeExplicitPin:
+		if state.RequestedRevisionName == "" {
+			return false
+		}
+		if state.PinState == effective.RuntimePinStateResolved ||
+			state.PinState == effective.RuntimePinStateDesiredReportedMismatch {
+			if !available || active.Origin != reportv1alpha1.ConfigurationOriginControllerRevision {
+				return false
+			}
+			mismatch := state.ReportedRevisionName != "" &&
+				state.ReportedRevisionName != state.RequestedRevisionName
+			return mismatch == (state.PinState == effective.RuntimePinStateDesiredReportedMismatch)
+		}
+		return !available && failedRevisionPinState(state.PinState)
+	default:
+		return false
+	}
+}
+
+func validConfigurationRelation(
+	state *effective.RuntimeState,
+	active reportv1alpha1.RuntimeConfiguration,
+	available bool,
+) bool {
+	if !available {
+		return state.LiveToActive == effective.RuntimeHashRelationUnknown
+	}
+	switch active.Origin {
+	case reportv1alpha1.ConfigurationOriginLiveRuntime:
+		return state.LiveAvailability() == effective.LiveRuntimeAvailable &&
+			state.LiveToActive == effective.RuntimeHashRelationEqual
+	case reportv1alpha1.ConfigurationOriginControllerRevision:
+		if state.LiveAvailability() != effective.LiveRuntimeAvailable {
+			return state.LiveToActive == effective.RuntimeHashRelationUnknown
+		}
+		if state.LiveShortHash == "" || active.Hash == "" {
+			return true
+		}
+		if state.LiveShortHash != active.Hash {
+			return state.LiveToActive == effective.RuntimeHashRelationDifferent
+		}
+		return state.LiveToActive == effective.RuntimeHashRelationEqual ||
+			state.LiveToActive == effective.RuntimeHashRelationAmbiguous
+	default:
+		return false
+	}
+}
+
+func failedRevisionPinState(state effective.RuntimePinState) bool {
+	switch state {
+	case effective.RuntimePinStateRevisionMissing,
+		effective.RuntimePinStateRevisionInvalid,
+		effective.RuntimePinStateRevisionDisabled,
+		effective.RuntimePinStateUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
 func validInputs(isvc *v1beta1.InferenceService, state *effective.RuntimeState) bool {
 	if isvc == nil || state == nil || isvc.Name == "" || isvc.Namespace == "" {
 		return false
 	}
+	if !state.MatchesInferenceService(isvc) {
+		return false
+	}
 	if isvc.Generation != state.Generation || isvc.Status.ObservedGeneration != state.ObservedGeneration {
+		return false
+	}
+	if state.StatusFreshness != expectedStatusFreshness(state.Generation, state.ObservedGeneration) ||
+		state.SyncTokenState != expectedSyncTokenState(isvc) {
+		return false
+	}
+	expectedDriftState, expectedDriftReason := expectedDriftObservation(isvc)
+	if state.DriftState != expectedDriftState || state.DriftReason != expectedDriftReason {
 		return false
 	}
 	requestedRevision := ""
@@ -127,6 +258,11 @@ func validInputs(isvc *v1beta1.InferenceService, state *effective.RuntimeState) 
 		requestedRevision = *isvc.Spec.Runtime.Revision
 	}
 	if requestedRevision != state.RequestedRevisionName || isvc.Status.PinnedRevisionName != state.ReportedRevisionName {
+		return false
+	}
+	expectedMode, expectedDeclaredKind, expectedDeclaredNamespace := expectedPinIntent(isvc)
+	if state.PinMode != expectedMode || state.DeclaredSourceKind != expectedDeclaredKind ||
+		state.DeclaredSourceNamespace != expectedDeclaredNamespace {
 		return false
 	}
 	explicitRuntimeName := ""
@@ -142,7 +278,116 @@ func validInputs(isvc *v1beta1.InferenceService, state *effective.RuntimeState) 
 	return true
 }
 
+func expectedStatusFreshness(generation, observedGeneration int64) effective.StatusFreshness {
+	switch {
+	case observedGeneration == 0:
+		return effective.StatusFreshnessUnknown
+	case observedGeneration == generation:
+		return effective.StatusFreshnessCurrent
+	case observedGeneration < generation:
+		return effective.StatusFreshnessStale
+	default:
+		return effective.StatusFreshnessInconsistent
+	}
+}
+
+func expectedSyncTokenState(isvc *v1beta1.InferenceService) effective.SyncTokenState {
+	annotation := isvc.Annotations[constants.RuntimeSyncAnnotationKey]
+	status := isvc.Status.LastRuntimeSyncToken
+	switch {
+	case annotation == "" && status == "":
+		return effective.SyncTokenStateAbsent
+	case annotation == "":
+		return effective.SyncTokenStateStatusOnly
+	case annotation == status:
+		return effective.SyncTokenStateAcknowledged
+	default:
+		return effective.SyncTokenStatePending
+	}
+}
+
+func expectedDriftObservation(
+	isvc *v1beta1.InferenceService,
+) (effective.RuntimeDriftState, effective.RuntimeDriftReason) {
+	found := false
+	status := ""
+	reason := ""
+	for _, condition := range isvc.Status.Conditions {
+		if string(condition.Type) != constants.RuntimeDriftedConditionType {
+			continue
+		}
+		if found {
+			return effective.RuntimeDriftStateMalformed, ""
+		}
+		found = true
+		status = string(condition.Status)
+		reason = condition.Reason
+	}
+	if !found {
+		return effective.RuntimeDriftStateNotReported, ""
+	}
+	classifiedReason := classifyExpectedDriftReason(reason)
+	switch status {
+	case "True":
+		return effective.RuntimeDriftStateReportedTrue, classifiedReason
+	case "False":
+		return effective.RuntimeDriftStateReportedFalse, classifiedReason
+	case "Unknown":
+		return effective.RuntimeDriftStateReportedUnknown, classifiedReason
+	default:
+		return effective.RuntimeDriftStateMalformed, classifiedReason
+	}
+}
+
+func classifyExpectedDriftReason(reason string) effective.RuntimeDriftReason {
+	switch effective.RuntimeDriftReason(reason) {
+	case effective.RuntimeDriftReasonRevisionMismatch,
+		effective.RuntimeDriftReasonRevisionMissing,
+		effective.RuntimeDriftReasonSourceRuntimeMissing,
+		effective.RuntimeDriftReasonRuntimeMismatch,
+		effective.RuntimeDriftReasonPinAdvanced:
+		return effective.RuntimeDriftReason(reason)
+	default:
+		return effective.RuntimeDriftReasonOther
+	}
+}
+
+func expectedPinIntent(isvc *v1beta1.InferenceService) (effective.RuntimePinMode, string, string) {
+	if isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name == "" {
+		return effective.RuntimePinModeAutoSync, "", ""
+	}
+	reference := isvc.Spec.Runtime
+	kindValid := reference.Kind == nil || *reference.Kind == runtimeselector.KindClusterServingRuntime ||
+		*reference.Kind == runtimeselector.KindServingRuntime
+	autoSync := reference.AutoSync == nil || *reference.AutoSync
+	if !kindValid {
+		if autoSync {
+			return effective.RuntimePinModeAutoSync, "", ""
+		}
+		return effective.RuntimePinModeInvalidPin, "", ""
+	}
+	kind := runtimeselector.KindClusterServingRuntime
+	namespace := ""
+	if reference.Kind != nil && *reference.Kind == runtimeselector.KindServingRuntime {
+		kind = runtimeselector.KindServingRuntime
+		namespace = isvc.Namespace
+	}
+	if autoSync {
+		return effective.RuntimePinModeAutoSync, kind, namespace
+	}
+	if reference.Revision != nil && *reference.Revision != "" {
+		return effective.RuntimePinModeExplicitPin, kind, namespace
+	}
+	return effective.RuntimePinModeManagedPin, kind, namespace
+}
+
 func validStateEvidence(state *effective.RuntimeState, live *effective.LiveConfiguration) bool {
+	if !validClosedStateEnums(state) || !validActiveRevisionNameEvidence(state) {
+		return false
+	}
+	if !validLiveEvidenceShape(state.LiveAvailability(), live != nil) {
+		return false
+	}
 	if state.RuntimeKind != "" {
 		if _, ok := mapRuntimeKind(state.RuntimeKind); !ok {
 			return false
@@ -155,13 +400,78 @@ func validStateEvidence(state *effective.RuntimeState, live *effective.LiveConfi
 		return false
 	}
 	if live == nil {
-		return state.LiveAvailability() != effective.LiveRuntimeAvailable
+		return state.RuntimeKind == "" && state.RuntimeNamespace == "" && state.LiveShortHash == ""
 	}
 	if live.Runtime.Name != state.RuntimeName || live.Runtime.Kind != state.RuntimeKind ||
 		live.Runtime.Namespace != state.RuntimeNamespace || live.Runtime.SelectionSource != state.SelectionSource {
 		return false
 	}
 	return true
+}
+
+func validActiveRevisionNameEvidence(state *effective.RuntimeState) bool {
+	active, err := state.RequireActive()
+	if err != nil {
+		return state.ActiveRevisionName == ""
+	}
+	switch active.Origin {
+	case effective.ConfigurationOriginLiveRuntime:
+		return state.ActiveRevisionName == "" && active.RevisionName == ""
+	case effective.ConfigurationOriginControllerRevision:
+		return active.RevisionName != "" && state.ActiveRevisionName == active.RevisionName
+	default:
+		return false
+	}
+}
+
+func validLiveEvidenceShape(availability effective.LiveRuntimeAvailability, livePresent bool) bool {
+	switch availability {
+	case effective.LiveRuntimeAvailable:
+		return livePresent
+	case effective.LiveRuntimeNotFound, effective.LiveRuntimeDisabled, effective.LiveRuntimeUnavailable:
+		return !livePresent
+	default:
+		return false
+	}
+}
+
+func validClosedStateEnums(state *effective.RuntimeState) bool {
+	if _, ok := mapSelectionSource(state.SelectionSource); !ok {
+		return false
+	}
+	if _, ok := mapPinMode(state.PinMode); !ok {
+		return false
+	}
+	if _, ok := mapPinState(state.PinState); !ok {
+		return false
+	}
+	if _, ok := mapFreshness(state.StatusFreshness); !ok {
+		return false
+	}
+	if _, ok := mapSyncState(state.SyncTokenState); !ok {
+		return false
+	}
+	if _, ok := mapDriftState(state.DriftState); !ok {
+		return false
+	}
+	if _, ok := mapDriftCause(state.DriftReason); !ok {
+		return false
+	}
+	if _, ok := mapHashRelation(state.LiveToActive); !ok {
+		return false
+	}
+	switch state.DriftState {
+	case effective.RuntimeDriftStateNotReported:
+		return state.DriftReason == ""
+	case effective.RuntimeDriftStateReportedTrue,
+		effective.RuntimeDriftStateReportedFalse,
+		effective.RuntimeDriftStateReportedUnknown:
+		return state.DriftReason != ""
+	case effective.RuntimeDriftStateMalformed:
+		return true
+	default:
+		return false
+	}
 }
 
 func validVerifiedShortHash(value string) bool {
@@ -329,6 +639,7 @@ func mapHashRelation(value effective.RuntimeHashRelation) (reportv1alpha1.Runtim
 func projectInheritance(
 	state *effective.RuntimeState,
 	live *effective.LiveConfiguration,
+	notConfigured bool,
 ) (reportv1alpha1.RuntimeInheritance, *reportv1alpha1.RuntimeObjectReference, bool) {
 	runtimeKind := state.RuntimeKind
 	runtimeNamespace := state.RuntimeNamespace
@@ -342,7 +653,7 @@ func projectInheritance(
 	}
 	if live == nil {
 		reason := liveUnavailableReason(state)
-		if state.RuntimeName == "" {
+		if notConfigured {
 			reason = reportv1alpha1.UnavailableNotConfigured
 		}
 		return reportv1alpha1.RuntimeInheritance{
@@ -432,13 +743,18 @@ func projectLiveConfiguration(
 	state *effective.RuntimeState,
 	live *effective.LiveConfiguration,
 	runtimeIdentity *reportv1alpha1.RuntimeObjectReference,
+	notConfigured bool,
 ) (reportv1alpha1.RuntimeConfiguration, bool) {
 	if live == nil || state.LiveAvailability() != effective.LiveRuntimeAvailable {
+		reason := liveUnavailableReason(state)
+		if notConfigured {
+			reason = reportv1alpha1.UnavailableNotConfigured
+		}
 		return reportv1alpha1.RuntimeConfiguration{
 			State:             reportv1alpha1.ConfigurationStateUnavailable,
-			Source:            copyRuntimeReference(runtimeIdentity),
+			Source:            configurationRuntimeSource(runtimeIdentity),
 			Components:        []reportv1alpha1.RuntimeComponent{},
-			UnavailableReason: liveUnavailableReason(state),
+			UnavailableReason: reason,
 		}, true
 	}
 	components, ok := projectComponents(live.Components)
@@ -457,14 +773,27 @@ func projectLiveConfiguration(
 func projectActiveConfiguration(
 	state *effective.RuntimeState,
 	runtimeIdentity *reportv1alpha1.RuntimeObjectReference,
+	notConfigured bool,
 ) (reportv1alpha1.RuntimeConfiguration, bool) {
 	active, err := state.RequireActive()
 	if err != nil {
+		reason := activeUnavailableReason(state)
+		revision, revisionReason, valid := projectUnavailableActiveRevision(state)
+		if !valid {
+			return reportv1alpha1.RuntimeConfiguration{}, false
+		}
+		if revisionReason != "" {
+			reason = revisionReason
+		}
+		if notConfigured {
+			reason = reportv1alpha1.UnavailableNotConfigured
+		}
 		return reportv1alpha1.RuntimeConfiguration{
 			State:             reportv1alpha1.ConfigurationStateUnavailable,
-			Source:            copyRuntimeReference(runtimeIdentity),
+			Source:            configurationRuntimeSource(runtimeIdentity),
+			Revision:          revision,
 			Components:        []reportv1alpha1.RuntimeComponent{},
-			UnavailableReason: activeUnavailableReason(state),
+			UnavailableReason: reason,
 		}, true
 	}
 	origin, ok := mapConfigurationOrigin(active.Origin)
@@ -608,9 +937,6 @@ func liveUnavailableReason(state *effective.RuntimeState) reportv1alpha1.Unavail
 }
 
 func activeUnavailableReason(state *effective.RuntimeState) reportv1alpha1.UnavailableReason {
-	if state.RuntimeName == "" {
-		return reportv1alpha1.UnavailableNotConfigured
-	}
 	switch state.PinState {
 	case effective.RuntimePinStateRevisionMissing:
 		return reportv1alpha1.UnavailableNotFound
@@ -618,6 +944,15 @@ func activeUnavailableReason(state *effective.RuntimeState) reportv1alpha1.Unava
 		return reportv1alpha1.UnavailableDisabled
 	case effective.RuntimePinStateInvalidIntent, effective.RuntimePinStateRevisionInvalid:
 		return reportv1alpha1.UnavailableMalformedPayload
+	case effective.RuntimePinStateUnavailable:
+		if state.PinMode == effective.RuntimePinModeAutoSync {
+			return liveUnavailableReason(state)
+		}
+		if state.LiveAvailability() != effective.LiveRuntimeAvailable &&
+			state.LiveAvailability() != effective.LiveRuntimeNotFound {
+			return liveUnavailableReason(state)
+		}
+		return reportv1alpha1.UnavailableUnreadable
 	default:
 		if state.PinMode == effective.RuntimePinModeAutoSync {
 			return liveUnavailableReason(state)
@@ -640,10 +975,22 @@ func projectBaseSources(isvc *v1beta1.InferenceService, live *effective.LiveConf
 			UID: string(live.Model.UID), Generation: live.Model.Generation, Evidence: reportv1alpha1.EvidenceObserved,
 		})
 	}
-	for _, source := range live.Runtime.DeclaredInheritance.Chain() {
+	inheritance := live.Runtime.DeclaredInheritance.Chain()
+	runtimeObserved := false
+	for _, source := range inheritance {
+		if source.Kind == live.Runtime.Kind && source.Namespace == live.Runtime.Namespace &&
+			source.Name == live.Runtime.Name {
+			runtimeObserved = true
+		}
 		sources = append(sources, reportv1alpha1.RuntimeSourceReference{
 			Kind: source.Kind, Namespace: source.Namespace, Name: source.Name,
 			UID: string(source.UID), Generation: source.Generation, Evidence: reportv1alpha1.EvidenceObserved,
+		})
+	}
+	if !runtimeObserved && live.Runtime.Name != "" {
+		sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+			Kind: live.Runtime.Kind, Namespace: live.Runtime.Namespace, Name: live.Runtime.Name,
+			Evidence: reportv1alpha1.EvidenceObserved,
 		})
 	}
 	return deduplicateSources(sources)
@@ -670,19 +1017,62 @@ func projectActiveRevision(
 	if matched == nil {
 		return nil, false
 	}
-	revision := &reportv1alpha1.RuntimeRevisionReference{
-		Namespace: matched.ExpectedNamespace(),
-		Name:      active.RevisionName,
+	revision := expectedRevisionReference(*matched, active.RevisionName)
+	return revision, true
+}
+
+func projectUnavailableActiveRevision(
+	state *effective.RuntimeState,
+) (*reportv1alpha1.RuntimeRevisionReference, reportv1alpha1.UnavailableReason, bool) {
+	expectedName := ""
+	switch state.PinMode {
+	case effective.RuntimePinModeManagedPin:
+		expectedName = state.ReportedRevisionName
+	case effective.RuntimePinModeExplicitPin:
+		expectedName = state.RequestedRevisionName
+	case effective.RuntimePinModeAutoSync, effective.RuntimePinModeInvalidPin:
+		return nil, "", true
+	default:
+		return nil, "", false
 	}
-	if matched.ObjectReturned() && matched.ReturnedName() == matched.ExpectedName() &&
-		matched.ReturnedNamespace() == matched.ExpectedNamespace() {
-		revision.UID = matched.UID
-		if !matched.CreationTimestamp.IsZero() {
-			createdAt := matched.CreationTimestamp.Time.UTC()
+	if expectedName == "" {
+		return nil, "", true
+	}
+	var matched *effective.RuntimeRevisionObservation
+	for _, observation := range state.RevisionObservations() {
+		if observation.ExpectedName() != expectedName {
+			continue
+		}
+		if matched != nil {
+			return nil, "", false
+		}
+		copy := observation
+		matched = &copy
+	}
+	if matched == nil {
+		return nil, "", false
+	}
+	reason, _ := failedRevisionReason(state.SourceIssues(), expectedName)
+	return expectedRevisionReference(*matched, expectedName), reason, true
+}
+
+func expectedRevisionReference(
+	observation effective.RuntimeRevisionObservation,
+	expectedName string,
+) *reportv1alpha1.RuntimeRevisionReference {
+	revision := &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: observation.ExpectedNamespace(),
+		Name:      expectedName,
+	}
+	if observation.ObjectReturned() && observation.ReturnedName() == observation.ExpectedName() &&
+		observation.ReturnedNamespace() == observation.ExpectedNamespace() {
+		revision.UID = observation.UID
+		if !observation.CreationTimestamp.IsZero() {
+			createdAt := observation.CreationTimestamp.Time.UTC()
 			revision.CreatedAt = &createdAt
 		}
 	}
-	return revision, true
+	return revision
 }
 
 func hasRevisionRole(values []effective.RuntimeRevisionRole, target effective.RuntimeRevisionRole) bool {
@@ -713,6 +1103,15 @@ func copyRuntimeReference(value *reportv1alpha1.RuntimeObjectReference) *reportv
 	}
 	copy := *value
 	return &copy
+}
+
+func configurationRuntimeSource(
+	value *reportv1alpha1.RuntimeObjectReference,
+) *reportv1alpha1.RuntimeObjectReference {
+	if value == nil || value.Kind == reportv1alpha1.RuntimeKindUnknown {
+		return nil
+	}
+	return copyRuntimeReference(value)
 }
 
 func sameRuntimeReference(left, right *reportv1alpha1.RuntimeObjectReference) bool {

--- a/pkg/cli/runtimeprojection/projection.go
+++ b/pkg/cli/runtimeprojection/projection.go
@@ -1,0 +1,724 @@
+// Package runtimeprojection converts internal runtime evidence into the
+// versioned, allowlisted kubectl-ome report contract.
+package runtimeprojection
+
+import (
+	"errors"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+// ErrInvalidEvidence is returned when collector evidence is nil,
+// contradictory, or contains a value outside a closed enum.
+var ErrInvalidEvidence = errors.New("runtime report projection input is invalid")
+
+// ProjectEffective projects runtime collector evidence into the safe,
+// versioned effective-runtime report contract.
+func ProjectEffective(
+	isvc *v1beta1.InferenceService,
+	state *effective.RuntimeState,
+	clock reportv1alpha1.Clock,
+) (reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent], error) {
+	if !validInputs(isvc, state) {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+
+	selectionSource, ok := mapSelectionSource(state.SelectionSource)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	pinMode, ok := mapPinMode(state.PinMode)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	pinState, ok := mapPinState(state.PinState)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	freshness, ok := mapFreshness(state.StatusFreshness)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	syncState, ok := mapSyncState(state.SyncTokenState)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	driftState, ok := mapDriftState(state.DriftState)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	driftCause, ok := mapDriftCause(state.DriftReason)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	relation, ok := mapHashRelation(state.LiveToActive)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+
+	live := state.LiveConfiguration()
+	if !validStateEvidence(state, live) {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	inheritance, runtimeIdentity, ok := projectInheritance(state, live)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	selectionRuntime := runtimeIdentity
+	if state.RuntimeName == "" {
+		selectionRuntime = nil
+	}
+
+	liveConfiguration, ok := projectLiveConfiguration(state, live, runtimeIdentity)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	activeConfiguration, ok := projectActiveConfiguration(state, runtimeIdentity)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+
+	issues, sources, warnings, ok := projectEffectiveDiagnostics(isvc, state, live, inheritance, activeConfiguration)
+	if !ok {
+		return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, ErrInvalidEvidence
+	}
+	content := reportv1alpha1.RuntimeEffectiveContent{
+		Selection:   reportv1alpha1.RuntimeSelection{Source: selectionSource, Runtime: selectionRuntime},
+		Inheritance: inheritance,
+		Pin: reportv1alpha1.RuntimePin{
+			Mode:              pinMode,
+			State:             pinState,
+			RequestedRevision: state.RequestedRevisionName,
+			ReportedRevision:  state.ReportedRevisionName,
+			Status: reportv1alpha1.RuntimeStatusObservation{
+				Generation:         state.Generation,
+				ObservedGeneration: state.ObservedGeneration,
+				Freshness:          freshness,
+			},
+			ReportedDrift: reportv1alpha1.RuntimeDriftObservation{State: driftState, Cause: driftCause},
+			SyncState:     syncState,
+		},
+		Live:         liveConfiguration,
+		Active:       activeConfiguration,
+		LiveToActive: relation,
+		Issues:       issues,
+	}
+	reportValue := reportv1alpha1.NewRuntimeEffectiveReport(
+		reportv1alpha1.Metadata{Namespace: isvc.Namespace, Name: isvc.Name}, content, clock,
+	)
+	reportValue.Sources = sources
+	reportValue.Warnings = warnings
+	return reportValue.Canonical(), nil
+}
+
+func validInputs(isvc *v1beta1.InferenceService, state *effective.RuntimeState) bool {
+	if isvc == nil || state == nil || isvc.Name == "" || isvc.Namespace == "" {
+		return false
+	}
+	if isvc.Generation != state.Generation || isvc.Status.ObservedGeneration != state.ObservedGeneration {
+		return false
+	}
+	requestedRevision := ""
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Revision != nil {
+		requestedRevision = *isvc.Spec.Runtime.Revision
+	}
+	if requestedRevision != state.RequestedRevisionName || isvc.Status.PinnedRevisionName != state.ReportedRevisionName {
+		return false
+	}
+	explicitRuntimeName := ""
+	if isvc.Spec.Runtime != nil {
+		explicitRuntimeName = isvc.Spec.Runtime.Name
+	}
+	if state.SelectionSource == effective.RuntimeExplicit {
+		return explicitRuntimeName != "" && explicitRuntimeName == state.RuntimeName
+	}
+	if state.SelectionSource == effective.RuntimeSelected {
+		return explicitRuntimeName == ""
+	}
+	return true
+}
+
+func validStateEvidence(state *effective.RuntimeState, live *effective.LiveConfiguration) bool {
+	if state.RuntimeKind != "" {
+		if _, ok := mapRuntimeKind(state.RuntimeKind); !ok {
+			return false
+		}
+	}
+	if !validVerifiedShortHash(state.LiveShortHash) {
+		return false
+	}
+	if state.DriftState == effective.RuntimeDriftStateNotReported && state.DriftReason != "" {
+		return false
+	}
+	if live == nil {
+		return state.LiveAvailability() != effective.LiveRuntimeAvailable
+	}
+	if live.Runtime.Name != state.RuntimeName || live.Runtime.Kind != state.RuntimeKind ||
+		live.Runtime.Namespace != state.RuntimeNamespace || live.Runtime.SelectionSource != state.SelectionSource {
+		return false
+	}
+	return true
+}
+
+func validVerifiedShortHash(value string) bool {
+	if value == "" {
+		return true
+	}
+	if len(value) != 8 {
+		return false
+	}
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func mapSelectionSource(value effective.RuntimeSelectionSource) (reportv1alpha1.RuntimeSelectionSource, bool) {
+	switch value {
+	case effective.RuntimeExplicit:
+		return reportv1alpha1.RuntimeSelectionSourceExplicit, true
+	case effective.RuntimeSelected:
+		return reportv1alpha1.RuntimeSelectionSourceSelected, true
+	default:
+		return "", false
+	}
+}
+
+func mapRuntimeKind(value string) (reportv1alpha1.RuntimeKind, bool) {
+	switch value {
+	case runtimeselector.KindServingRuntime:
+		return reportv1alpha1.RuntimeKindServingRuntime, true
+	case runtimeselector.KindClusterServingRuntime:
+		return reportv1alpha1.RuntimeKindClusterServingRuntime, true
+	case "":
+		return reportv1alpha1.RuntimeKindUnknown, true
+	default:
+		return "", false
+	}
+}
+
+func mapPinMode(value effective.RuntimePinMode) (reportv1alpha1.RuntimePinMode, bool) {
+	switch value {
+	case effective.RuntimePinModeAutoSync:
+		return reportv1alpha1.RuntimePinModeAutoSync, true
+	case effective.RuntimePinModeManagedPin:
+		return reportv1alpha1.RuntimePinModeManagedPin, true
+	case effective.RuntimePinModeExplicitPin:
+		return reportv1alpha1.RuntimePinModeExplicitPin, true
+	case effective.RuntimePinModeInvalidPin:
+		return reportv1alpha1.RuntimePinModeInvalidPin, true
+	default:
+		return "", false
+	}
+}
+
+func mapPinState(value effective.RuntimePinState) (reportv1alpha1.RuntimePinState, bool) {
+	switch value {
+	case effective.RuntimePinStateNotApplicable:
+		return reportv1alpha1.RuntimePinStateNotApplicable, true
+	case effective.RuntimePinStateAwaitingPin:
+		return reportv1alpha1.RuntimePinStateAwaitingPin, true
+	case effective.RuntimePinStateResolved:
+		return reportv1alpha1.RuntimePinStateResolved, true
+	case effective.RuntimePinStateDesiredReportedMismatch:
+		return reportv1alpha1.RuntimePinStateDesiredReportedMismatch, true
+	case effective.RuntimePinStateRevisionMissing:
+		return reportv1alpha1.RuntimePinStateRevisionMissing, true
+	case effective.RuntimePinStateRevisionInvalid:
+		return reportv1alpha1.RuntimePinStateRevisionInvalid, true
+	case effective.RuntimePinStateRevisionDisabled:
+		return reportv1alpha1.RuntimePinStateRevisionDisabled, true
+	case effective.RuntimePinStateUnavailable:
+		return reportv1alpha1.RuntimePinStateUnavailable, true
+	case effective.RuntimePinStateInvalidIntent:
+		return reportv1alpha1.RuntimePinStateInvalidIntent, true
+	default:
+		return "", false
+	}
+}
+
+func mapFreshness(value effective.StatusFreshness) (reportv1alpha1.StatusFreshness, bool) {
+	switch value {
+	case effective.StatusFreshnessCurrent:
+		return reportv1alpha1.StatusFreshnessCurrent, true
+	case effective.StatusFreshnessStale:
+		return reportv1alpha1.StatusFreshnessStale, true
+	case effective.StatusFreshnessUnknown:
+		return reportv1alpha1.StatusFreshnessUnobserved, true
+	case effective.StatusFreshnessInconsistent:
+		return reportv1alpha1.StatusFreshnessInvalid, true
+	default:
+		return "", false
+	}
+}
+
+func mapSyncState(value effective.SyncTokenState) (reportv1alpha1.RuntimeSyncState, bool) {
+	switch value {
+	case effective.SyncTokenStateAbsent:
+		return reportv1alpha1.RuntimeSyncStateAbsent, true
+	case effective.SyncTokenStateAcknowledged:
+		return reportv1alpha1.RuntimeSyncStateAcknowledged, true
+	case effective.SyncTokenStatePending:
+		return reportv1alpha1.RuntimeSyncStatePending, true
+	case effective.SyncTokenStateStatusOnly:
+		return reportv1alpha1.RuntimeSyncStateStatusOnly, true
+	default:
+		return "", false
+	}
+}
+
+func mapDriftState(value effective.RuntimeDriftState) (reportv1alpha1.DriftConditionState, bool) {
+	switch value {
+	case effective.RuntimeDriftStateNotReported:
+		return reportv1alpha1.DriftConditionStateNotReported, true
+	case effective.RuntimeDriftStateReportedTrue:
+		return reportv1alpha1.DriftConditionStateReportedTrue, true
+	case effective.RuntimeDriftStateReportedFalse:
+		return reportv1alpha1.DriftConditionStateReportedFalse, true
+	case effective.RuntimeDriftStateReportedUnknown:
+		return reportv1alpha1.DriftConditionStateReportedUnknown, true
+	case effective.RuntimeDriftStateMalformed:
+		return reportv1alpha1.DriftConditionStateMalformed, true
+	default:
+		return "", false
+	}
+}
+
+func mapDriftCause(value effective.RuntimeDriftReason) (reportv1alpha1.RuntimeDriftCause, bool) {
+	switch value {
+	case "":
+		return "", true
+	case effective.RuntimeDriftReasonRevisionMismatch:
+		return reportv1alpha1.RuntimeDriftCauseRevisionMismatch, true
+	case effective.RuntimeDriftReasonRevisionMissing:
+		return reportv1alpha1.RuntimeDriftCauseRevisionMissing, true
+	case effective.RuntimeDriftReasonSourceRuntimeMissing:
+		return reportv1alpha1.RuntimeDriftCauseSourceRuntimeMissing, true
+	case effective.RuntimeDriftReasonRuntimeMismatch:
+		return reportv1alpha1.RuntimeDriftCauseRuntimeMismatch, true
+	case effective.RuntimeDriftReasonPinAdvanced:
+		return reportv1alpha1.RuntimeDriftCausePinAdvanced, true
+	case effective.RuntimeDriftReasonOther:
+		return reportv1alpha1.RuntimeDriftCauseOther, true
+	default:
+		return "", false
+	}
+}
+
+func mapHashRelation(value effective.RuntimeHashRelation) (reportv1alpha1.RuntimeHashRelation, bool) {
+	switch value {
+	case effective.RuntimeHashRelationUnknown:
+		return reportv1alpha1.RuntimeHashRelationUnknown, true
+	case effective.RuntimeHashRelationEqual:
+		return reportv1alpha1.RuntimeHashRelationEqual, true
+	case effective.RuntimeHashRelationDifferent:
+		return reportv1alpha1.RuntimeHashRelationDifferent, true
+	case effective.RuntimeHashRelationAmbiguous:
+		return reportv1alpha1.RuntimeHashRelationAmbiguous, true
+	default:
+		return "", false
+	}
+}
+
+func projectInheritance(
+	state *effective.RuntimeState,
+	live *effective.LiveConfiguration,
+) (reportv1alpha1.RuntimeInheritance, *reportv1alpha1.RuntimeObjectReference, bool) {
+	runtimeKind := state.RuntimeKind
+	runtimeNamespace := state.RuntimeNamespace
+	if runtimeKind == "" && state.RuntimeName != "" {
+		runtimeKind = state.DeclaredSourceKind
+		runtimeNamespace = state.DeclaredSourceNamespace
+	}
+	runtimeIdentity, validIdentity := runtimeReference(state.RuntimeName, runtimeKind, runtimeNamespace)
+	if !validIdentity {
+		return reportv1alpha1.RuntimeInheritance{}, nil, false
+	}
+	if live == nil {
+		reason := liveUnavailableReason(state)
+		if state.RuntimeName == "" {
+			reason = reportv1alpha1.UnavailableNotConfigured
+		}
+		return reportv1alpha1.RuntimeInheritance{
+			State:             reportv1alpha1.InheritanceStateUnavailable,
+			Sources:           []reportv1alpha1.RuntimeObjectReference{},
+			UnavailableReason: reason,
+		}, runtimeIdentity, true
+	}
+	observation := live.Runtime.DeclaredInheritance
+	if observation.Validate() != nil {
+		return reportv1alpha1.RuntimeInheritance{}, nil, false
+	}
+	switch observation.State() {
+	case effective.InheritanceObserved:
+		chain := observation.Chain()
+		sources := make([]reportv1alpha1.RuntimeObjectReference, len(chain))
+		for i := range chain {
+			kind, ok := mapRuntimeKind(chain[i].Kind)
+			if !ok || kind == reportv1alpha1.RuntimeKindUnknown || chain[i].Name == "" {
+				return reportv1alpha1.RuntimeInheritance{}, nil, false
+			}
+			sources[i] = reportv1alpha1.RuntimeObjectReference{
+				APIVersion: chain[i].APIVersion,
+				Kind:       kind,
+				Namespace:  chain[i].Namespace,
+				Name:       chain[i].Name,
+				UID:        string(chain[i].UID),
+				Generation: chain[i].Generation,
+			}
+			if chain[i].Name == state.RuntimeName && chain[i].Kind == state.RuntimeKind && chain[i].Namespace == state.RuntimeNamespace {
+				copy := sources[i]
+				runtimeIdentity = &copy
+			}
+		}
+		return reportv1alpha1.RuntimeInheritance{
+			State:   reportv1alpha1.InheritanceStateObserved,
+			Sources: sources,
+		}, runtimeIdentity, true
+	case effective.InheritanceUnavailable:
+		reason, ok := mapInheritanceUnavailableReason(observation.UnavailableReason())
+		return reportv1alpha1.RuntimeInheritance{
+			State:             reportv1alpha1.InheritanceStateUnavailable,
+			Sources:           []reportv1alpha1.RuntimeObjectReference{},
+			UnavailableReason: reason,
+		}, runtimeIdentity, ok
+	default:
+		return reportv1alpha1.RuntimeInheritance{}, nil, false
+	}
+}
+
+func mapInheritanceUnavailableReason(value effective.InheritanceUnavailableReason) (reportv1alpha1.UnavailableReason, bool) {
+	switch value {
+	case effective.InheritanceNotFound:
+		return reportv1alpha1.UnavailableNotFound, true
+	case effective.InheritanceForbidden:
+		return reportv1alpha1.UnavailableForbidden, true
+	case effective.InheritanceCycle:
+		return reportv1alpha1.UnavailableCycle, true
+	case effective.InheritanceMaxDepthExceeded:
+		return reportv1alpha1.UnavailableMaxDepthExceeded, true
+	case effective.InheritanceMalformed:
+		return reportv1alpha1.UnavailableMalformedPayload, true
+	case effective.InheritanceUnreadable:
+		return reportv1alpha1.UnavailableUnreadable, true
+	default:
+		return "", false
+	}
+}
+
+func runtimeReference(name, kind, namespace string) (*reportv1alpha1.RuntimeObjectReference, bool) {
+	if name == "" {
+		return nil, true
+	}
+	reportKind, ok := mapRuntimeKind(kind)
+	if !ok {
+		return nil, false
+	}
+	return &reportv1alpha1.RuntimeObjectReference{
+		APIVersion: v1beta1.SchemeGroupVersion.String(),
+		Kind:       reportKind,
+		Namespace:  namespace,
+		Name:       name,
+	}, true
+}
+
+func projectLiveConfiguration(
+	state *effective.RuntimeState,
+	live *effective.LiveConfiguration,
+	runtimeIdentity *reportv1alpha1.RuntimeObjectReference,
+) (reportv1alpha1.RuntimeConfiguration, bool) {
+	if live == nil || state.LiveAvailability() != effective.LiveRuntimeAvailable {
+		return reportv1alpha1.RuntimeConfiguration{
+			State:             reportv1alpha1.ConfigurationStateUnavailable,
+			Source:            copyRuntimeReference(runtimeIdentity),
+			Components:        []reportv1alpha1.RuntimeComponent{},
+			UnavailableReason: liveUnavailableReason(state),
+		}, true
+	}
+	components, ok := projectComponents(live.Components)
+	if !ok {
+		return reportv1alpha1.RuntimeConfiguration{}, false
+	}
+	return reportv1alpha1.RuntimeConfiguration{
+		State:      reportv1alpha1.ConfigurationStateAvailable,
+		Origin:     reportv1alpha1.ConfigurationOriginLiveRuntime,
+		Source:     copyRuntimeReference(runtimeIdentity),
+		Hash:       state.LiveShortHash,
+		Components: components,
+	}, true
+}
+
+func projectActiveConfiguration(
+	state *effective.RuntimeState,
+	runtimeIdentity *reportv1alpha1.RuntimeObjectReference,
+) (reportv1alpha1.RuntimeConfiguration, bool) {
+	active, err := state.RequireActive()
+	if err != nil {
+		return reportv1alpha1.RuntimeConfiguration{
+			State:             reportv1alpha1.ConfigurationStateUnavailable,
+			Source:            copyRuntimeReference(runtimeIdentity),
+			Components:        []reportv1alpha1.RuntimeComponent{},
+			UnavailableReason: activeUnavailableReason(state),
+		}, true
+	}
+	origin, ok := mapConfigurationOrigin(active.Origin)
+	if !ok {
+		return reportv1alpha1.RuntimeConfiguration{}, false
+	}
+	components, ok := projectComponents(active.Components())
+	if !ok {
+		return reportv1alpha1.RuntimeConfiguration{}, false
+	}
+	source, ok := runtimeReference(active.RuntimeName, active.RuntimeKind, active.RuntimeNamespace)
+	if !ok {
+		return reportv1alpha1.RuntimeConfiguration{}, false
+	}
+	if sameRuntimeReference(source, runtimeIdentity) {
+		source = copyRuntimeReference(runtimeIdentity)
+	}
+	hash := active.RevisionShortHash
+	if active.Origin == effective.ConfigurationOriginLiveRuntime {
+		hash = state.LiveShortHash
+	}
+	configuration := reportv1alpha1.RuntimeConfiguration{
+		State:      reportv1alpha1.ConfigurationStateAvailable,
+		Origin:     origin,
+		Source:     source,
+		Hash:       hash,
+		Components: components,
+	}
+	if active.Origin == effective.ConfigurationOriginControllerRevision {
+		revision, valid := projectActiveRevision(state, active)
+		if !valid {
+			return reportv1alpha1.RuntimeConfiguration{}, false
+		}
+		configuration.Revision = revision
+	}
+	return configuration, true
+}
+
+func mapConfigurationOrigin(value effective.ConfigurationOrigin) (reportv1alpha1.ConfigurationOrigin, bool) {
+	switch value {
+	case effective.ConfigurationOriginLiveRuntime:
+		return reportv1alpha1.ConfigurationOriginLiveRuntime, true
+	case effective.ConfigurationOriginControllerRevision:
+		return reportv1alpha1.ConfigurationOriginControllerRevision, true
+	default:
+		return "", false
+	}
+}
+
+func projectComponents(values []effective.EffectiveComponent) ([]reportv1alpha1.RuntimeComponent, bool) {
+	result := make([]reportv1alpha1.RuntimeComponent, len(values))
+	for i := range values {
+		componentType, ok := mapComponentType(values[i].Type)
+		if !ok {
+			return nil, false
+		}
+		mode, ok := mapDeploymentMode(values[i].DeploymentMode)
+		if !ok {
+			return nil, false
+		}
+		source, ok := mapDeploymentModeSource(values[i].DeploymentModeSource)
+		if !ok {
+			return nil, false
+		}
+		result[i] = reportv1alpha1.RuntimeComponent{
+			Type: componentType, DeploymentMode: mode, DeploymentModeSource: source,
+		}
+	}
+	return result, true
+}
+
+func mapComponentType(value v1beta1.ComponentType) (reportv1alpha1.RuntimeComponentType, bool) {
+	switch value {
+	case v1beta1.EngineComponent:
+		return reportv1alpha1.RuntimeComponentEngine, true
+	case v1beta1.DecoderComponent:
+		return reportv1alpha1.RuntimeComponentDecoder, true
+	case v1beta1.RouterComponent:
+		return reportv1alpha1.RuntimeComponentRouter, true
+	default:
+		return "", false
+	}
+}
+
+func mapDeploymentMode(value constants.DeploymentModeType) (reportv1alpha1.DeploymentMode, bool) {
+	switch value {
+	case constants.RawDeployment:
+		return reportv1alpha1.DeploymentModeRawDeployment, true
+	case constants.MultiNode:
+		return reportv1alpha1.DeploymentModeMultiNode, true
+	case constants.VirtualDeployment:
+		return reportv1alpha1.DeploymentModeVirtualDeployment, true
+	case constants.OMENative:
+		return reportv1alpha1.DeploymentModeOMENative, true
+	default:
+		return "", false
+	}
+}
+
+func mapDeploymentModeSource(value effective.ComponentDeploymentModeSource) (reportv1alpha1.DeploymentModeSource, bool) {
+	switch value {
+	case effective.DeploymentModeComponentAnnotation:
+		return reportv1alpha1.DeploymentModeSourceComponentAnnotation, true
+	case effective.DeploymentModeServiceSpec:
+		return reportv1alpha1.DeploymentModeSourceServiceSpec, true
+	case effective.DeploymentModeLeaderWorkerShape:
+		return reportv1alpha1.DeploymentModeSourceLeaderWorkerShape, true
+	case effective.DeploymentModeDefault:
+		return reportv1alpha1.DeploymentModeSourceDefault, true
+	default:
+		return "", false
+	}
+}
+
+func mapLiveUnavailableReason(value effective.LiveRuntimeAvailability) reportv1alpha1.UnavailableReason {
+	switch value {
+	case effective.LiveRuntimeNotFound:
+		return reportv1alpha1.UnavailableNotFound
+	case effective.LiveRuntimeDisabled:
+		return reportv1alpha1.UnavailableDisabled
+	case effective.LiveRuntimeUnavailable:
+		return reportv1alpha1.UnavailableUnreadable
+	default:
+		return reportv1alpha1.UnavailableUnreadable
+	}
+}
+
+func liveUnavailableReason(state *effective.RuntimeState) reportv1alpha1.UnavailableReason {
+	for _, issue := range state.SourceIssues() {
+		switch issue.Code {
+		case effective.RuntimeSourceIssueLiveNotFound,
+			effective.RuntimeSourceIssueLiveDisabled,
+			effective.RuntimeSourceIssueLiveUnavailable:
+			_, reason, ok := projectSourceIssue(issue)
+			if ok {
+				return reason
+			}
+		}
+	}
+	return mapLiveUnavailableReason(state.LiveAvailability())
+}
+
+func activeUnavailableReason(state *effective.RuntimeState) reportv1alpha1.UnavailableReason {
+	if state.RuntimeName == "" {
+		return reportv1alpha1.UnavailableNotConfigured
+	}
+	switch state.PinState {
+	case effective.RuntimePinStateRevisionMissing:
+		return reportv1alpha1.UnavailableNotFound
+	case effective.RuntimePinStateRevisionDisabled:
+		return reportv1alpha1.UnavailableDisabled
+	case effective.RuntimePinStateInvalidIntent, effective.RuntimePinStateRevisionInvalid:
+		return reportv1alpha1.UnavailableMalformedPayload
+	default:
+		if state.PinMode == effective.RuntimePinModeAutoSync {
+			return liveUnavailableReason(state)
+		}
+		return reportv1alpha1.UnavailableUnreadable
+	}
+}
+
+func projectBaseSources(isvc *v1beta1.InferenceService, live *effective.LiveConfiguration) []reportv1alpha1.RuntimeSourceReference {
+	sources := []reportv1alpha1.RuntimeSourceReference{{
+		Kind: "InferenceService", Namespace: isvc.Namespace, Name: isvc.Name,
+		UID: string(isvc.UID), Generation: isvc.Generation, Evidence: reportv1alpha1.EvidenceObserved,
+	}}
+	if live == nil {
+		return sources
+	}
+	if live.Model != nil {
+		sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+			Kind: live.Model.Kind, Namespace: live.Model.Namespace, Name: live.Model.Name,
+			UID: string(live.Model.UID), Generation: live.Model.Generation, Evidence: reportv1alpha1.EvidenceObserved,
+		})
+	}
+	for _, source := range live.Runtime.DeclaredInheritance.Chain() {
+		sources = append(sources, reportv1alpha1.RuntimeSourceReference{
+			Kind: source.Kind, Namespace: source.Namespace, Name: source.Name,
+			UID: string(source.UID), Generation: source.Generation, Evidence: reportv1alpha1.EvidenceObserved,
+		})
+	}
+	return deduplicateSources(sources)
+}
+
+func projectActiveRevision(
+	state *effective.RuntimeState,
+	active *effective.ActiveConfiguration,
+) (*reportv1alpha1.RuntimeRevisionReference, bool) {
+	if active.RevisionName == "" || !validVerifiedShortHash(active.RevisionShortHash) {
+		return nil, false
+	}
+	var matched *effective.RuntimeRevisionObservation
+	for _, observation := range state.RevisionObservations() {
+		if observation.ExpectedName() != active.RevisionName || !hasRevisionRole(observation.Roles(), effective.RuntimeRevisionRoleActive) {
+			continue
+		}
+		if matched != nil {
+			return nil, false
+		}
+		copy := observation
+		matched = &copy
+	}
+	if matched == nil {
+		return nil, false
+	}
+	revision := &reportv1alpha1.RuntimeRevisionReference{
+		Namespace: matched.ExpectedNamespace(),
+		Name:      active.RevisionName,
+	}
+	if matched.ObjectReturned() && matched.ReturnedName() == matched.ExpectedName() &&
+		matched.ReturnedNamespace() == matched.ExpectedNamespace() {
+		revision.UID = matched.UID
+		if !matched.CreationTimestamp.IsZero() {
+			createdAt := matched.CreationTimestamp.Time.UTC()
+			revision.CreatedAt = &createdAt
+		}
+	}
+	return revision, true
+}
+
+func hasRevisionRole(values []effective.RuntimeRevisionRole, target effective.RuntimeRevisionRole) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func deduplicateSources(values []reportv1alpha1.RuntimeSourceReference) []reportv1alpha1.RuntimeSourceReference {
+	result := make([]reportv1alpha1.RuntimeSourceReference, 0, len(values))
+	seen := make(map[reportv1alpha1.RuntimeSourceReference]struct{}, len(values))
+	for _, value := range values {
+		if _, found := seen[value]; found {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func copyRuntimeReference(value *reportv1alpha1.RuntimeObjectReference) *reportv1alpha1.RuntimeObjectReference {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func sameRuntimeReference(left, right *reportv1alpha1.RuntimeObjectReference) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.APIVersion == right.APIVersion && left.Kind == right.Kind &&
+		left.Namespace == right.Namespace && left.Name == right.Name
+}

--- a/pkg/cli/runtimeprojection/projection_test.go
+++ b/pkg/cli/runtimeprojection/projection_test.go
@@ -1,0 +1,296 @@
+package runtimeprojection
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+var projectionTestClock = v1alpha1.ClockFunc(func() time.Time {
+	return time.Date(2026, time.August, 31, 20, 15, 0, 0, time.UTC)
+})
+
+func TestProjectEffectiveRejectsNilInputsWithFixedSentinel(t *testing.T) {
+	isvc := &v1beta1.InferenceService{}
+	state := &effective.RuntimeState{}
+
+	_, err := ProjectEffective(nil, state, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+
+	_, err = ProjectEffective(isvc, nil, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+}
+
+func TestProjectEffectiveMapsResolvedLiveConfiguration(t *testing.T) {
+	isvc, state := resolveLiveProjectionFixture(t)
+
+	reportValue, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	wantRuntime := &v1alpha1.RuntimeObjectReference{
+		APIVersion: v1beta1.SchemeGroupVersion.String(),
+		Kind:       v1alpha1.RuntimeKindClusterServingRuntime,
+		Name:       "gpu-runtime",
+		UID:        "runtime-uid",
+		Generation: 5,
+	}
+	wantConfiguration := v1alpha1.RuntimeConfiguration{
+		State:  v1alpha1.ConfigurationStateAvailable,
+		Origin: v1alpha1.ConfigurationOriginLiveRuntime,
+		Source: wantRuntime,
+		Hash:   state.LiveShortHash,
+		Components: []v1alpha1.RuntimeComponent{{
+			Type:                 v1alpha1.RuntimeComponentEngine,
+			DeploymentMode:       v1alpha1.DeploymentModeOMENative,
+			DeploymentModeSource: v1alpha1.DeploymentModeSourceServiceSpec,
+		}},
+	}
+	assert.Equal(t, v1alpha1.APIVersion, reportValue.APIVersion)
+	assert.Equal(t, v1alpha1.RuntimeEffectiveReportKind, reportValue.Kind)
+	assert.Equal(t, v1alpha1.Metadata{Namespace: "workloads", Name: "chat"}, reportValue.Metadata)
+	assert.Equal(t, projectionTestClock.Now(), reportValue.CollectedAt)
+	assert.Equal(t, v1alpha1.RuntimeEffectiveContent{
+		Selection: v1alpha1.RuntimeSelection{
+			Source:  v1alpha1.RuntimeSelectionSourceExplicit,
+			Runtime: wantRuntime,
+		},
+		Inheritance: v1alpha1.RuntimeInheritance{
+			State: v1alpha1.InheritanceStateObserved,
+			Sources: []v1alpha1.RuntimeObjectReference{
+				{
+					APIVersion: v1beta1.SchemeGroupVersion.String(),
+					Kind:       v1alpha1.RuntimeKindClusterServingRuntime,
+					Name:       "base-runtime",
+					UID:        "base-uid",
+					Generation: 2,
+				},
+				*wantRuntime,
+			},
+		},
+		Pin: v1alpha1.RuntimePin{
+			Mode:  v1alpha1.RuntimePinModeAutoSync,
+			State: v1alpha1.RuntimePinStateNotApplicable,
+			Status: v1alpha1.RuntimeStatusObservation{
+				Generation:         7,
+				ObservedGeneration: 7,
+				Freshness:          v1alpha1.StatusFreshnessCurrent,
+			},
+			ReportedDrift: v1alpha1.RuntimeDriftObservation{State: v1alpha1.DriftConditionStateNotReported},
+			SyncState:     v1alpha1.RuntimeSyncStateAbsent,
+		},
+		Live:         wantConfiguration,
+		Active:       wantConfiguration,
+		LiveToActive: v1alpha1.RuntimeHashRelationEqual,
+		Issues:       []v1alpha1.RuntimeIssue{},
+	}, reportValue.Content)
+	assert.Equal(t, []v1alpha1.RuntimeSourceReference{
+		{
+			Kind: "ClusterServingRuntime", Name: "base-runtime", UID: "base-uid", Generation: 2,
+			Evidence: v1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+		{
+			Kind: "ClusterServingRuntime", Name: "gpu-runtime", UID: "runtime-uid", Generation: 5,
+			Evidence: v1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+		{
+			Kind: "InferenceService", Namespace: "workloads", Name: "chat", UID: "isvc-uid", Generation: 7,
+			Evidence: v1alpha1.EvidenceObserved, CollectedAt: projectionTestClock.Now(),
+		},
+	}, reportValue.Sources)
+	assert.Empty(t, reportValue.Warnings)
+}
+
+func TestProjectEffectiveRejectsMismatchedStateGeneration(t *testing.T) {
+	isvc, state := resolveLiveProjectionFixture(t)
+	state.Generation++
+
+	_, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.ErrorIs(t, err, ErrInvalidEvidence)
+	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+}
+
+func TestProjectEffectiveRejectsCrossAssociatedOrHostileEvidence(t *testing.T) {
+	baseISVC, baseState := resolveLiveProjectionFixture(t)
+	tests := []struct {
+		name   string
+		mutate func(*v1beta1.InferenceService, *effective.RuntimeState)
+	}{
+		{
+			name: "empty service name",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Name = ""
+			},
+		},
+		{
+			name: "empty service namespace",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Namespace = ""
+			},
+		},
+		{
+			name: "observed generation mismatch",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Status.ObservedGeneration++
+			},
+		},
+		{
+			name: "requested revision mismatch",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Spec.Runtime.Revision = pointerTo("other-revision")
+			},
+		},
+		{
+			name: "reported revision mismatch",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Status.PinnedRevisionName = "other-revision"
+			},
+		},
+		{
+			name: "explicit runtime mismatch",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Spec.Runtime.Name = "other-runtime"
+			},
+		},
+		{
+			name: "unknown selection source",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.SelectionSource = effective.RuntimeSelectionSource("secret-selection")
+			},
+		},
+		{
+			name: "unknown runtime kind",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.RuntimeKind = "secret-runtime-kind"
+			},
+		},
+		{
+			name: "unknown pin mode",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.PinMode = effective.RuntimePinMode("secret-pin-mode")
+			},
+		},
+		{
+			name: "unknown pin state",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.PinState = effective.RuntimePinState("secret-pin-state")
+			},
+		},
+		{
+			name: "unknown freshness",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.StatusFreshness = effective.StatusFreshness("secret-freshness")
+			},
+		},
+		{
+			name: "unknown sync state",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.SyncTokenState = effective.SyncTokenState("secret-sync")
+			},
+		},
+		{
+			name: "unknown drift state",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.DriftState = effective.RuntimeDriftState("secret-drift")
+			},
+		},
+		{
+			name: "unknown drift cause",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.DriftReason = effective.RuntimeDriftReason("secret-drift-reason")
+			},
+		},
+		{
+			name: "cause without reported drift",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.DriftReason = effective.RuntimeDriftReasonRevisionMismatch
+			},
+		},
+		{
+			name: "unknown hash relation",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.LiveToActive = effective.RuntimeHashRelation("secret-relation")
+			},
+		},
+		{
+			name: "unverified live hash",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.LiveShortHash = "secret-unverified-hash"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := baseISVC.DeepCopy()
+			stateCopy := *baseState
+			test.mutate(isvc, &stateCopy)
+
+			_, err := ProjectEffective(isvc, &stateCopy, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			assert.NotContains(t, err.Error(), "secret")
+		})
+	}
+}
+
+func pointerTo[T any](value T) *T {
+	return &value
+}
+
+func resolveLiveProjectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	base := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "base-runtime", UID: "base-uid", Generation: 2},
+		Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "runner", Image: "secret.example/base:latest"}},
+		}},
+	}
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-runtime", UID: "runtime-uid", Generation: 5,
+			Annotations: map[string]string{constants.RuntimeInheritFromAnnotationKey: base.Name},
+		},
+	}
+	client := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(base, runtimeObject).Build()
+	mode := constants.OMENative
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			DeploymentMode: &mode,
+			Runtime:        &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name},
+			Engine:         &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	resolver, err := effective.NewRuntimePinResolver(
+		k8sfake.NewSimpleClientset().AppsV1(),
+		effective.NewRuntimeResolver(client),
+		"ome-system",
+		paging.Limits{PageSize: 10, MaxItems: 20, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{})
+	require.NoError(t, err)
+	_, err = state.RequireActive()
+	require.NoError(t, err)
+	return isvc, state
+}

--- a/pkg/cli/runtimeprojection/projection_test.go
+++ b/pkg/cli/runtimeprojection/projection_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -124,6 +125,27 @@ func TestProjectEffectiveRejectsMismatchedStateGeneration(t *testing.T) {
 	assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
 }
 
+func TestProjectEffectiveRejectsEvidenceCapturedWithoutStablePrimaryIdentity(t *testing.T) {
+	tests := []struct {
+		name            string
+		uid             string
+		resourceVersion string
+	}{
+		{name: "missing uid", resourceVersion: "resource-version"},
+		{name: "missing resource version", uid: "isvc-uid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc, state := resolveLiveProjectionFixtureWithIdentity(t, test.uid, test.resourceVersion)
+
+			_, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
 func TestProjectEffectiveRejectsCrossAssociatedOrHostileEvidence(t *testing.T) {
 	baseISVC, baseState := resolveLiveProjectionFixture(t)
 	tests := []struct {
@@ -143,9 +165,57 @@ func TestProjectEffectiveRejectsCrossAssociatedOrHostileEvidence(t *testing.T) {
 			},
 		},
 		{
+			name: "different service name",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Name = "other-chat"
+			},
+		},
+		{
+			name: "different service namespace",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.Namespace = "other-workloads"
+			},
+		},
+		{
+			name: "different service uid",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.UID = "other-uid"
+			},
+		},
+		{
+			name: "different service resource version",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				isvc.ResourceVersion = "secret-other-resource-version"
+			},
+		},
+		{
 			name: "observed generation mismatch",
 			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
 				isvc.Status.ObservedGeneration++
+			},
+		},
+		{
+			name: "freshness contradicts generations",
+			mutate: func(isvc *v1beta1.InferenceService, state *effective.RuntimeState) {
+				isvc.Status.ObservedGeneration = 6
+				state.ObservedGeneration = 6
+				state.StatusFreshness = effective.StatusFreshnessCurrent
+			},
+		},
+		{
+			name: "sync state contradicts service snapshot",
+			mutate: func(isvc *v1beta1.InferenceService, _ *effective.RuntimeState) {
+				if isvc.Annotations == nil {
+					isvc.Annotations = map[string]string{}
+				}
+				isvc.Annotations[constants.RuntimeSyncAnnotationKey] = "secret-sync-token"
+			},
+		},
+		{
+			name: "drift state contradicts service snapshot",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.DriftState = effective.RuntimeDriftStateReportedTrue
+				state.DriftReason = effective.RuntimeDriftReasonRevisionMismatch
 			},
 		},
 		{
@@ -191,6 +261,19 @@ func TestProjectEffectiveRejectsCrossAssociatedOrHostileEvidence(t *testing.T) {
 			},
 		},
 		{
+			name: "known but mismatched pin intent",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.PinMode = effective.RuntimePinModeManagedPin
+				state.PinState = effective.RuntimePinStateAwaitingPin
+			},
+		},
+		{
+			name: "known but impossible pin state",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.PinState = effective.RuntimePinStateUnavailable
+			},
+		},
+		{
 			name: "unknown freshness",
 			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
 				state.StatusFreshness = effective.StatusFreshness("secret-freshness")
@@ -227,6 +310,12 @@ func TestProjectEffectiveRejectsCrossAssociatedOrHostileEvidence(t *testing.T) {
 			},
 		},
 		{
+			name: "live active relation contradicts auto sync",
+			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
+				state.LiveToActive = effective.RuntimeHashRelationDifferent
+			},
+		},
+		{
 			name: "unverified live hash",
 			mutate: func(_ *v1beta1.InferenceService, state *effective.RuntimeState) {
 				state.LiveShortHash = "secret-unverified-hash"
@@ -248,11 +337,75 @@ func TestProjectEffectiveRejectsCrossAssociatedOrHostileEvidence(t *testing.T) {
 	}
 }
 
+func TestProjectionRejectsActiveRevisionNameContradictions(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolve    func(*testing.T) (*v1beta1.InferenceService, *effective.RuntimeState)
+		activeName string
+	}{
+		{
+			name: "live active claims revision",
+			resolve: func(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+				return resolveLiveProjectionFixture(t)
+			},
+			activeName: "secret-fabricated-active-revision",
+		},
+		{
+			name: "unavailable active claims revision",
+			resolve: func(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+				return resolveUnavailableLiveFixture(t, nil)
+			},
+			activeName: "secret-fabricated-active-revision",
+		},
+		{
+			name:    "controller revision active omits revision",
+			resolve: resolveControllerRevisionActiveProjectionFixture,
+		},
+		{
+			name:       "controller revision active names another revision",
+			resolve:    resolveControllerRevisionActiveProjectionFixture,
+			activeName: "secret-other-active-revision",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc, state := test.resolve(t)
+			state.ActiveRevisionName = test.activeName
+
+			_, err := ProjectEffective(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+			_, err = ProjectHistory(isvc, state, projectionTestClock)
+			require.ErrorIs(t, err, ErrInvalidEvidence)
+			assert.Equal(t, ErrInvalidEvidence.Error(), err.Error())
+		})
+	}
+}
+
+func resolveControllerRevisionActiveProjectionFixture(
+	t *testing.T,
+) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	t.Helper()
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	revision := projectionRevision(t, "revision-uid", "gpu-runtime", liveSpec)
+	return resolveProjectionWithRevisionClient(
+		t, k8sfake.NewSimpleClientset(revision.DeepCopy()), liveSpec, revision.Name, nil,
+	)
+}
+
 func pointerTo[T any](value T) *T {
 	return &value
 }
 
 func resolveLiveProjectionFixture(t *testing.T) (*v1beta1.InferenceService, *effective.RuntimeState) {
+	return resolveLiveProjectionFixtureWithIdentity(t, "isvc-uid", "secret-isvc-resource-version")
+}
+
+func resolveLiveProjectionFixtureWithIdentity(
+	t *testing.T,
+	uid, resourceVersion string,
+) (*v1beta1.InferenceService, *effective.RuntimeState) {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1beta1.AddToScheme(scheme))
@@ -272,7 +425,8 @@ func resolveLiveProjectionFixture(t *testing.T) (*v1beta1.InferenceService, *eff
 	mode := constants.OMENative
 	isvc := &v1beta1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "chat", Namespace: "workloads", UID: "isvc-uid", Generation: 7,
+			Name: "chat", Namespace: "workloads", UID: types.UID(uid), Generation: 7,
+			ResourceVersion: resourceVersion,
 		},
 		Spec: v1beta1.InferenceServiceSpec{
 			DeploymentMode: &mode,

--- a/pkg/cli/runtimeprojection/security_test.go
+++ b/pkg/cli/runtimeprojection/security_test.go
@@ -1,0 +1,324 @@
+package runtimeprojection
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	knapis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestProjectionRenderingIsIndependentOfHistoryListOrder(t *testing.T) {
+	liveSpec := projectionRuntimeSpec("private.registry/live:secret")
+	active := projectionRevision(t, "active-uid", "gpu-runtime", liveSpec)
+	active.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 31, 19, 0, 0, 0, time.UTC))
+	older := projectionRevision(t, "older-uid", "gpu-runtime", projectionRuntimeSpec("private.registry/older:secret"))
+	older.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 30, 19, 0, 0, 0, time.UTC))
+
+	firstClient := projectionClientWithHistoryOrder(active, older, []appsv1.ControllerRevision{
+		*active.DeepCopy(), *active.DeepCopy(), *older.DeepCopy(),
+	})
+	secondClient := projectionClientWithHistoryOrder(active, older, []appsv1.ControllerRevision{
+		*older.DeepCopy(), *active.DeepCopy(), *active.DeepCopy(),
+	})
+
+	firstISVC, firstState := resolveProjectionWithRevisionClient(t, firstClient, liveSpec, active.Name, nil)
+	secondISVC, secondState := resolveProjectionWithRevisionClient(t, secondClient, liveSpec, active.Name, nil)
+	firstEffective, err := ProjectEffective(firstISVC, firstState, projectionTestClock)
+	require.NoError(t, err)
+	secondEffective, err := ProjectEffective(secondISVC, secondState, projectionTestClock)
+	require.NoError(t, err)
+	firstHistory, err := ProjectHistory(firstISVC, firstState, projectionTestClock)
+	require.NoError(t, err)
+	secondHistory, err := ProjectHistory(secondISVC, secondState, projectionTestClock)
+	require.NoError(t, err)
+
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		assert.Equal(t, renderProjectionDocument(t, format, firstEffective), renderProjectionDocument(t, format, secondEffective))
+		assert.Equal(t, renderProjectionDocument(t, format, firstHistory), renderProjectionDocument(t, format, secondHistory))
+	}
+}
+
+func TestRuntimeProjectionDoesNotLeakOrMutatePrivateEvidence(t *testing.T) {
+	isvc, state, canaries := resolveProjectionLeakCanaryFixture(t)
+	isvcBefore := isvc.DeepCopy()
+	stateBefore := snapshotProjectionState(state)
+
+	effectiveReport, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	historyReport, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+
+	require.Equal(t, isvcBefore, isvc)
+	require.True(t, reflect.DeepEqual(stateBefore, snapshotProjectionState(state)), "projection mutated collector evidence")
+	require.NotEmpty(t, historyReport.Content.Revisions)
+	require.Contains(t, historyReport.Content.Issues, reportv1alpha1.RuntimeIssue{
+		Code: reportv1alpha1.RuntimeIssueHistoryUnavailable,
+	})
+	require.Contains(t, historyReport.Warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningPartialData})
+	require.Contains(t, historyReport.Warnings, reportv1alpha1.RuntimeWarning{Code: reportv1alpha1.WarningSourceUnavailable})
+
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		outputs := []string{
+			renderProjectionDocument(t, format, effectiveReport),
+			renderProjectionDocument(t, format, historyReport),
+		}
+		for _, output := range outputs {
+			for _, canary := range canaries {
+				assert.NotContains(t, output, canary, "private evidence leaked in %s output", format)
+			}
+		}
+	}
+	for _, format := range []report.Format{report.FormatJSON, report.FormatYAML} {
+		combined := renderProjectionDocument(t, format, effectiveReport) + renderProjectionDocument(t, format, historyReport)
+		for _, forbiddenField := range []string{
+			"resourceVersion", "lastRuntimeSyncToken", "annotations", "labels", "continue", "message",
+		} {
+			assert.NotContains(t, strings.ToLower(combined), strings.ToLower(forbiddenField))
+		}
+	}
+
+	baselineEffective, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	baselineHistory, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	effectiveReport.Sources[0].Name = "mutated-output"
+	effectiveReport.Content.Inheritance.Sources[0].Name = "mutated-output"
+	if effectiveReport.Content.Active.Revision != nil {
+		effectiveReport.Content.Active.Revision.Name = "mutated-output"
+	}
+	historyReport.Sources[0].Name = "mutated-output"
+	historyReport.Content.Revisions[0].Roles[0] = reportv1alpha1.RuntimeRevisionRole("mutated-output")
+	if historyReport.Content.Revisions[0].Revision.CreatedAt != nil {
+		*historyReport.Content.Revisions[0].Revision.CreatedAt = time.Time{}
+	}
+
+	afterEffective, err := ProjectEffective(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	afterHistory, err := ProjectHistory(isvc, state, projectionTestClock)
+	require.NoError(t, err)
+	assert.Equal(t, baselineEffective, afterEffective, "mutating projected output must not alias collector input")
+	assert.Equal(t, baselineHistory, afterHistory, "mutating projected output must not alias collector input")
+}
+
+func projectionClientWithHistoryOrder(
+	active, older *appsv1.ControllerRevision,
+	items []appsv1.ControllerRevision,
+) *k8sfake.Clientset {
+	clientset := k8sfake.NewSimpleClientset(active.DeepCopy(), older.DeepCopy())
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		copied := make([]appsv1.ControllerRevision, len(items))
+		for i := range items {
+			copied[i] = *items[i].DeepCopy()
+		}
+		return true, &appsv1.ControllerRevisionList{Items: copied}, nil
+	})
+	return clientset
+}
+
+func resolveProjectionLeakCanaryFixture(
+	t *testing.T,
+) (*v1beta1.InferenceService, *effective.RuntimeState, []string) {
+	t.Helper()
+	const (
+		isvcResourceVersion = "CANARY_ISVC_RESOURCE_VERSION"
+		isvcAnnotationValue = "CANARY_ISVC_ANNOTATION_VALUE"
+		syncToken           = "CANARY_SYNC_TOKEN"
+		conditionReason     = "CANARY_CONDITION_REASON"
+		conditionMessage    = "CANARY_CONDITION_MESSAGE"
+		runtimeResourceVer  = "CANARY_RUNTIME_RESOURCE_VERSION"
+		runtimeLabelValue   = "CANARY_RUNTIME_LABEL_VALUE"
+		runtimeAnnotation   = "CANARY_RUNTIME_ANNOTATION_VALUE"
+		image               = "CANARY_PRIVATE_IMAGE"
+		command             = "CANARY_PRIVATE_COMMAND"
+		argument            = "CANARY_PRIVATE_ARGUMENT"
+		environmentValue    = "CANARY_PRIVATE_ENV_VALUE"
+		secretReference     = "CANARY_SECRET_REFERENCE"
+		rawMapKey           = "CANARY_RAW_MAP_KEY"
+		rawMapValue         = "CANARY_RAW_MAP_VALUE"
+		revisionResourceVer = "CANARY_REVISION_RESOURCE_VERSION"
+		revisionLabelValue  = "CANARY_REVISION_LABEL_VALUE"
+		revisionAnnotation  = "CANARY_REVISION_ANNOTATION_VALUE"
+		continueToken       = "CANARY_CONTINUE_TOKEN"
+		listError           = "CANARY_LIST_ERROR"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	liveSpec := projectionRuntimeSpec(image)
+	liveSpec.EngineConfig.Runner.Command = []string{command}
+	liveSpec.EngineConfig.Runner.Args = []string{argument}
+	liveSpec.EngineConfig.Runner.Env = []corev1.EnvVar{
+		{Name: "PRIVATE_LITERAL", Value: environmentValue},
+		{
+			Name: "PRIVATE_REFERENCE",
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretReference}, Key: "token",
+			}},
+		},
+	}
+	liveSpec.EngineConfig.Volumes = []corev1.Volume{{
+		Name: "private-volume",
+		VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+			SecretName: secretReference,
+		}},
+	}}
+	liveSpec.RouterConfig = &v1beta1.RouterSpec{Config: map[string]string{rawMapKey: rawMapValue}}
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-runtime", UID: "runtime-uid", Generation: 5, ResourceVersion: runtimeResourceVer,
+			Labels:      map[string]string{"private-label": runtimeLabelValue},
+			Annotations: map[string]string{"private-annotation": runtimeAnnotation},
+		},
+		Spec: *liveSpec.DeepCopy(),
+	}
+	liveClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeObject).Build()
+	revision := projectionRevision(t, "revision-uid", runtimeObject.Name, liveSpec)
+	revision.CreationTimestamp = metav1.NewTime(time.Date(2026, time.August, 31, 19, 0, 0, 0, time.UTC))
+	revision.ResourceVersion = revisionResourceVer
+	revision.Labels["private-label"] = revisionLabelValue
+	revision.Annotations["private-annotation"] = revisionAnnotation
+	clientset := k8sfake.NewSimpleClientset(revision.DeepCopy())
+	listCalls := 0
+	clientset.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		listCalls++
+		if listCalls == 1 {
+			return true, &appsv1.ControllerRevisionList{
+				ListMeta: metav1.ListMeta{Continue: continueToken},
+				Items:    []appsv1.ControllerRevision{*revision.DeepCopy()},
+			}, nil
+		}
+		return true, nil, errors.New(listError)
+	})
+	autoSync := false
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "workloads", UID: types.UID("isvc-uid"), Generation: 7,
+			ResourceVersion: isvcResourceVersion,
+			Annotations: map[string]string{
+				constants.RuntimeSyncAnnotationKey: syncToken,
+				"private-annotation":               isvcAnnotationValue,
+			},
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeObject.Name, AutoSync: &autoSync},
+			Engine: &v1beta1.EngineSpec{Runner: &v1beta1.RunnerSpec{Container: corev1.Container{
+				Name: "runner", Env: []corev1.EnvVar{{Name: "ISVC_PRIVATE", Value: environmentValue}},
+			}}},
+		},
+	}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.PinnedRevisionName = revision.Name
+	isvc.Status.LastRuntimeSyncToken = syncToken
+	isvc.Status.Conditions = duckv1.Conditions{{
+		Type: knapis.ConditionType(constants.RuntimeDriftedConditionType), Status: corev1.ConditionUnknown,
+		Reason: conditionReason, Message: conditionMessage,
+	}}
+	resolver, err := effective.NewRuntimePinResolver(
+		clientset.AppsV1(), effective.NewRuntimeResolver(liveClient), "ome-system",
+		paging.Limits{PageSize: 1, MaxItems: 2, MaxPages: 2, RequestTimeout: time.Second},
+	)
+	require.NoError(t, err)
+	state, err := resolver.Resolve(t.Context(), isvc, effective.RuntimeResolveOptions{IncludeHistory: true})
+	require.NoError(t, err)
+	require.Equal(t, 2, listCalls)
+
+	return isvc, state, []string{
+		isvcResourceVersion, isvcAnnotationValue, syncToken, conditionReason, conditionMessage,
+		runtimeResourceVer, runtimeLabelValue, runtimeAnnotation, image, command, argument,
+		environmentValue, secretReference, rawMapKey, rawMapValue, revisionResourceVer,
+		revisionLabelValue, revisionAnnotation, continueToken, listError,
+	}
+}
+
+type projectionStateSnapshot struct {
+	Generation              int64
+	ObservedGeneration      int64
+	RuntimeName             string
+	RuntimeKind             string
+	RuntimeNamespace        string
+	DeclaredSourceKind      string
+	DeclaredSourceNamespace string
+	SelectionSource         effective.RuntimeSelectionSource
+	PinMode                 effective.RuntimePinMode
+	PinState                effective.RuntimePinState
+	RequestedRevisionName   string
+	ReportedRevisionName    string
+	ActiveRevisionName      string
+	StatusFreshness         effective.StatusFreshness
+	SyncTokenState          effective.SyncTokenState
+	DriftState              effective.RuntimeDriftState
+	DriftReason             effective.RuntimeDriftReason
+	LiveToActive            effective.RuntimeHashRelation
+	LiveShortHash           string
+	HistoryRequested        bool
+	HistoryPages            int
+	HistoryPageLimit        int
+	HistoryRequestedPages   int
+	HistoryObservedPages    int
+	HistoryComplete         bool
+	HistoryTruncated        bool
+	HistoryNamespace        string
+	LiveAvailability        effective.LiveRuntimeAvailability
+	Identity                effective.InferenceServiceIdentity
+	Live                    *effective.LiveConfiguration
+	Active                  *effective.ActiveConfiguration
+	Revisions               []effective.RuntimeRevisionObservation
+	Issues                  []effective.RuntimeSourceIssue
+}
+
+func snapshotProjectionState(state *effective.RuntimeState) projectionStateSnapshot {
+	active, _ := state.RequireActive()
+	return projectionStateSnapshot{
+		Generation: state.Generation, ObservedGeneration: state.ObservedGeneration,
+		RuntimeName: state.RuntimeName, RuntimeKind: state.RuntimeKind, RuntimeNamespace: state.RuntimeNamespace,
+		DeclaredSourceKind: state.DeclaredSourceKind, DeclaredSourceNamespace: state.DeclaredSourceNamespace,
+		SelectionSource: state.SelectionSource, PinMode: state.PinMode, PinState: state.PinState,
+		RequestedRevisionName: state.RequestedRevisionName, ReportedRevisionName: state.ReportedRevisionName,
+		ActiveRevisionName: state.ActiveRevisionName, StatusFreshness: state.StatusFreshness,
+		SyncTokenState: state.SyncTokenState, DriftState: state.DriftState, DriftReason: state.DriftReason,
+		LiveToActive: state.LiveToActive, LiveShortHash: state.LiveShortHash,
+		HistoryRequested: state.HistoryRequested, HistoryPages: state.HistoryPages,
+		HistoryPageLimit: state.HistoryPageLimit, HistoryRequestedPages: state.HistoryRequestedPages,
+		HistoryObservedPages: state.HistoryObservedPages, HistoryComplete: state.HistoryComplete,
+		HistoryTruncated: state.HistoryTruncated, HistoryNamespace: state.HistoryNamespace(),
+		LiveAvailability: state.LiveAvailability(), Identity: state.InferenceServiceIdentity(),
+		Live: state.LiveConfiguration(), Active: active, Revisions: state.RevisionObservations(), Issues: state.SourceIssues(),
+	}
+}
+
+func renderProjectionDocument[T report.Document[T]](t *testing.T, format report.Format, document T) string {
+	t.Helper()
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, format, document))
+	return output.String()
+}
+
+func setMalformedProjectionDrift(isvc *v1beta1.InferenceService) {
+	condition := knapis.Condition{
+		Type: knapis.ConditionType(constants.RuntimeDriftedConditionType), Status: corev1.ConditionTrue,
+		Reason: string(effective.RuntimeDriftReasonRevisionMismatch),
+	}
+	isvc.Status.Conditions = duckv1.Conditions{condition, condition}
+}

--- a/pkg/cli/runtimeprojection/security_test.go
+++ b/pkg/cli/runtimeprojection/security_test.go
@@ -3,7 +3,6 @@ package runtimeprojection
 import (
 	"bytes"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -71,7 +70,7 @@ func TestRuntimeProjectionDoesNotLeakOrMutatePrivateEvidence(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, isvcBefore, isvc)
-	require.True(t, reflect.DeepEqual(stateBefore, snapshotProjectionState(state)), "projection mutated collector evidence")
+	require.Equal(t, stateBefore, snapshotProjectionState(state), "projection mutated collector evidence")
 	require.NotEmpty(t, historyReport.Content.Revisions)
 	require.Contains(t, historyReport.Content.Issues, reportv1alpha1.RuntimeIssue{
 		Code: reportv1alpha1.RuntimeIssueHistoryUnavailable,


### PR DESCRIPTION
## What this PR does

Adds the safe projection layer that converts the controller-faithful runtime
evidence from #822 into the typed effective and history report contracts from
#821.

The new `pkg/cli/runtimeprojection` package exposes two read-only entry points:

- `ProjectEffective` builds the live-versus-active configuration report; and
- `ProjectHistory` builds the bounded ControllerRevision provenance report.

Both projectors require an InferenceService and a `RuntimeState` captured for
that same name, namespace, UID, generation, status, spec, and private resource
version. They reject cross-object, cross-generation, cross-snapshot, and
internally contradictory evidence instead of constructing a plausible-looking
report.

The projection covers:

- live, active, requested, reported, and history revision roles;
- AutoSync, ManagedPin, ExplicitPin, and invalid declared pin intent;
- awaiting, resolved, missing, disabled, invalid, and unavailable pins;
- runtime inheritance, component deployment modes, and mode provenance;
- synchronization, status freshness, reported drift, and live relation;
- complete, retention-bounded, partial, unavailable, and truncated history;
- exact GET evidence that remains useful when the optional history LIST fails;
- duplicate identity/content, conflicting identity, hash mismatch/collision,
  source mismatch, malformed payload, and bounded collection anomalies; and
- controller-faithful disabled/unreadable live behavior, where no retained pin
  is presented as active.

The effective report deliberately excludes observations whose only role is
history. When an observation is Active, Requested, or Reported as well as
History, its collection anomaly remains visible. History page counts, bounds,
LIST outcomes, active revision names, pin states, verified hashes, and source
relationships are checked together so copied or mutated evidence fails closed.

No command is wired in this projection PR, so current CLI stdout does not
change. The exact relevant output remains:

```text
$ kubectl ome runtime --help
Inspect OME runtime selection

Usage:
  ome runtime [command]

Available Commands:
  explain     Explain which serving runtimes match a model and why
```

The projection now produces the following exact representative effective
table for the later `runtime effective` command wiring:

```text
VIEW     STATE       REASON   RUNTIME                              REVISION     HASH       COMPONENT   MODE                MODE-SOURCE           PIN          PIN-STATE   SYNC      STATUS   DRIFT                      LIVE-RELATION   ISSUES
Live     Available   -        ServingRuntime/prod/vllm             -            11223344   engine      RawDeployment       Default               ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale
Live     Available   -        ServingRuntime/prod/vllm             -            11223344   decoder     MultiNode           LeaderWorkerShape     ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale
Live     Available   -        ServingRuntime/prod/vllm             -            11223344   router      VirtualDeployment   ServiceSpec           ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale
Active   Available   -        ClusterServingRuntime/cluster-vllm   revision-a   aabbccdd   engine      OMENative           ComponentAnnotation   ManagedPin   Resolved    Pending   Stale    ReportedTrue/PinAdvanced   Different       RevisionHashMismatch(revision-a),StatusStale
```

The exact representative history table is:

```text
OBSERVATION   COMPLETENESS   PAGES   REVISION       CREATED                HASH       ROLES                               SOURCE                     CONSISTENCY    RELATION          REVISION-ISSUES                            REPORT-ISSUES
Partial       Incomplete     2/3     revision-a     2026-08-31T18:20:00Z   aaaaaaaa   Active,Requested,Reported,History   ServingRuntime/prod/vllm   Inconsistent   MatchesLive       RevisionHashInvalid,RevisionNameMismatch   HistoryTruncated,RevisionHashCollision(revision-b)
Partial       Incomplete     2/3     revision-b     2026-08-31T18:20:00Z   bbbbbbbb   History                             ServingRuntime/prod/vllm   Inconsistent   DiffersFromLive   RevisionSourceMismatch                     HistoryTruncated,RevisionHashCollision(revision-b)
Partial       Incomplete     2/3     revision-old   2026-08-31T18:10:00Z   -          -                                   -                          Unknown        Unknown           -                                          HistoryTruncated,RevisionHashCollision(revision-b)
```

These tables are generated from the typed projection/report APIs and pinned by
tests. They are not claimed as a newly available command in this PR. JSON and
YAML use the same canonical `RuntimeEffectiveReport` and
`RuntimeHistoryReport` objects, with non-nil arrays and deterministic ordering.

## Why we need it

OME can serve a retained ControllerRevision while the live runtime changes,
disappears, is disabled, or is temporarily unreadable. A report assembled
directly from one API field can therefore claim the wrong active configuration
or hide the reason evidence is incomplete.

This layer gives command wiring one validated boundary between internal runtime
specs and public operational output. It also prevents a diagnostic command from
silently joining evidence from different InferenceService snapshots or treating
forged counters and enum combinations as controller output.

The public reports intentionally omit runtime specs, pod configuration, images,
commands, environment values, Secret references, raw ControllerRevision data,
resource versions, continuation tokens, annotations, labels, synchronization
tokens, raw API errors, and arbitrary condition messages. Unknown declared
runtime kinds collapse to `InvalidDeclaredKind`; the raw hostile value is never
rendered.

Fixes: N/A; this implements the projection foundation in OEP-0011.1.

## How to test

```shell
go test -count=1 ./pkg/cli/... ./cmd/kubectl-ome/...
go test -race -count=1 ./pkg/cli/... ./cmd/kubectl-ome/...
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
go test -cover -count=1 ./pkg/cli/runtimeprojection
```

The runtime projection package has 89.7% statement coverage. The final tree
also passes the host build and `CGO_ENABLED=0` builds for Linux, Darwin, and
Windows on amd64 and arm64.

Focused coverage includes:

- resolver-produced auto, managed, explicit, invalid-kind, disabled,
  unreadable, missing, nil GET/LIST, and retained-pin states;
- exact/list role joining and complete, partial, unavailable, truncated, and
  non-advancing history collection;
- page-limit, LIST-failure, active-revision, pin-state, hash, freshness, sync,
  drift, source, and live-relation contradiction matrices;
- deterministic rendering across history permutations;
- defensive-copy and input-nonmutation checks; and
- table, JSON, and YAML leak canaries repeated across the full private runtime
  spec, revision payload, errors, metadata, and synchronization evidence.

## Checklist

- [x] Tests added/updated
- [x] Docs updated (N/A: command documentation lands with command wiring; the
  current CLI surface is unchanged and exact future report output is included
  above)
- [ ] `make test` passes locally

The complete scoped CLI suite, race detector, vet, coverage run, host build,
six cross-builds, formatting, diff check, DCO identity check, and independent
code review pass. Required repository CI remains the authoritative full-suite
gate.
