### PR TITLE
[Core] Add rollout status command

### DIFF
--- a/pkg/cli/cmd/rollout/rollout.go
+++ b/pkg/cli/cmd/rollout/rollout.go
@@ -1,0 +1,113 @@
+// Package rollout implements read-only rollout inspection commands.
+package rollout
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/apierror"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/cli/rolloutprojection"
+)
+
+var (
+	// ErrReturnedInferenceServiceNameMismatch rejects a response that is not
+	// bound to the requested resource name.
+	ErrReturnedInferenceServiceNameMismatch = errors.New("returned inference service name does not match request")
+	// ErrReturnedInferenceServiceNamespaceMismatch rejects a response that is
+	// not bound to the resolved request namespace.
+	ErrReturnedInferenceServiceNamespaceMismatch = errors.New("returned inference service namespace does not match request")
+	// ErrInvalidInferenceServiceName rejects an invalid local resource identity
+	// without copying the hostile value into user-visible output.
+	ErrInvalidInferenceServiceName = errors.New("inference service name is invalid")
+)
+
+// NewCmd builds the rollout command family.
+func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	return newCmdWithClock(f, streams, reportv1alpha1.SystemClock{})
+}
+
+func newCmdWithClock(
+	f factory.Factory,
+	streams genericiooptions.IOStreams,
+	clock reportv1alpha1.Clock,
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rollout",
+		Short: "Inspect InferenceService rollouts",
+	}
+	cmd.AddCommand(newStatusCmd(f, streams, clock))
+	return cmd
+}
+
+type statusOptions struct {
+	streams genericiooptions.IOStreams
+	output  string
+	clock   reportv1alpha1.Clock
+}
+
+func newStatusCmd(
+	f factory.Factory,
+	streams genericiooptions.IOStreams,
+	clock reportv1alpha1.Clock,
+) *cobra.Command {
+	options := &statusOptions{streams: streams, clock: clock}
+	cmd := &cobra.Command{
+		Use:   "status INFERENCESERVICE",
+		Short: "Show rollout progress for an InferenceService",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := report.ParseFormat(options.output)
+			if err != nil {
+				return err
+			}
+			return options.run(cmd.Context(), f, args[0], format)
+		},
+	}
+	cmd.Flags().StringVarP(&options.output, "output", "o", "table", "Output format: table, json, or yaml")
+	return cmd
+}
+
+func (o *statusOptions) run(
+	ctx context.Context,
+	f factory.Factory,
+	name string,
+	format report.Format,
+) error {
+	if problems := utilvalidation.IsDNS1123Subdomain(name); len(problems) > 0 {
+		return ErrInvalidInferenceServiceName
+	}
+	namespace, _, err := f.Namespace()
+	if err != nil {
+		return err
+	}
+	client, err := f.OMEClient()
+	if err != nil {
+		return err
+	}
+	isvc, err := client.OmeV1beta1().InferenceServices(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return apierror.Friendly(err)
+	}
+	if isvc == nil {
+		return rolloutprojection.ErrNilInferenceService
+	}
+	if isvc.Name != name {
+		return ErrReturnedInferenceServiceNameMismatch
+	}
+	if isvc.Namespace != namespace {
+		return ErrReturnedInferenceServiceNamespaceMismatch
+	}
+	reportValue, err := rolloutprojection.Project(isvc, o.clock)
+	if err != nil {
+		return err
+	}
+	return report.Write(o.streams.Out, format, reportValue)
+}

--- a/pkg/cli/cmd/rollout/rollout_test.go
+++ b/pkg/cli/cmd/rollout/rollout_test.go
@@ -1,0 +1,402 @@
+package rollout
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	k8stesting "k8s.io/client-go/testing"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/ome/pkg/client/clientset/versioned"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/cli/rolloutprojection"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestStatusRejectsOutputBeforeNamespaceOrClient(t *testing.T) {
+	f := &trackingFactory{}
+	_, err := execute(t, f, fixedClock(), "status", "chat", "-o", "wide")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "supported: table, json, yaml")
+	assert.Zero(t, f.namespaceCalls)
+	assert.Zero(t, f.omeCalls)
+}
+
+func TestStatusRequiresExactlyOneInferenceServiceBeforeReads(t *testing.T) {
+	f := &trackingFactory{}
+	_, err := execute(t, f, fixedClock(), "status")
+
+	require.Error(t, err)
+	assert.Zero(t, f.namespaceCalls)
+	assert.Zero(t, f.omeCalls)
+}
+
+func TestStatusRejectsInvalidInferenceServiceNameBeforeReads(t *testing.T) {
+	for _, name := range []string{"", "   ", "bad/name", "UpperCase"} {
+		t.Run(name, func(t *testing.T) {
+			f := &trackingFactory{}
+			output, err := execute(t, f, fixedClock(), "status", name)
+
+			require.ErrorIs(t, err, ErrInvalidInferenceServiceName)
+			assert.Empty(t, output)
+			assert.Zero(t, f.namespaceCalls)
+			assert.Zero(t, f.omeCalls)
+			if name != "" {
+				assert.NotContains(t, err.Error(), name)
+			}
+		})
+	}
+}
+
+func TestStatusPerformsExactlyOneInferenceServiceGet(t *testing.T) {
+	isvc := minimalInferenceService()
+	client := omefake.NewSimpleClientset(isvc)
+	f := factory.Static{OME: client, NS: "prod"}
+
+	output, err := execute(t, f, fixedClock(), "status", "chat")
+	require.NoError(t, err)
+	assert.Equal(t,
+		"STATE           REPORTED-STATE   EVIDENCE   EPOCH           GROUP   STRATEGY   GROUP-PHASE   CURRENT-COMPONENT   PREVIOUS-COMPONENT   COMPONENT   COMPONENT-PHASE   STEP   GATE   CAPACITY   TARGET-TRAFFIC   OBSERVED-TRAFFIC   ROLLED-OUT   READY   PREVIOUS   ISSUES\n"+
+			"NotConfigured   NotConfigured    Declared   NotApplicable   -       -          -             -                   -                    -           -                 -      -      -          -                -                  -            -       -          -\n",
+		output,
+	)
+	require.Len(t, client.Actions(), 1)
+	action := client.Actions()[0]
+	assert.Equal(t, "get", action.GetVerb())
+	assert.Equal(t, "inferenceservices", action.GetResource().Resource)
+	assert.Equal(t, "prod", action.GetNamespace())
+}
+
+func TestStatusRejectsUnboundInferenceServiceResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.InferenceService)
+		want   error
+	}{
+		{name: "returned name mismatch", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Name = "other"
+		}, want: ErrReturnedInferenceServiceNameMismatch},
+		{name: "returned namespace mismatch", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Namespace = "other"
+		}, want: ErrReturnedInferenceServiceNamespaceMismatch},
+		{name: "returned uid absent", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.UID = ""
+		}, want: rolloutprojection.ErrSubjectUIDRequired},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			returned := minimalInferenceService()
+			tt.mutate(returned)
+			client := omefake.NewSimpleClientset()
+			client.PrependReactor("get", "inferenceservices", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, returned.DeepCopy(), nil
+			})
+
+			output, err := execute(
+				t,
+				factory.Static{OME: client, NS: "prod"},
+				fixedClock(),
+				"status", "chat",
+			)
+
+			require.ErrorIs(t, err, tt.want)
+			assert.Empty(t, output)
+			require.Len(t, client.Actions(), 1)
+			assert.Equal(t, "get", client.Actions()[0].GetVerb())
+		})
+	}
+}
+
+func TestStatusWritesExactJSON(t *testing.T) {
+	client := omefake.NewSimpleClientset(minimalInferenceService())
+	output, err := execute(t, factory.Static{OME: client, NS: "prod"}, fixedClock(), "status", "chat", "-o", "json")
+
+	require.NoError(t, err)
+	assert.Equal(t, `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "RolloutStatusReport",
+  "metadata": {
+    "namespace": "prod",
+    "name": "chat"
+  },
+  "collectedAt": "2026-08-31T18:30:00Z",
+  "sources": [
+    {
+      "kind": "InferenceService",
+      "namespace": "prod",
+      "name": "chat",
+      "uid": "isvc-uid",
+      "generation": 7,
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T18:30:00Z"
+    }
+  ],
+  "content": {
+    "summary": {
+      "state": "NotConfigured",
+      "reportedState": "NotConfigured",
+      "evidence": "Declared",
+      "epoch": "NotApplicable",
+      "coordinationReady": "NotApplicable"
+    },
+    "groups": [],
+    "components": [],
+    "issues": []
+  },
+  "warnings": []
+}
+`, output)
+}
+
+func TestStatusWritesExactYAML(t *testing.T) {
+	client := omefake.NewSimpleClientset(minimalInferenceService())
+	output, err := execute(t, factory.Static{OME: client, NS: "prod"}, fixedClock(), "status", "chat", "-o", "yaml")
+
+	require.NoError(t, err)
+	assert.Equal(t, `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T18:30:00Z"
+content:
+  components: []
+  groups: []
+  issues: []
+  summary:
+    coordinationReady: NotApplicable
+    epoch: NotApplicable
+    evidence: Declared
+    reportedState: NotConfigured
+    state: NotConfigured
+kind: RolloutStatusReport
+metadata:
+  name: chat
+  namespace: prod
+sources:
+- collectedAt: "2026-08-31T18:30:00Z"
+  evidence: Observed
+  generation: 7
+  kind: InferenceService
+  name: chat
+  namespace: prod
+  uid: isvc-uid
+warnings: []
+`, output)
+}
+
+func TestStatusWritesExactIndependentFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{
+			name: "table",
+			want: "STATE     REPORTED-STATE   EVIDENCE   EPOCH          GROUP   STRATEGY      GROUP-PHASE   CURRENT-COMPONENT   PREVIOUS-COMPONENT   COMPONENT   COMPONENT-PHASE   STEP   GATE   CAPACITY   TARGET-TRAFFIC   OBSERVED-TRAFFIC   ROLLED-OUT   READY   PREVIOUS   ISSUES\n" +
+				"Unknown   Succeeded        Reported   Unverifiable   -       Independent   -             -                   -                    engine      Stable            -      -      -          -                -                  -            -       -          EpochUnverifiable\n",
+		},
+		{
+			name: "json", format: "json",
+			want: `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "RolloutStatusReport",
+  "metadata": {
+    "namespace": "prod",
+    "name": "chat"
+  },
+  "collectedAt": "2026-08-31T18:30:00Z",
+  "sources": [
+    {
+      "kind": "InferenceService",
+      "namespace": "prod",
+      "name": "chat",
+      "uid": "isvc-uid",
+      "generation": 7,
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T18:30:00Z"
+    }
+  ],
+  "content": {
+    "summary": {
+      "state": "Unknown",
+      "reportedState": "Succeeded",
+      "evidence": "Reported",
+      "epoch": "Unverifiable",
+      "coordinationReady": "NotApplicable"
+    },
+    "groups": [],
+    "components": [
+      {
+        "type": "engine",
+        "strategy": "Independent",
+        "phase": "Stable",
+        "traffic": []
+      }
+    ],
+    "issues": [
+      {
+        "code": "EpochUnverifiable"
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "code": "PartialData"
+    }
+  ]
+}
+`,
+		},
+		{
+			name: "yaml", format: "yaml",
+			want: `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T18:30:00Z"
+content:
+  components:
+  - phase: Stable
+    strategy: Independent
+    traffic: []
+    type: engine
+  groups: []
+  issues:
+  - code: EpochUnverifiable
+  summary:
+    coordinationReady: NotApplicable
+    epoch: Unverifiable
+    evidence: Reported
+    reportedState: Succeeded
+    state: Unknown
+kind: RolloutStatusReport
+metadata:
+  name: chat
+  namespace: prod
+sources:
+- collectedAt: "2026-08-31T18:30:00Z"
+  evidence: Observed
+  generation: 7
+  kind: InferenceService
+  name: chat
+  namespace: prod
+  uid: isvc-uid
+warnings:
+- code: PartialData
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := omefake.NewSimpleClientset(independentInferenceService())
+			args := []string{"status", "chat"}
+			if tt.format != "" {
+				args = append(args, "-o", tt.format)
+			}
+			output, err := execute(t, factory.Static{OME: client, NS: "prod"}, fixedClock(), args...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, output)
+		})
+	}
+}
+
+func TestStatusReturnsFriendlyGetError(t *testing.T) {
+	output, err := execute(t, factory.Static{OME: omefake.NewSimpleClientset(), NS: "prod"}, fixedClock(), "status", "missing")
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "not found")
+	assert.Empty(t, output)
+}
+
+func TestRolloutCommandLocalHelpIsExact(t *testing.T) {
+	var output bytes.Buffer
+	cmd := NewCmd(factory.Static{NS: "prod"}, genericiooptions.IOStreams{Out: &output, ErrOut: &output})
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"status", "--help"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, `Show rollout progress for an InferenceService
+
+Usage:
+  rollout status INFERENCESERVICE [flags]
+
+Flags:
+  -h, --help            help for status
+  -o, --output string   Output format: table, json, or yaml (default "table")
+`, output.String())
+}
+
+func execute(t *testing.T, f factory.Factory, clock reportv1alpha1.Clock, args ...string) (string, error) {
+	t.Helper()
+	var output bytes.Buffer
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &output, ErrOut: &output}
+	cmd := newCmdWithClock(f, streams, clock)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return output.String(), err
+}
+
+func minimalInferenceService() *omev1beta1.InferenceService {
+	return &omev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod", Name: "chat", UID: "isvc-uid", Generation: 7,
+			ResourceVersion: "SECRET_RESOURCE_VERSION",
+			Annotations:     map[string]string{"ome.io/rollout-promote": "SECRET_MAILBOX"},
+		},
+		Status: omev1beta1.InferenceServiceStatus{
+			Status: duckv1.Status{
+				ObservedGeneration: 7,
+				Annotations:        map[string]string{"secret": "SECRET_STATUS_ANNOTATION"},
+			},
+			LastRuntimeSyncToken: "SECRET_SYNC_TOKEN",
+		},
+	}
+}
+
+func independentInferenceService() *omev1beta1.InferenceService {
+	isvc := minimalInferenceService()
+	mode := constants.OMENative
+	isvc.Spec.DeploymentMode = &mode
+	isvc.Spec.Engine = &omev1beta1.EngineSpec{}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			Lifecycle: &omev1beta1.LifecycleStatus{
+				CurrentRevision: "chat-engine-aaaaaaaa",
+				UpdateRevision:  "chat-engine-aaaaaaaa",
+			},
+		},
+	}
+	return isvc
+}
+
+func fixedClock() reportv1alpha1.Clock {
+	return reportv1alpha1.ClockFunc(func() time.Time {
+		return time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)
+	})
+}
+
+type trackingFactory struct {
+	factory.Static
+	namespaceCalls int
+	omeCalls       int
+}
+
+func (f *trackingFactory) Namespace() (string, bool, error) {
+	f.namespaceCalls++
+	return "", false, errors.New("namespace must not be called")
+}
+
+func (f *trackingFactory) OMEClient() (versioned.Interface, error) {
+	f.omeCalls++
+	return nil, errors.New("OME client must not be called")
+}

--- a/pkg/cli/report/v1alpha1/rollout_status.go
+++ b/pkg/cli/report/v1alpha1/rollout_status.go
@@ -1,0 +1,841 @@
+package v1alpha1
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+// RolloutStatusReportKind identifies the rollout status report schema.
+const RolloutStatusReportKind = "RolloutStatusReport"
+
+// RolloutSourceKind is the closed set of objects read by rollout status.
+type RolloutSourceKind string
+
+const (
+	// RolloutSourceInferenceService is the single object read by rollout status.
+	RolloutSourceInferenceService RolloutSourceKind = "InferenceService"
+)
+
+// RolloutState is the bounded aggregate state of the reported rollout.
+type RolloutState string
+
+const (
+	RolloutStateUnknown       RolloutState = "Unknown"
+	RolloutStateNotConfigured RolloutState = "NotConfigured"
+	RolloutStateSucceeded     RolloutState = "Succeeded"
+	RolloutStateInProgress    RolloutState = "InProgress"
+	RolloutStatePaused        RolloutState = "Paused"
+	RolloutStateStaged        RolloutState = "Staged"
+	RolloutStateFailed        RolloutState = "Failed"
+	RolloutStateRollingBack   RolloutState = "RollingBack"
+	RolloutStateRolledBack    RolloutState = "RolledBack"
+)
+
+// RolloutEpochState identifies whether a rollout conclusion can be bound to
+// the current InferenceService generation.
+type RolloutEpochState string
+
+const (
+	RolloutEpochNotApplicable RolloutEpochState = "NotApplicable"
+	RolloutEpochUnverifiable  RolloutEpochState = "Unverifiable"
+)
+
+// RolloutStrategy identifies the progression applied to a rollout group.
+type RolloutStrategy string
+
+const (
+	RolloutStrategyUnknown       RolloutStrategy = "Unknown"
+	RolloutStrategyIndependent   RolloutStrategy = "Independent"
+	RolloutStrategyCanary        RolloutStrategy = "Canary"
+	RolloutStrategyBlueGreen     RolloutStrategy = "BlueGreen"
+	RolloutStrategyRollingUpdate RolloutStrategy = "RollingUpdate"
+	RolloutStrategySequential    RolloutStrategy = "Sequential"
+)
+
+// RolloutPhase is the allowlisted union of shipped component and coordination
+// phases. Unknown input is projected as Unknown rather than copied verbatim.
+type RolloutPhase string
+
+const (
+	RolloutPhaseUnknown               RolloutPhase = "Unknown"
+	RolloutPhaseStable                RolloutPhase = "Stable"
+	RolloutPhaseCanarying             RolloutPhase = "Canarying"
+	RolloutPhaseBlueGreenStandby      RolloutPhase = "BlueGreenStandby"
+	RolloutPhasePending               RolloutPhase = "Pending"
+	RolloutPhasePaused                RolloutPhase = "Paused"
+	RolloutPhasePromoting             RolloutPhase = "Promoting"
+	RolloutPhaseRollingBack           RolloutPhase = "RollingBack"
+	RolloutPhaseRolledBack            RolloutPhase = "RolledBack"
+	RolloutPhaseFailed                RolloutPhase = "Failed"
+	RolloutPhaseIdle                  RolloutPhase = "Idle"
+	RolloutPhaseSurging               RolloutPhase = "Surging"
+	RolloutPhaseWaiting               RolloutPhase = "Waiting"
+	RolloutPhaseShifting              RolloutPhase = "Shifting"
+	RolloutPhaseUpdating              RolloutPhase = "Updating"
+	RolloutPhaseDraining              RolloutPhase = "Draining"
+	RolloutPhaseScalingDown           RolloutPhase = "ScalingDown"
+	RolloutPhaseStaged                RolloutPhase = "Staged"
+	RolloutPhaseAwaitingNextComponent RolloutPhase = "AwaitingNextComponent"
+)
+
+// RolloutGate identifies how the active canary step advances.
+type RolloutGate string
+
+const (
+	RolloutGateUnknown   RolloutGate = "Unknown"
+	RolloutGateImmediate RolloutGate = "Immediate"
+	RolloutGateManual    RolloutGate = "Manual"
+	RolloutGateTimed     RolloutGate = "Timed"
+	RolloutGateAnalysis  RolloutGate = "Analysis"
+)
+
+// RolloutAnalysisState is a message-free summary of the latest analysis
+// results. Metric names, values, thresholds, queries, and messages are absent.
+type RolloutAnalysisState string
+
+const (
+	RolloutAnalysisUnobserved   RolloutAnalysisState = "Unobserved"
+	RolloutAnalysisPassing      RolloutAnalysisState = "Passing"
+	RolloutAnalysisFailing      RolloutAnalysisState = "Failing"
+	RolloutAnalysisInconclusive RolloutAnalysisState = "Inconclusive"
+)
+
+// RolloutConditionState is a bounded condition-status projection.
+type RolloutConditionState string
+
+const (
+	RolloutConditionNotApplicable RolloutConditionState = "NotApplicable"
+	RolloutConditionUnobserved    RolloutConditionState = "Unobserved"
+	RolloutConditionTrue          RolloutConditionState = "True"
+	RolloutConditionFalse         RolloutConditionState = "False"
+	RolloutConditionUnknown       RolloutConditionState = "Unknown"
+	RolloutConditionInvalid       RolloutConditionState = "Invalid"
+)
+
+// RolloutRevisionRole identifies a safe revision-hash relation.
+type RolloutRevisionRole string
+
+const (
+	RolloutRevisionCurrent  RolloutRevisionRole = "Current"
+	RolloutRevisionTarget   RolloutRevisionRole = "Target"
+	RolloutRevisionPrevious RolloutRevisionRole = "Previous"
+	RolloutRevisionOther    RolloutRevisionRole = "Other"
+)
+
+// RolloutIssueCode is a stable message-free rollout diagnostic.
+type RolloutIssueCode string
+
+const (
+	RolloutIssueSpecMalformed          RolloutIssueCode = "SpecMalformed"
+	RolloutIssueStatusMalformed        RolloutIssueCode = "StatusMalformed"
+	RolloutIssueGroupStatusMissing     RolloutIssueCode = "GroupStatusMissing"
+	RolloutIssueGroupStatusUnexpected  RolloutIssueCode = "GroupStatusUnexpected"
+	RolloutIssueComponentStatusMissing RolloutIssueCode = "ComponentStatusMissing"
+	RolloutIssueCanaryStatusMissing    RolloutIssueCode = "CanaryStatusMissing"
+	RolloutIssueCanaryStatusUnexpected RolloutIssueCode = "CanaryStatusUnexpected"
+	RolloutIssueCanaryStepInvalid      RolloutIssueCode = "CanaryStepInvalid"
+	RolloutIssueRevisionNameInvalid    RolloutIssueCode = "RevisionNameInvalid"
+	RolloutIssueTrafficInvalid         RolloutIssueCode = "TrafficInvalid"
+	RolloutIssueAnalysisInconclusive   RolloutIssueCode = "AnalysisInconclusive"
+	RolloutIssueEpochUnverifiable      RolloutIssueCode = "EpochUnverifiable"
+)
+
+// RolloutSourceReference is an allowlisted source identity. It intentionally
+// has no ResourceVersion or arbitrary message field.
+type RolloutSourceReference struct {
+	Kind        RolloutSourceKind `json:"kind"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Name        string            `json:"name"`
+	UID         string            `json:"uid,omitempty"`
+	Generation  int64             `json:"generation,omitempty"`
+	Evidence    EvidenceLevel     `json:"evidence"`
+	CollectedAt time.Time         `json:"collectedAt"`
+}
+
+// RolloutWarning is deliberately code-only.
+type RolloutWarning struct {
+	Code WarningCode `json:"code"`
+}
+
+// RolloutSummary is the bounded aggregate of rollout-owned evidence. Evidence
+// and Epoch transitively qualify ReportedState, CoordinationReady, and every
+// status-derived field in Groups and Components.
+type RolloutSummary struct {
+	State             RolloutState          `json:"state"`
+	ReportedState     RolloutState          `json:"reportedState"`
+	Evidence          EvidenceLevel         `json:"evidence"`
+	Epoch             RolloutEpochState     `json:"epoch"`
+	CoordinationReady RolloutConditionState `json:"coordinationReady"`
+}
+
+// RolloutStepStatus is the bounded projection of the active canary step.
+type RolloutStepStatus struct {
+	Index           int32                `json:"index"`
+	Total           int32                `json:"total"`
+	Capacity        string               `json:"capacity"`
+	TargetTraffic   int32                `json:"targetTraffic"`
+	ObservedTraffic int32                `json:"observedTraffic"`
+	Gate            RolloutGate          `json:"gate"`
+	Analysis        RolloutAnalysisState `json:"analysis,omitempty"`
+	EnteredAt       *time.Time           `json:"enteredAt,omitempty"`
+}
+
+// RolloutGroupStatus describes one declared or controller-collapsed group.
+// Status-derived fields are qualified by RolloutSummary.Evidence and Epoch.
+type RolloutGroupStatus struct {
+	Index                int                    `json:"index"`
+	Strategy             RolloutStrategy        `json:"strategy"`
+	Phase                RolloutPhase           `json:"phase"`
+	Components           []RuntimeComponentType `json:"components"`
+	CurrentComponent     RuntimeComponentType   `json:"currentComponent,omitempty"`
+	PreviousComponent    RuntimeComponentType   `json:"previousComponent,omitempty"`
+	ObservedSurge        string                 `json:"observedSurge,omitempty"`
+	StableRevisionHash   string                 `json:"stableRevisionHash,omitempty"`
+	TargetRevisionHash   string                 `json:"targetRevisionHash,omitempty"`
+	RejectedRevisionHash string                 `json:"rejectedRevisionHash,omitempty"`
+	Step                 *RolloutStepStatus     `json:"step,omitempty"`
+	TransitionedAt       *time.Time             `json:"transitionedAt,omitempty"`
+}
+
+// RolloutTrafficTarget identifies a traffic allocation by safe revision hash.
+type RolloutTrafficTarget struct {
+	RevisionHash string              `json:"revisionHash"`
+	Percent      int32               `json:"percent"`
+	Role         RolloutRevisionRole `json:"role"`
+}
+
+// RolloutComponentStatus is the safe per-component rollout observation.
+// Status-derived fields are qualified by RolloutSummary.Evidence and Epoch.
+type RolloutComponentStatus struct {
+	Type                  RuntimeComponentType   `json:"type"`
+	Strategy              RolloutStrategy        `json:"strategy"`
+	Group                 *int                   `json:"group,omitempty"`
+	Phase                 RolloutPhase           `json:"phase"`
+	RolledOutRevisionHash string                 `json:"rolledOutRevisionHash,omitempty"`
+	ReadyRevisionHash     string                 `json:"readyRevisionHash,omitempty"`
+	PreviousRevisionHash  string                 `json:"previousRevisionHash,omitempty"`
+	Traffic               []RolloutTrafficTarget `json:"traffic"`
+}
+
+// RolloutIssue scopes one stable diagnostic code without arbitrary text.
+type RolloutIssue struct {
+	Code      RolloutIssueCode     `json:"code"`
+	Group     *int                 `json:"group,omitempty"`
+	Component RuntimeComponentType `json:"component,omitempty"`
+}
+
+// RolloutStatusContent is the typed body shared by all output formats.
+type RolloutStatusContent struct {
+	Summary    RolloutSummary           `json:"summary"`
+	Groups     []RolloutGroupStatus     `json:"groups"`
+	Components []RolloutComponentStatus `json:"components"`
+	Issues     []RolloutIssue           `json:"issues"`
+}
+
+// RolloutStatusReport is the dedicated read-only rollout output contract.
+type RolloutStatusReport struct {
+	APIVersion  string                   `json:"apiVersion"`
+	Kind        string                   `json:"kind"`
+	Metadata    Metadata                 `json:"metadata"`
+	CollectedAt time.Time                `json:"collectedAt"`
+	Sources     []RolloutSourceReference `json:"sources"`
+	Content     RolloutStatusContent     `json:"content"`
+	Warnings    []RolloutWarning         `json:"warnings"`
+}
+
+// NewRolloutStatusReport builds a canonical report with an injectable clock.
+func NewRolloutStatusReport(metadata Metadata, content RolloutStatusContent, clock Clock) RolloutStatusReport {
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	return (RolloutStatusReport{
+		APIVersion: APIVersion, Kind: RolloutStatusReportKind, Metadata: metadata,
+		CollectedAt: clock.Now().UTC(), Sources: []RolloutSourceReference{},
+		Content: content, Warnings: []RolloutWarning{},
+	}).Canonical()
+}
+
+// Canonical returns a deeply copied, deterministically ordered report.
+func (r RolloutStatusReport) Canonical() RolloutStatusReport {
+	result := r
+	result.APIVersion = APIVersion
+	result.Kind = RolloutStatusReportKind
+	result.CollectedAt = r.CollectedAt.UTC()
+	result.Sources = append([]RolloutSourceReference{}, r.Sources...)
+	for i := range result.Sources {
+		result.Sources[i].Kind = canonicalRolloutSourceKind(result.Sources[i].Kind)
+		result.Sources[i].Evidence = canonicalRolloutEvidenceLevel(result.Sources[i].Evidence)
+		if result.Sources[i].CollectedAt.IsZero() {
+			result.Sources[i].CollectedAt = result.CollectedAt
+		} else {
+			result.Sources[i].CollectedAt = result.Sources[i].CollectedAt.UTC()
+		}
+	}
+	sort.SliceStable(result.Sources, func(i, j int) bool {
+		a, b := result.Sources[i], result.Sources[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.UID != b.UID {
+			return a.UID < b.UID
+		}
+		if a.Generation != b.Generation {
+			return a.Generation < b.Generation
+		}
+		if a.Evidence != b.Evidence {
+			return a.Evidence < b.Evidence
+		}
+		return a.CollectedAt.Before(b.CollectedAt)
+	})
+	result.Warnings = append([]RolloutWarning{}, r.Warnings...)
+	for i := range result.Warnings {
+		result.Warnings[i].Code = canonicalRolloutWarningCode(result.Warnings[i].Code)
+	}
+	sort.Slice(result.Warnings, func(i, j int) bool { return result.Warnings[i].Code < result.Warnings[j].Code })
+	result.Content = r.Content.Canonical()
+	return result
+}
+
+// Canonical returns deeply copied, deterministically ordered content.
+func (c RolloutStatusContent) Canonical() RolloutStatusContent {
+	result := c
+	result.Summary.State = canonicalRolloutState(c.Summary.State)
+	result.Summary.ReportedState = canonicalRolloutState(c.Summary.ReportedState)
+	result.Summary.Evidence = canonicalRolloutEvidenceLevel(c.Summary.Evidence)
+	result.Summary.Epoch = canonicalRolloutEpochState(c.Summary.Epoch)
+	result.Summary.CoordinationReady = canonicalRolloutConditionState(c.Summary.CoordinationReady)
+	result.Groups = make([]RolloutGroupStatus, len(c.Groups))
+	for i := range c.Groups {
+		result.Groups[i] = c.Groups[i]
+		result.Groups[i].Strategy = canonicalRolloutStrategy(c.Groups[i].Strategy)
+		result.Groups[i].Phase = canonicalRolloutPhase(c.Groups[i].Phase)
+		result.Groups[i].Components = make([]RuntimeComponentType, 0, len(c.Groups[i].Components))
+		for _, component := range c.Groups[i].Components {
+			if canonical := canonicalRolloutComponentType(component); canonical != "" {
+				result.Groups[i].Components = append(result.Groups[i].Components, canonical)
+			}
+		}
+		result.Groups[i].CurrentComponent = canonicalRolloutComponentType(c.Groups[i].CurrentComponent)
+		result.Groups[i].PreviousComponent = canonicalRolloutComponentType(c.Groups[i].PreviousComponent)
+		if c.Groups[i].Step != nil {
+			step := *c.Groups[i].Step
+			step.Gate = canonicalRolloutGate(step.Gate)
+			step.Analysis = canonicalRolloutAnalysisState(step.Analysis)
+			if step.EnteredAt != nil {
+				entered := step.EnteredAt.UTC()
+				step.EnteredAt = &entered
+			}
+			result.Groups[i].Step = &step
+		}
+		if c.Groups[i].TransitionedAt != nil {
+			transitioned := c.Groups[i].TransitionedAt.UTC()
+			result.Groups[i].TransitionedAt = &transitioned
+		}
+	}
+	sort.Slice(result.Groups, func(i, j int) bool {
+		return compareRolloutGroups(result.Groups[i], result.Groups[j]) < 0
+	})
+	result.Components = make([]RolloutComponentStatus, 0, len(c.Components))
+	for i := range c.Components {
+		component := c.Components[i]
+		component.Type = canonicalRolloutComponentType(component.Type)
+		if component.Type == "" {
+			continue
+		}
+		component.Strategy = canonicalRolloutStrategy(component.Strategy)
+		component.Phase = canonicalRolloutPhase(component.Phase)
+		if c.Components[i].Group != nil {
+			group := *c.Components[i].Group
+			component.Group = &group
+		}
+		component.Traffic = append([]RolloutTrafficTarget{}, c.Components[i].Traffic...)
+		for trafficIndex := range component.Traffic {
+			component.Traffic[trafficIndex].Role = canonicalRolloutRevisionRole(
+				component.Traffic[trafficIndex].Role,
+			)
+		}
+		sort.Slice(component.Traffic, func(a, b int) bool {
+			return compareRolloutTrafficTargets(
+				component.Traffic[a], component.Traffic[b],
+			) < 0
+		})
+		result.Components = append(result.Components, component)
+	}
+	sort.Slice(result.Components, func(i, j int) bool {
+		return compareRolloutComponents(result.Components[i], result.Components[j]) < 0
+	})
+	result.Issues = make([]RolloutIssue, len(c.Issues))
+	for i := range c.Issues {
+		result.Issues[i] = c.Issues[i]
+		result.Issues[i].Code = canonicalRolloutIssueCode(c.Issues[i].Code)
+		result.Issues[i].Component = canonicalRolloutComponentType(c.Issues[i].Component)
+		if c.Issues[i].Group != nil {
+			group := *c.Issues[i].Group
+			result.Issues[i].Group = &group
+		}
+	}
+	sort.Slice(result.Issues, func(i, j int) bool {
+		a, b := result.Issues[i], result.Issues[j]
+		if a.Code != b.Code {
+			return a.Code < b.Code
+		}
+		if compareOptionalInt(a.Group, b.Group) != 0 {
+			return compareOptionalInt(a.Group, b.Group) < 0
+		}
+		return a.Component < b.Component
+	})
+	return result
+}
+
+// Table derives the human view from the report's typed content.
+func (r RolloutStatusReport) Table() report.Table { return r.Content.Table() }
+
+// Table returns the deterministic operator-focused rollout view.
+func (c RolloutStatusContent) Table() report.Table {
+	canonical := c.Canonical()
+	table := report.Table{Headers: []string{
+		"STATE", "REPORTED-STATE", "EVIDENCE", "EPOCH", "GROUP", "STRATEGY", "GROUP-PHASE",
+		"CURRENT-COMPONENT", "PREVIOUS-COMPONENT", "COMPONENT", "COMPONENT-PHASE",
+		"STEP", "GATE", "CAPACITY", "TARGET-TRAFFIC", "OBSERVED-TRAFFIC", "ROLLED-OUT", "READY", "PREVIOUS", "ISSUES",
+	}}
+	groups := make(map[int]RolloutGroupStatus, len(canonical.Groups))
+	for _, group := range canonical.Groups {
+		groups[group.Index] = group
+	}
+	for _, component := range canonical.Components {
+		issues := rolloutIssueDisplay(rolloutIssuesForComponent(canonical.Issues, component))
+		groupName, strategy, groupPhase, currentComponent, previousComponent, step, gate, capacity, targetTraffic, observedTraffic := "-", orDash(string(component.Strategy)), "-", "-", "-", "-", "-", "-", "-", "-"
+		if component.Group != nil {
+			groupName = fmt.Sprintf("%d", *component.Group)
+			groupPhase = string(RolloutPhaseUnknown)
+			if group, found := groups[*component.Group]; found {
+				groupPhase = orDash(string(group.Phase))
+				currentComponent = orDash(string(group.CurrentComponent))
+				previousComponent = orDash(string(group.PreviousComponent))
+				if group.Step != nil {
+					step = fmt.Sprintf("%d/%d", group.Step.Index+1, group.Step.Total)
+					gate = orDash(string(group.Step.Gate))
+					capacity = orDash(group.Step.Capacity)
+					targetTraffic = fmt.Sprintf("%d%%", group.Step.TargetTraffic)
+					observedTraffic = fmt.Sprintf("%d%%", group.Step.ObservedTraffic)
+				}
+			}
+		}
+		table.Rows = append(table.Rows, []string{
+			orDash(string(canonical.Summary.State)), orDash(string(canonical.Summary.ReportedState)),
+			orDash(string(canonical.Summary.Evidence)), orDash(string(canonical.Summary.Epoch)),
+			groupName, strategy, groupPhase,
+			currentComponent, previousComponent,
+			orDash(string(component.Type)), orDash(string(component.Phase)),
+			step, gate, capacity, targetTraffic, observedTraffic,
+			orDash(component.RolledOutRevisionHash), orDash(component.ReadyRevisionHash),
+			orDash(component.PreviousRevisionHash), issues,
+		})
+	}
+	if len(table.Rows) == 0 {
+		table.Rows = append(table.Rows, rolloutIssueOnlyRow(canonical.Summary, canonical.Issues))
+	} else if unmatched := rolloutIssuesWithoutComponentMatch(canonical.Issues, canonical.Components); len(unmatched) > 0 {
+		table.Rows = append(table.Rows, rolloutIssueOnlyRow(canonical.Summary, unmatched))
+	}
+	return table
+}
+
+func rolloutIssueOnlyRow(summary RolloutSummary, issues []RolloutIssue) []string {
+	return []string{
+		orDash(string(summary.State)), orDash(string(summary.ReportedState)),
+		orDash(string(summary.Evidence)), orDash(string(summary.Epoch)),
+		"-", "-", "-", "-", "-", "-", "-", "-", "-", "-",
+		"-", "-", "-", "-", "-", rolloutIssueDisplay(issues),
+	}
+}
+
+func rolloutRevisionRoleOrder(role RolloutRevisionRole) int {
+	switch role {
+	case RolloutRevisionCurrent:
+		return 0
+	case RolloutRevisionTarget:
+		return 1
+	case RolloutRevisionPrevious:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func compareRolloutGroups(a, b RolloutGroupStatus) int {
+	for _, result := range []int{
+		cmp.Compare(a.Index, b.Index),
+		cmp.Compare(a.Strategy, b.Strategy),
+		cmp.Compare(a.Phase, b.Phase),
+		slices.Compare(a.Components, b.Components),
+		cmp.Compare(a.CurrentComponent, b.CurrentComponent),
+		cmp.Compare(a.PreviousComponent, b.PreviousComponent),
+		cmp.Compare(a.ObservedSurge, b.ObservedSurge),
+		cmp.Compare(a.StableRevisionHash, b.StableRevisionHash),
+		cmp.Compare(a.TargetRevisionHash, b.TargetRevisionHash),
+		cmp.Compare(a.RejectedRevisionHash, b.RejectedRevisionHash),
+		compareRolloutSteps(a.Step, b.Step),
+		compareOptionalTime(a.TransitionedAt, b.TransitionedAt),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareRolloutComponents(a, b RolloutComponentStatus) int {
+	for _, result := range []int{
+		cmp.Compare(componentOrder(a.Type), componentOrder(b.Type)),
+		cmp.Compare(a.Type, b.Type),
+		cmp.Compare(a.Strategy, b.Strategy),
+		compareOptionalInt(a.Group, b.Group),
+		cmp.Compare(a.Phase, b.Phase),
+		cmp.Compare(a.RolledOutRevisionHash, b.RolledOutRevisionHash),
+		cmp.Compare(a.ReadyRevisionHash, b.ReadyRevisionHash),
+		cmp.Compare(a.PreviousRevisionHash, b.PreviousRevisionHash),
+		compareRolloutTrafficSlices(a.Traffic, b.Traffic),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func canonicalRolloutStrategy(strategy RolloutStrategy) RolloutStrategy {
+	switch strategy {
+	case RolloutStrategyUnknown,
+		RolloutStrategyIndependent,
+		RolloutStrategyCanary,
+		RolloutStrategyBlueGreen,
+		RolloutStrategyRollingUpdate,
+		RolloutStrategySequential:
+		return strategy
+	default:
+		return RolloutStrategyUnknown
+	}
+}
+
+func canonicalRolloutSourceKind(kind RolloutSourceKind) RolloutSourceKind {
+	if kind == RolloutSourceInferenceService {
+		return kind
+	}
+	return RolloutSourceInferenceService
+}
+
+func canonicalRolloutEvidenceLevel(evidence EvidenceLevel) EvidenceLevel {
+	switch evidence {
+	case EvidenceDeclared,
+		EvidenceReported,
+		EvidenceObserved,
+		EvidenceComputed,
+		EvidenceUnavailable:
+		return evidence
+	default:
+		return EvidenceUnavailable
+	}
+}
+
+func canonicalRolloutWarningCode(code WarningCode) WarningCode {
+	switch code {
+	case WarningPartialData,
+		WarningSourceUnavailable,
+		WarningStaleEvidence,
+		WarningTruncated:
+		return code
+	default:
+		return WarningPartialData
+	}
+}
+
+func canonicalRolloutState(state RolloutState) RolloutState {
+	switch state {
+	case RolloutStateUnknown,
+		RolloutStateNotConfigured,
+		RolloutStateSucceeded,
+		RolloutStateInProgress,
+		RolloutStatePaused,
+		RolloutStateStaged,
+		RolloutStateFailed,
+		RolloutStateRollingBack,
+		RolloutStateRolledBack:
+		return state
+	default:
+		return RolloutStateUnknown
+	}
+}
+
+func canonicalRolloutEpochState(epoch RolloutEpochState) RolloutEpochState {
+	switch epoch {
+	case RolloutEpochNotApplicable, RolloutEpochUnverifiable:
+		return epoch
+	default:
+		return RolloutEpochUnverifiable
+	}
+}
+
+func canonicalRolloutConditionState(condition RolloutConditionState) RolloutConditionState {
+	switch condition {
+	case RolloutConditionNotApplicable,
+		RolloutConditionUnobserved,
+		RolloutConditionTrue,
+		RolloutConditionFalse,
+		RolloutConditionUnknown,
+		RolloutConditionInvalid:
+		return condition
+	default:
+		return RolloutConditionInvalid
+	}
+}
+
+func canonicalRolloutComponentType(component RuntimeComponentType) RuntimeComponentType {
+	switch component {
+	case RuntimeComponentEngine, RuntimeComponentDecoder, RuntimeComponentRouter:
+		return component
+	default:
+		return ""
+	}
+}
+
+func canonicalRolloutPhase(phase RolloutPhase) RolloutPhase {
+	switch phase {
+	case RolloutPhaseUnknown,
+		RolloutPhaseStable,
+		RolloutPhaseCanarying,
+		RolloutPhaseBlueGreenStandby,
+		RolloutPhasePending,
+		RolloutPhasePaused,
+		RolloutPhasePromoting,
+		RolloutPhaseRollingBack,
+		RolloutPhaseRolledBack,
+		RolloutPhaseFailed,
+		RolloutPhaseIdle,
+		RolloutPhaseSurging,
+		RolloutPhaseWaiting,
+		RolloutPhaseShifting,
+		RolloutPhaseUpdating,
+		RolloutPhaseDraining,
+		RolloutPhaseScalingDown,
+		RolloutPhaseStaged,
+		RolloutPhaseAwaitingNextComponent:
+		return phase
+	default:
+		return RolloutPhaseUnknown
+	}
+}
+
+func canonicalRolloutGate(gate RolloutGate) RolloutGate {
+	switch gate {
+	case RolloutGateUnknown,
+		RolloutGateImmediate,
+		RolloutGateManual,
+		RolloutGateTimed,
+		RolloutGateAnalysis:
+		return gate
+	default:
+		return RolloutGateUnknown
+	}
+}
+
+func canonicalRolloutAnalysisState(analysis RolloutAnalysisState) RolloutAnalysisState {
+	switch analysis {
+	case "":
+		return ""
+	case RolloutAnalysisUnobserved,
+		RolloutAnalysisPassing,
+		RolloutAnalysisFailing,
+		RolloutAnalysisInconclusive:
+		return analysis
+	default:
+		return RolloutAnalysisUnobserved
+	}
+}
+
+func canonicalRolloutRevisionRole(role RolloutRevisionRole) RolloutRevisionRole {
+	switch role {
+	case RolloutRevisionCurrent,
+		RolloutRevisionTarget,
+		RolloutRevisionPrevious,
+		RolloutRevisionOther:
+		return role
+	default:
+		return RolloutRevisionOther
+	}
+}
+
+func canonicalRolloutIssueCode(code RolloutIssueCode) RolloutIssueCode {
+	switch code {
+	case RolloutIssueSpecMalformed,
+		RolloutIssueStatusMalformed,
+		RolloutIssueGroupStatusMissing,
+		RolloutIssueGroupStatusUnexpected,
+		RolloutIssueComponentStatusMissing,
+		RolloutIssueCanaryStatusMissing,
+		RolloutIssueCanaryStatusUnexpected,
+		RolloutIssueCanaryStepInvalid,
+		RolloutIssueRevisionNameInvalid,
+		RolloutIssueTrafficInvalid,
+		RolloutIssueAnalysisInconclusive,
+		RolloutIssueEpochUnverifiable:
+		return code
+	default:
+		return RolloutIssueStatusMalformed
+	}
+}
+
+func compareRolloutTrafficSlices(a, b []RolloutTrafficTarget) int {
+	for i := 0; i < min(len(a), len(b)); i++ {
+		if result := compareRolloutTrafficTargets(a[i], b[i]); result != 0 {
+			return result
+		}
+	}
+	return cmp.Compare(len(a), len(b))
+}
+
+func compareRolloutTrafficTargets(a, b RolloutTrafficTarget) int {
+	for _, result := range []int{
+		cmp.Compare(rolloutRevisionRoleOrder(a.Role), rolloutRevisionRoleOrder(b.Role)),
+		cmp.Compare(a.Role, b.Role),
+		cmp.Compare(a.RevisionHash, b.RevisionHash),
+		cmp.Compare(a.Percent, b.Percent),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareRolloutSteps(a, b *RolloutStepStatus) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	for _, result := range []int{
+		cmp.Compare(a.Index, b.Index),
+		cmp.Compare(a.Total, b.Total),
+		cmp.Compare(a.Capacity, b.Capacity),
+		cmp.Compare(a.TargetTraffic, b.TargetTraffic),
+		cmp.Compare(a.ObservedTraffic, b.ObservedTraffic),
+		cmp.Compare(a.Gate, b.Gate),
+		cmp.Compare(a.Analysis, b.Analysis),
+		compareOptionalTime(a.EnteredAt, b.EnteredAt),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareOptionalTime(a, b *time.Time) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	if a.Equal(*b) {
+		return 0
+	}
+	if a.Before(*b) {
+		return -1
+	}
+	return 1
+}
+
+func compareOptionalInt(a, b *int) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+func rolloutIssueDisplay(issues []RolloutIssue) string {
+	values := make([]string, len(issues))
+	for i, issue := range issues {
+		value := string(issue.Code)
+		parts := []string{}
+		if issue.Group != nil {
+			parts = append(parts, fmt.Sprintf("group=%d", *issue.Group))
+		}
+		if issue.Component != "" {
+			parts = append(parts, "component="+string(issue.Component))
+		}
+		if len(parts) > 0 {
+			value += "(" + strings.Join(parts, ",") + ")"
+		}
+		values[i] = value
+	}
+	return orDash(strings.Join(values, ","))
+}
+
+func rolloutIssuesForComponent(issues []RolloutIssue, component RolloutComponentStatus) []RolloutIssue {
+	result := make([]RolloutIssue, 0, len(issues))
+	for _, issue := range issues {
+		if rolloutIssueMatchesComponent(issue, component) {
+			result = append(result, issue)
+		}
+	}
+	return result
+}
+
+func rolloutIssuesWithoutComponentMatch(
+	issues []RolloutIssue,
+	components []RolloutComponentStatus,
+) []RolloutIssue {
+	result := make([]RolloutIssue, 0, len(issues))
+	for _, issue := range issues {
+		matched := false
+		for _, component := range components {
+			if rolloutIssueMatchesComponent(issue, component) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			result = append(result, issue)
+		}
+	}
+	return result
+}
+
+func rolloutIssueMatchesComponent(issue RolloutIssue, component RolloutComponentStatus) bool {
+	if issue.Group != nil && (component.Group == nil || *issue.Group != *component.Group) {
+		return false
+	}
+	return issue.Component == "" || issue.Component == component.Type
+}

--- a/pkg/cli/report/v1alpha1/rollout_status_test.go
+++ b/pkg/cli/report/v1alpha1/rollout_status_test.go
@@ -1,0 +1,640 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestRolloutStatusReportEnumValuesAreStable(t *testing.T) {
+	got := []string{
+		string(v1alpha1.RolloutSourceInferenceService),
+		string(v1alpha1.RolloutStateUnknown), string(v1alpha1.RolloutStateNotConfigured),
+		string(v1alpha1.RolloutStateSucceeded), string(v1alpha1.RolloutStateInProgress),
+		string(v1alpha1.RolloutStatePaused), string(v1alpha1.RolloutStateStaged),
+		string(v1alpha1.RolloutStateFailed), string(v1alpha1.RolloutStateRollingBack),
+		string(v1alpha1.RolloutStateRolledBack),
+		string(v1alpha1.RolloutEpochNotApplicable), string(v1alpha1.RolloutEpochUnverifiable),
+		string(v1alpha1.RolloutStrategyUnknown), string(v1alpha1.RolloutStrategyIndependent),
+		string(v1alpha1.RolloutStrategyCanary), string(v1alpha1.RolloutStrategyBlueGreen),
+		string(v1alpha1.RolloutStrategyRollingUpdate), string(v1alpha1.RolloutStrategySequential),
+		string(v1alpha1.RolloutPhaseUnknown), string(v1alpha1.RolloutPhaseStable),
+		string(v1alpha1.RolloutPhaseCanarying), string(v1alpha1.RolloutPhaseBlueGreenStandby),
+		string(v1alpha1.RolloutPhasePending), string(v1alpha1.RolloutPhasePaused),
+		string(v1alpha1.RolloutPhasePromoting), string(v1alpha1.RolloutPhaseRollingBack),
+		string(v1alpha1.RolloutPhaseRolledBack), string(v1alpha1.RolloutPhaseFailed),
+		string(v1alpha1.RolloutPhaseIdle), string(v1alpha1.RolloutPhaseSurging),
+		string(v1alpha1.RolloutPhaseWaiting), string(v1alpha1.RolloutPhaseShifting),
+		string(v1alpha1.RolloutPhaseUpdating),
+		string(v1alpha1.RolloutPhaseDraining), string(v1alpha1.RolloutPhaseScalingDown),
+		string(v1alpha1.RolloutPhaseStaged), string(v1alpha1.RolloutPhaseAwaitingNextComponent),
+		string(v1alpha1.RolloutGateUnknown), string(v1alpha1.RolloutGateImmediate),
+		string(v1alpha1.RolloutGateManual), string(v1alpha1.RolloutGateTimed),
+		string(v1alpha1.RolloutGateAnalysis),
+		string(v1alpha1.RolloutAnalysisUnobserved), string(v1alpha1.RolloutAnalysisPassing),
+		string(v1alpha1.RolloutAnalysisFailing), string(v1alpha1.RolloutAnalysisInconclusive),
+		string(v1alpha1.RolloutConditionNotApplicable), string(v1alpha1.RolloutConditionUnobserved),
+		string(v1alpha1.RolloutConditionTrue), string(v1alpha1.RolloutConditionFalse),
+		string(v1alpha1.RolloutConditionUnknown), string(v1alpha1.RolloutConditionInvalid),
+		string(v1alpha1.RolloutRevisionCurrent), string(v1alpha1.RolloutRevisionTarget),
+		string(v1alpha1.RolloutRevisionPrevious), string(v1alpha1.RolloutRevisionOther),
+	}
+	want := []string{
+		"InferenceService",
+		"Unknown", "NotConfigured", "Succeeded", "InProgress", "Paused", "Staged", "Failed", "RollingBack", "RolledBack",
+		"NotApplicable", "Unverifiable",
+		"Unknown", "Independent", "Canary", "BlueGreen", "RollingUpdate", "Sequential",
+		"Unknown", "Stable", "Canarying", "BlueGreenStandby", "Pending", "Paused", "Promoting", "RollingBack", "RolledBack", "Failed",
+		"Idle", "Surging", "Waiting", "Shifting", "Updating", "Draining", "ScalingDown", "Staged", "AwaitingNextComponent",
+		"Unknown", "Immediate", "Manual", "Timed", "Analysis",
+		"Unobserved", "Passing", "Failing", "Inconclusive",
+		"NotApplicable", "Unobserved", "True", "False", "Unknown", "Invalid",
+		"Current", "Target", "Previous", "Other",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestRolloutStatusIssueCodesAreStable(t *testing.T) {
+	got := []string{
+		string(v1alpha1.RolloutIssueSpecMalformed), string(v1alpha1.RolloutIssueStatusMalformed),
+		string(v1alpha1.RolloutIssueGroupStatusMissing),
+		string(v1alpha1.RolloutIssueGroupStatusUnexpected), string(v1alpha1.RolloutIssueComponentStatusMissing),
+		string(v1alpha1.RolloutIssueCanaryStatusMissing), string(v1alpha1.RolloutIssueCanaryStatusUnexpected),
+		string(v1alpha1.RolloutIssueCanaryStepInvalid), string(v1alpha1.RolloutIssueRevisionNameInvalid),
+		string(v1alpha1.RolloutIssueTrafficInvalid), string(v1alpha1.RolloutIssueAnalysisInconclusive),
+		string(v1alpha1.RolloutIssueEpochUnverifiable),
+	}
+	assert.Equal(t, []string{
+		"SpecMalformed", "StatusMalformed", "GroupStatusMissing", "GroupStatusUnexpected",
+		"ComponentStatusMissing", "CanaryStatusMissing",
+		"CanaryStatusUnexpected", "CanaryStepInvalid", "RevisionNameInvalid", "TrafficInvalid",
+		"AnalysisInconclusive", "EpochUnverifiable",
+	}, got)
+}
+
+func TestRolloutStatusReportSchemaIsTypedAndAllowlisted(t *testing.T) {
+	for _, typ := range []reflect.Type{
+		reflect.TypeOf(v1alpha1.RolloutStatusReport{}),
+		reflect.TypeOf(v1alpha1.RolloutSourceReference{}),
+		reflect.TypeOf(v1alpha1.RolloutStatusContent{}),
+		reflect.TypeOf(v1alpha1.RolloutGroupStatus{}),
+		reflect.TypeOf(v1alpha1.RolloutComponentStatus{}),
+		reflect.TypeOf(v1alpha1.RolloutIssue{}),
+	} {
+		assertRuntimeReportSchema(t, typ, map[reflect.Type]bool{})
+	}
+	warningType := reflect.TypeOf(v1alpha1.RolloutWarning{})
+	require.Equal(t, 1, warningType.NumField())
+	assert.Equal(t, "Code", warningType.Field(0).Name)
+}
+
+func TestNewRolloutStatusReportBuildsCanonicalTypedReport(t *testing.T) {
+	collectedAt := time.Date(2026, time.August, 31, 11, 30, 0, 0, time.FixedZone("test", -7*60*60))
+	transitionedAt := time.Date(2026, time.August, 31, 11, 20, 0, 0, time.FixedZone("test", -7*60*60))
+	groupIndex := 0
+	reportValue := v1alpha1.NewRolloutStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RolloutStatusContent{
+			Summary: v1alpha1.RolloutSummary{
+				State:             v1alpha1.RolloutStateUnknown,
+				ReportedState:     v1alpha1.RolloutStateInProgress,
+				Evidence:          v1alpha1.EvidenceReported,
+				Epoch:             v1alpha1.RolloutEpochUnverifiable,
+				CoordinationReady: v1alpha1.RolloutConditionFalse,
+			},
+			Groups: []v1alpha1.RolloutGroupStatus{{
+				Index: 0, Strategy: v1alpha1.RolloutStrategyCanary, Phase: v1alpha1.RolloutPhaseCanarying,
+				Components:         []v1alpha1.RuntimeComponentType{v1alpha1.RuntimeComponentEngine},
+				StableRevisionHash: "aaaaaaaa", TargetRevisionHash: "bbbbbbbb",
+				Step: &v1alpha1.RolloutStepStatus{
+					Index: 1, Total: 3, Capacity: "50%", TargetTraffic: 20, ObservedTraffic: 20,
+					Gate: v1alpha1.RolloutGateManual, EnteredAt: &transitionedAt,
+				},
+			}},
+			Components: []v1alpha1.RolloutComponentStatus{{
+				Type: v1alpha1.RuntimeComponentEngine, Strategy: v1alpha1.RolloutStrategyCanary,
+				Group:                 &groupIndex,
+				Phase:                 v1alpha1.RolloutPhaseCanarying,
+				RolledOutRevisionHash: "aaaaaaaa", ReadyRevisionHash: "bbbbbbbb",
+				Traffic: []v1alpha1.RolloutTrafficTarget{
+					{RevisionHash: "bbbbbbbb", Percent: 20, Role: v1alpha1.RolloutRevisionTarget},
+					{RevisionHash: "aaaaaaaa", Percent: 80, Role: v1alpha1.RolloutRevisionCurrent},
+				},
+			}},
+			Issues: []v1alpha1.RolloutIssue{
+				{Code: v1alpha1.RolloutIssueAnalysisInconclusive, Group: &groupIndex},
+				{Code: v1alpha1.RolloutIssueTrafficInvalid},
+			},
+		},
+		fixedClock{now: collectedAt},
+	)
+	reportValue.Sources = []v1alpha1.RolloutSourceReference{{
+		Kind: "InferenceService", Namespace: "prod", Name: "chat", UID: "uid-1", Generation: 7,
+		Evidence: v1alpha1.EvidenceObserved,
+	}}
+	reportValue.Warnings = []v1alpha1.RolloutWarning{{Code: v1alpha1.WarningPartialData}}
+
+	canonical := reportValue.Canonical()
+
+	assert.Equal(t, v1alpha1.APIVersion, canonical.APIVersion)
+	assert.Equal(t, v1alpha1.RolloutStatusReportKind, canonical.Kind)
+	assert.Equal(t, "2026-08-31T18:30:00Z", canonical.CollectedAt.Format(time.RFC3339))
+	require.Len(t, canonical.Sources, 1)
+	assert.Equal(t, canonical.CollectedAt, canonical.Sources[0].CollectedAt)
+	assert.Equal(t, []v1alpha1.RolloutWarning{{Code: v1alpha1.WarningPartialData}}, canonical.Warnings)
+	assert.Equal(t, []v1alpha1.RolloutTrafficTarget{
+		{RevisionHash: "aaaaaaaa", Percent: 80, Role: v1alpha1.RolloutRevisionCurrent},
+		{RevisionHash: "bbbbbbbb", Percent: 20, Role: v1alpha1.RolloutRevisionTarget},
+	}, canonical.Content.Components[0].Traffic)
+	assert.Equal(t, time.UTC, canonical.Content.Groups[0].Step.EnteredAt.Location())
+	assert.Equal(t, v1alpha1.RolloutIssueAnalysisInconclusive, canonical.Content.Issues[0].Code)
+	assert.Equal(t, v1alpha1.RolloutIssueTrafficInvalid, canonical.Content.Issues[1].Code)
+
+	canonical.Content.Groups[0].Components[0] = v1alpha1.RuntimeComponentDecoder
+	canonical.Content.Groups[0].Step.Capacity = "returned"
+	canonical.Content.Components[0].Traffic[0].RevisionHash = "returned"
+	*canonical.Content.Components[0].Group = 9
+	*canonical.Content.Issues[0].Group = 9
+	assert.Equal(t, v1alpha1.RuntimeComponentEngine, reportValue.Content.Groups[0].Components[0])
+	assert.Equal(t, "50%", reportValue.Content.Groups[0].Step.Capacity)
+	assert.Equal(t, "aaaaaaaa", reportValue.Content.Components[0].Traffic[0].RevisionHash)
+	assert.Equal(t, 0, *reportValue.Content.Components[0].Group)
+	assert.Equal(t, 0, *reportValue.Content.Issues[0].Group)
+}
+
+func TestRolloutStatusReportCanonicalBoundsEveryEnumField(t *testing.T) {
+	group := 0
+	reportValue := v1alpha1.RolloutStatusReport{
+		Metadata:    v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		CollectedAt: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC),
+		Sources: []v1alpha1.RolloutSourceReference{{
+			Kind: v1alpha1.RolloutSourceKind("SECRET_SOURCE_KIND"),
+			Name: "chat", Evidence: v1alpha1.EvidenceLevel("SECRET_SOURCE_EVIDENCE"),
+		}},
+		Content: v1alpha1.RolloutStatusContent{
+			Summary: v1alpha1.RolloutSummary{
+				State:             v1alpha1.RolloutState("SECRET_STATE"),
+				ReportedState:     v1alpha1.RolloutState("SECRET_REPORTED_STATE"),
+				Evidence:          v1alpha1.EvidenceLevel("SECRET_SUMMARY_EVIDENCE"),
+				Epoch:             v1alpha1.RolloutEpochState("SECRET_EPOCH"),
+				CoordinationReady: v1alpha1.RolloutConditionState("SECRET_CONDITION"),
+			},
+			Groups: []v1alpha1.RolloutGroupStatus{{
+				Index:             group,
+				Strategy:          v1alpha1.RolloutStrategy("SECRET_GROUP_STRATEGY"),
+				Phase:             v1alpha1.RolloutPhase("SECRET_GROUP_PHASE"),
+				Components:        []v1alpha1.RuntimeComponentType{v1alpha1.RuntimeComponentType("SECRET_GROUP_COMPONENT")},
+				CurrentComponent:  v1alpha1.RuntimeComponentType("SECRET_CURRENT_COMPONENT"),
+				PreviousComponent: v1alpha1.RuntimeComponentType("SECRET_PREVIOUS_COMPONENT"),
+				Step: &v1alpha1.RolloutStepStatus{
+					Gate:     v1alpha1.RolloutGate("SECRET_GATE"),
+					Analysis: v1alpha1.RolloutAnalysisState("SECRET_ANALYSIS"),
+				},
+			}},
+			Components: []v1alpha1.RolloutComponentStatus{
+				{
+					Type:     v1alpha1.RuntimeComponentEngine,
+					Strategy: v1alpha1.RolloutStrategy("SECRET_COMPONENT_STRATEGY"),
+					Group:    &group,
+					Phase:    v1alpha1.RolloutPhase("SECRET_COMPONENT_PHASE"),
+					Traffic: []v1alpha1.RolloutTrafficTarget{{
+						RevisionHash: "aaaaaaaa", Percent: 100,
+						Role: v1alpha1.RolloutRevisionRole("SECRET_REVISION_ROLE"),
+					}},
+				},
+				{
+					Type:     v1alpha1.RuntimeComponentType("SECRET_COMPONENT_TYPE"),
+					Strategy: v1alpha1.RolloutStrategyIndependent,
+					Phase:    v1alpha1.RolloutPhaseStable,
+				},
+			},
+			Issues: []v1alpha1.RolloutIssue{{
+				Code:      v1alpha1.RolloutIssueCode("SECRET_ISSUE_CODE"),
+				Component: v1alpha1.RuntimeComponentType("SECRET_ISSUE_COMPONENT"),
+			}},
+		},
+		Warnings: []v1alpha1.RolloutWarning{{Code: v1alpha1.WarningCode("SECRET_WARNING_CODE")}},
+	}
+
+	canonical := reportValue.Canonical()
+
+	require.Len(t, canonical.Sources, 1)
+	assert.Equal(t, v1alpha1.RolloutSourceInferenceService, canonical.Sources[0].Kind)
+	assert.Equal(t, v1alpha1.EvidenceUnavailable, canonical.Sources[0].Evidence)
+	assert.Equal(t, []v1alpha1.RolloutWarning{{Code: v1alpha1.WarningPartialData}}, canonical.Warnings)
+	assert.Equal(t, v1alpha1.RolloutSummary{
+		State:             v1alpha1.RolloutStateUnknown,
+		ReportedState:     v1alpha1.RolloutStateUnknown,
+		Evidence:          v1alpha1.EvidenceUnavailable,
+		Epoch:             v1alpha1.RolloutEpochUnverifiable,
+		CoordinationReady: v1alpha1.RolloutConditionInvalid,
+	}, canonical.Content.Summary)
+	require.Len(t, canonical.Content.Groups, 1)
+	assert.Equal(t, v1alpha1.RolloutStrategyUnknown, canonical.Content.Groups[0].Strategy)
+	assert.Equal(t, v1alpha1.RolloutPhaseUnknown, canonical.Content.Groups[0].Phase)
+	assert.Empty(t, canonical.Content.Groups[0].Components)
+	assert.Empty(t, canonical.Content.Groups[0].CurrentComponent)
+	assert.Empty(t, canonical.Content.Groups[0].PreviousComponent)
+	require.NotNil(t, canonical.Content.Groups[0].Step)
+	assert.Equal(t, v1alpha1.RolloutGateUnknown, canonical.Content.Groups[0].Step.Gate)
+	assert.Equal(t, v1alpha1.RolloutAnalysisUnobserved, canonical.Content.Groups[0].Step.Analysis)
+	require.Len(t, canonical.Content.Components, 1)
+	assert.Equal(t, v1alpha1.RolloutStrategyUnknown, canonical.Content.Components[0].Strategy)
+	assert.Equal(t, v1alpha1.RolloutPhaseUnknown, canonical.Content.Components[0].Phase)
+	require.Len(t, canonical.Content.Components[0].Traffic, 1)
+	assert.Equal(t, v1alpha1.RolloutRevisionOther, canonical.Content.Components[0].Traffic[0].Role)
+	assert.Equal(t, []v1alpha1.RolloutIssue{{
+		Code: v1alpha1.RolloutIssueStatusMalformed,
+	}}, canonical.Content.Issues)
+
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, report.Write(&output, format, reportValue))
+			assert.NotContains(t, output.String(), "SECRET_")
+		})
+	}
+}
+
+func TestRolloutStatusReportCanonicalPreservesAbsentOptionalAnalysis(t *testing.T) {
+	reportValue := v1alpha1.NewRolloutStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RolloutStatusContent{
+			Groups: []v1alpha1.RolloutGroupStatus{{
+				Strategy: v1alpha1.RolloutStrategyCanary,
+				Phase:    v1alpha1.RolloutPhaseCanarying,
+				Step:     &v1alpha1.RolloutStepStatus{Gate: v1alpha1.RolloutGateImmediate},
+			}},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+
+	require.Len(t, reportValue.Content.Groups, 1)
+	require.NotNil(t, reportValue.Content.Groups[0].Step)
+	assert.Empty(t, reportValue.Content.Groups[0].Step.Analysis)
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatJSON, reportValue))
+	assert.NotContains(t, output.String(), `"analysis"`)
+}
+
+func TestRolloutStatusReportTableUsesTypedContent(t *testing.T) {
+	reportValue := rolloutStatusFixture()
+
+	assert.Equal(t, report.Table{
+		Headers: []string{
+			"STATE", "REPORTED-STATE", "EVIDENCE", "EPOCH", "GROUP", "STRATEGY", "GROUP-PHASE",
+			"CURRENT-COMPONENT", "PREVIOUS-COMPONENT", "COMPONENT", "COMPONENT-PHASE",
+			"STEP", "GATE", "CAPACITY", "TARGET-TRAFFIC", "OBSERVED-TRAFFIC", "ROLLED-OUT", "READY", "PREVIOUS", "ISSUES",
+		},
+		Rows: [][]string{{
+			"Unknown", "InProgress", "Reported", "Unverifiable", "0", "Canary", "Canarying", "-", "-", "engine", "Canarying",
+			"2/3", "Manual", "50%", "20%", "20%", "aaaaaaaa", "bbbbbbbb", "-", "-",
+		}}}, reportValue.Table())
+
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatTable, reportValue))
+	assert.Equal(t,
+		"STATE     REPORTED-STATE   EVIDENCE   EPOCH          GROUP   STRATEGY   GROUP-PHASE   CURRENT-COMPONENT   PREVIOUS-COMPONENT   COMPONENT   COMPONENT-PHASE   STEP   GATE     CAPACITY   TARGET-TRAFFIC   OBSERVED-TRAFFIC   ROLLED-OUT   READY      PREVIOUS   ISSUES\n"+
+			"Unknown   InProgress       Reported   Unverifiable   0       Canary     Canarying     -                   -                    engine      Canarying         2/3    Manual   50%        20%              20%                aaaaaaaa     bbbbbbbb   -          -\n",
+		output.String())
+}
+
+func TestRolloutStatusReportComponentStrategyIsAuthoritativeAcrossFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy v1alpha1.RolloutStrategy
+		want     v1alpha1.RolloutStrategy
+	}{
+		{name: "missing becomes bounded unknown", want: v1alpha1.RolloutStrategyUnknown},
+		{name: "valid mismatch remains component value", strategy: v1alpha1.RolloutStrategyRollingUpdate, want: v1alpha1.RolloutStrategyRollingUpdate},
+		{name: "invalid becomes bounded unknown", strategy: v1alpha1.RolloutStrategy("SECRET_STRATEGY"), want: v1alpha1.RolloutStrategyUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group := 0
+			reportValue := v1alpha1.NewRolloutStatusReport(
+				v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+				v1alpha1.RolloutStatusContent{
+					Summary: v1alpha1.RolloutSummary{
+						State:             v1alpha1.RolloutStateUnknown,
+						ReportedState:     v1alpha1.RolloutStateUnknown,
+						Evidence:          v1alpha1.EvidenceReported,
+						Epoch:             v1alpha1.RolloutEpochUnverifiable,
+						CoordinationReady: v1alpha1.RolloutConditionUnobserved,
+					},
+					Groups: []v1alpha1.RolloutGroupStatus{{
+						Index: group, Strategy: v1alpha1.RolloutStrategyCanary,
+						Phase: v1alpha1.RolloutPhaseUnknown,
+					}},
+					Components: []v1alpha1.RolloutComponentStatus{{
+						Type: v1alpha1.RuntimeComponentEngine, Strategy: tt.strategy,
+						Group: &group, Phase: v1alpha1.RolloutPhaseUnknown,
+					}},
+				},
+				fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+			)
+
+			table := reportValue.Table()
+			require.Len(t, table.Rows, 1)
+			assert.Equal(t, string(tt.want), table.Rows[0][5])
+
+			for _, format := range []report.Format{report.FormatJSON, report.FormatYAML} {
+				t.Run(string(format), func(t *testing.T) {
+					var output bytes.Buffer
+					require.NoError(t, report.Write(&output, format, reportValue))
+					var decoded v1alpha1.RolloutStatusReport
+					if format == report.FormatJSON {
+						require.NoError(t, json.Unmarshal(output.Bytes(), &decoded))
+					} else {
+						require.NoError(t, yaml.Unmarshal(output.Bytes(), &decoded))
+					}
+					require.Len(t, decoded.Content.Components, 1)
+					assert.Equal(t, tt.want, decoded.Content.Components[0].Strategy)
+					assert.Equal(t, v1alpha1.RolloutStrategyCanary, decoded.Content.Groups[0].Strategy)
+				})
+			}
+		})
+	}
+}
+
+func TestRolloutStatusReportTableScopesIssuesToMatchingRows(t *testing.T) {
+	groupZero, groupOne := 0, 1
+	content := v1alpha1.RolloutStatusContent{
+		Summary: v1alpha1.RolloutSummary{
+			State:             v1alpha1.RolloutStateUnknown,
+			ReportedState:     v1alpha1.RolloutStateInProgress,
+			Evidence:          v1alpha1.EvidenceReported,
+			Epoch:             v1alpha1.RolloutEpochUnverifiable,
+			CoordinationReady: v1alpha1.RolloutConditionFalse,
+		},
+		Groups: []v1alpha1.RolloutGroupStatus{
+			{Index: groupZero, Strategy: v1alpha1.RolloutStrategyCanary, Phase: v1alpha1.RolloutPhaseCanarying},
+			{Index: groupOne, Strategy: v1alpha1.RolloutStrategyRollingUpdate, Phase: v1alpha1.RolloutPhaseSurging},
+		},
+		Components: []v1alpha1.RolloutComponentStatus{
+			{Type: v1alpha1.RuntimeComponentEngine, Strategy: v1alpha1.RolloutStrategyCanary, Group: &groupZero, Phase: v1alpha1.RolloutPhaseCanarying},
+			{Type: v1alpha1.RuntimeComponentDecoder, Strategy: v1alpha1.RolloutStrategyCanary, Group: &groupZero, Phase: v1alpha1.RolloutPhaseCanarying},
+			{Type: v1alpha1.RuntimeComponentRouter, Strategy: v1alpha1.RolloutStrategyRollingUpdate, Group: &groupOne, Phase: v1alpha1.RolloutPhaseSurging},
+			{Type: v1alpha1.RuntimeComponentEngine, Strategy: v1alpha1.RolloutStrategyIndependent, Phase: v1alpha1.RolloutPhaseUpdating},
+		},
+		Issues: []v1alpha1.RolloutIssue{
+			{Code: v1alpha1.RolloutIssueSpecMalformed},
+			{Code: v1alpha1.RolloutIssueGroupStatusMissing, Group: &groupZero},
+			{Code: v1alpha1.RolloutIssueStatusMalformed, Group: &groupOne},
+			{Code: v1alpha1.RolloutIssueRevisionNameInvalid, Component: v1alpha1.RuntimeComponentEngine},
+			{Code: v1alpha1.RolloutIssueTrafficInvalid, Group: &groupZero, Component: v1alpha1.RuntimeComponentDecoder},
+			{Code: v1alpha1.RolloutIssueCanaryStepInvalid, Group: &groupOne, Component: v1alpha1.RuntimeComponentEngine},
+		},
+	}
+	original := content.Canonical()
+
+	table := content.Table()
+	reversed := content
+	reversed.Components = append([]v1alpha1.RolloutComponentStatus{}, content.Components...)
+	reversed.Issues = append([]v1alpha1.RolloutIssue{}, content.Issues...)
+	for left, right := 0, len(reversed.Components)-1; left < right; left, right = left+1, right-1 {
+		reversed.Components[left], reversed.Components[right] = reversed.Components[right], reversed.Components[left]
+	}
+	for left, right := 0, len(reversed.Issues)-1; left < right; left, right = left+1, right-1 {
+		reversed.Issues[left], reversed.Issues[right] = reversed.Issues[right], reversed.Issues[left]
+	}
+	assert.Equal(t, table, reversed.Table(), "canonical table ordering must not depend on input order")
+	assert.Equal(t, original, content.Canonical(), "Table must not mutate its input")
+
+	issuesByRow := map[string]string{}
+	for _, row := range table.Rows {
+		issuesByRow[row[4]+"/"+row[9]] = row[19]
+	}
+	assert.Equal(t, map[string]string{
+		"-/-":       "CanaryStepInvalid(group=1,component=engine)",
+		"0/engine":  "GroupStatusMissing(group=0),RevisionNameInvalid(component=engine),SpecMalformed",
+		"-/engine":  "RevisionNameInvalid(component=engine),SpecMalformed",
+		"0/decoder": "GroupStatusMissing(group=0),SpecMalformed,TrafficInvalid(group=0,component=decoder)",
+		"1/router":  "SpecMalformed,StatusMalformed(group=1)",
+	}, issuesByRow)
+}
+
+func TestRolloutStatusReportTableRetainsUnmatchedScopedIssues(t *testing.T) {
+	groupZero, groupSeven, groupNine := 0, 7, 9
+	content := v1alpha1.RolloutStatusContent{
+		Summary: v1alpha1.RolloutSummary{
+			State:             v1alpha1.RolloutStateUnknown,
+			ReportedState:     v1alpha1.RolloutStateUnknown,
+			Evidence:          v1alpha1.EvidenceReported,
+			Epoch:             v1alpha1.RolloutEpochUnverifiable,
+			CoordinationReady: v1alpha1.RolloutConditionUnobserved,
+		},
+		Groups: []v1alpha1.RolloutGroupStatus{{
+			Index: groupZero, Strategy: v1alpha1.RolloutStrategyCanary,
+			Phase: v1alpha1.RolloutPhaseCanarying,
+		}},
+		Components: []v1alpha1.RolloutComponentStatus{
+			{Type: v1alpha1.RuntimeComponentEngine, Strategy: v1alpha1.RolloutStrategyCanary, Group: &groupZero, Phase: v1alpha1.RolloutPhaseCanarying},
+			{Type: v1alpha1.RuntimeComponentDecoder, Strategy: v1alpha1.RolloutStrategyIndependent, Phase: v1alpha1.RolloutPhaseStable},
+		},
+		Issues: []v1alpha1.RolloutIssue{
+			{Code: v1alpha1.RolloutIssueSpecMalformed},
+			{Code: v1alpha1.RolloutIssueStatusMalformed, Group: &groupZero},
+			{Code: v1alpha1.RolloutIssueGroupStatusMissing, Group: &groupNine},
+			{Code: v1alpha1.RolloutIssueRevisionNameInvalid, Component: v1alpha1.RuntimeComponentRouter},
+			{Code: v1alpha1.RolloutIssueTrafficInvalid, Group: &groupSeven, Component: v1alpha1.RuntimeComponentDecoder},
+		},
+	}
+	before, err := json.Marshal(content)
+	require.NoError(t, err)
+
+	table := content.Table()
+	require.Len(t, table.Rows, 3)
+	assert.Equal(t, "SpecMalformed,StatusMalformed(group=0)", table.Rows[0][19])
+	assert.Equal(t, "SpecMalformed", table.Rows[1][19])
+	assert.Equal(t, []string{
+		"Unknown", "Unknown", "Reported", "Unverifiable", "-", "-", "-", "-", "-", "-",
+		"-", "-", "-", "-", "-", "-", "-", "-", "-",
+		"GroupStatusMissing(group=9),RevisionNameInvalid(component=router),TrafficInvalid(group=7,component=decoder)",
+	}, table.Rows[2])
+
+	reversed := content
+	reversed.Components = append([]v1alpha1.RolloutComponentStatus{}, content.Components...)
+	reversed.Issues = append([]v1alpha1.RolloutIssue{}, content.Issues...)
+	for left, right := 0, len(reversed.Components)-1; left < right; left, right = left+1, right-1 {
+		reversed.Components[left], reversed.Components[right] = reversed.Components[right], reversed.Components[left]
+	}
+	for left, right := 0, len(reversed.Issues)-1; left < right; left, right = left+1, right-1 {
+		reversed.Issues[left], reversed.Issues[right] = reversed.Issues[right], reversed.Issues[left]
+	}
+	assert.Equal(t, table, reversed.Table())
+	after, err := json.Marshal(content)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "Table must not mutate source content")
+
+	allIssues := strings.Join([]string{table.Rows[0][19], table.Rows[1][19], table.Rows[2][19]}, ",")
+	assert.Equal(t, 1, strings.Count(allIssues, "GroupStatusMissing(group=9)"))
+	assert.Equal(t, 1, strings.Count(allIssues, "RevisionNameInvalid(component=router)"))
+	assert.Equal(t, 1, strings.Count(allIssues, "TrafficInvalid(group=7,component=decoder)"))
+	assert.Equal(t, 1, strings.Count(allIssues, "StatusMalformed(group=0)"))
+	assert.Equal(t, 2, strings.Count(allIssues, "SpecMalformed"))
+}
+
+func TestRolloutStatusReportTableRetainsAllIssuesWithoutComponentRows(t *testing.T) {
+	group := 1
+	content := v1alpha1.RolloutStatusContent{
+		Summary: v1alpha1.RolloutSummary{
+			State:             v1alpha1.RolloutStateUnknown,
+			ReportedState:     v1alpha1.RolloutStateUnknown,
+			Evidence:          v1alpha1.EvidenceReported,
+			Epoch:             v1alpha1.RolloutEpochUnverifiable,
+			CoordinationReady: v1alpha1.RolloutConditionUnobserved,
+		},
+		Issues: []v1alpha1.RolloutIssue{
+			{Code: v1alpha1.RolloutIssueStatusMalformed, Group: &group},
+			{Code: v1alpha1.RolloutIssueRevisionNameInvalid, Component: v1alpha1.RuntimeComponentEngine},
+		},
+	}
+
+	table := content.Table()
+	require.Len(t, table.Rows, 1)
+	assert.Equal(t,
+		"RevisionNameInvalid(component=engine),StatusMalformed(group=1)",
+		table.Rows[0][19],
+	)
+}
+
+func TestRolloutStatusReportTableSeparatesCurrentAndReportedState(t *testing.T) {
+	reportValue := v1alpha1.NewRolloutStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RolloutStatusContent{
+			Summary: v1alpha1.RolloutSummary{
+				State:             v1alpha1.RolloutStateUnknown,
+				ReportedState:     v1alpha1.RolloutStateFailed,
+				Evidence:          v1alpha1.EvidenceReported,
+				Epoch:             v1alpha1.RolloutEpochUnverifiable,
+				CoordinationReady: v1alpha1.RolloutConditionFalse,
+			},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+
+	table := reportValue.Table()
+	assert.Equal(t, []string{
+		"STATE", "REPORTED-STATE", "EVIDENCE", "EPOCH", "GROUP", "STRATEGY",
+		"GROUP-PHASE", "CURRENT-COMPONENT", "PREVIOUS-COMPONENT", "COMPONENT",
+		"COMPONENT-PHASE", "STEP", "GATE", "CAPACITY",
+		"TARGET-TRAFFIC", "OBSERVED-TRAFFIC", "ROLLED-OUT", "READY", "PREVIOUS", "ISSUES",
+	}, table.Headers)
+	require.Len(t, table.Rows, 1)
+	assert.Equal(t, []string{
+		"Unknown", "Failed", "Reported", "Unverifiable", "-", "-", "-", "-", "-",
+		"-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-",
+	}, table.Rows[0])
+}
+
+func TestRolloutStatusReportTableShowsSequentialCursor(t *testing.T) {
+	group := 0
+	reportValue := v1alpha1.NewRolloutStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RolloutStatusContent{
+			Summary: v1alpha1.RolloutSummary{
+				State: v1alpha1.RolloutStateUnknown, ReportedState: v1alpha1.RolloutStateInProgress,
+				Evidence: v1alpha1.EvidenceReported, Epoch: v1alpha1.RolloutEpochUnverifiable,
+				CoordinationReady: v1alpha1.RolloutConditionTrue,
+			},
+			Groups: []v1alpha1.RolloutGroupStatus{{
+				Index: 0, Strategy: v1alpha1.RolloutStrategySequential,
+				Phase: v1alpha1.RolloutPhaseAwaitingNextComponent,
+				Components: []v1alpha1.RuntimeComponentType{
+					v1alpha1.RuntimeComponentDecoder, v1alpha1.RuntimeComponentEngine,
+				},
+				CurrentComponent:  v1alpha1.RuntimeComponentEngine,
+				PreviousComponent: v1alpha1.RuntimeComponentDecoder,
+			}},
+			Components: []v1alpha1.RolloutComponentStatus{
+				{Type: v1alpha1.RuntimeComponentEngine, Strategy: v1alpha1.RolloutStrategySequential, Group: &group, Phase: v1alpha1.RolloutPhaseUnknown, Traffic: []v1alpha1.RolloutTrafficTarget{}},
+				{Type: v1alpha1.RuntimeComponentDecoder, Strategy: v1alpha1.RolloutStrategySequential, Group: &group, Phase: v1alpha1.RolloutPhaseUnknown, Traffic: []v1alpha1.RolloutTrafficTarget{}},
+			},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+
+	table := reportValue.Table()
+	assert.Equal(t, []string{
+		"STATE", "REPORTED-STATE", "EVIDENCE", "EPOCH", "GROUP", "STRATEGY",
+		"GROUP-PHASE", "CURRENT-COMPONENT", "PREVIOUS-COMPONENT", "COMPONENT",
+		"COMPONENT-PHASE", "STEP", "GATE", "CAPACITY", "TARGET-TRAFFIC",
+		"OBSERVED-TRAFFIC", "ROLLED-OUT", "READY", "PREVIOUS", "ISSUES",
+	}, table.Headers)
+	require.Len(t, table.Rows, 2)
+	for _, row := range table.Rows {
+		assert.Equal(t, "engine", row[7])
+		assert.Equal(t, "decoder", row[8])
+	}
+}
+
+func TestRolloutStatusCanonicalOrderingIsTotal(t *testing.T) {
+	groupA := v1alpha1.RolloutGroupStatus{
+		Index: 1, Strategy: v1alpha1.RolloutStrategyCanary, Phase: v1alpha1.RolloutPhaseStable,
+		Components: []v1alpha1.RuntimeComponentType{v1alpha1.RuntimeComponentRouter},
+	}
+	groupB := v1alpha1.RolloutGroupStatus{
+		Index: 1, Strategy: v1alpha1.RolloutStrategyCanary, Phase: v1alpha1.RolloutPhaseFailed,
+		Components: []v1alpha1.RuntimeComponentType{v1alpha1.RuntimeComponentEngine},
+	}
+	componentA := v1alpha1.RolloutComponentStatus{
+		Type: v1alpha1.RuntimeComponentEngine, Phase: v1alpha1.RolloutPhaseStable,
+		Traffic: []v1alpha1.RolloutTrafficTarget{{RevisionHash: "aaaaaaaa", Percent: 90, Role: v1alpha1.RolloutRevisionCurrent}},
+	}
+	componentB := v1alpha1.RolloutComponentStatus{
+		Type: v1alpha1.RuntimeComponentEngine, Phase: v1alpha1.RolloutPhaseFailed,
+		Traffic: []v1alpha1.RolloutTrafficTarget{{RevisionHash: "aaaaaaaa", Percent: 10, Role: v1alpha1.RolloutRevisionCurrent}},
+	}
+	left := v1alpha1.RolloutStatusContent{
+		Groups:     []v1alpha1.RolloutGroupStatus{groupA, groupB},
+		Components: []v1alpha1.RolloutComponentStatus{componentA, componentB},
+	}.Canonical()
+	right := v1alpha1.RolloutStatusContent{
+		Groups:     []v1alpha1.RolloutGroupStatus{groupB, groupA},
+		Components: []v1alpha1.RolloutComponentStatus{componentB, componentA},
+	}.Canonical()
+
+	assert.Equal(t, left, right)
+}
+
+func rolloutStatusFixture() v1alpha1.RolloutStatusReport {
+	group := 0
+	return v1alpha1.NewRolloutStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.RolloutStatusContent{
+			Summary: v1alpha1.RolloutSummary{
+				State:             v1alpha1.RolloutStateUnknown,
+				ReportedState:     v1alpha1.RolloutStateInProgress,
+				Evidence:          v1alpha1.EvidenceReported,
+				Epoch:             v1alpha1.RolloutEpochUnverifiable,
+				CoordinationReady: v1alpha1.RolloutConditionNotApplicable,
+			},
+			Groups: []v1alpha1.RolloutGroupStatus{{
+				Index: 0, Strategy: v1alpha1.RolloutStrategyCanary, Phase: v1alpha1.RolloutPhaseCanarying,
+				Components: []v1alpha1.RuntimeComponentType{v1alpha1.RuntimeComponentEngine},
+				Step: &v1alpha1.RolloutStepStatus{
+					Index: 1, Total: 3, Capacity: "50%", TargetTraffic: 20, ObservedTraffic: 20,
+					Gate: v1alpha1.RolloutGateManual,
+				},
+			}},
+			Components: []v1alpha1.RolloutComponentStatus{{
+				Type: v1alpha1.RuntimeComponentEngine, Strategy: v1alpha1.RolloutStrategyCanary,
+				Group:                 &group,
+				Phase:                 v1alpha1.RolloutPhaseCanarying,
+				RolledOutRevisionHash: "aaaaaaaa", ReadyRevisionHash: "bbbbbbbb",
+			}},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+}

--- a/pkg/cli/rolloutprojection/project.go
+++ b/pkg/cli/rolloutprojection/project.go
@@ -1,0 +1,1689 @@
+// Package rolloutprojection projects the rollout fields of one already-read
+// InferenceService into the bounded kubectl-ome report contract.
+package rolloutprojection
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"knative.dev/pkg/apis"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+	omevalidation "sigs.k8s.io/ome/pkg/validation"
+)
+
+var (
+	// ErrNilInferenceService indicates that projection received no subject.
+	ErrNilInferenceService = errors.New("inference service is required")
+	// ErrSubjectNameRequired indicates that the observed subject has no name.
+	ErrSubjectNameRequired = errors.New("inference service name is required")
+	// ErrNamespaceRequired indicates that the observed subject has no namespace.
+	ErrNamespaceRequired = errors.New("inference service namespace is required")
+	// ErrSubjectUIDRequired indicates that observed evidence cannot be bound to
+	// an immutable InferenceService identity.
+	ErrSubjectUIDRequired = errors.New("inference service UID is required")
+)
+
+var revisionHashPattern = regexp.MustCompile(`^[0-9a-f]{8}$`)
+
+// Project builds a safe, deterministic rollout report from one observed
+// InferenceService. It performs no cluster reads.
+func Project(
+	isvc *omev1beta1.InferenceService,
+	clock reportv1alpha1.Clock,
+) (reportv1alpha1.RolloutStatusReport, error) {
+	if isvc == nil {
+		return reportv1alpha1.RolloutStatusReport{}, ErrNilInferenceService
+	}
+	if isvc.Name == "" {
+		return reportv1alpha1.RolloutStatusReport{}, ErrSubjectNameRequired
+	}
+	if isvc.Namespace == "" {
+		return reportv1alpha1.RolloutStatusReport{}, ErrNamespaceRequired
+	}
+	if isvc.UID == "" {
+		return reportv1alpha1.RolloutStatusReport{}, ErrSubjectUIDRequired
+	}
+
+	b := projector{
+		isvc:         isvc,
+		groupFor:     make(map[omev1beta1.ComponentType]int),
+		declared:     make(map[omev1beta1.ComponentType]struct{}),
+		issueKeys:    make(map[string]struct{}),
+		warningCodes: make(map[reportv1alpha1.WarningCode]struct{}),
+	}
+	if !validStoredRolloutSpec(&isvc.Spec) {
+		b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, nil, "")
+	}
+	b.projectGroups()
+	b.projectComponents()
+	b.projectCoordinationReady()
+	b.projectSummary()
+
+	reportValue := reportv1alpha1.NewRolloutStatusReport(
+		reportv1alpha1.Metadata{Namespace: isvc.Namespace, Name: isvc.Name},
+		b.content,
+		clock,
+	)
+	reportValue.Sources = []reportv1alpha1.RolloutSourceReference{{
+		Kind:       reportv1alpha1.RolloutSourceInferenceService,
+		Namespace:  isvc.Namespace,
+		Name:       isvc.Name,
+		UID:        string(isvc.UID),
+		Generation: isvc.Generation,
+		Evidence:   reportv1alpha1.EvidenceObserved,
+	}}
+	for code := range b.warningCodes {
+		reportValue.Warnings = append(reportValue.Warnings, reportv1alpha1.RolloutWarning{Code: code})
+	}
+	return reportValue.Canonical(), nil
+}
+
+// validStoredRolloutSpec applies the same pure, static checks as admission and
+// mirrors the small set of CRD-only shape constraints needed to consume an
+// already-stored object safely. Validator error text is intentionally dropped:
+// report diagnostics are code-only and must never copy arbitrary input.
+func validStoredRolloutSpec(spec *omev1beta1.InferenceServiceSpec) bool {
+	groups := spec.GetRolloutGroups()
+	if len(groups) > 3 {
+		return false
+	}
+	for i := range groups {
+		group := &groups[i]
+		if len(group.Components) == 0 || len(group.Components) > 3 || len(group.Order) > 3 {
+			return false
+		}
+		progressions := 0
+		if group.Canary != nil {
+			progressions++
+		}
+		if group.BlueGreen != nil {
+			progressions++
+		}
+		if group.RollingUpdate != nil {
+			progressions++
+		}
+		if progressions > 1 {
+			return false
+		}
+		if group.Canary == nil {
+			continue
+		}
+		if len(group.Canary.Steps) > 20 {
+			return false
+		}
+		for stepIndex := range group.Canary.Steps {
+			analysis := group.Canary.Steps[stepIndex].Analysis
+			if analysis == nil {
+				continue
+			}
+			if len(analysis.Metrics) > 10 {
+				return false
+			}
+			if analysis.OnInconclusive != nil &&
+				*analysis.OnInconclusive != omev1beta1.OnInconclusiveHold &&
+				*analysis.OnInconclusive != omev1beta1.OnInconclusiveRollback {
+				return false
+			}
+		}
+	}
+	if err := omevalidation.ValidateCanary(spec); err != nil {
+		return false
+	}
+	if err := omevalidation.ValidateCoordination(spec); err != nil {
+		return false
+	}
+	if err := omevalidation.ValidateLifecycle(spec); err != nil {
+		return false
+	}
+	return omevalidation.ValidateRolloutOrderingEnforced(spec) == nil
+}
+
+type projector struct {
+	isvc         *omev1beta1.InferenceService
+	content      reportv1alpha1.RolloutStatusContent
+	groupFor     map[omev1beta1.ComponentType]int
+	declared     map[omev1beta1.ComponentType]struct{}
+	issueKeys    map[string]struct{}
+	warningCodes map[reportv1alpha1.WarningCode]struct{}
+	malformed    bool
+}
+
+func (b *projector) projectGroups() {
+	groups := b.isvc.Spec.GetRolloutGroups()
+	if len(groups) == 0 {
+		b.rejectUnexpectedComponentPhaseResidue()
+		if b.isvc.Status.Canary != nil {
+			b.markMalformed(reportv1alpha1.RolloutIssueCanaryStatusUnexpected, nil, "")
+		}
+		b.flagUnexpectedCoordination(nil)
+		return
+	}
+	canaryGroups := 0
+	for i := range groups {
+		if groups[i].Canary != nil {
+			canaryGroups++
+		}
+	}
+	if canaryGroups > 1 {
+		b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, nil, "")
+	}
+
+	if b.canCollapseSequential(groups) {
+		b.projectSequential(groups)
+	} else {
+		if len(groups) > 1 {
+			b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, nil, "")
+		}
+		for index := range groups {
+			b.projectGroup(index, &groups[index])
+		}
+	}
+	b.flagUnexpectedCoordination(groups)
+}
+
+func (b *projector) rejectUnexpectedComponentPhaseResidue() {
+	for component, status := range b.isvc.Status.Components {
+		if !supportedComponent(component) || status.RolloutPhase == "" || status.RolloutPhase == omev1beta1.RolloutPhaseStable {
+			continue
+		}
+		b.markMalformed(
+			reportv1alpha1.RolloutIssueStatusMalformed,
+			nil,
+			projectComponent(component),
+		)
+	}
+}
+
+func (b *projector) canCollapseSequential(groups []omev1beta1.RolloutGroup) bool {
+	if len(groups) < 2 {
+		return false
+	}
+	seen := make(map[omev1beta1.ComponentType]struct{}, len(groups))
+	for i := range groups {
+		group := &groups[i]
+		if len(group.Components) != 1 || group.Canary != nil || group.RollingUpdate != nil {
+			return false
+		}
+		if _, duplicate := seen[group.Components[0]]; duplicate {
+			return false
+		}
+		if !supportedComponent(group.Components[0]) {
+			return false
+		}
+		seen[group.Components[0]] = struct{}{}
+	}
+	return true
+}
+
+func (b *projector) projectSequential(groups []omev1beta1.RolloutGroup) {
+	projected := reportv1alpha1.RolloutGroupStatus{
+		Index:      0,
+		Strategy:   reportv1alpha1.RolloutStrategySequential,
+		Phase:      reportv1alpha1.RolloutPhaseUnknown,
+		Components: make([]reportv1alpha1.RuntimeComponentType, 0, len(groups)),
+	}
+	expectedComponents := make([]omev1beta1.ComponentType, 0, len(groups))
+	for i := range groups {
+		component := groups[i].Components[0]
+		expectedComponents = append(expectedComponents, component)
+		b.declared[component] = struct{}{}
+		b.groupFor[component] = 0
+		projected.Components = append(projected.Components, projectComponent(component))
+	}
+	if observed := b.coordinationGroup("0"); observed != nil {
+		b.applyCoordinationStatus(
+			&projected,
+			observed,
+			omev1beta1.CoordinationPolicySequential,
+			expectedComponents,
+		)
+	} else {
+		b.addIssue(reportv1alpha1.RolloutIssueGroupStatusMissing, ptrInt(0), "")
+	}
+	b.content.Groups = append(b.content.Groups, projected)
+}
+
+func (b *projector) projectGroup(index int, group *omev1beta1.RolloutGroup) {
+	projected := reportv1alpha1.RolloutGroupStatus{
+		Index: index, Phase: reportv1alpha1.RolloutPhaseUnknown,
+	}
+	progressions := 0
+	if group.Canary != nil {
+		progressions++
+		projected.Strategy = reportv1alpha1.RolloutStrategyCanary
+	}
+	if group.BlueGreen != nil {
+		progressions++
+		projected.Strategy = reportv1alpha1.RolloutStrategyBlueGreen
+	}
+	if group.RollingUpdate != nil {
+		progressions++
+		projected.Strategy = reportv1alpha1.RolloutStrategyRollingUpdate
+	}
+	if progressions == 0 {
+		projected.Strategy = reportv1alpha1.RolloutStrategyBlueGreen
+	}
+	if progressions > 1 {
+		projected.Strategy = reportv1alpha1.RolloutStrategyUnknown
+		b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, ptrInt(index), "")
+	}
+
+	seen := make(map[omev1beta1.ComponentType]struct{}, len(group.Components))
+	for _, component := range group.Components {
+		if !supportedComponent(component) {
+			b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, ptrInt(index), "")
+			continue
+		}
+		if _, duplicate := seen[component]; duplicate {
+			b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, ptrInt(index), projectComponent(component))
+			continue
+		}
+		seen[component] = struct{}{}
+		if _, alreadyGrouped := b.groupFor[component]; alreadyGrouped {
+			b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, ptrInt(index), projectComponent(component))
+			continue
+		}
+		b.declared[component] = struct{}{}
+		b.groupFor[component] = index
+		projected.Components = append(projected.Components, projectComponent(component))
+	}
+	if len(projected.Components) == 0 {
+		b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, ptrInt(index), "")
+	}
+
+	if group.Canary != nil && progressions == 1 {
+		b.applyCanaryStatus(&projected, group)
+	} else if progressions <= 1 {
+		expectedPolicy := omev1beta1.CoordinationPolicyBlueGreen
+		if group.RollingUpdate != nil {
+			expectedPolicy = omev1beta1.CoordinationPolicyRollingUpdate
+		}
+		if observed := b.coordinationGroup(strconv.Itoa(index)); observed != nil {
+			b.applyCoordinationStatus(&projected, observed, expectedPolicy, group.Components)
+		} else {
+			b.addIssue(reportv1alpha1.RolloutIssueGroupStatusMissing, ptrInt(index), "")
+		}
+	}
+	b.content.Groups = append(b.content.Groups, projected)
+}
+
+func (b *projector) applyCanaryStatus(
+	projected *reportv1alpha1.RolloutGroupStatus,
+	group *omev1beta1.RolloutGroup,
+) {
+	primary := canaryPrimary(group.Components)
+	projected.Phase = b.canaryGroupPhase(projected.Index, group.Components, primary)
+	if primary == "" {
+		b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, ptrInt(projected.Index), "")
+		return
+	}
+	if projected.Phase == reportv1alpha1.RolloutPhaseBlueGreenStandby {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	status := b.isvc.Status.Canary
+	if status == nil {
+		if canaryPhaseNeedsStatus(projected.Phase) {
+			b.addIssue(reportv1alpha1.RolloutIssueCanaryStatusMissing, ptrInt(projected.Index), "")
+		}
+		return
+	}
+	projected.StableRevisionHash = b.safeDirectHash(status.StableRevisionHash, projected.Index)
+	projected.TargetRevisionHash = b.safeDirectHash(status.CanaryRevisionHash, projected.Index)
+	projected.RejectedRevisionHash = b.safeDirectHash(status.RolledBackRevisionHash, projected.Index)
+	if status.CanaryRevisionHash == "" {
+		b.markMalformed(reportv1alpha1.RolloutIssueRevisionNameInvalid, ptrInt(projected.Index), "")
+	}
+	if projected.Phase == reportv1alpha1.RolloutPhaseStable {
+		b.applyCompletedCanaryStatus(projected, group, primary, status)
+		return
+	}
+	if !canaryPhaseNeedsStatus(projected.Phase) {
+		b.markMalformed(reportv1alpha1.RolloutIssueCanaryStatusUnexpected, ptrInt(projected.Index), "")
+		return
+	}
+	if status.CurrentStep < 0 || int(status.CurrentStep) >= len(group.Canary.Steps) {
+		b.markMalformed(reportv1alpha1.RolloutIssueCanaryStepInvalid, ptrInt(projected.Index), "")
+		return
+	}
+	if !validCanaryPhaseStepResidue(projected.Phase, group.Canary.Steps, status) {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	if canaryPhaseBindsTraffic(projected.Phase) &&
+		!b.activeCanaryTrafficMatches(primary, projected.Phase, status) {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	stepSpec := &group.Canary.Steps[status.CurrentStep]
+	if canaryPhaseBindsStepTraffic(projected.Phase) &&
+		!canaryObservedTrafficMatchesStep(projected.Phase, group.Canary.Steps, status) {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	step := reportv1alpha1.RolloutStepStatus{
+		Index:           status.CurrentStep,
+		Total:           int32(len(group.Canary.Steps)),
+		TargetTraffic:   stepSpec.Traffic,
+		ObservedTraffic: status.ObservedTrafficWeight,
+		Gate:            gateFor(stepSpec),
+	}
+	if safeCapacity(stepSpec.Capacity) {
+		step.Capacity = stepSpec.Capacity.String()
+	} else {
+		b.markMalformed(reportv1alpha1.RolloutIssueCanaryStepInvalid, ptrInt(projected.Index), "")
+	}
+	if step.TargetTraffic < 0 || step.TargetTraffic > 100 || step.ObservedTraffic < 0 || step.ObservedTraffic > 100 {
+		step.TargetTraffic = 0
+		step.ObservedTraffic = 0
+		b.markMalformed(reportv1alpha1.RolloutIssueTrafficInvalid, ptrInt(projected.Index), "")
+	}
+	if stepSpec.Analysis != nil {
+		var valid bool
+		step.Analysis, valid = analysisState(stepSpec.Analysis, status)
+		if !valid {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		} else if step.Analysis == reportv1alpha1.RolloutAnalysisInconclusive {
+			b.addIssue(reportv1alpha1.RolloutIssueAnalysisInconclusive, ptrInt(projected.Index), "")
+		}
+	}
+	if status.StepEnteredTime != nil {
+		if status.StepEnteredTime.IsZero() {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		} else {
+			enteredAt := status.StepEnteredTime.Time.UTC()
+			step.EnteredAt = &enteredAt
+		}
+	}
+	projected.Step = &step
+}
+
+func (b *projector) applyCompletedCanaryStatus(
+	projected *reportv1alpha1.RolloutGroupStatus,
+	group *omev1beta1.RolloutGroup,
+	primary omev1beta1.ComponentType,
+	status *omev1beta1.CanaryStatus,
+) {
+	validFinalStep := false
+	if len(group.Canary.Steps) > 0 {
+		finalStep := group.Canary.Steps[len(group.Canary.Steps)-1]
+		validFinalStep = finalStep.Traffic == 100 && validCompletedCanaryCapacity(finalStep.Capacity)
+	}
+	valid := validFinalStep &&
+		int(status.CurrentStep) == len(group.Canary.Steps) &&
+		status.ObservedTrafficWeight == 100 &&
+		status.StableRevisionHash == "" &&
+		status.RolledBackRevisionHash == "" &&
+		status.PromotedThrough == "" &&
+		projected.TargetRevisionHash != "" &&
+		b.completedCanaryTrafficMatches(primary, projected.TargetRevisionHash)
+	if !valid {
+		b.markMalformed(reportv1alpha1.RolloutIssueCanaryStepInvalid, ptrInt(projected.Index), "")
+	}
+}
+
+func (b *projector) activeCanaryTrafficMatches(
+	primary omev1beta1.ComponentType,
+	phase reportv1alpha1.RolloutPhase,
+	status *omev1beta1.CanaryStatus,
+) bool {
+	if status.ObservedTrafficWeight < 0 || status.ObservedTrafficWeight > 100 ||
+		!safeRevisionHash(status.CanaryRevisionHash) ||
+		(status.StableRevisionHash != "" && !safeRevisionHash(status.StableRevisionHash)) ||
+		(status.StableRevisionHash != "" && status.StableRevisionHash == status.CanaryRevisionHash) {
+		return false
+	}
+
+	expected := make(map[string]int32, 2)
+	if phase == reportv1alpha1.RolloutPhaseRollingBack || phase == reportv1alpha1.RolloutPhaseRolledBack {
+		if status.RolledBackRevisionHash == "" ||
+			status.RolledBackRevisionHash != status.CanaryRevisionHash ||
+			status.StableRevisionHash == "" || status.ObservedTrafficWeight != 0 {
+			return false
+		}
+		expected[status.StableRevisionHash] = 100
+	} else {
+		if status.RolledBackRevisionHash != "" {
+			return false
+		}
+		if status.ObservedTrafficWeight > 0 {
+			expected[status.CanaryRevisionHash] = status.ObservedTrafficWeight
+		}
+		stableWeight := int32(100) - status.ObservedTrafficWeight
+		if stableWeight > 0 {
+			if status.StableRevisionHash == "" {
+				return false
+			}
+			expected[status.StableRevisionHash] = stableWeight
+		}
+	}
+
+	component, found := b.isvc.Status.Components[primary]
+	if !found || len(component.Traffic) != len(expected) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(component.Traffic))
+	for _, target := range component.Traffic {
+		hash := extractRevisionHash(b.isvc.Name, primary, target.RevisionName)
+		if hash == "" {
+			return false
+		}
+		if _, duplicate := seen[hash]; duplicate {
+			return false
+		}
+		seen[hash] = struct{}{}
+		expectedPercent, expectedHash := expected[hash]
+		if !expectedHash || expectedPercent != target.Percent {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *projector) completedCanaryTrafficMatches(
+	primary omev1beta1.ComponentType,
+	targetHash string,
+) bool {
+	component, found := b.isvc.Status.Components[primary]
+	if !found || len(component.Traffic) != 1 {
+		return false
+	}
+	target := component.Traffic[0]
+	return target.Percent == 100 &&
+		extractRevisionHash(b.isvc.Name, primary, target.RevisionName) == targetHash
+}
+
+func (b *projector) applyCoordinationStatus(
+	projected *reportv1alpha1.RolloutGroupStatus,
+	observed *omev1beta1.RolloutCoordinationGroupStatus,
+	expected omev1beta1.CoordinationPolicy,
+	expectedComponents []omev1beta1.ComponentType,
+) {
+	projected.Phase = projectCoordinationPhase(observed.Phase)
+	if projected.Phase == reportv1alpha1.RolloutPhaseUnknown {
+		if observed.Phase == "" {
+			b.addIssue(reportv1alpha1.RolloutIssueGroupStatusMissing, ptrInt(projected.Index), "")
+		} else {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		}
+	}
+	if observed.Policy != expected {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	if !slices.Equal(observed.Components, expectedComponents) {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	if expected == omev1beta1.CoordinationPolicySequential {
+		if !slices.Equal(observed.Order, expectedComponents) ||
+			!validSequentialCursor(
+				expectedComponents,
+				observed.Phase,
+				observed.CurrentComponent,
+				observed.PreviousComponent,
+			) ||
+			!validSequentialComposite(
+				observed.Phase,
+				observed.CompositePhase,
+				observed.CurrentComponent,
+				observed.PreviousComponent,
+			) {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		} else if observed.Phase == omev1beta1.CoordinationPhaseIdle &&
+			observed.CompositePhase == omev1beta1.CompositePhaseSequentialAwaiting {
+			projected.Phase = reportv1alpha1.RolloutPhaseAwaitingNextComponent
+		}
+	} else if len(observed.Order) > 0 || observed.CurrentComponent != "" || observed.PreviousComponent != "" {
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+	}
+	if observed.CurrentComponent != "" {
+		if b.groupContains(projected, observed.CurrentComponent) {
+			projected.CurrentComponent = projectComponent(observed.CurrentComponent)
+		} else {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		}
+	}
+	if observed.PreviousComponent != "" {
+		if b.groupContains(projected, observed.PreviousComponent) {
+			projected.PreviousComponent = projectComponent(observed.PreviousComponent)
+		} else {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		}
+	}
+	if observed.ObservedSurge != nil {
+		if safeCapacity(*observed.ObservedSurge) {
+			projected.ObservedSurge = observed.ObservedSurge.String()
+		} else {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		}
+	}
+	if observed.LastTransitionTime != nil {
+		if observed.LastTransitionTime.IsZero() {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, ptrInt(projected.Index), "")
+		} else {
+			transitionedAt := observed.LastTransitionTime.Time.UTC()
+			projected.TransitionedAt = &transitionedAt
+		}
+	}
+}
+
+func (b *projector) projectComponents() {
+	if b.isvc.Spec.Engine != nil {
+		b.declared[omev1beta1.EngineComponent] = struct{}{}
+	}
+	if b.isvc.Spec.Decoder != nil {
+		b.declared[omev1beta1.DecoderComponent] = struct{}{}
+	}
+	if b.isvc.Spec.Router != nil {
+		b.declared[omev1beta1.RouterComponent] = struct{}{}
+	}
+	for component := range b.isvc.Status.Components {
+		if supportedComponent(component) {
+			b.declared[component] = struct{}{}
+		} else {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, nil, "")
+		}
+	}
+	components := make([]omev1beta1.ComponentType, 0, len(b.declared))
+	for component := range b.declared {
+		components = append(components, component)
+	}
+	sort.Slice(components, func(i, j int) bool { return componentOrder(components[i]) < componentOrder(components[j]) })
+	for _, component := range components {
+		projected := reportv1alpha1.RolloutComponentStatus{
+			Type:     projectComponent(component),
+			Strategy: reportv1alpha1.RolloutStrategyUnknown,
+			Phase:    reportv1alpha1.RolloutPhaseUnknown,
+			Traffic:  []reportv1alpha1.RolloutTrafficTarget{},
+		}
+		if group, found := b.groupFor[component]; found {
+			projected.Group = ptrInt(group)
+			projected.Strategy = b.groupStrategy(group)
+		} else if b.componentExplicitlyOMENative(component) {
+			projected.Strategy = reportv1alpha1.RolloutStrategyIndependent
+		}
+		observed, found := b.isvc.Status.Components[component]
+		if !found {
+			if projected.Group != nil || !b.componentExplicitlyNonOMENative(component) {
+				b.addIssue(reportv1alpha1.RolloutIssueComponentStatusMissing, projected.Group, projected.Type)
+			}
+			b.content.Components = append(b.content.Components, projected)
+			continue
+		}
+		if projected.Group == nil && observed.Lifecycle != nil {
+			projected.Strategy = reportv1alpha1.RolloutStrategyIndependent
+			projected.Phase = b.independentLifecyclePhase(component, observed.Lifecycle)
+			if observed.RolloutPhase != "" &&
+				projectComponentPhase(observed.RolloutPhase) != projected.Phase {
+				b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, nil, projected.Type)
+				projected.Phase = reportv1alpha1.RolloutPhaseUnknown
+			}
+		} else {
+			if projected.Group == nil && !b.componentExplicitlyNonOMENative(component) {
+				b.addIssue(reportv1alpha1.RolloutIssueComponentStatusMissing, nil, projected.Type)
+			}
+			projected.Phase = projectComponentPhase(observed.RolloutPhase)
+			coordinated := b.nonCanaryCoordinationGroup(projected.Group)
+			if projected.Group != nil && observed.RolloutPhase == "" &&
+				!coordinated &&
+				!b.normalEmptyCanarySecondary(component, projected.Group) {
+				b.addIssue(reportv1alpha1.RolloutIssueComponentStatusMissing, projected.Group, projected.Type)
+			}
+			if projected.Phase == reportv1alpha1.RolloutPhaseUnknown && observed.RolloutPhase != "" {
+				b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, projected.Group, projected.Type)
+			}
+			if coordinated &&
+				projected.Phase != reportv1alpha1.RolloutPhaseUnknown &&
+				b.nonCanaryComponentPhaseContradicts(projected.Group, projected.Phase) {
+				b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, projected.Group, projected.Type)
+			}
+		}
+		projected.RolledOutRevisionHash = b.serviceRevisionHash(observed.LatestRolledoutRevision, component, projected.Group)
+		projected.ReadyRevisionHash = b.serviceRevisionHash(observed.LatestReadyRevision, component, projected.Group)
+		projected.PreviousRevisionHash = b.serviceRevisionHash(observed.PreviousRolledoutRevision, component, projected.Group)
+		projected.Traffic = b.projectTraffic(observed.Traffic, component, &projected)
+		b.content.Components = append(b.content.Components, projected)
+	}
+}
+
+func (b *projector) groupStrategy(index int) reportv1alpha1.RolloutStrategy {
+	for _, group := range b.content.Groups {
+		if group.Index == index {
+			return group.Strategy
+		}
+	}
+	return reportv1alpha1.RolloutStrategyUnknown
+}
+
+func (b *projector) independentLifecyclePhase(
+	component omev1beta1.ComponentType,
+	lifecycle *omev1beta1.LifecycleStatus,
+) reportv1alpha1.RolloutPhase {
+	projectedComponent := projectComponent(component)
+	if lifecycle.CurrentRevision == "" || lifecycle.UpdateRevision == "" {
+		b.addIssue(reportv1alpha1.RolloutIssueComponentStatusMissing, nil, projectedComponent)
+		return reportv1alpha1.RolloutPhaseUnknown
+	}
+	currentHash := extractControllerRevisionHash(b.isvc.Name, component, lifecycle.CurrentRevision)
+	updateHash := extractControllerRevisionHash(b.isvc.Name, component, lifecycle.UpdateRevision)
+	if currentHash == "" || updateHash == "" {
+		b.markMalformed(reportv1alpha1.RolloutIssueRevisionNameInvalid, nil, projectedComponent)
+		return reportv1alpha1.RolloutPhaseUnknown
+	}
+	if lifecycle.CurrentRevision == lifecycle.UpdateRevision {
+		return reportv1alpha1.RolloutPhaseStable
+	}
+	return reportv1alpha1.RolloutPhaseUpdating
+}
+
+func (b *projector) componentExplicitlyNonOMENative(component omev1beta1.ComponentType) bool {
+	mode, found := b.componentDeploymentModeAnnotation(component)
+	return found && mode.IsValid() && mode != constants.OMENative
+}
+
+func (b *projector) componentExplicitlyOMENative(component omev1beta1.ComponentType) bool {
+	mode, found := b.componentDeploymentModeAnnotation(component)
+	return found && mode == constants.OMENative
+}
+
+func (b *projector) componentDeploymentModeAnnotation(
+	component omev1beta1.ComponentType,
+) (constants.DeploymentModeType, bool) {
+	var annotations map[string]string
+	switch component {
+	case omev1beta1.EngineComponent:
+		if b.isvc.Spec.Engine == nil {
+			return "", false
+		}
+		annotations = b.isvc.Spec.Engine.Annotations
+	case omev1beta1.DecoderComponent:
+		if b.isvc.Spec.Decoder == nil {
+			return "", false
+		}
+		annotations = b.isvc.Spec.Decoder.Annotations
+	case omev1beta1.RouterComponent:
+		if b.isvc.Spec.Router == nil {
+			return "", false
+		}
+		annotations = b.isvc.Spec.Router.Annotations
+	default:
+		return "", false
+	}
+	raw, found := annotations[constants.DeploymentMode]
+	if !found {
+		return "", false
+	}
+	return constants.DeploymentModeType(raw), true
+}
+
+func (b *projector) provesNotConfigured() bool {
+	if b.hasRolloutStatusResidue() {
+		return false
+	}
+	for _, component := range []omev1beta1.ComponentType{
+		omev1beta1.EngineComponent,
+		omev1beta1.DecoderComponent,
+		omev1beta1.RouterComponent,
+	} {
+		if b.componentDeclared(component) && !b.componentExplicitlyNonOMENative(component) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *projector) componentDeclared(component omev1beta1.ComponentType) bool {
+	switch component {
+	case omev1beta1.EngineComponent:
+		return b.isvc.Spec.Engine != nil
+	case omev1beta1.DecoderComponent:
+		return b.isvc.Spec.Decoder != nil
+	case omev1beta1.RouterComponent:
+		return b.isvc.Spec.Router != nil
+	default:
+		return false
+	}
+}
+
+func (b *projector) hasRolloutStatusResidue() bool {
+	if b.isvc.Status.Canary != nil || b.isvc.Status.RolloutCoordination != nil {
+		return true
+	}
+	if b.hasComponentStatusResidue() {
+		return true
+	}
+	for _, condition := range b.isvc.Status.Conditions {
+		if condition.Type == apis.ConditionType(omev1beta1.RolloutCoordinationReady) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *projector) hasComponentStatusResidue() bool {
+	for _, component := range b.isvc.Status.Components {
+		if component.Lifecycle != nil || component.RolloutPhase != "" ||
+			component.LatestReadyRevision != "" || component.LatestRolledoutRevision != "" ||
+			component.PreviousRolledoutRevision != "" || len(component.Traffic) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *projector) projectTraffic(
+	observed []omev1beta1.ComponentTrafficTarget,
+	component omev1beta1.ComponentType,
+	projected *reportv1alpha1.RolloutComponentStatus,
+) []reportv1alpha1.RolloutTrafficTarget {
+	if len(observed) == 0 {
+		return []reportv1alpha1.RolloutTrafficTarget{}
+	}
+	result := make([]reportv1alpha1.RolloutTrafficTarget, 0, len(observed))
+	valid := true
+	total := int64(0)
+	seen := make(map[string]struct{}, len(observed))
+	for _, target := range observed {
+		hash := extractRevisionHash(b.isvc.Name, component, target.RevisionName)
+		if hash == "" || target.Percent < 0 || target.Percent > 100 {
+			valid = false
+			continue
+		}
+		if _, duplicate := seen[hash]; duplicate {
+			valid = false
+			continue
+		}
+		seen[hash] = struct{}{}
+		total += int64(target.Percent)
+		result = append(result, reportv1alpha1.RolloutTrafficTarget{
+			RevisionHash: hash,
+			Percent:      target.Percent,
+			Role:         revisionRole(hash, projected),
+		})
+	}
+	if total != 100 {
+		valid = false
+	}
+	if !valid {
+		b.markMalformed(reportv1alpha1.RolloutIssueTrafficInvalid, projected.Group, projected.Type)
+		return []reportv1alpha1.RolloutTrafficTarget{}
+	}
+	return result
+}
+
+func (b *projector) projectCoordinationReady() {
+	hasCoordination := false
+	for _, group := range b.content.Groups {
+		if group.Strategy != reportv1alpha1.RolloutStrategyCanary && group.Strategy != reportv1alpha1.RolloutStrategyUnknown {
+			hasCoordination = true
+			break
+		}
+	}
+	if !hasCoordination {
+		b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionNotApplicable
+		return
+	}
+	expected := b.coordinationReadyFromGroups()
+	var matches []apis.Condition
+	for _, condition := range b.isvc.Status.Conditions {
+		if condition.Type == apis.ConditionType(omev1beta1.RolloutCoordinationReady) {
+			matches = append(matches, condition)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionUnobserved
+	case 1:
+		switch matches[0].Status {
+		case corev1.ConditionTrue:
+			b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionTrue
+		case corev1.ConditionFalse:
+			b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionFalse
+		case corev1.ConditionUnknown:
+			b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionUnknown
+		default:
+			b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionInvalid
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, nil, "")
+		}
+		if b.content.Summary.CoordinationReady != reportv1alpha1.RolloutConditionInvalid &&
+			b.content.Summary.CoordinationReady != expected {
+			b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionInvalid
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, nil, "")
+		}
+	default:
+		b.content.Summary.CoordinationReady = reportv1alpha1.RolloutConditionInvalid
+		b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, nil, "")
+	}
+}
+
+func (b *projector) projectSummary() {
+	reportedState := b.reportedState()
+	b.content.Summary.ReportedState = reportedState
+	if b.summaryDependsOnParentStatus() {
+		b.content.Summary.State = reportv1alpha1.RolloutStateUnknown
+		b.content.Summary.Evidence = reportv1alpha1.EvidenceReported
+		b.content.Summary.Epoch = reportv1alpha1.RolloutEpochUnverifiable
+		b.addIssue(reportv1alpha1.RolloutIssueEpochUnverifiable, nil, "")
+		return
+	}
+	b.content.Summary.State = reportedState
+	b.content.Summary.Evidence = reportv1alpha1.EvidenceDeclared
+	b.content.Summary.Epoch = reportv1alpha1.RolloutEpochNotApplicable
+}
+
+func (b *projector) reportedState() reportv1alpha1.RolloutState {
+	if b.malformed {
+		return reportv1alpha1.RolloutStateUnknown
+	}
+	if len(b.isvc.Spec.GetRolloutGroups()) == 0 && !hasIndependentComponent(b.content.Components) {
+		if b.provesNotConfigured() {
+			return reportv1alpha1.RolloutStateNotConfigured
+		}
+		return reportv1alpha1.RolloutStateUnknown
+	}
+	phases := make([]reportv1alpha1.RolloutPhase, 0, len(b.content.Groups)+len(b.content.Components))
+	for _, group := range b.content.Groups {
+		phases = append(phases, group.Phase)
+	}
+	for _, component := range b.content.Components {
+		if b.componentPhaseContributes(component) {
+			phases = append(phases, component.Phase)
+		}
+	}
+	switch {
+	case hasPhase(phases, reportv1alpha1.RolloutPhaseFailed):
+		return reportv1alpha1.RolloutStateFailed
+	case hasPhase(phases, reportv1alpha1.RolloutPhaseRollingBack):
+		return reportv1alpha1.RolloutStateRollingBack
+	case hasPhase(phases, reportv1alpha1.RolloutPhaseRolledBack):
+		return reportv1alpha1.RolloutStateRolledBack
+	case hasPhase(phases, reportv1alpha1.RolloutPhasePaused):
+		return reportv1alpha1.RolloutStatePaused
+	case hasPhase(phases, reportv1alpha1.RolloutPhaseUnknown):
+		return reportv1alpha1.RolloutStateUnknown
+	case anyActivePhase(phases):
+		return reportv1alpha1.RolloutStateInProgress
+	case hasPhase(phases, reportv1alpha1.RolloutPhaseStaged):
+		return reportv1alpha1.RolloutStateStaged
+	default:
+		return reportv1alpha1.RolloutStateSucceeded
+	}
+}
+
+func (b *projector) summaryDependsOnParentStatus() bool {
+	if len(b.isvc.Spec.GetRolloutGroups()) == 0 &&
+		!hasIndependentComponent(b.content.Components) &&
+		!b.provesNotConfigured() {
+		return true
+	}
+	if len(b.isvc.Spec.GetRolloutGroups()) > 0 {
+		return true
+	}
+	return b.hasRolloutStatusResidue()
+}
+
+func (b *projector) componentPhaseContributes(component reportv1alpha1.RolloutComponentStatus) bool {
+	if component.Group == nil {
+		return component.Strategy == reportv1alpha1.RolloutStrategyIndependent
+	}
+	apiComponent := apiComponent(component.Type)
+	if b.nonCanaryCoordinationGroup(component.Group) {
+		_, found := b.isvc.Status.Components[apiComponent]
+		return !found
+	}
+	return !b.normalEmptyCanarySecondary(apiComponent, component.Group)
+}
+
+func hasIndependentComponent(components []reportv1alpha1.RolloutComponentStatus) bool {
+	for _, component := range components {
+		if component.Strategy == reportv1alpha1.RolloutStrategyIndependent {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *projector) nonCanaryCoordinationGroup(groupIndex *int) bool {
+	if groupIndex == nil || *groupIndex < 0 || *groupIndex >= len(b.content.Groups) {
+		return false
+	}
+	switch b.content.Groups[*groupIndex].Strategy {
+	case reportv1alpha1.RolloutStrategyBlueGreen,
+		reportv1alpha1.RolloutStrategyRollingUpdate,
+		reportv1alpha1.RolloutStrategySequential:
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *projector) nonCanaryComponentPhaseContradicts(
+	groupIndex *int,
+	componentPhase reportv1alpha1.RolloutPhase,
+) bool {
+	if !b.nonCanaryCoordinationGroup(groupIndex) {
+		return false
+	}
+	groupPhase := b.content.Groups[*groupIndex].Phase
+	switch groupPhase {
+	case reportv1alpha1.RolloutPhaseIdle,
+		reportv1alpha1.RolloutPhaseAwaitingNextComponent:
+		return componentPhase != reportv1alpha1.RolloutPhaseStable
+	case reportv1alpha1.RolloutPhaseStaged:
+		return componentPhase != reportv1alpha1.RolloutPhaseStable &&
+			componentPhase != reportv1alpha1.RolloutPhaseBlueGreenStandby
+	case reportv1alpha1.RolloutPhaseFailed:
+		return componentPhase != reportv1alpha1.RolloutPhaseStable &&
+			componentPhase != reportv1alpha1.RolloutPhaseFailed
+	case reportv1alpha1.RolloutPhaseRollingBack:
+		return componentPhase != reportv1alpha1.RolloutPhaseStable &&
+			componentPhase != reportv1alpha1.RolloutPhaseRollingBack &&
+			componentPhase != reportv1alpha1.RolloutPhaseRolledBack
+	case reportv1alpha1.RolloutPhasePaused:
+		return componentPhase == reportv1alpha1.RolloutPhaseFailed ||
+			componentPhase == reportv1alpha1.RolloutPhaseRollingBack ||
+			componentPhase == reportv1alpha1.RolloutPhaseRolledBack
+	case reportv1alpha1.RolloutPhaseSurging,
+		reportv1alpha1.RolloutPhaseWaiting,
+		reportv1alpha1.RolloutPhaseShifting,
+		reportv1alpha1.RolloutPhaseDraining,
+		reportv1alpha1.RolloutPhaseScalingDown:
+		return componentPhase == reportv1alpha1.RolloutPhaseFailed ||
+			componentPhase == reportv1alpha1.RolloutPhaseRollingBack ||
+			componentPhase == reportv1alpha1.RolloutPhaseRolledBack ||
+			componentPhase == reportv1alpha1.RolloutPhasePaused
+	default:
+		return false
+	}
+}
+
+func (b *projector) normalEmptyCanarySecondary(component omev1beta1.ComponentType, groupIndex *int) bool {
+	if groupIndex == nil || component == "" {
+		return false
+	}
+	groups := b.isvc.Spec.GetRolloutGroups()
+	if *groupIndex < 0 || *groupIndex >= len(groups) || groups[*groupIndex].Canary == nil {
+		return false
+	}
+	if component == canaryPrimary(groups[*groupIndex].Components) {
+		return false
+	}
+	observed, found := b.isvc.Status.Components[component]
+	return found && observed.RolloutPhase == ""
+}
+
+func (b *projector) coordinationReadyFromGroups() reportv1alpha1.RolloutConditionState {
+	anyFailed := false
+	anyActive := false
+	anyUnknown := false
+	for _, group := range b.content.Groups {
+		if group.Strategy == reportv1alpha1.RolloutStrategyCanary ||
+			group.Strategy == reportv1alpha1.RolloutStrategyUnknown {
+			continue
+		}
+		switch group.Phase {
+		case reportv1alpha1.RolloutPhaseFailed:
+			anyFailed = true
+		case reportv1alpha1.RolloutPhaseIdle,
+			reportv1alpha1.RolloutPhaseStaged,
+			reportv1alpha1.RolloutPhaseAwaitingNextComponent:
+		case reportv1alpha1.RolloutPhaseUnknown:
+			anyUnknown = true
+		default:
+			anyActive = true
+		}
+	}
+	switch {
+	case anyFailed, anyActive:
+		return reportv1alpha1.RolloutConditionFalse
+	case anyUnknown:
+		return reportv1alpha1.RolloutConditionUnknown
+	default:
+		return reportv1alpha1.RolloutConditionTrue
+	}
+}
+
+func (b *projector) flagUnexpectedCoordination(groups []omev1beta1.RolloutGroup) {
+	if b.isvc.Status.RolloutCoordination == nil {
+		return
+	}
+	expected := make(map[string]struct{})
+	if b.canCollapseSequential(groups) {
+		expected["0"] = struct{}{}
+	} else {
+		for i := range groups {
+			if groups[i].Canary == nil {
+				expected[strconv.Itoa(i)] = struct{}{}
+			}
+		}
+	}
+	for _, observed := range b.isvc.Status.RolloutCoordination.Groups {
+		if _, found := expected[observed.Name]; !found {
+			b.markMalformed(reportv1alpha1.RolloutIssueGroupStatusUnexpected, nil, "")
+		}
+	}
+}
+
+func (b *projector) coordinationGroup(name string) *omev1beta1.RolloutCoordinationGroupStatus {
+	if b.isvc.Status.RolloutCoordination == nil {
+		return nil
+	}
+	var found *omev1beta1.RolloutCoordinationGroupStatus
+	for i := range b.isvc.Status.RolloutCoordination.Groups {
+		candidate := &b.isvc.Status.RolloutCoordination.Groups[i]
+		if candidate.Name != name {
+			continue
+		}
+		if found != nil {
+			b.markMalformed(reportv1alpha1.RolloutIssueStatusMalformed, nil, "")
+			return found
+		}
+		found = candidate
+	}
+	return found
+}
+
+func (b *projector) canaryGroupPhase(
+	group int,
+	components []omev1beta1.ComponentType,
+	primary omev1beta1.ComponentType,
+) reportv1alpha1.RolloutPhase {
+	if primary == "" {
+		return reportv1alpha1.RolloutPhaseUnknown
+	}
+	primaryStatus, found := b.isvc.Status.Components[primary]
+	if !found {
+		return reportv1alpha1.RolloutPhaseUnknown
+	}
+	primaryPhase := projectComponentPhase(primaryStatus.RolloutPhase)
+	if primaryStatus.RolloutPhase != "" && primaryPhase == reportv1alpha1.RolloutPhaseUnknown {
+		b.markMalformed(
+			reportv1alpha1.RolloutIssueStatusMalformed,
+			ptrInt(group),
+			projectComponent(primary),
+		)
+	}
+	for _, component := range components {
+		if component == primary {
+			continue
+		}
+		secondary, found := b.isvc.Status.Components[component]
+		if !found || secondary.RolloutPhase == "" {
+			continue
+		}
+		secondaryPhase := projectComponentPhase(secondary.RolloutPhase)
+		if secondaryPhase == reportv1alpha1.RolloutPhaseUnknown ||
+			(primaryPhase != reportv1alpha1.RolloutPhaseUnknown && secondaryPhase != primaryPhase) {
+			b.markMalformed(
+				reportv1alpha1.RolloutIssueStatusMalformed,
+				ptrInt(group),
+				projectComponent(component),
+			)
+		}
+	}
+	return primaryPhase
+}
+
+func canaryPrimary(components []omev1beta1.ComponentType) omev1beta1.ComponentType {
+	for _, candidate := range []omev1beta1.ComponentType{
+		omev1beta1.RouterComponent,
+		omev1beta1.EngineComponent,
+		omev1beta1.DecoderComponent,
+	} {
+		if slices.Contains(components, candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func (b *projector) safeDirectHash(value string, group int) string {
+	if value == "" {
+		return ""
+	}
+	if !safeRevisionHash(value) {
+		b.markMalformed(reportv1alpha1.RolloutIssueRevisionNameInvalid, ptrInt(group), "")
+		return ""
+	}
+	return value
+}
+
+func (b *projector) serviceRevisionHash(
+	name string,
+	component omev1beta1.ComponentType,
+	group *int,
+) string {
+	if name == "" {
+		return ""
+	}
+	hash := extractRevisionHash(b.isvc.Name, component, name)
+	if hash == "" {
+		b.markMalformed(reportv1alpha1.RolloutIssueRevisionNameInvalid, group, projectComponent(component))
+	}
+	return hash
+}
+
+func (b *projector) groupContains(group *reportv1alpha1.RolloutGroupStatus, component omev1beta1.ComponentType) bool {
+	projected := projectComponent(component)
+	for _, member := range group.Components {
+		if member == projected {
+			return projected != ""
+		}
+	}
+	return false
+}
+
+func (b *projector) markMalformed(code reportv1alpha1.RolloutIssueCode, group *int, component reportv1alpha1.RuntimeComponentType) {
+	b.malformed = true
+	b.addIssue(code, group, component)
+	b.addWarning(reportv1alpha1.WarningPartialData)
+}
+
+func (b *projector) addIssue(code reportv1alpha1.RolloutIssueCode, group *int, component reportv1alpha1.RuntimeComponentType) {
+	key := string(code) + "/" + string(component) + "/"
+	if group != nil {
+		key += strconv.Itoa(*group)
+	}
+	if _, found := b.issueKeys[key]; found {
+		return
+	}
+	b.issueKeys[key] = struct{}{}
+	var groupCopy *int
+	if group != nil {
+		groupCopy = ptrInt(*group)
+	}
+	b.content.Issues = append(b.content.Issues, reportv1alpha1.RolloutIssue{
+		Code: code, Group: groupCopy, Component: component,
+	})
+	b.addWarning(reportv1alpha1.WarningPartialData)
+}
+
+func (b *projector) addWarning(code reportv1alpha1.WarningCode) {
+	b.warningCodes[code] = struct{}{}
+}
+
+func projectComponent(component omev1beta1.ComponentType) reportv1alpha1.RuntimeComponentType {
+	switch component {
+	case omev1beta1.EngineComponent:
+		return reportv1alpha1.RuntimeComponentEngine
+	case omev1beta1.DecoderComponent:
+		return reportv1alpha1.RuntimeComponentDecoder
+	case omev1beta1.RouterComponent:
+		return reportv1alpha1.RuntimeComponentRouter
+	default:
+		return ""
+	}
+}
+
+func apiComponent(component reportv1alpha1.RuntimeComponentType) omev1beta1.ComponentType {
+	switch component {
+	case reportv1alpha1.RuntimeComponentEngine:
+		return omev1beta1.EngineComponent
+	case reportv1alpha1.RuntimeComponentDecoder:
+		return omev1beta1.DecoderComponent
+	case reportv1alpha1.RuntimeComponentRouter:
+		return omev1beta1.RouterComponent
+	default:
+		return ""
+	}
+}
+
+func validSequentialCursor(
+	order []omev1beta1.ComponentType,
+	phase omev1beta1.CoordinationPhase,
+	current omev1beta1.ComponentType,
+	previous omev1beta1.ComponentType,
+) bool {
+	if phase == omev1beta1.CoordinationPhasePaused {
+		return current == "" && previous == ""
+	}
+	if current == "" {
+		return phase == omev1beta1.CoordinationPhaseIdle && previous == ""
+	}
+	index := slices.Index(order, current)
+	if index < 0 {
+		return false
+	}
+	if index == 0 {
+		return phase != omev1beta1.CoordinationPhaseIdle && previous == ""
+	}
+	return previous == order[index-1]
+}
+
+func validSequentialComposite(
+	phase omev1beta1.CoordinationPhase,
+	composite string,
+	current omev1beta1.ComponentType,
+	previous omev1beta1.ComponentType,
+) bool {
+	if phase == omev1beta1.CoordinationPhaseIdle {
+		if current == "" && previous == "" {
+			return composite == "" || composite == string(omev1beta1.CoordinationPhaseIdle)
+		}
+		return composite == omev1beta1.CompositePhaseSequentialAwaiting
+	}
+	if composite == "" {
+		return true
+	}
+	if phase == omev1beta1.CoordinationPhaseFailed {
+		return composite == omev1beta1.CompositePhaseSequentialFailed
+	}
+	if current == "" {
+		return composite == string(phase)
+	}
+	return composite == string(current)+"."+string(phase)
+}
+
+func supportedComponent(component omev1beta1.ComponentType) bool {
+	return projectComponent(component) != ""
+}
+
+func componentOrder(component omev1beta1.ComponentType) int {
+	switch component {
+	case omev1beta1.EngineComponent:
+		return 0
+	case omev1beta1.DecoderComponent:
+		return 1
+	case omev1beta1.RouterComponent:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func projectComponentPhase(phase omev1beta1.RolloutPhase) reportv1alpha1.RolloutPhase {
+	switch phase {
+	case omev1beta1.RolloutPhaseStable:
+		return reportv1alpha1.RolloutPhaseStable
+	case omev1beta1.RolloutPhaseCanarying:
+		return reportv1alpha1.RolloutPhaseCanarying
+	case omev1beta1.RolloutPhaseBlueGreenStandby:
+		return reportv1alpha1.RolloutPhaseBlueGreenStandby
+	case omev1beta1.RolloutPhasePending:
+		return reportv1alpha1.RolloutPhasePending
+	case omev1beta1.RolloutPhasePaused:
+		return reportv1alpha1.RolloutPhasePaused
+	case omev1beta1.RolloutPhasePromoting:
+		return reportv1alpha1.RolloutPhasePromoting
+	case omev1beta1.RolloutPhaseRollingBack:
+		return reportv1alpha1.RolloutPhaseRollingBack
+	case omev1beta1.RolloutPhaseRolledBack:
+		return reportv1alpha1.RolloutPhaseRolledBack
+	case omev1beta1.RolloutPhaseFailed:
+		return reportv1alpha1.RolloutPhaseFailed
+	default:
+		return reportv1alpha1.RolloutPhaseUnknown
+	}
+}
+
+func projectCoordinationPhase(phase omev1beta1.CoordinationPhase) reportv1alpha1.RolloutPhase {
+	switch phase {
+	case omev1beta1.CoordinationPhaseIdle:
+		return reportv1alpha1.RolloutPhaseIdle
+	case omev1beta1.CoordinationPhaseSurging:
+		return reportv1alpha1.RolloutPhaseSurging
+	case omev1beta1.CoordinationPhaseWaiting:
+		return reportv1alpha1.RolloutPhaseWaiting
+	case omev1beta1.CoordinationPhaseShifting:
+		return reportv1alpha1.RolloutPhaseShifting
+	case omev1beta1.CoordinationPhaseDraining:
+		return reportv1alpha1.RolloutPhaseDraining
+	case omev1beta1.CoordinationPhaseScalingDown:
+		return reportv1alpha1.RolloutPhaseScalingDown
+	case omev1beta1.CoordinationPhaseStaged:
+		return reportv1alpha1.RolloutPhaseStaged
+	case omev1beta1.CoordinationPhaseFailed:
+		return reportv1alpha1.RolloutPhaseFailed
+	case omev1beta1.CoordinationPhaseRollingBack:
+		return reportv1alpha1.RolloutPhaseRollingBack
+	case omev1beta1.CoordinationPhasePaused:
+		return reportv1alpha1.RolloutPhasePaused
+	default:
+		return reportv1alpha1.RolloutPhaseUnknown
+	}
+}
+
+func gateFor(step *omev1beta1.RolloutGroupStep) reportv1alpha1.RolloutGate {
+	switch {
+	case step.Analysis != nil:
+		return reportv1alpha1.RolloutGateAnalysis
+	case step.Pause != nil && step.Pause.Duration != nil:
+		return reportv1alpha1.RolloutGateTimed
+	case step.Pause != nil:
+		return reportv1alpha1.RolloutGateManual
+	default:
+		return reportv1alpha1.RolloutGateImmediate
+	}
+}
+
+func analysisState(
+	analysis *omev1beta1.RolloutAnalysis,
+	status *omev1beta1.CanaryStatus,
+) (reportv1alpha1.RolloutAnalysisState, bool) {
+	if analysis == nil {
+		return reportv1alpha1.RolloutAnalysisUnobserved, false
+	}
+	if len(status.MetricResults) == 0 &&
+		status.LastEvaluationTime == nil &&
+		status.LastConclusiveEvaluationTime == nil &&
+		status.AnalysisFailedChecks == 0 {
+		return reportv1alpha1.RolloutAnalysisUnobserved, true
+	}
+	if status.AnalysisFailedChecks < 0 ||
+		status.LastEvaluationTime == nil ||
+		status.LastEvaluationTime.IsZero() ||
+		len(status.MetricResults) == 0 {
+		return reportv1alpha1.RolloutAnalysisInconclusive, false
+	}
+	if status.LastConclusiveEvaluationTime != nil {
+		if status.LastConclusiveEvaluationTime.IsZero() ||
+			status.LastConclusiveEvaluationTime.Time.After(status.LastEvaluationTime.Time) {
+			return reportv1alpha1.RolloutAnalysisInconclusive, false
+		}
+	}
+	if status.AnalysisFailedChecks > 0 && status.LastConclusiveEvaluationTime == nil {
+		return reportv1alpha1.RolloutAnalysisInconclusive, false
+	}
+	expected := make(map[string]omev1beta1.AnalysisMetric, len(analysis.Metrics))
+	for _, metric := range analysis.Metrics {
+		expected[metric.Name] = metric
+	}
+	seen := make(map[string]struct{}, len(status.MetricResults))
+	anyFail := false
+	anyInconclusive := false
+	for _, result := range status.MetricResults {
+		if result.Time == nil || result.Time.IsZero() ||
+			!result.Time.Time.Equal(status.LastEvaluationTime.Time) ||
+			(result.Value == "" && result.Passed) {
+			return reportv1alpha1.RolloutAnalysisInconclusive, false
+		}
+		metric, found := expected[result.Name]
+		if !found {
+			anyInconclusive = true
+			continue
+		}
+		if _, duplicate := seen[result.Name]; duplicate {
+			anyInconclusive = true
+			continue
+		}
+		seen[result.Name] = struct{}{}
+		if result.Threshold != metric.Threshold || result.Operator != metric.Operator {
+			anyInconclusive = true
+			continue
+		}
+		if result.Value == "" {
+			anyInconclusive = true
+			continue
+		}
+		value, valueErr := strconv.ParseFloat(result.Value, 64)
+		threshold, thresholdErr := strconv.ParseFloat(metric.Threshold, 64)
+		if valueErr != nil || thresholdErr != nil ||
+			math.IsNaN(value) || math.IsInf(value, 0) ||
+			math.IsNaN(threshold) || math.IsInf(threshold, 0) {
+			return reportv1alpha1.RolloutAnalysisInconclusive, false
+		}
+		passed, comparable := analysisComparison(value, metric.Operator, threshold)
+		if !comparable || passed != result.Passed {
+			return reportv1alpha1.RolloutAnalysisInconclusive, false
+		}
+		if !passed {
+			anyFail = true
+		}
+	}
+	if len(seen) != len(expected) {
+		anyInconclusive = true
+	}
+	state := reportv1alpha1.RolloutAnalysisPassing
+	switch {
+	case anyFail:
+		state = reportv1alpha1.RolloutAnalysisFailing
+	case anyInconclusive:
+		state = reportv1alpha1.RolloutAnalysisInconclusive
+	}
+	if state == reportv1alpha1.RolloutAnalysisFailing && status.AnalysisFailedChecks == 0 {
+		return reportv1alpha1.RolloutAnalysisInconclusive, false
+	}
+	if (state == reportv1alpha1.RolloutAnalysisPassing ||
+		state == reportv1alpha1.RolloutAnalysisFailing) &&
+		(status.LastConclusiveEvaluationTime == nil ||
+			!status.LastConclusiveEvaluationTime.Time.Equal(status.LastEvaluationTime.Time)) {
+		return reportv1alpha1.RolloutAnalysisInconclusive, false
+	}
+	return state, true
+}
+
+func analysisComparison(
+	value float64,
+	operator omev1beta1.ComparisonOperator,
+	threshold float64,
+) (bool, bool) {
+	switch operator {
+	case omev1beta1.ComparisonLT:
+		return value < threshold, true
+	case omev1beta1.ComparisonLTE:
+		return value <= threshold, true
+	case omev1beta1.ComparisonGT:
+		return value > threshold, true
+	case omev1beta1.ComparisonGTE:
+		return value >= threshold, true
+	default:
+		return false, false
+	}
+}
+
+func safeCapacity(value intstr.IntOrString) bool {
+	switch value.Type {
+	case intstr.Int:
+		return value.IntVal >= 0
+	case intstr.String:
+		raw := value.StrVal
+		if !strings.HasSuffix(raw, "%") {
+			return false
+		}
+		raw = strings.TrimSuffix(raw, "%")
+		parsed, err := strconv.Atoi(raw)
+		return err == nil && parsed >= 0 && parsed <= 100
+	default:
+		return false
+	}
+}
+
+func validCompletedCanaryCapacity(value intstr.IntOrString) bool {
+	if !safeCapacity(value) {
+		return false
+	}
+	if value.Type == intstr.Int {
+		return value.IntVal > 0
+	}
+	percentage, err := strconv.Atoi(strings.TrimSuffix(value.StrVal, "%"))
+	return err == nil && percentage == 100
+}
+
+func extractRevisionHash(isvcName string, component omev1beta1.ComponentType, serviceName string) string {
+	if len(serviceName) < 8 {
+		return ""
+	}
+	hash := serviceName[len(serviceName)-8:]
+	if !safeRevisionHash(hash) {
+		return ""
+	}
+	rawName := fmt.Sprintf("%s-%s-rev-%s", isvcName, component, hash)
+	expected := constants.TruncateNameWithMaxLength(rawName, validation.DNS1035LabelMaxLength)
+	if serviceName != expected {
+		return ""
+	}
+	return hash
+}
+
+func extractControllerRevisionHash(
+	isvcName string,
+	component omev1beta1.ComponentType,
+	revisionName string,
+) string {
+	if len(revisionName) < 8 {
+		return ""
+	}
+	hash := revisionName[len(revisionName)-8:]
+	if !safeRevisionHash(hash) {
+		return ""
+	}
+	if revisionName != fmt.Sprintf("%s-%s-%s", isvcName, component, hash) {
+		return ""
+	}
+	return hash
+}
+
+func safeRevisionHash(hash string) bool {
+	return revisionHashPattern.MatchString(hash)
+}
+
+func revisionRole(hash string, component *reportv1alpha1.RolloutComponentStatus) reportv1alpha1.RolloutRevisionRole {
+	switch hash {
+	case component.RolledOutRevisionHash:
+		return reportv1alpha1.RolloutRevisionCurrent
+	case component.ReadyRevisionHash:
+		return reportv1alpha1.RolloutRevisionTarget
+	case component.PreviousRevisionHash:
+		return reportv1alpha1.RolloutRevisionPrevious
+	default:
+		return reportv1alpha1.RolloutRevisionOther
+	}
+}
+
+func canaryPhaseNeedsStatus(phase reportv1alpha1.RolloutPhase) bool {
+	switch phase {
+	case reportv1alpha1.RolloutPhasePending,
+		reportv1alpha1.RolloutPhaseCanarying,
+		reportv1alpha1.RolloutPhasePaused,
+		reportv1alpha1.RolloutPhasePromoting,
+		reportv1alpha1.RolloutPhaseRollingBack,
+		reportv1alpha1.RolloutPhaseRolledBack,
+		reportv1alpha1.RolloutPhaseFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func canaryPhaseBindsTraffic(phase reportv1alpha1.RolloutPhase) bool {
+	switch phase {
+	case reportv1alpha1.RolloutPhaseCanarying,
+		reportv1alpha1.RolloutPhasePaused,
+		reportv1alpha1.RolloutPhasePromoting,
+		reportv1alpha1.RolloutPhaseRollingBack,
+		reportv1alpha1.RolloutPhaseRolledBack:
+		return true
+	default:
+		return false
+	}
+}
+
+func canaryPhaseBindsStepTraffic(phase reportv1alpha1.RolloutPhase) bool {
+	switch phase {
+	case reportv1alpha1.RolloutPhaseCanarying,
+		reportv1alpha1.RolloutPhasePaused,
+		reportv1alpha1.RolloutPhasePromoting:
+		return true
+	default:
+		return false
+	}
+}
+
+func canaryObservedTrafficMatchesStep(
+	phase reportv1alpha1.RolloutPhase,
+	steps []omev1beta1.RolloutGroupStep,
+	status *omev1beta1.CanaryStatus,
+) bool {
+	current := int(status.CurrentStep)
+	if current < 0 || current >= len(steps) {
+		return false
+	}
+	if status.ObservedTrafficWeight == steps[current].Traffic {
+		return true
+	}
+	return phase == reportv1alpha1.RolloutPhaseCanarying &&
+		current > 0 &&
+		status.ObservedTrafficWeight == steps[current-1].Traffic
+}
+
+func validCanaryPhaseStepResidue(
+	phase reportv1alpha1.RolloutPhase,
+	steps []omev1beta1.RolloutGroupStep,
+	status *omev1beta1.CanaryStatus,
+) bool {
+	current := int(status.CurrentStep)
+	if current < 0 || current >= len(steps) {
+		return false
+	}
+	last := len(steps) - 1
+	switch phase {
+	case reportv1alpha1.RolloutPhasePromoting:
+		if current != last {
+			return false
+		}
+	case reportv1alpha1.RolloutPhasePaused:
+		if current >= last {
+			return false
+		}
+	case reportv1alpha1.RolloutPhaseCanarying:
+		if current == last &&
+			(current == 0 || status.ObservedTrafficWeight != steps[current-1].Traffic) {
+			return false
+		}
+	}
+
+	rollbackPhase := phase == reportv1alpha1.RolloutPhaseRollingBack ||
+		phase == reportv1alpha1.RolloutPhaseRolledBack
+	if status.RolledBackRevisionHash != "" && !rollbackPhase {
+		return false
+	}
+	if status.PromotedThrough == "" {
+		return true
+	}
+	if current < 1 {
+		return false
+	}
+	previousStep := &steps[current-1]
+	if gateFor(previousStep) == reportv1alpha1.RolloutGateManual {
+		return status.PromotedThrough == status.CanaryRevisionHash
+	}
+	return true
+}
+
+func hasPhase(phases []reportv1alpha1.RolloutPhase, want reportv1alpha1.RolloutPhase) bool {
+	for _, phase := range phases {
+		if phase == want {
+			return true
+		}
+	}
+	return false
+}
+
+func anyActivePhase(phases []reportv1alpha1.RolloutPhase) bool {
+	for _, phase := range phases {
+		switch phase {
+		case reportv1alpha1.RolloutPhaseCanarying,
+			reportv1alpha1.RolloutPhaseBlueGreenStandby,
+			reportv1alpha1.RolloutPhasePending,
+			reportv1alpha1.RolloutPhasePromoting,
+			reportv1alpha1.RolloutPhaseSurging,
+			reportv1alpha1.RolloutPhaseWaiting,
+			reportv1alpha1.RolloutPhaseShifting,
+			reportv1alpha1.RolloutPhaseUpdating,
+			reportv1alpha1.RolloutPhaseDraining,
+			reportv1alpha1.RolloutPhaseScalingDown,
+			reportv1alpha1.RolloutPhaseAwaitingNextComponent:
+			return true
+		}
+	}
+	return false
+}
+
+func ptrInt(value int) *int { return &value }

--- a/pkg/cli/rolloutprojection/project_internal_test.go
+++ b/pkg/cli/rolloutprojection/project_internal_test.go
@@ -1,0 +1,245 @@
+package rolloutprojection
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestComponentPhaseProjectionIsExhaustiveAndClosed(t *testing.T) {
+	tests := []struct {
+		input omev1beta1.RolloutPhase
+		want  reportv1alpha1.RolloutPhase
+	}{
+		{omev1beta1.RolloutPhaseStable, reportv1alpha1.RolloutPhaseStable},
+		{omev1beta1.RolloutPhaseCanarying, reportv1alpha1.RolloutPhaseCanarying},
+		{omev1beta1.RolloutPhaseBlueGreenStandby, reportv1alpha1.RolloutPhaseBlueGreenStandby},
+		{omev1beta1.RolloutPhasePending, reportv1alpha1.RolloutPhasePending},
+		{omev1beta1.RolloutPhasePaused, reportv1alpha1.RolloutPhasePaused},
+		{omev1beta1.RolloutPhasePromoting, reportv1alpha1.RolloutPhasePromoting},
+		{omev1beta1.RolloutPhaseRollingBack, reportv1alpha1.RolloutPhaseRollingBack},
+		{omev1beta1.RolloutPhaseRolledBack, reportv1alpha1.RolloutPhaseRolledBack},
+		{omev1beta1.RolloutPhaseFailed, reportv1alpha1.RolloutPhaseFailed},
+		{"", reportv1alpha1.RolloutPhaseUnknown},
+		{"Never serialize this", reportv1alpha1.RolloutPhaseUnknown},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, projectComponentPhase(tt.input), "input %q", tt.input)
+	}
+}
+
+func TestCoordinationPhaseProjectionIsExhaustiveAndClosed(t *testing.T) {
+	tests := []struct {
+		input omev1beta1.CoordinationPhase
+		want  reportv1alpha1.RolloutPhase
+	}{
+		{omev1beta1.CoordinationPhaseIdle, reportv1alpha1.RolloutPhaseIdle},
+		{omev1beta1.CoordinationPhaseSurging, reportv1alpha1.RolloutPhaseSurging},
+		{omev1beta1.CoordinationPhaseWaiting, reportv1alpha1.RolloutPhaseWaiting},
+		{omev1beta1.CoordinationPhaseShifting, reportv1alpha1.RolloutPhaseShifting},
+		{omev1beta1.CoordinationPhaseDraining, reportv1alpha1.RolloutPhaseDraining},
+		{omev1beta1.CoordinationPhaseScalingDown, reportv1alpha1.RolloutPhaseScalingDown},
+		{omev1beta1.CoordinationPhaseStaged, reportv1alpha1.RolloutPhaseStaged},
+		{omev1beta1.CoordinationPhaseFailed, reportv1alpha1.RolloutPhaseFailed},
+		{omev1beta1.CoordinationPhaseRollingBack, reportv1alpha1.RolloutPhaseRollingBack},
+		{omev1beta1.CoordinationPhasePaused, reportv1alpha1.RolloutPhasePaused},
+		{"", reportv1alpha1.RolloutPhaseUnknown},
+		{"Never serialize this", reportv1alpha1.RolloutPhaseUnknown},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, projectCoordinationPhase(tt.input), "input %q", tt.input)
+	}
+}
+
+func TestCanaryGateProjectionUsesShippedPrecedence(t *testing.T) {
+	duration := metav1.Duration{Duration: time.Minute}
+	tests := []struct {
+		name string
+		step omev1beta1.RolloutGroupStep
+		want reportv1alpha1.RolloutGate
+	}{
+		{name: "immediate", want: reportv1alpha1.RolloutGateImmediate},
+		{name: "manual", step: omev1beta1.RolloutGroupStep{Pause: &omev1beta1.RolloutPause{}}, want: reportv1alpha1.RolloutGateManual},
+		{name: "timed", step: omev1beta1.RolloutGroupStep{Pause: &omev1beta1.RolloutPause{Duration: &duration}}, want: reportv1alpha1.RolloutGateTimed},
+		{name: "analysis wins over duration", step: omev1beta1.RolloutGroupStep{Pause: &omev1beta1.RolloutPause{Duration: &duration}, Analysis: &omev1beta1.RolloutAnalysis{}}, want: reportv1alpha1.RolloutGateAnalysis},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { assert.Equal(t, tt.want, gateFor(&tt.step)) })
+	}
+}
+
+func TestAnalysisProjectionNeverReturnsMetricPayloads(t *testing.T) {
+	evaluated := metav1.NewTime(time.Date(2026, time.August, 31, 18, 0, 0, 0, time.UTC))
+	tests := []struct {
+		name   string
+		status *omev1beta1.CanaryStatus
+		want   reportv1alpha1.RolloutAnalysisState
+		valid  bool
+	}{
+		{name: "unobserved", status: &omev1beta1.CanaryStatus{}, want: reportv1alpha1.RolloutAnalysisUnobserved, valid: true},
+		{name: "passing", status: &omev1beta1.CanaryStatus{
+			LastEvaluationTime: &evaluated, LastConclusiveEvaluationTime: &evaluated,
+			MetricResults: []omev1beta1.AnalysisMetricResult{{
+				Name: "secret", Value: "1", Threshold: "1", Operator: omev1beta1.ComparisonLTE,
+				Passed: true, Time: &evaluated,
+			}},
+		}, want: reportv1alpha1.RolloutAnalysisPassing, valid: true},
+		{name: "failing", status: &omev1beta1.CanaryStatus{
+			AnalysisFailedChecks: 1, LastEvaluationTime: &evaluated, LastConclusiveEvaluationTime: &evaluated,
+			MetricResults: []omev1beta1.AnalysisMetricResult{{
+				Name: "secret", Value: "2", Threshold: "1", Operator: omev1beta1.ComparisonLTE,
+				Passed: false, Time: &evaluated,
+			}},
+		}, want: reportv1alpha1.RolloutAnalysisFailing, valid: true},
+		{name: "inconclusive", status: &omev1beta1.CanaryStatus{
+			LastEvaluationTime: &evaluated,
+			MetricResults: []omev1beta1.AnalysisMetricResult{{
+				Name: "secret", Threshold: "1", Operator: omev1beta1.ComparisonLTE,
+				Passed: false, Message: "secret", Time: &evaluated,
+			}},
+		}, want: reportv1alpha1.RolloutAnalysisInconclusive, valid: true},
+	}
+	analysis := &omev1beta1.RolloutAnalysis{Metrics: []omev1beta1.AnalysisMetric{{
+		Name: "secret", Threshold: "1", Operator: omev1beta1.ComparisonLTE,
+	}}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, valid := analysisState(analysis, tt.status)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.valid, valid)
+		})
+	}
+}
+
+func TestCapacityAndRevisionExtractionAreBounded(t *testing.T) {
+	for _, value := range []intstr.IntOrString{
+		intstr.FromInt32(3), intstr.FromString("25%"), intstr.FromString("+10%"),
+	} {
+		assert.True(t, safeCapacity(value), "value %q", value.String())
+	}
+	for _, value := range []intstr.IntOrString{
+		intstr.FromInt32(-1), intstr.FromString("3"), intstr.FromString("101%"),
+		intstr.FromString("secret value"), intstr.FromString(""),
+	} {
+		assert.False(t, safeCapacity(value), "value %q", value.String())
+	}
+
+	assert.Equal(t, "aaaaaaaa", extractRevisionHash("chat", omev1beta1.EngineComponent, "chat-engine-rev-aaaaaaaa"))
+	for _, value := range []string{
+		"other-engine-rev-aaaaaaaa", "chat-decoder-rev-aaaaaaaa", "chat-engine-rev-",
+		"chat-engine-rev-UPPERCASE", "chat-engine-rev-secret/value",
+	} {
+		assert.Empty(t, extractRevisionHash("chat", omev1beta1.EngineComponent, value), "value %q", value)
+	}
+}
+
+func TestRevisionExtractionAcceptsOnlyExactControllerBoundedName(t *testing.T) {
+	owner := strings.Repeat("long-owner-", 7) + "chat"
+	raw := fmt.Sprintf("%s-%s-rev-%s", owner, omev1beta1.EngineComponent, "deadbeef")
+	serviceName := constants.TruncateNameWithMaxLength(raw, validation.DNS1035LabelMaxLength)
+	require.Len(t, serviceName, validation.DNS1035LabelMaxLength)
+
+	assert.Equal(t, "deadbeef", extractRevisionHash(owner, omev1beta1.EngineComponent, serviceName))
+	assert.Empty(t, extractRevisionHash(owner, omev1beta1.EngineComponent, "z"+serviceName[1:]))
+	assert.Empty(t, extractRevisionHash(owner, omev1beta1.EngineComponent, serviceName[:len(serviceName)-8]+"DEADBEEF"))
+}
+
+func TestControllerRevisionExtractionAcceptsOnlyExactBoundedIdentity(t *testing.T) {
+	assert.Equal(t, "deadbeef", extractControllerRevisionHash(
+		"chat", omev1beta1.EngineComponent, "chat-engine-deadbeef",
+	))
+	for _, value := range []string{
+		"other-engine-deadbeef",
+		"chat-decoder-deadbeef",
+		"chat-engine-rev-deadbeef",
+		"chat-engine-DEADBEEF",
+		"chat-engine-secret/value",
+	} {
+		assert.Empty(t, extractControllerRevisionHash(
+			"chat", omev1beta1.EngineComponent, value,
+		), "value %q", value)
+	}
+}
+
+func TestCoordinationConditionProjectionIsBounded(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []apis.Condition
+		phase      omev1beta1.CoordinationPhase
+		want       reportv1alpha1.RolloutConditionState
+		wantIssue  bool
+	}{
+		{name: "absent", phase: omev1beta1.CoordinationPhaseIdle, want: reportv1alpha1.RolloutConditionUnobserved},
+		{name: "true", phase: omev1beta1.CoordinationPhaseIdle, conditions: []apis.Condition{{Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionTrue}}, want: reportv1alpha1.RolloutConditionTrue},
+		{name: "false", phase: omev1beta1.CoordinationPhaseSurging, conditions: []apis.Condition{{Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionFalse}}, want: reportv1alpha1.RolloutConditionFalse},
+		{name: "unknown", conditions: []apis.Condition{{Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionUnknown}}, want: reportv1alpha1.RolloutConditionUnknown},
+		{name: "invalid", phase: omev1beta1.CoordinationPhaseIdle, conditions: []apis.Condition{{Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionStatus("Secret")}}, want: reportv1alpha1.RolloutConditionInvalid, wantIssue: true},
+		{name: "duplicate", conditions: []apis.Condition{
+			{Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionTrue},
+			{Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionFalse},
+		}, want: reportv1alpha1.RolloutConditionInvalid, wantIssue: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := coordinatedFixture()
+			isvc.Status.RolloutCoordination.Groups[0].Phase = tt.phase
+			isvc.Status.Conditions = tt.conditions
+			got, err := Project(isvc, reportv1alpha1.ClockFunc(func() time.Time { return time.Unix(1, 0) }))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.Content.Summary.CoordinationReady)
+			if tt.wantIssue {
+				assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{Code: reportv1alpha1.RolloutIssueStatusMalformed})
+			}
+		})
+	}
+}
+
+func TestMissingObservedGroupIsExplicitPartialData(t *testing.T) {
+	isvc := coordinatedFixture()
+	isvc.Status.RolloutCoordination = nil
+
+	got, err := Project(isvc, reportv1alpha1.ClockFunc(func() time.Time { return time.Unix(1, 0) }))
+	require.NoError(t, err)
+	group := 0
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{Code: reportv1alpha1.RolloutIssueGroupStatusMissing, Group: &group})
+	assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{Code: reportv1alpha1.WarningPartialData})
+	assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+}
+
+func coordinatedFixture() *omev1beta1.InferenceService {
+	mode := constants.OMENative
+	return &omev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "chat", UID: "isvc-uid", Generation: 7},
+		Spec: omev1beta1.InferenceServiceSpec{
+			DeploymentMode: &mode,
+			Engine:         &omev1beta1.EngineSpec{},
+			Rollout: &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+				Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+			}}},
+		},
+		Status: omev1beta1.InferenceServiceStatus{
+			Status: duckv1.Status{ObservedGeneration: 7},
+			Components: map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+				omev1beta1.EngineComponent: {},
+			},
+			RolloutCoordination: &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+				Name: "0", Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+				Policy: omev1beta1.CoordinationPolicyBlueGreen, Phase: omev1beta1.CoordinationPhaseIdle,
+			}}},
+		},
+	}
+}

--- a/pkg/cli/rolloutprojection/project_test.go
+++ b/pkg/cli/rolloutprojection/project_test.go
@@ -1,0 +1,2366 @@
+package rolloutprojection_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/apis"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/cli/rolloutprojection"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestProjectCanaryProducesSafeFaithfulReport(t *testing.T) {
+	entered := metav1.NewTime(time.Date(2026, time.August, 31, 17, 0, 0, 0, time.UTC))
+	evaluated := metav1.NewTime(time.Date(2026, time.August, 31, 17, 1, 0, 0, time.UTC))
+	analysis := validAnalysis("SECRET_METRIC")
+	analysis.Metrics[0].Query = "SECRET_QUERY"
+	isvc := baseInferenceService()
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Canary: &omev1beta1.GroupCanary{Steps: []omev1beta1.RolloutGroupStep{
+			{Capacity: intstr.FromString("25%"), Traffic: 5},
+			{
+				Capacity: intstr.FromString("50%"), Traffic: 20,
+				Pause:    &omev1beta1.RolloutPause{},
+				Analysis: analysis,
+			},
+			{Capacity: intstr.FromString("100%"), Traffic: 100},
+		}},
+	}}}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			RolloutPhase:              omev1beta1.RolloutPhaseCanarying,
+			LatestRolledoutRevision:   "chat-engine-rev-aaaaaaaa",
+			LatestReadyRevision:       "chat-engine-rev-bbbbbbbb",
+			PreviousRolledoutRevision: "chat-engine-rev-cccccccc",
+			Traffic: []omev1beta1.ComponentTrafficTarget{
+				{RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 80, Tag: "SECRET_TAG", LatestRevision: true},
+				{RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 20},
+			},
+		},
+	}
+	isvc.Status.Canary = &omev1beta1.CanaryStatus{
+		CanaryRevisionHash: "bbbbbbbb", StableRevisionHash: "aaaaaaaa",
+		CurrentStep: 1, StepEnteredTime: &entered, ObservedTrafficWeight: 20,
+		PromotedThrough: "SECRET_MAILBOX", AnalysisFailedChecks: 1,
+		LastEvaluationTime: &evaluated, LastConclusiveEvaluationTime: &evaluated,
+		MetricResults: []omev1beta1.AnalysisMetricResult{{
+			Name: "SECRET_METRIC", Value: "2", Threshold: "1",
+			Operator: omev1beta1.ComparisonLTE, Passed: false, Message: "SECRET_MESSAGE",
+			Time: &evaluated,
+		}},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RolloutSummary{
+		State:             reportv1alpha1.RolloutStateUnknown,
+		ReportedState:     reportv1alpha1.RolloutStateInProgress,
+		Evidence:          reportv1alpha1.EvidenceReported,
+		Epoch:             reportv1alpha1.RolloutEpochUnverifiable,
+		CoordinationReady: reportv1alpha1.RolloutConditionNotApplicable,
+	}, got.Content.Summary)
+	require.Len(t, got.Sources, 1)
+	assert.Equal(t, reportv1alpha1.RolloutSourceReference{
+		Kind: "InferenceService", Namespace: "prod", Name: "chat", UID: "isvc-uid",
+		Generation: 7, Evidence: reportv1alpha1.EvidenceObserved,
+		CollectedAt: fixedClock().Now(),
+	}, got.Sources[0])
+	require.Len(t, got.Content.Groups, 1)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyCanary, got.Content.Groups[0].Strategy)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseCanarying, got.Content.Groups[0].Phase)
+	assert.Equal(t, "aaaaaaaa", got.Content.Groups[0].StableRevisionHash)
+	assert.Equal(t, "bbbbbbbb", got.Content.Groups[0].TargetRevisionHash)
+	require.NotNil(t, got.Content.Groups[0].Step)
+	assert.Equal(t, reportv1alpha1.RolloutStepStatus{
+		Index: 1, Total: 3, Capacity: "50%", TargetTraffic: 20, ObservedTraffic: 20,
+		Gate: reportv1alpha1.RolloutGateAnalysis, Analysis: reportv1alpha1.RolloutAnalysisFailing,
+		EnteredAt: ptrTime(entered.Time),
+	}, *got.Content.Groups[0].Step)
+	require.Len(t, got.Content.Components, 1)
+	assert.Equal(t, []reportv1alpha1.RolloutTrafficTarget{
+		{RevisionHash: "aaaaaaaa", Percent: 80, Role: reportv1alpha1.RolloutRevisionCurrent},
+		{RevisionHash: "bbbbbbbb", Percent: 20, Role: reportv1alpha1.RolloutRevisionTarget},
+	}, got.Content.Components[0].Traffic)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	for _, secret := range []string{
+		"SECRET_TAG", "SECRET_MAILBOX", "SECRET_METRIC", "SECRET_VALUE",
+		"SECRET_QUERY", "SECRET_MESSAGE", "resourceVersion",
+	} {
+		assert.NotContains(t, string(encoded), secret)
+	}
+}
+
+func TestProjectMarksStatusDerivedSummaryEpochUnverifiable(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RolloutSummary{
+		State:             reportv1alpha1.RolloutStateUnknown,
+		ReportedState:     reportv1alpha1.RolloutStateInProgress,
+		Evidence:          reportv1alpha1.EvidenceReported,
+		Epoch:             reportv1alpha1.RolloutEpochUnverifiable,
+		CoordinationReady: reportv1alpha1.RolloutConditionNotApplicable,
+	}, got.Content.Summary)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueEpochUnverifiable,
+	})
+	assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{
+		Code: reportv1alpha1.WarningPartialData,
+	})
+}
+
+func TestProjectKeepsNonRolloutSummaryDeclared(t *testing.T) {
+	isvc := baseInferenceService()
+	mode := constants.RawDeployment
+	isvc.Spec.DeploymentMode = &mode
+	isvc.Spec.Engine = nil
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RolloutSummary{
+		State:             reportv1alpha1.RolloutStateNotConfigured,
+		ReportedState:     reportv1alpha1.RolloutStateNotConfigured,
+		Evidence:          reportv1alpha1.EvidenceDeclared,
+		Epoch:             reportv1alpha1.RolloutEpochNotApplicable,
+		CoordinationReady: reportv1alpha1.RolloutConditionNotApplicable,
+	}, got.Content.Summary)
+	assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueEpochUnverifiable,
+	})
+	assert.Empty(t, got.Warnings)
+}
+
+func TestProjectImplicitIndependentStableFromLifecycle(t *testing.T) {
+	isvc := independentLifecycleInferenceService(
+		"chat-engine-aaaaaaaa",
+		"chat-engine-aaaaaaaa",
+	)
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Components, 1)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyIndependent, got.Content.Components[0].Strategy)
+	assert.Nil(t, got.Content.Components[0].Group)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseStable, got.Content.Components[0].Phase)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateSucceeded)
+}
+
+func TestProjectImplicitIndependentInProgressFromLifecycle(t *testing.T) {
+	isvc := independentLifecycleInferenceService(
+		"chat-engine-aaaaaaaa",
+		"chat-engine-bbbbbbbb",
+	)
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Components, 1)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyIndependent, got.Content.Components[0].Strategy)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseUpdating, got.Content.Components[0].Phase)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+}
+
+func TestProjectIncludesUngroupedIndependentAlongsideDeclaredGroup(t *testing.T) {
+	isvc := coordinationBoundInferenceService()
+	isvc.Spec.Decoder = &omev1beta1.DecoderSpec{}
+	isvc.Status.Components[omev1beta1.DecoderComponent] = omev1beta1.ComponentStatusSpec{
+		Lifecycle: &omev1beta1.LifecycleStatus{
+			CurrentRevision: "chat-decoder-cccccccc",
+			UpdateRevision:  "chat-decoder-dddddddd",
+		},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Components, 2)
+	assert.Equal(t, reportv1alpha1.RuntimeComponentEngine, got.Content.Components[0].Type)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyBlueGreen, got.Content.Components[0].Strategy)
+	require.NotNil(t, got.Content.Components[0].Group)
+	assert.Equal(t, 0, *got.Content.Components[0].Group)
+	assert.Equal(t, reportv1alpha1.RuntimeComponentDecoder, got.Content.Components[1].Type)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyIndependent, got.Content.Components[1].Strategy)
+	assert.Nil(t, got.Content.Components[1].Group)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseUpdating, got.Content.Components[1].Phase)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+}
+
+func TestProjectExplicitOMENativeIndependentContributesUnknownBeforeLifecycleArrives(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Spec.Engine.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.OMENative),
+	}
+	isvc.Spec.Decoder = &omev1beta1.DecoderSpec{}
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent},
+	}}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.DecoderComponent: {},
+	}
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{
+		Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+			Name:       "0",
+			Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent},
+			Policy:     omev1beta1.CoordinationPolicyBlueGreen,
+			Phase:      omev1beta1.CoordinationPhaseIdle,
+		}},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Components, 2)
+	engine := got.Content.Components[0]
+	assert.Equal(t, reportv1alpha1.RuntimeComponentEngine, engine.Type)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyIndependent, engine.Strategy)
+	assert.Nil(t, engine.Group)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseUnknown, engine.Phase)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code:      reportv1alpha1.RolloutIssueComponentStatusMissing,
+		Component: reportv1alpha1.RuntimeComponentEngine,
+	})
+	assertStatusDerivedSummary(t, got, reportv1alpha1.RolloutStateUnknown)
+}
+
+func TestProjectNonOMENativeWithoutRolloutRemainsNotConfigured(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Spec.Engine.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.RawDeployment),
+	}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Components, 1)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyUnknown, got.Content.Components[0].Strategy)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseUnknown, got.Content.Components[0].Phase)
+	assert.Equal(t, reportv1alpha1.RolloutSummary{
+		State:             reportv1alpha1.RolloutStateNotConfigured,
+		ReportedState:     reportv1alpha1.RolloutStateNotConfigured,
+		Evidence:          reportv1alpha1.EvidenceDeclared,
+		Epoch:             reportv1alpha1.RolloutEpochNotApplicable,
+		CoordinationReady: reportv1alpha1.RolloutConditionNotApplicable,
+	}, got.Content.Summary)
+	assert.Empty(t, got.Content.Issues)
+	assert.Empty(t, got.Warnings)
+}
+
+func TestProjectUnprovenModeWithoutLifecycleIsUnknown(t *testing.T) {
+	isvc := baseInferenceService()
+	mode := constants.RawDeployment
+	isvc.Spec.DeploymentMode = &mode
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Components, 1)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyUnknown, got.Content.Components[0].Strategy)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseUnknown, got.Content.Components[0].Phase)
+	assertStatusDerivedSummary(t, got, reportv1alpha1.RolloutStateUnknown)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code:      reportv1alpha1.RolloutIssueComponentStatusMissing,
+		Component: reportv1alpha1.RuntimeComponentEngine,
+	})
+}
+
+func TestProjectRequiresExplicitNonOMENativeProofForEveryDeclaredComponent(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Spec.Decoder = &omev1beta1.DecoderSpec{}
+	isvc.Spec.Engine.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.RawDeployment),
+	}
+
+	partial, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertStatusDerivedSummary(t, partial, reportv1alpha1.RolloutStateUnknown)
+	assert.Contains(t, partial.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code:      reportv1alpha1.RolloutIssueComponentStatusMissing,
+		Component: reportv1alpha1.RuntimeComponentDecoder,
+	})
+
+	isvc.Spec.Decoder.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.MultiNode),
+	}
+	complete, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.RolloutSummary{
+		State:             reportv1alpha1.RolloutStateNotConfigured,
+		ReportedState:     reportv1alpha1.RolloutStateNotConfigured,
+		Evidence:          reportv1alpha1.EvidenceDeclared,
+		Epoch:             reportv1alpha1.RolloutEpochNotApplicable,
+		CoordinationReady: reportv1alpha1.RolloutConditionNotApplicable,
+	}, complete.Content.Summary)
+	assert.Empty(t, complete.Content.Issues)
+	assert.Empty(t, complete.Warnings)
+}
+
+func TestProjectBoundsInvalidIndependentLifecycleEvidence(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		update   string
+		phase    omev1beta1.RolloutPhase
+		wantCode reportv1alpha1.RolloutIssueCode
+	}{
+		{
+			name: "current revision absent", update: "chat-engine-bbbbbbbb",
+			wantCode: reportv1alpha1.RolloutIssueComponentStatusMissing,
+		},
+		{
+			name: "update revision absent", current: "chat-engine-aaaaaaaa",
+			wantCode: reportv1alpha1.RolloutIssueComponentStatusMissing,
+		},
+		{
+			name: "current revision identity is foreign", current: "other-engine-SECRET000",
+			update: "chat-engine-bbbbbbbb", wantCode: reportv1alpha1.RolloutIssueRevisionNameInvalid,
+		},
+		{
+			name:    "reported stable phase contradicts revision skew",
+			current: "chat-engine-aaaaaaaa", update: "chat-engine-bbbbbbbb",
+			phase: omev1beta1.RolloutPhaseStable, wantCode: reportv1alpha1.RolloutIssueStatusMalformed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := independentLifecycleInferenceService(tt.current, tt.update)
+			component := isvc.Status.Components[omev1beta1.EngineComponent]
+			component.RolloutPhase = tt.phase
+			isvc.Status.Components[omev1beta1.EngineComponent] = component
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			require.Len(t, got.Content.Components, 1)
+			assert.Equal(t, reportv1alpha1.RolloutStrategyIndependent, got.Content.Components[0].Strategy)
+			assert.Equal(t, reportv1alpha1.RolloutPhaseUnknown, got.Content.Components[0].Phase)
+			assertStatusDerivedSummary(t, got, reportv1alpha1.RolloutStateUnknown)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: tt.wantCode, Component: reportv1alpha1.RuntimeComponentEngine,
+			})
+			encoded, marshalErr := json.Marshal(got)
+			require.NoError(t, marshalErr)
+			assert.NotContains(t, string(encoded), "SECRET")
+		})
+	}
+}
+
+func TestProjectCollapsesShippedSequentialShape(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Spec.Decoder = &omev1beta1.DecoderSpec{}
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{
+		{Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent}},
+		{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}, BlueGreen: &omev1beta1.GroupBlueGreen{}},
+	}}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.DecoderComponent: {},
+		omev1beta1.EngineComponent:  {},
+	}
+	transitioned := metav1.NewTime(time.Date(2026, time.August, 31, 16, 0, 0, 0, time.UTC))
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+		Name: "0", Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent, omev1beta1.EngineComponent},
+		Order:  []omev1beta1.ComponentType{omev1beta1.DecoderComponent, omev1beta1.EngineComponent},
+		Policy: omev1beta1.CoordinationPolicySequential, Phase: omev1beta1.CoordinationPhaseWaiting,
+		CurrentComponent: omev1beta1.DecoderComponent, ObservedSurge: ptrIntOrString(intstr.FromString("25%")),
+		LastTransitionTime: &transitioned, CompositePhase: "decoder.Waiting", Message: "SECRET_REASON",
+	}}}
+	isvc.Status.SetCondition(apis.ConditionType(omev1beta1.RolloutCoordinationReady), &apis.Condition{
+		Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionFalse,
+		Reason: "SECRET_CONDITION_REASON", Message: "SECRET_CONDITION_MESSAGE",
+	})
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Groups, 1)
+	assert.Equal(t, reportv1alpha1.RolloutGroupStatus{
+		Index: 0, Strategy: reportv1alpha1.RolloutStrategySequential,
+		Phase: reportv1alpha1.RolloutPhaseWaiting,
+		Components: []reportv1alpha1.RuntimeComponentType{
+			reportv1alpha1.RuntimeComponentDecoder, reportv1alpha1.RuntimeComponentEngine,
+		},
+		CurrentComponent: reportv1alpha1.RuntimeComponentDecoder,
+		ObservedSurge:    "25%", TransitionedAt: ptrTime(transitioned.Time),
+	}, got.Content.Groups[0])
+	assert.Equal(t, reportv1alpha1.RolloutConditionFalse, got.Content.Summary.CoordinationReady)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+	require.Len(t, got.Content.Components, 2)
+	for _, component := range got.Content.Components {
+		require.NotNil(t, component.Group)
+		assert.Equal(t, 0, *component.Group)
+	}
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "SECRET_")
+}
+
+func TestProjectStrategyAndSummaryMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		group     omev1beta1.RolloutGroup
+		status    *omev1beta1.RolloutCoordinationGroupStatus
+		want      reportv1alpha1.RolloutStrategy
+		wantState reportv1alpha1.RolloutState
+		wantPhase reportv1alpha1.RolloutPhase
+	}{
+		{
+			name: "blue green default", group: omev1beta1.RolloutGroup{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}},
+			status: &omev1beta1.RolloutCoordinationGroupStatus{Name: "0", Policy: omev1beta1.CoordinationPolicyBlueGreen, Phase: omev1beta1.CoordinationPhaseIdle},
+			want:   reportv1alpha1.RolloutStrategyBlueGreen, wantState: reportv1alpha1.RolloutStateSucceeded, wantPhase: reportv1alpha1.RolloutPhaseIdle,
+		},
+		{
+			name: "blue green active", group: omev1beta1.RolloutGroup{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}, BlueGreen: &omev1beta1.GroupBlueGreen{}},
+			status: &omev1beta1.RolloutCoordinationGroupStatus{Name: "0", Policy: omev1beta1.CoordinationPolicyBlueGreen, Phase: omev1beta1.CoordinationPhaseShifting},
+			want:   reportv1alpha1.RolloutStrategyBlueGreen, wantState: reportv1alpha1.RolloutStateInProgress, wantPhase: reportv1alpha1.RolloutPhaseShifting,
+		},
+		{
+			name: "rolling update active", group: omev1beta1.RolloutGroup{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}, RollingUpdate: &omev1beta1.GroupRollingUpdate{}},
+			status: &omev1beta1.RolloutCoordinationGroupStatus{Name: "0", Policy: omev1beta1.CoordinationPolicyRollingUpdate, Phase: omev1beta1.CoordinationPhaseSurging},
+			want:   reportv1alpha1.RolloutStrategyRollingUpdate, wantState: reportv1alpha1.RolloutStateInProgress, wantPhase: reportv1alpha1.RolloutPhaseSurging,
+		},
+		{
+			name: "rolling update staged", group: omev1beta1.RolloutGroup{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}, RollingUpdate: &omev1beta1.GroupRollingUpdate{}},
+			status: &omev1beta1.RolloutCoordinationGroupStatus{Name: "0", Policy: omev1beta1.CoordinationPolicyRollingUpdate, Phase: omev1beta1.CoordinationPhaseStaged},
+			want:   reportv1alpha1.RolloutStrategyRollingUpdate, wantState: reportv1alpha1.RolloutStateStaged, wantPhase: reportv1alpha1.RolloutPhaseStaged,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := baseInferenceService()
+			isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{tt.group}}
+			isvc.Status.ObservedGeneration = 7
+			isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+				omev1beta1.EngineComponent: {},
+			}
+			status := *tt.status
+			status.Components = append([]omev1beta1.ComponentType{}, tt.group.Components...)
+			isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{status}}
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			require.Len(t, got.Content.Groups, 1)
+			assert.Equal(t, tt.want, got.Content.Groups[0].Strategy)
+			assert.Equal(t, tt.wantPhase, got.Content.Groups[0].Phase)
+			assertOnlyEpochBoundary(t, got, tt.wantState)
+		})
+	}
+}
+
+func TestProjectRejectsMalformedStoredRolloutSpecs(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.InferenceService)
+		canary bool
+	}{
+		{
+			name: "group member is not declared",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Engine = nil
+			},
+		},
+		{
+			name: "group member is not OMENative",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				mode := constants.RawDeployment
+				isvc.Spec.DeploymentMode = &mode
+			},
+		},
+		{
+			name: "group order is not shipped",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Order = []omev1beta1.ComponentType{omev1beta1.EngineComponent}
+			},
+		},
+		{
+			name: "progression selectors are not one of",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].BlueGreen = &omev1beta1.GroupBlueGreen{}
+				isvc.Spec.Rollout.Groups[0].RollingUpdate = &omev1beta1.GroupRollingUpdate{}
+			},
+		},
+		{
+			name: "rolling budgets both resolve to zero",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].BlueGreen = nil
+				isvc.Spec.Rollout.Groups[0].RollingUpdate = &omev1beta1.GroupRollingUpdate{
+					MaxSurge:       ptrIntOrString(intstr.FromInt(0)),
+					MaxUnavailable: ptrIntOrString(intstr.FromString("0%")),
+				}
+			},
+		},
+		{
+			name: "component lifecycle budgets both resolve to zero",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Engine.Lifecycle = lifecycleWithRollingBudgets(
+					ptrIntOrString(intstr.FromString("0%")),
+					ptrIntOrString(intstr.FromInt(0)),
+				)
+			},
+		},
+		{
+			name: "component lifecycle budget is negative",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Engine.Lifecycle = lifecycleWithRollingBudgets(
+					ptrIntOrString(intstr.FromInt(-1)), nil,
+				)
+			},
+		},
+		{
+			name: "component lifecycle budget is a bare numeric string",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Engine.Lifecycle = lifecycleWithRollingBudgets(
+					ptrIntOrString(intstr.FromString("3")), nil,
+				)
+			},
+		},
+		{
+			name: "soak is not honored by one group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Soak = &metav1.Duration{Duration: time.Minute}
+			},
+		},
+		{
+			name:   "canary steps are empty",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps = nil
+			},
+		},
+		{
+			name:   "canary traffic decreases",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps = []omev1beta1.RolloutGroupStep{
+					{Capacity: intstr.FromString("60%"), Traffic: 60},
+					{Capacity: intstr.FromString("80%"), Traffic: 50},
+					{Capacity: intstr.FromString("100%"), Traffic: 100},
+				}
+			},
+		},
+		{
+			name:   "canary final traffic is partial",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps[1].Traffic = 90
+			},
+		},
+		{
+			name:   "canary final percent capacity is partial",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps[1].Capacity = intstr.FromString("50%")
+			},
+		},
+		{
+			name:   "analysis shape is incomplete",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = &omev1beta1.RolloutAnalysis{}
+			},
+		},
+		{
+			name:   "analysis policy enum bypassed schema",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				analysis := validAnalysis("latency")
+				invalid := omev1beta1.OnInconclusive("SECRET_POLICY")
+				analysis.OnInconclusive = &invalid
+				isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = analysis
+			},
+		},
+		{
+			name:   "step count bypassed schema",
+			canary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				steps := make([]omev1beta1.RolloutGroupStep, 21)
+				for i := range steps {
+					steps[i] = omev1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+				}
+				isvc.Spec.Rollout.Groups[0].Canary.Steps = steps
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := coordinationBoundInferenceService()
+			if tt.canary {
+				isvc = activeCanaryInferenceService()
+			}
+			tt.mutate(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueSpecMalformed,
+			})
+			assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{
+				Code: reportv1alpha1.WarningPartialData,
+			})
+		})
+	}
+}
+
+func TestProjectUsesRolloutEvidenceWhenTopLevelObservedGenerationIsZero(t *testing.T) {
+	isvc := baseInferenceService()
+	mode := constants.OMENative
+	isvc.Spec.DeploymentMode = &mode
+	isvc.Spec.Engine = &omev1beta1.EngineSpec{}
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+	}}}
+	isvc.Status.ObservedGeneration = 0
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {},
+	}
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+		Name: "0", Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Policy: omev1beta1.CoordinationPolicyBlueGreen, Phase: omev1beta1.CoordinationPhaseIdle,
+	}}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateSucceeded)
+
+	summaryJSON, err := json.Marshal(got.Content.Summary)
+	require.NoError(t, err)
+	assert.NotContains(t, string(summaryJSON), "generation")
+	assert.NotContains(t, string(summaryJSON), "freshness")
+}
+
+func TestProjectAcceptsCompletedCanarySentinel(t *testing.T) {
+	isvc := completedCanaryInferenceService()
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateSucceeded)
+	require.Len(t, got.Content.Groups, 1)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseStable, got.Content.Groups[0].Phase)
+	assert.Equal(t, "bbbbbbbb", got.Content.Groups[0].TargetRevisionHash)
+	assert.Empty(t, got.Content.Groups[0].StableRevisionHash)
+	assert.Empty(t, got.Content.Groups[0].RejectedRevisionHash)
+	assert.Nil(t, got.Content.Groups[0].Step)
+}
+
+func TestProjectRejectsInconsistentCompletedCanarySentinel(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.InferenceService)
+	}{
+		{name: "step beyond sentinel", mutate: func(isvc *omev1beta1.InferenceService) { isvc.Status.Canary.CurrentStep = 2 }},
+		{name: "traffic weight is not complete", mutate: func(isvc *omev1beta1.InferenceService) { isvc.Status.Canary.ObservedTrafficWeight = 99 }},
+		{name: "old stable identity remains", mutate: func(isvc *omev1beta1.InferenceService) { isvc.Status.Canary.StableRevisionHash = "aaaaaaaa" }},
+		{name: "rollback identity remains", mutate: func(isvc *omev1beta1.InferenceService) { isvc.Status.Canary.RolledBackRevisionHash = "cccccccc" }},
+		{name: "promotion mailbox remains", mutate: func(isvc *omev1beta1.InferenceService) { isvc.Status.Canary.PromotedThrough = "SECRET_MAILBOX" }},
+		{name: "final spec traffic is not terminal", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Traffic = 50
+		}},
+		{name: "final spec capacity is not shipped form", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Capacity = intstr.FromString("3")
+		}},
+		{name: "final percentage capacity is not full", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Capacity = intstr.FromString("50%")
+		}},
+		{name: "final absolute capacity is zero", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Capacity = intstr.FromInt(0)
+		}},
+		{name: "target traffic absent", mutate: func(isvc *omev1beta1.InferenceService) {
+			status := isvc.Status.Components[omev1beta1.EngineComponent]
+			status.Traffic = nil
+			isvc.Status.Components[omev1beta1.EngineComponent] = status
+		}},
+		{name: "traffic targets another revision", mutate: func(isvc *omev1beta1.InferenceService) {
+			status := isvc.Status.Components[omev1beta1.EngineComponent]
+			status.Traffic = []omev1beta1.ComponentTrafficTarget{{RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 100}}
+			isvc.Status.Components[omev1beta1.EngineComponent] = status
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := completedCanaryInferenceService()
+			tt.mutate(isvc)
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueCanaryStepInvalid, Group: ptrInt(0),
+			})
+		})
+	}
+}
+
+func TestProjectAcceptsCompletedCanaryWithAbsoluteFinalCapacity(t *testing.T) {
+	isvc := completedCanaryInferenceService()
+	isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Capacity = intstr.FromInt(3)
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateSucceeded)
+}
+
+func TestProjectCanaryPhaseUsesShippedPrimarySelection(t *testing.T) {
+	isvc := multiComponentCanaryInferenceService()
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	require.Len(t, got.Content.Groups, 1)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseCanarying, got.Content.Groups[0].Phase)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+}
+
+func TestProjectAcceptsControllerStepAdvanceBeforeNextTrafficProgramming(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*omev1beta1.InferenceService)
+		wantIndex  int32
+		wantTarget int32
+	}{
+		{
+			name: "first intermediate advance",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+			},
+			wantIndex: 1, wantTarget: 100,
+		},
+		{
+			name: "later intermediate advance",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps = []omev1beta1.RolloutGroupStep{
+					{Capacity: intstr.FromString("25%"), Traffic: 25},
+					{Capacity: intstr.FromString("50%"), Traffic: 50},
+					{Capacity: intstr.FromString("100%"), Traffic: 100},
+				}
+				isvc.Status.Canary.CurrentStep = 2
+			},
+			wantIndex: 2, wantTarget: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			// The controller applies step N's traffic and then advances
+			// CurrentStep in the same status update. The next reconcile applies
+			// step N+1's traffic.
+			tt.configure(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+			require.Len(t, got.Content.Groups, 1)
+			require.NotNil(t, got.Content.Groups[0].Step)
+			assert.Equal(t, tt.wantIndex, got.Content.Groups[0].Step.Index)
+			assert.Equal(t, tt.wantTarget, got.Content.Groups[0].Step.TargetTraffic)
+			assert.Equal(t, int32(50), got.Content.Groups[0].Step.ObservedTraffic)
+		})
+	}
+}
+
+func TestProjectRejectsMalformedCanaryStepAdvanceEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.InferenceService)
+	}{
+		{
+			name: "arbitrary matching traffic is not a plan epoch",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				setActiveCanaryTraffic(isvc, 25)
+			},
+		},
+		{
+			name: "two-step-old traffic is not the advance edge",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps = []omev1beta1.RolloutGroupStep{
+					{Capacity: intstr.FromString("25%"), Traffic: 25},
+					{Capacity: intstr.FromString("50%"), Traffic: 50},
+					{Capacity: intstr.FromString("100%"), Traffic: 100},
+				}
+				isvc.Status.Canary.CurrentStep = 2
+				setActiveCanaryTraffic(isvc, 25)
+			},
+		},
+		{
+			name: "paused phase remains bound to the current step",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePaused
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+		{
+			name: "promoting phase remains bound to the current step",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePromoting
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+		{
+			name: "primary traffic must match observed previous-step weight",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.Traffic = []omev1beta1.ComponentTrafficTarget{{
+					RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 100,
+				}}
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+		{
+			name: "primary traffic must use the bound revision epoch",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.Traffic = []omev1beta1.ComponentTrafficTarget{
+					{RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 50},
+					{RevisionName: "chat-engine-rev-cccccccc", Percent: 50},
+				}
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			tt.mutate(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+			assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{
+				Code: reportv1alpha1.WarningPartialData,
+			})
+		})
+	}
+}
+
+func TestProjectRejectsControllerImpossibleCanaryStateMatrix(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.InferenceService)
+	}{
+		{
+			name: "intermediate promoting",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePromoting
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+		{
+			name: "final paused",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				setActiveCanaryTraffic(isvc, 100)
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePaused
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+		{
+			name: "final canarying already at current traffic",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				setActiveCanaryTraffic(isvc, 100)
+			},
+		},
+		{
+			name: "step zero promoted through",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.PromotedThrough = "SECRET_PROMOTION"
+			},
+		},
+		{
+			name: "pending retains rollback identity",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePending
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+				isvc.Status.Canary.RolledBackRevisionHash = "bbbbbbbb"
+			},
+		},
+		{
+			name: "failed retains rollback identity",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhaseFailed
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+				isvc.Status.Canary.RolledBackRevisionHash = "bbbbbbbb"
+			},
+		},
+		{
+			name: "manual advance records a foreign promotion value",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Pause = &omev1beta1.RolloutPause{}
+				isvc.Status.Canary.CurrentStep = 1
+				isvc.Status.Canary.PromotedThrough = "SECRET_FOREIGN_PROMOTION"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			tt.mutate(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+			encoded, marshalErr := json.Marshal(got)
+			require.NoError(t, marshalErr)
+			assert.NotContains(t, string(encoded), "SECRET_")
+		})
+	}
+}
+
+func TestProjectAcceptsEqualWeightFinalStepAdvanceEdge(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Traffic = 100
+	isvc.Status.Canary.CurrentStep = 1
+	isvc.Status.Canary.ObservedTrafficWeight = 100
+	component := isvc.Status.Components[omev1beta1.EngineComponent]
+	component.Traffic = []omev1beta1.ComponentTrafficTarget{{
+		RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 100,
+	}}
+	isvc.Status.Components[omev1beta1.EngineComponent] = component
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Groups, 1)
+	require.NotNil(t, got.Content.Groups[0].Step)
+	assert.Equal(t, int32(1), got.Content.Groups[0].Step.Index)
+	assert.Equal(t, int32(100), got.Content.Groups[0].Step.ObservedTraffic)
+	assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+	})
+}
+
+func TestProjectAcceptsAutomaticPromotedThroughResidue(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	isvc.Status.Canary.CurrentStep = 1
+	isvc.Status.Canary.PromotedThrough = "SECRET_AUTOMATIC_PROMOTION"
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+	})
+	encoded, marshalErr := json.Marshal(got)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(encoded), "SECRET_AUTOMATIC_PROMOTION")
+}
+
+func TestProjectBindsActiveCanaryStatusToPrimaryTraffic(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*omev1beta1.InferenceService)
+		valid     bool
+		wantState reportv1alpha1.RolloutState
+	}{
+		{
+			name:      "canarying exact split",
+			configure: func(*omev1beta1.InferenceService) {},
+			valid:     true, wantState: reportv1alpha1.RolloutStateInProgress,
+		},
+		{
+			name: "paused exact split",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePaused
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+			valid: true, wantState: reportv1alpha1.RolloutStatePaused,
+		},
+		{
+			name: "promoting exact cutover",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CurrentStep = 1
+				isvc.Status.Canary.ObservedTrafficWeight = 100
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.RolloutPhase = omev1beta1.RolloutPhasePromoting
+				status.Traffic = []omev1beta1.ComponentTrafficTarget{{
+					RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 100,
+				}}
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+			valid: true, wantState: reportv1alpha1.RolloutStateInProgress,
+		},
+		{
+			name: "rolling back exact stable traffic",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				configureRollbackCanary(isvc, omev1beta1.RolloutPhaseRollingBack)
+			},
+			valid: true, wantState: reportv1alpha1.RolloutStateRollingBack,
+		},
+		{
+			name: "rolled back exact stable traffic",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				configureRollbackCanary(isvc, omev1beta1.RolloutPhaseRolledBack)
+			},
+			valid: true, wantState: reportv1alpha1.RolloutStateRolledBack,
+		},
+		{
+			name: "observed weight from another epoch",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.ObservedTrafficWeight = 25
+			},
+		},
+		{
+			name: "target hash from another epoch",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.CanaryRevisionHash = "cccccccc"
+			},
+		},
+		{
+			name: "stable hash from another epoch",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Canary.StableRevisionHash = "cccccccc"
+			},
+		},
+		{
+			name: "primary split from another epoch",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.Traffic = []omev1beta1.ComponentTrafficTarget{
+					{RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 60},
+					{RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 40},
+				}
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+		{
+			name: "rollback status still routes rejected revision",
+			configure: func(isvc *omev1beta1.InferenceService) {
+				configureRollbackCanary(isvc, omev1beta1.RolloutPhaseRollingBack)
+				status := isvc.Status.Components[omev1beta1.EngineComponent]
+				status.Traffic = []omev1beta1.ComponentTrafficTarget{{
+					RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 100,
+				}}
+				isvc.Status.Components[omev1beta1.EngineComponent] = status
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			tt.configure(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			if tt.valid {
+				assertStatusDerivedSummary(t, got, tt.wantState)
+				assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+					Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+				})
+				return
+			}
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+		})
+	}
+}
+
+func TestProjectAnalysisRequiresExactActiveStepMetricSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []omev1beta1.AnalysisMetricResult
+		want    reportv1alpha1.RolloutAnalysisState
+		issue   bool
+	}{
+		{
+			name: "exact passing set",
+			results: []omev1beta1.AnalysisMetricResult{
+				exactMetricResult("latency", "1", true),
+				exactMetricResult("errors", "0", true),
+			},
+			want: reportv1alpha1.RolloutAnalysisPassing,
+		},
+		{
+			name: "exact failing set",
+			results: []omev1beta1.AnalysisMetricResult{
+				exactMetricResult("errors", "2", false),
+				exactMetricResult("latency", "1", true),
+			},
+			want: reportv1alpha1.RolloutAnalysisFailing,
+		},
+		{
+			name:    "missing result",
+			results: []omev1beta1.AnalysisMetricResult{exactMetricResult("latency", "1", true)},
+			want:    reportv1alpha1.RolloutAnalysisInconclusive, issue: true,
+		},
+		{
+			name: "extra result",
+			results: []omev1beta1.AnalysisMetricResult{
+				exactMetricResult("latency", "1", true),
+				exactMetricResult("errors", "0", true),
+				exactMetricResult("foreign", "0", true),
+			},
+			want: reportv1alpha1.RolloutAnalysisInconclusive, issue: true,
+		},
+		{
+			name: "duplicate result",
+			results: []omev1beta1.AnalysisMetricResult{
+				exactMetricResult("latency", "1", true),
+				exactMetricResult("latency", "1", true),
+			},
+			want: reportv1alpha1.RolloutAnalysisInconclusive, issue: true,
+		},
+		{
+			name: "threshold belongs to an earlier step",
+			results: []omev1beta1.AnalysisMetricResult{
+				{Name: "latency", Value: "1", Threshold: "2", Operator: omev1beta1.ComparisonLTE, Passed: true},
+				exactMetricResult("errors", "0", true),
+			},
+			want: reportv1alpha1.RolloutAnalysisInconclusive, issue: true,
+		},
+		{
+			name: "operator belongs to an earlier step",
+			results: []omev1beta1.AnalysisMetricResult{
+				{Name: "latency", Value: "1", Threshold: "1", Operator: omev1beta1.ComparisonGTE, Passed: true},
+				exactMetricResult("errors", "0", true),
+			},
+			want: reportv1alpha1.RolloutAnalysisInconclusive, issue: true,
+		},
+		{
+			name: "no results",
+			want: reportv1alpha1.RolloutAnalysisUnobserved,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			analysis := validAnalysis("latency")
+			analysis.Metrics = append(analysis.Metrics, omev1beta1.AnalysisMetric{
+				Name: "errors", Query: "safe_query", Operator: omev1beta1.ComparisonLTE, Threshold: "1",
+			})
+			isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = analysis
+			setAnalysisResults(isvc, tt.results)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			require.NotNil(t, got.Content.Groups[0].Step)
+			assert.Equal(t, tt.want, got.Content.Groups[0].Step.Analysis)
+			issue := reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueAnalysisInconclusive, Group: ptrInt(0),
+			}
+			if tt.issue {
+				assert.Contains(t, got.Content.Issues, issue)
+				assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{Code: reportv1alpha1.WarningPartialData})
+			} else {
+				assert.NotContains(t, got.Content.Issues, issue)
+			}
+		})
+	}
+}
+
+func TestProjectAnalysisFailTakesPrecedenceOverInconclusive(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = validAnalysis("latency")
+	setAnalysisResults(isvc, []omev1beta1.AnalysisMetricResult{
+		exactMetricResult("latency", "2", false),
+		{Name: "auth", Passed: false, Message: "SECRET_AUTH_ERROR"},
+	})
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Content.Groups[0].Step)
+	assert.Equal(t, reportv1alpha1.RolloutAnalysisFailing, got.Content.Groups[0].Step.Analysis)
+	assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueAnalysisInconclusive, Group: ptrInt(0),
+	})
+	encoded, marshalErr := json.Marshal(got)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(encoded), "SECRET_AUTH_ERROR")
+}
+
+func TestProjectRejectsControllerImpossibleAnalysisEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.InferenceService)
+	}{
+		{name: "nonnumeric value", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = "SECRET_NOT_A_NUMBER"
+		}},
+		{name: "nan value", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = "NaN"
+		}},
+		{name: "positive infinity value", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = "+Inf"
+		}},
+		{name: "negative infinity value", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = "-Inf"
+		}},
+		{name: "passed boolean contradicts comparison", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = "2"
+			isvc.Status.Canary.MetricResults[0].Passed = true
+		}},
+		{name: "empty value marked passed", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = ""
+			isvc.Status.Canary.MetricResults[0].Passed = true
+		}},
+		{name: "sample time absent", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Time = nil
+		}},
+		{name: "sample time differs from evaluation", mutate: func(isvc *omev1beta1.InferenceService) {
+			other := metav1.NewTime(isvc.Status.Canary.LastEvaluationTime.Time.Add(time.Second))
+			isvc.Status.Canary.MetricResults[0].Time = &other
+		}},
+		{name: "sample time is zero", mutate: func(isvc *omev1beta1.InferenceService) {
+			zero := metav1.Time{}
+			isvc.Status.Canary.MetricResults[0].Time = &zero
+		}},
+		{name: "evaluation time is zero", mutate: func(isvc *omev1beta1.InferenceService) {
+			zero := metav1.Time{}
+			isvc.Status.Canary.LastEvaluationTime = &zero
+		}},
+		{name: "evaluation exists without results", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults = nil
+		}},
+		{name: "conclusive time after evaluation", mutate: func(isvc *omev1beta1.InferenceService) {
+			other := metav1.NewTime(isvc.Status.Canary.LastEvaluationTime.Time.Add(time.Second))
+			isvc.Status.Canary.LastConclusiveEvaluationTime = &other
+		}},
+		{name: "negative failure counter", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.AnalysisFailedChecks = -1
+		}},
+		{name: "failing sample has zero counter", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.MetricResults[0].Value = "2"
+			isvc.Status.Canary.MetricResults[0].Passed = false
+			isvc.Status.Canary.AnalysisFailedChecks = 0
+		}},
+		{name: "positive counter has no conclusive history", mutate: func(isvc *omev1beta1.InferenceService) {
+			isvc.Status.Canary.AnalysisFailedChecks = 1
+			isvc.Status.Canary.LastConclusiveEvaluationTime = nil
+		}},
+		{name: "current pass lacks matching conclusive time", mutate: func(isvc *omev1beta1.InferenceService) {
+			other := metav1.NewTime(isvc.Status.Canary.LastEvaluationTime.Time.Add(-time.Second))
+			isvc.Status.Canary.LastConclusiveEvaluationTime = &other
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := analysisEvidenceInferenceService()
+			tt.mutate(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+			encoded, marshalErr := json.Marshal(got)
+			require.NoError(t, marshalErr)
+			assert.NotContains(t, string(encoded), "SECRET_NOT_A_NUMBER")
+		})
+	}
+}
+
+func TestProjectAcceptsLegitimateInconclusiveAnalysisEvidence(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []omev1beta1.AnalysisMetricResult
+	}{
+		{name: "synthetic auth result", results: []omev1beta1.AnalysisMetricResult{{
+			Name: "auth", Passed: false, Message: "SECRET_AUTH_ERROR",
+		}}},
+		{name: "stale metric plan", results: []omev1beta1.AnalysisMetricResult{{
+			Name: "latency", Value: "1", Threshold: "2", Operator: omev1beta1.ComparisonLTE, Passed: true,
+		}}},
+		{name: "matching no-data result", results: []omev1beta1.AnalysisMetricResult{{
+			Name: "latency", Threshold: "1", Operator: omev1beta1.ComparisonLTE,
+			Passed: false, Message: "SECRET_NO_DATA",
+		}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = validAnalysis("latency")
+			setAnalysisResults(isvc, tt.results)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			require.NotNil(t, got.Content.Groups[0].Step)
+			assert.Equal(t, reportv1alpha1.RolloutAnalysisInconclusive, got.Content.Groups[0].Step.Analysis)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueAnalysisInconclusive, Group: ptrInt(0),
+			})
+			assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+			encoded, marshalErr := json.Marshal(got)
+			require.NoError(t, marshalErr)
+			assert.NotContains(t, string(encoded), "SECRET_")
+		})
+	}
+}
+
+func TestProjectAcceptsControllerRetargetBeforeCanaryTrafficIsApplied(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     omev1beta1.RolloutPhase
+		wantState reportv1alpha1.RolloutState
+	}{
+		{name: "capacity is pending", phase: omev1beta1.RolloutPhasePending, wantState: reportv1alpha1.RolloutStateInProgress},
+		{name: "capacity wait failed", phase: omev1beta1.RolloutPhaseFailed, wantState: reportv1alpha1.RolloutStateFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := activeCanaryInferenceService()
+			component := isvc.Status.Components[omev1beta1.EngineComponent]
+			component.RolloutPhase = tt.phase
+			isvc.Status.Components[omev1beta1.EngineComponent] = component
+			// resetCanaryStatus binds the new target and clears observed traffic.
+			// While its capacity gate is unsatisfied, the controller writes Pending
+			// (then possibly Failed) before applyTraffic, so the component traffic
+			// can still truthfully describe the previous target epoch.
+			isvc.Status.Canary.CanaryRevisionHash = "cccccccc"
+			isvc.Status.Canary.ObservedTrafficWeight = 0
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assertStatusDerivedSummary(t, got, tt.wantState)
+			assert.Equal(t, "cccccccc", got.Content.Groups[0].TargetRevisionHash)
+			assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+		})
+	}
+}
+
+func TestProjectRejectsContradictoryNonPrimaryCanaryPhase(t *testing.T) {
+	isvc := multiComponentCanaryInferenceService()
+	engine := isvc.Status.Components[omev1beta1.EngineComponent]
+	engine.RolloutPhase = omev1beta1.RolloutPhaseFailed
+	isvc.Status.Components[omev1beta1.EngineComponent] = engine
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+		Component: reportv1alpha1.RuntimeComponentEngine,
+	})
+}
+
+func TestProjectRejectsCoordinationStatusFromAnotherSpec(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.RolloutCoordinationGroupStatus)
+	}{
+		{name: "policy absent", mutate: func(status *omev1beta1.RolloutCoordinationGroupStatus) { status.Policy = "" }},
+		{name: "components absent", mutate: func(status *omev1beta1.RolloutCoordinationGroupStatus) { status.Components = nil }},
+		{name: "components belong to old spec", mutate: func(status *omev1beta1.RolloutCoordinationGroupStatus) {
+			status.Components = []omev1beta1.ComponentType{omev1beta1.DecoderComponent}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := coordinationBoundInferenceService()
+			tt.mutate(&isvc.Status.RolloutCoordination.Groups[0])
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+		})
+	}
+}
+
+func TestProjectRejectsSequentialStatusOrderFromOldSpec(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.ObservedGeneration = 7
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{
+		{Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent}},
+		{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}},
+	}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.DecoderComponent: {},
+		omev1beta1.EngineComponent:  {},
+	}
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+		Name: "0", Policy: omev1beta1.CoordinationPolicySequential, Phase: omev1beta1.CoordinationPhaseIdle,
+		Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent, omev1beta1.EngineComponent},
+		Order:      []omev1beta1.ComponentType{omev1beta1.EngineComponent, omev1beta1.DecoderComponent},
+	}}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+	})
+}
+
+func TestProjectAggregatesGroupedComponentEvidence(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*omev1beta1.InferenceService)
+		want      reportv1alpha1.RolloutState
+		wantIssue reportv1alpha1.RolloutIssue
+		hasIssue  bool
+		useCanary bool
+	}{
+		{
+			name: "missing coordination member status",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				delete(isvc.Status.Components, omev1beta1.EngineComponent)
+			},
+			want: reportv1alpha1.RolloutStateUnknown,
+			wantIssue: reportv1alpha1.RolloutIssue{
+				Code:  reportv1alpha1.RolloutIssueComponentStatusMissing,
+				Group: ptrInt(0), Component: reportv1alpha1.RuntimeComponentEngine,
+			},
+			hasIssue: true,
+		},
+		{
+			name: "empty coordination member phase is group-owned",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{}
+			},
+			want: reportv1alpha1.RolloutStateSucceeded,
+		},
+		{
+			name: "failed coordination member contradicts idle group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhaseFailed,
+				}
+			},
+			want: reportv1alpha1.RolloutStateUnknown,
+			wantIssue: reportv1alpha1.RolloutIssue{
+				Code:  reportv1alpha1.RolloutIssueStatusMalformed,
+				Group: ptrInt(0), Component: reportv1alpha1.RuntimeComponentEngine,
+			},
+			hasIssue: true,
+		},
+		{
+			name: "rolling back coordination member contradicts idle group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhaseRollingBack,
+				}
+			},
+			want: reportv1alpha1.RolloutStateUnknown,
+			wantIssue: reportv1alpha1.RolloutIssue{
+				Code:  reportv1alpha1.RolloutIssueStatusMalformed,
+				Group: ptrInt(0), Component: reportv1alpha1.RuntimeComponentEngine,
+			},
+			hasIssue: true,
+		},
+		{
+			name: "failed coordination member agrees with failed group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.RolloutCoordination.Groups[0].Phase = omev1beta1.CoordinationPhaseFailed
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhaseFailed,
+				}
+			},
+			want: reportv1alpha1.RolloutStateFailed,
+		},
+		{
+			name: "rolling back coordination member agrees with rolling back group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.RolloutCoordination.Groups[0].Phase = omev1beta1.CoordinationPhaseRollingBack
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhaseRollingBack,
+				}
+			},
+			want: reportv1alpha1.RolloutStateRollingBack,
+		},
+		{
+			name: "paused coordination member agrees with paused group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.RolloutCoordination.Groups[0].Phase = omev1beta1.CoordinationPhasePaused
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhasePaused,
+				}
+			},
+			want: reportv1alpha1.RolloutStatePaused,
+		},
+		{
+			name: "pending coordination member agrees with active group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.RolloutCoordination.Groups[0].Phase = omev1beta1.CoordinationPhaseWaiting
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhasePending,
+				}
+			},
+			want: reportv1alpha1.RolloutStateInProgress,
+		},
+		{
+			name: "stable coordination member does not override active group",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.RolloutCoordination.Groups[0].Phase = omev1beta1.CoordinationPhaseWaiting
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhaseStable,
+				}
+			},
+			want: reportv1alpha1.RolloutStateInProgress,
+		},
+		{
+			name: "unknown coordination member phase is malformed",
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+					RolloutPhase: omev1beta1.RolloutPhase("SECRET_PHASE"),
+				}
+			},
+			want: reportv1alpha1.RolloutStateUnknown,
+			wantIssue: reportv1alpha1.RolloutIssue{
+				Code:  reportv1alpha1.RolloutIssueStatusMalformed,
+				Group: ptrInt(0), Component: reportv1alpha1.RuntimeComponentEngine,
+			},
+			hasIssue: true,
+		},
+		{
+			name:      "missing canary secondary is unknown",
+			useCanary: true,
+			mutate: func(isvc *omev1beta1.InferenceService) {
+				delete(isvc.Status.Components, omev1beta1.EngineComponent)
+			},
+			want: reportv1alpha1.RolloutStateUnknown,
+			wantIssue: reportv1alpha1.RolloutIssue{
+				Code:  reportv1alpha1.RolloutIssueComponentStatusMissing,
+				Group: ptrInt(0), Component: reportv1alpha1.RuntimeComponentEngine,
+			},
+			hasIssue: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := coordinationBoundInferenceService()
+			if tt.useCanary {
+				isvc = multiComponentCanaryInferenceService()
+			}
+			tt.mutate(isvc)
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Equal(t, tt.want, got.Content.Summary.ReportedState)
+			if tt.hasIssue {
+				assert.Contains(t, got.Content.Issues, tt.wantIssue)
+				assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{
+					Code: reportv1alpha1.WarningPartialData,
+				})
+			} else {
+				assertOnlyEpochBoundary(t, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectBindsCoordinationReadyToObservedGroupPhases(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     omev1beta1.CoordinationPhase
+		condition corev1.ConditionStatus
+		want      reportv1alpha1.RolloutConditionState
+		malformed bool
+	}{
+		{name: "idle true", phase: omev1beta1.CoordinationPhaseIdle, condition: corev1.ConditionTrue, want: reportv1alpha1.RolloutConditionTrue},
+		{name: "staged true", phase: omev1beta1.CoordinationPhaseStaged, condition: corev1.ConditionTrue, want: reportv1alpha1.RolloutConditionTrue},
+		{name: "active false", phase: omev1beta1.CoordinationPhaseSurging, condition: corev1.ConditionFalse, want: reportv1alpha1.RolloutConditionFalse},
+		{name: "failed false", phase: omev1beta1.CoordinationPhaseFailed, condition: corev1.ConditionFalse, want: reportv1alpha1.RolloutConditionFalse},
+		{name: "unobserved phase unknown", phase: "", condition: corev1.ConditionUnknown, want: reportv1alpha1.RolloutConditionUnknown},
+		{name: "idle cannot be false", phase: omev1beta1.CoordinationPhaseIdle, condition: corev1.ConditionFalse, want: reportv1alpha1.RolloutConditionInvalid, malformed: true},
+		{name: "active cannot be true", phase: omev1beta1.CoordinationPhaseSurging, condition: corev1.ConditionTrue, want: reportv1alpha1.RolloutConditionInvalid, malformed: true},
+		{name: "failed cannot be true", phase: omev1beta1.CoordinationPhaseFailed, condition: corev1.ConditionTrue, want: reportv1alpha1.RolloutConditionInvalid, malformed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := coordinationBoundInferenceService()
+			isvc.Status.RolloutCoordination.Groups[0].Phase = tt.phase
+			isvc.Status.SetCondition(apis.ConditionType(omev1beta1.RolloutCoordinationReady), &apis.Condition{
+				Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: tt.condition,
+			})
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.Content.Summary.CoordinationReady)
+			if tt.malformed {
+				assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+				assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+					Code: reportv1alpha1.RolloutIssueStatusMalformed,
+				})
+			}
+		})
+	}
+}
+
+func TestProjectRejectsPolicyForeignCoordinationStatusFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.RolloutCoordinationGroupStatus)
+	}{
+		{
+			name: "blue green order residue",
+			mutate: func(status *omev1beta1.RolloutCoordinationGroupStatus) {
+				status.Order = []omev1beta1.ComponentType{omev1beta1.EngineComponent}
+			},
+		},
+		{
+			name: "blue green current component residue",
+			mutate: func(status *omev1beta1.RolloutCoordinationGroupStatus) {
+				status.CurrentComponent = omev1beta1.EngineComponent
+			},
+		},
+		{
+			name: "blue green previous component residue",
+			mutate: func(status *omev1beta1.RolloutCoordinationGroupStatus) {
+				status.PreviousComponent = omev1beta1.EngineComponent
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := coordinationBoundInferenceService()
+			tt.mutate(&isvc.Status.RolloutCoordination.Groups[0])
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+		})
+	}
+}
+
+func TestProjectBindsSequentialCursorToExactOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     omev1beta1.CoordinationPhase
+		composite string
+		current   omev1beta1.ComponentType
+		previous  omev1beta1.ComponentType
+		valid     bool
+	}{
+		{name: "idle settled cursor", phase: omev1beta1.CoordinationPhaseIdle, valid: true},
+		{name: "idle cannot await first component", phase: omev1beta1.CoordinationPhaseIdle, composite: omev1beta1.CompositePhaseSequentialAwaiting, current: omev1beta1.DecoderComponent},
+		{name: "idle awaits next component", phase: omev1beta1.CoordinationPhaseIdle, composite: omev1beta1.CompositePhaseSequentialAwaiting, current: omev1beta1.EngineComponent, previous: omev1beta1.DecoderComponent, valid: true},
+		{name: "active phase requires current component", phase: omev1beta1.CoordinationPhaseSurging},
+		{name: "active first component has no predecessor", phase: omev1beta1.CoordinationPhaseSurging, current: omev1beta1.DecoderComponent, valid: true},
+		{name: "active second component follows first", phase: omev1beta1.CoordinationPhaseWaiting, current: omev1beta1.EngineComponent, previous: omev1beta1.DecoderComponent, valid: true},
+		{name: "failed phase requires current component", phase: omev1beta1.CoordinationPhaseFailed},
+		{name: "global paused status has no cursor", phase: omev1beta1.CoordinationPhasePaused, valid: true},
+		{name: "global paused status rejects stale cursor", phase: omev1beta1.CoordinationPhasePaused, current: omev1beta1.DecoderComponent},
+		{name: "previous without current", phase: omev1beta1.CoordinationPhaseIdle, previous: omev1beta1.DecoderComponent},
+		{name: "first component cannot have predecessor", phase: omev1beta1.CoordinationPhaseSurging, current: omev1beta1.DecoderComponent, previous: omev1beta1.EngineComponent},
+		{name: "second component requires immediate predecessor", phase: omev1beta1.CoordinationPhaseWaiting, current: omev1beta1.EngineComponent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := sequentialInferenceService()
+			status := &isvc.Status.RolloutCoordination.Groups[0]
+			status.Phase = tt.phase
+			status.CompositePhase = tt.composite
+			status.CurrentComponent = tt.current
+			status.PreviousComponent = tt.previous
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			if tt.valid {
+				assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+					Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+				})
+				return
+			}
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+				Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+			})
+		})
+	}
+}
+
+func TestProjectSequentialAwaitingCursorIsInProgress(t *testing.T) {
+	isvc := sequentialInferenceService()
+	status := &isvc.Status.RolloutCoordination.Groups[0]
+	status.Phase = omev1beta1.CoordinationPhaseIdle
+	status.CompositePhase = omev1beta1.CompositePhaseSequentialAwaiting
+	status.CurrentComponent = omev1beta1.EngineComponent
+	status.PreviousComponent = omev1beta1.DecoderComponent
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Groups, 1)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseAwaitingNextComponent, got.Content.Groups[0].Phase)
+	assert.Equal(t, reportv1alpha1.RuntimeComponentEngine, got.Content.Groups[0].CurrentComponent)
+	assert.Equal(t, reportv1alpha1.RuntimeComponentDecoder, got.Content.Groups[0].PreviousComponent)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+}
+
+func TestProjectSequentialAwaitingPreservesControllerReadyTrue(t *testing.T) {
+	isvc := sequentialInferenceService()
+	status := &isvc.Status.RolloutCoordination.Groups[0]
+	status.Phase = omev1beta1.CoordinationPhaseIdle
+	status.CompositePhase = omev1beta1.CompositePhaseSequentialAwaiting
+	status.CurrentComponent = omev1beta1.EngineComponent
+	status.PreviousComponent = omev1beta1.DecoderComponent
+	isvc.Status.SetCondition(apis.ConditionType(omev1beta1.RolloutCoordinationReady), &apis.Condition{
+		Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionTrue,
+	})
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.RolloutConditionTrue, got.Content.Summary.CoordinationReady)
+	assert.NotContains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed,
+	})
+}
+
+func TestProjectRejectsContradictoryComponentDuringSequentialAwaiting(t *testing.T) {
+	isvc := sequentialInferenceService()
+	status := &isvc.Status.RolloutCoordination.Groups[0]
+	status.Phase = omev1beta1.CoordinationPhaseIdle
+	status.CompositePhase = omev1beta1.CompositePhaseSequentialAwaiting
+	status.CurrentComponent = omev1beta1.EngineComponent
+	status.PreviousComponent = omev1beta1.DecoderComponent
+	isvc.Status.Components[omev1beta1.EngineComponent] = omev1beta1.ComponentStatusSpec{
+		RolloutPhase: omev1beta1.RolloutPhaseFailed,
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+		Component: reportv1alpha1.RuntimeComponentEngine,
+	})
+}
+
+func TestProjectRejectsIdleCursorWithoutExactAwaitingComposite(t *testing.T) {
+	isvc := sequentialInferenceService()
+	status := &isvc.Status.RolloutCoordination.Groups[0]
+	status.Phase = omev1beta1.CoordinationPhaseIdle
+	status.CompositePhase = "SECRET_NOT_AWAITING"
+	status.CurrentComponent = omev1beta1.EngineComponent
+	status.PreviousComponent = omev1beta1.DecoderComponent
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+	})
+	encoded, marshalErr := json.Marshal(got)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(encoded), "SECRET_NOT_AWAITING")
+}
+
+func TestProjectRejectsAwaitingCompositeWithoutValidCursor(t *testing.T) {
+	isvc := sequentialInferenceService()
+	status := &isvc.Status.RolloutCoordination.Groups[0]
+	status.Phase = omev1beta1.CoordinationPhaseIdle
+	status.CompositePhase = omev1beta1.CompositePhaseSequentialAwaiting
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueStatusMalformed, Group: ptrInt(0),
+	})
+}
+
+func TestProjectSequentialSettledIdleIsSucceeded(t *testing.T) {
+	for _, composite := range []string{"", string(omev1beta1.CoordinationPhaseIdle)} {
+		t.Run("composite="+composite, func(t *testing.T) {
+			isvc := sequentialInferenceService()
+			status := &isvc.Status.RolloutCoordination.Groups[0]
+			status.Phase = omev1beta1.CoordinationPhaseIdle
+			status.CompositePhase = composite
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+
+			require.Len(t, got.Content.Groups, 1)
+			assert.Equal(t, reportv1alpha1.RolloutPhaseIdle, got.Content.Groups[0].Phase)
+			assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateSucceeded)
+		})
+	}
+}
+
+func TestProjectRejectsActiveCanaryPhaseWhenNoRolloutIsConfigured(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {RolloutPhase: omev1beta1.RolloutPhaseCanarying},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code:      reportv1alpha1.RolloutIssueStatusMalformed,
+		Component: reportv1alpha1.RuntimeComponentEngine,
+	})
+}
+
+func TestProjectDoesNotTreatStableResidueAsProvenNotConfigured(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {RolloutPhase: omev1beta1.RolloutPhaseStable},
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertStatusDerivedSummary(t, got, reportv1alpha1.RolloutStateUnknown)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code:      reportv1alpha1.RolloutIssueComponentStatusMissing,
+		Component: reportv1alpha1.RuntimeComponentEngine,
+	})
+}
+
+func TestProjectTreatsEveryComponentRolloutFieldAsStatusResidue(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*omev1beta1.ComponentStatusSpec)
+	}{
+		{
+			name: "lifecycle",
+			mutate: func(status *omev1beta1.ComponentStatusSpec) {
+				status.Lifecycle = &omev1beta1.LifecycleStatus{
+					CurrentRevision: "chat-engine-aaaaaaaa",
+					UpdateRevision:  "chat-engine-aaaaaaaa",
+				}
+			},
+		},
+		{
+			name: "rollout phase",
+			mutate: func(status *omev1beta1.ComponentStatusSpec) {
+				status.RolloutPhase = omev1beta1.RolloutPhaseStable
+			},
+		},
+		{
+			name: "latest ready revision",
+			mutate: func(status *omev1beta1.ComponentStatusSpec) {
+				status.LatestReadyRevision = "chat-engine-rev-aaaaaaaa"
+			},
+		},
+		{
+			name: "latest rolled out revision",
+			mutate: func(status *omev1beta1.ComponentStatusSpec) {
+				status.LatestRolledoutRevision = "chat-engine-rev-aaaaaaaa"
+			},
+		},
+		{
+			name: "previous rolled out revision",
+			mutate: func(status *omev1beta1.ComponentStatusSpec) {
+				status.PreviousRolledoutRevision = "chat-engine-rev-aaaaaaaa"
+			},
+		},
+		{
+			name: "traffic",
+			mutate: func(status *omev1beta1.ComponentStatusSpec) {
+				status.Traffic = []omev1beta1.ComponentTrafficTarget{{
+					RevisionName: "chat-engine-rev-aaaaaaaa",
+					Percent:      100,
+				}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := baseInferenceService()
+			isvc.Spec.Engine.Annotations = map[string]string{
+				constants.DeploymentMode: string(constants.RawDeployment),
+			}
+			status := omev1beta1.ComponentStatusSpec{}
+			tt.mutate(&status)
+			isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+				omev1beta1.EngineComponent: status,
+			}
+
+			got, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+			assert.NotEqual(t, reportv1alpha1.RolloutStateNotConfigured, got.Content.Summary.ReportedState)
+			assert.Equal(t, reportv1alpha1.EvidenceReported, got.Content.Summary.Evidence)
+			assert.Equal(t, reportv1alpha1.RolloutEpochUnverifiable, got.Content.Summary.Epoch)
+		})
+	}
+}
+
+func TestProjectTreatsCoordinationConditionAsIndependentStatusResidue(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Spec.Engine.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.OMENative),
+	}
+	isvc.Status.SetCondition(apis.ConditionType(omev1beta1.RolloutCoordinationReady), &apis.Condition{
+		Type:   apis.ConditionType(omev1beta1.RolloutCoordinationReady),
+		Status: corev1.ConditionUnknown,
+	})
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertStatusDerivedSummary(t, got, reportv1alpha1.RolloutStateUnknown)
+}
+
+func TestProjectDoesNotUseTopLevelObservedGenerationAsRolloutFreshness(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Generation = 8
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+	}}}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {},
+	}
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+		Name: "0", Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Policy: omev1beta1.CoordinationPolicyBlueGreen, Phase: omev1beta1.CoordinationPhaseFailed,
+	}}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateFailed)
+	assert.Equal(t, reportv1alpha1.RolloutPhaseFailed, got.Content.Groups[0].Phase)
+}
+
+func TestProjectFailsClosedForMalformedAndSecretBearingFields(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Annotations = map[string]string{"ome.io/rollout-promote": "SECRET_ANNOTATION"}
+	isvc.ResourceVersion = "SECRET_RESOURCE_VERSION"
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent, omev1beta1.EngineComponent},
+		Canary:     &omev1beta1.GroupCanary{Steps: []omev1beta1.RolloutGroupStep{{Capacity: intstr.FromString("not-safe SECRET_CAPACITY"), Traffic: 101}}},
+		BlueGreen:  &omev1beta1.GroupBlueGreen{},
+	}}}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			RolloutPhase: "SECRET_PHASE", LatestReadyRevision: "SECRET_FULL_OBJECT_NAME",
+			Traffic: []omev1beta1.ComponentTrafficTarget{{RevisionName: "SECRET_BACKEND", Percent: 200, Tag: "SECRET_TAG"}},
+		},
+	}
+	isvc.Status.Canary = &omev1beta1.CanaryStatus{
+		CanaryRevisionHash: "SECRET_HASH", CurrentStep: 9, PromotedThrough: "SECRET_MAILBOX",
+	}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+	assert.NotEmpty(t, got.Content.Issues)
+	assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{Code: reportv1alpha1.WarningPartialData})
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	for _, secret := range []string{
+		"SECRET_ANNOTATION", "SECRET_RESOURCE_VERSION", "SECRET_CAPACITY", "SECRET_PHASE",
+		"SECRET_FULL_OBJECT_NAME", "SECRET_BACKEND", "SECRET_TAG", "SECRET_HASH", "SECRET_MAILBOX",
+	} {
+		assert.NotContains(t, string(encoded), secret)
+	}
+}
+
+func TestProjectRejectsInvalidSubject(t *testing.T) {
+	tests := []struct {
+		name string
+		isvc *omev1beta1.InferenceService
+	}{
+		{name: "nil", isvc: nil},
+		{name: "empty name", isvc: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Namespace: "prod"}}},
+		{name: "empty namespace", isvc: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := rolloutprojection.Project(tt.isvc, fixedClock())
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestProjectRequiresUIDBeforeEmittingObservedEvidence(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.UID = ""
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.ErrorIs(t, err, rolloutprojection.ErrSubjectUIDRequired)
+	assert.Empty(t, got.Sources)
+}
+
+func TestProjectDoesNotMutateInput(t *testing.T) {
+	nonUTC := time.FixedZone("fixture", 5*60*60+30*60)
+	canary := activeCanaryInferenceService()
+	canary.Annotations = map[string]string{"private": "SECRET_ANNOTATION"}
+	canary.Spec.Engine.Annotations = map[string]string{"private": "SECRET_COMPONENT_ANNOTATION"}
+	canary.Status.Canary.StepEnteredTime = &metav1.Time{Time: time.Date(2026, 8, 31, 20, 0, 0, 0, nonUTC)}
+	canary.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = validAnalysis("latency")
+	setAnalysisResults(canary, []omev1beta1.AnalysisMetricResult{
+		exactMetricResult("latency", "1", true),
+	})
+
+	sequential := sequentialInferenceService()
+	sequential.Annotations = map[string]string{"private": "SECRET_SEQUENTIAL_ANNOTATION"}
+	sequential.Spec.Decoder.Annotations = map[string]string{"private": "SECRET_DECODER_ANNOTATION"}
+	sequentialStatus := &sequential.Status.RolloutCoordination.Groups[0]
+	sequentialStatus.Phase = omev1beta1.CoordinationPhaseIdle
+	sequentialStatus.CompositePhase = omev1beta1.CompositePhaseSequentialAwaiting
+	sequentialStatus.CurrentComponent = omev1beta1.EngineComponent
+	sequentialStatus.PreviousComponent = omev1beta1.DecoderComponent
+	sequentialStatus.ObservedSurge = ptrIntOrString(intstr.FromString("25%"))
+	sequentialStatus.LastTransitionTime = &metav1.Time{Time: time.Date(2026, 8, 31, 21, 0, 0, 0, nonUTC)}
+	sequential.Status.SetCondition(apis.ConditionType(omev1beta1.RolloutCoordinationReady), &apis.Condition{
+		Type: apis.ConditionType(omev1beta1.RolloutCoordinationReady), Status: corev1.ConditionTrue,
+	})
+
+	for name, isvc := range map[string]*omev1beta1.InferenceService{
+		"canary": canary, "sequential": sequential,
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := isvc.DeepCopy()
+			_, err := rolloutprojection.Project(isvc, fixedClock())
+			require.NoError(t, err)
+			assert.True(t, apiequality.Semantic.DeepEqual(before, isvc))
+		})
+	}
+}
+
+func TestProjectIsDeterministicAcrossTrafficPermutations(t *testing.T) {
+	left := activeCanaryInferenceService()
+	right := left.DeepCopy()
+	component := right.Status.Components[omev1beta1.EngineComponent]
+	component.Traffic[0], component.Traffic[1] = component.Traffic[1], component.Traffic[0]
+	right.Status.Components[omev1beta1.EngineComponent] = component
+
+	leftReport, err := rolloutprojection.Project(left, fixedClock())
+	require.NoError(t, err)
+	rightReport, err := rolloutprojection.Project(right, fixedClock())
+	require.NoError(t, err)
+
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			var leftOutput, rightOutput bytes.Buffer
+			require.NoError(t, report.Write(&leftOutput, format, leftReport))
+			require.NoError(t, report.Write(&rightOutput, format, rightReport))
+			assert.Equal(t, leftOutput.Bytes(), rightOutput.Bytes())
+		})
+	}
+}
+
+func baseInferenceService() *omev1beta1.InferenceService {
+	mode := constants.OMENative
+	return &omev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod", Name: "chat", UID: types.UID("isvc-uid"), Generation: 7,
+		},
+		Spec: omev1beta1.InferenceServiceSpec{
+			DeploymentMode: &mode,
+			Engine:         &omev1beta1.EngineSpec{},
+		},
+	}
+}
+
+func independentLifecycleInferenceService(current, update string) *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			Lifecycle: &omev1beta1.LifecycleStatus{
+				CurrentRevision: current,
+				UpdateRevision:  update,
+			},
+		},
+	}
+	return isvc
+}
+
+func coordinationBoundInferenceService() *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Status.ObservedGeneration = 7
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+	}}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {},
+	}
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+		Name: "0", Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Policy: omev1beta1.CoordinationPolicyBlueGreen, Phase: omev1beta1.CoordinationPhaseIdle,
+	}}}
+	return isvc
+}
+
+func sequentialInferenceService() *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Spec.Decoder = &omev1beta1.DecoderSpec{}
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{
+		{Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent}},
+		{Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent}},
+	}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.DecoderComponent: {},
+		omev1beta1.EngineComponent:  {},
+	}
+	isvc.Status.RolloutCoordination = &omev1beta1.RolloutCoordinationStatus{Groups: []omev1beta1.RolloutCoordinationGroupStatus{{
+		Name:       "0",
+		Components: []omev1beta1.ComponentType{omev1beta1.DecoderComponent, omev1beta1.EngineComponent},
+		Order:      []omev1beta1.ComponentType{omev1beta1.DecoderComponent, omev1beta1.EngineComponent},
+		Policy:     omev1beta1.CoordinationPolicySequential,
+		Phase:      omev1beta1.CoordinationPhaseIdle,
+	}}}
+	return isvc
+}
+
+func completedCanaryInferenceService() *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Canary: &omev1beta1.GroupCanary{Steps: []omev1beta1.RolloutGroupStep{{
+			Capacity: intstr.FromString("100%"), Traffic: 100,
+		}}},
+	}}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			RolloutPhase:            omev1beta1.RolloutPhaseStable,
+			LatestRolledoutRevision: "chat-engine-rev-bbbbbbbb",
+			LatestReadyRevision:     "chat-engine-rev-bbbbbbbb",
+			Traffic: []omev1beta1.ComponentTrafficTarget{{
+				RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 100,
+			}},
+		},
+	}
+	isvc.Status.Canary = &omev1beta1.CanaryStatus{
+		CanaryRevisionHash: "bbbbbbbb", CurrentStep: 1, ObservedTrafficWeight: 100,
+	}
+	return isvc
+}
+
+func activeCanaryInferenceService() *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Canary: &omev1beta1.GroupCanary{Steps: []omev1beta1.RolloutGroupStep{
+			{Capacity: intstr.FromString("50%"), Traffic: 50},
+			{Capacity: intstr.FromString("100%"), Traffic: 100},
+		}},
+	}}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			RolloutPhase:            omev1beta1.RolloutPhaseCanarying,
+			LatestRolledoutRevision: "chat-engine-rev-aaaaaaaa",
+			LatestReadyRevision:     "chat-engine-rev-bbbbbbbb",
+			Traffic: []omev1beta1.ComponentTrafficTarget{
+				{RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 50},
+				{RevisionName: "chat-engine-rev-bbbbbbbb", Percent: 50},
+			},
+		},
+	}
+	isvc.Status.Canary = &omev1beta1.CanaryStatus{
+		StableRevisionHash: "aaaaaaaa", CanaryRevisionHash: "bbbbbbbb",
+		CurrentStep: 0, ObservedTrafficWeight: 50,
+	}
+	return isvc
+}
+
+func analysisEvidenceInferenceService() *omev1beta1.InferenceService {
+	isvc := activeCanaryInferenceService()
+	isvc.Spec.Rollout.Groups[0].Canary.Steps[0].Analysis = validAnalysis("latency")
+	setAnalysisResults(isvc, []omev1beta1.AnalysisMetricResult{
+		exactMetricResult("latency", "1", true),
+	})
+	return isvc
+}
+
+func setAnalysisResults(
+	isvc *omev1beta1.InferenceService,
+	results []omev1beta1.AnalysisMetricResult,
+) {
+	isvc.Status.Canary.MetricResults = append([]omev1beta1.AnalysisMetricResult{}, results...)
+	isvc.Status.Canary.AnalysisFailedChecks = 0
+	isvc.Status.Canary.LastEvaluationTime = nil
+	isvc.Status.Canary.LastConclusiveEvaluationTime = nil
+	if len(results) == 0 {
+		return
+	}
+	evaluated := metav1.NewTime(time.Date(2026, time.August, 31, 18, 0, 0, 0, time.UTC))
+	isvc.Status.Canary.LastEvaluationTime = &evaluated
+	conclusive := false
+	for index := range isvc.Status.Canary.MetricResults {
+		isvc.Status.Canary.MetricResults[index].Time = &evaluated
+		if isvc.Status.Canary.MetricResults[index].Value != "" {
+			conclusive = true
+		}
+		if isvc.Status.Canary.MetricResults[index].Value != "" &&
+			!isvc.Status.Canary.MetricResults[index].Passed {
+			isvc.Status.Canary.AnalysisFailedChecks = 1
+		}
+	}
+	if conclusive {
+		isvc.Status.Canary.LastConclusiveEvaluationTime = &evaluated
+	}
+}
+
+func setActiveCanaryTraffic(isvc *omev1beta1.InferenceService, canaryWeight int32) {
+	isvc.Status.Canary.ObservedTrafficWeight = canaryWeight
+	status := isvc.Status.Components[omev1beta1.EngineComponent]
+	status.Traffic = []omev1beta1.ComponentTrafficTarget{
+		{RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 100 - canaryWeight},
+		{RevisionName: "chat-engine-rev-bbbbbbbb", Percent: canaryWeight},
+	}
+	isvc.Status.Components[omev1beta1.EngineComponent] = status
+}
+
+func configureRollbackCanary(isvc *omev1beta1.InferenceService, phase omev1beta1.RolloutPhase) {
+	isvc.Status.Canary.ObservedTrafficWeight = 0
+	isvc.Status.Canary.RolledBackRevisionHash = isvc.Status.Canary.CanaryRevisionHash
+	status := isvc.Status.Components[omev1beta1.EngineComponent]
+	status.RolloutPhase = phase
+	status.Traffic = []omev1beta1.ComponentTrafficTarget{{
+		RevisionName: "chat-engine-rev-aaaaaaaa", Percent: 100,
+	}}
+	isvc.Status.Components[omev1beta1.EngineComponent] = status
+}
+
+func multiComponentCanaryInferenceService() *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Spec.Decoder = &omev1beta1.DecoderSpec{}
+	isvc.Spec.Router = &omev1beta1.RouterSpec{}
+	isvc.Status.ObservedGeneration = 7
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{
+			omev1beta1.EngineComponent, omev1beta1.DecoderComponent, omev1beta1.RouterComponent,
+		},
+		Canary: &omev1beta1.GroupCanary{Steps: []omev1beta1.RolloutGroupStep{
+			{Capacity: intstr.FromString("25%"), Traffic: 10},
+			{Capacity: intstr.FromString("100%"), Traffic: 100},
+		}},
+	}}}
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent:  {},
+		omev1beta1.DecoderComponent: {},
+		omev1beta1.RouterComponent: {
+			RolloutPhase: omev1beta1.RolloutPhaseCanarying,
+			Traffic: []omev1beta1.ComponentTrafficTarget{
+				{RevisionName: "chat-router-rev-aaaaaaaa", Percent: 90},
+				{RevisionName: "chat-router-rev-bbbbbbbb", Percent: 10},
+			},
+		},
+	}
+	isvc.Status.Canary = &omev1beta1.CanaryStatus{
+		StableRevisionHash: "aaaaaaaa", CanaryRevisionHash: "bbbbbbbb",
+		CurrentStep: 0, ObservedTrafficWeight: 10,
+	}
+	return isvc
+}
+
+func fixedClock() reportv1alpha1.Clock {
+	return reportv1alpha1.ClockFunc(func() time.Time {
+		return time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)
+	})
+}
+
+func assertStatusDerivedSummary(
+	t *testing.T,
+	got reportv1alpha1.RolloutStatusReport,
+	reported reportv1alpha1.RolloutState,
+) {
+	t.Helper()
+	assert.Equal(t, reportv1alpha1.RolloutStateUnknown, got.Content.Summary.State)
+	assert.Equal(t, reported, got.Content.Summary.ReportedState)
+	assert.Equal(t, reportv1alpha1.EvidenceReported, got.Content.Summary.Evidence)
+	assert.Equal(t, reportv1alpha1.RolloutEpochUnverifiable, got.Content.Summary.Epoch)
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueEpochUnverifiable,
+	})
+	assert.Contains(t, got.Warnings, reportv1alpha1.RolloutWarning{
+		Code: reportv1alpha1.WarningPartialData,
+	})
+}
+
+func assertOnlyEpochBoundary(
+	t *testing.T,
+	got reportv1alpha1.RolloutStatusReport,
+	reported reportv1alpha1.RolloutState,
+) {
+	t.Helper()
+	assertStatusDerivedSummary(t, got, reported)
+	assert.Equal(t, []reportv1alpha1.RolloutIssue{{
+		Code: reportv1alpha1.RolloutIssueEpochUnverifiable,
+	}}, got.Content.Issues)
+	assert.Equal(t, []reportv1alpha1.RolloutWarning{{
+		Code: reportv1alpha1.WarningPartialData,
+	}}, got.Warnings)
+}
+
+func ptrTime(value time.Time) *time.Time { return &value }
+
+func ptrInt(value int) *int { return &value }
+
+func ptrIntOrString(value intstr.IntOrString) *intstr.IntOrString { return &value }
+
+func lifecycleWithRollingBudgets(
+	maxUnavailable, maxSurge *intstr.IntOrString,
+) *omev1beta1.LifecycleSpec {
+	return &omev1beta1.LifecycleSpec{UpdateStrategy: &omev1beta1.UpdateStrategy{
+		Type: omev1beta1.UpdateStrategySurgeThenDrain,
+		RollingUpdate: &omev1beta1.RollingUpdate{
+			MaxUnavailable: maxUnavailable,
+			MaxSurge:       maxSurge,
+		},
+	}}
+}
+
+func exactMetricResult(name, value string, passed bool) omev1beta1.AnalysisMetricResult {
+	return omev1beta1.AnalysisMetricResult{
+		Name: name, Value: value, Threshold: "1", Operator: omev1beta1.ComparisonLTE, Passed: passed,
+	}
+}
+
+func validAnalysis(name string) *omev1beta1.RolloutAnalysis {
+	return &omev1beta1.RolloutAnalysis{
+		Interval:     metav1.Duration{Duration: time.Minute},
+		FailureLimit: 1,
+		Metrics: []omev1beta1.AnalysisMetric{{
+			Name: name, Query: "safe_query", Operator: omev1beta1.ComparisonLTE, Threshold: "1",
+		}},
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/ome/pkg/cli/cmd/autoscale"
 	"sigs.k8s.io/ome/pkg/cli/cmd/get"
 	"sigs.k8s.io/ome/pkg/cli/cmd/logs"
+	"sigs.k8s.io/ome/pkg/cli/cmd/rollout"
 	runtimecmd "sigs.k8s.io/ome/pkg/cli/cmd/runtime"
 	"sigs.k8s.io/ome/pkg/cli/cmd/status"
 	"sigs.k8s.io/ome/pkg/cli/cmd/version"
@@ -38,8 +39,8 @@ func newRootCmd(f factory.Factory, configFlags *genericclioptions.ConfigFlags, s
   kubectl ome <command>
 
 It provides model-centric visibility into OME resources: rich listings,
-controller-reported autoscaling evidence, InferenceService readiness diagnosis,
-runtime-selection explanations and component-aware log streaming.`,
+controller-reported autoscaling evidence, InferenceService readiness and rollout
+diagnosis, runtime-selection explanations and component-aware log streaming.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -52,6 +53,7 @@ runtime-selection explanations and component-aware log streaming.`,
 	cmd.AddCommand(autoscale.NewCmd(f, streams))
 	cmd.AddCommand(get.NewCmd(f, streams))
 	cmd.AddCommand(logs.NewCmd(f, streams))
+	cmd.AddCommand(rollout.NewCmd(f, streams))
 	cmd.AddCommand(runtimecmd.NewCmd(f, streams))
 	cmd.AddCommand(status.NewCmd(f, streams))
 	cmd.AddCommand(version.NewCmd(f, streams))

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -28,6 +29,8 @@ func TestRootCommandTree(t *testing.T) {
 		"ome autoscale status",
 		"ome get",
 		"ome logs",
+		"ome rollout",
+		"ome rollout status",
 		"ome runtime",
 		"ome runtime effective",
 		"ome runtime explain",
@@ -80,6 +83,26 @@ func TestInjectedRootCarriesAllKubectlConfigFlags(t *testing.T) {
 	}
 	if flag := root.PersistentFlags().Lookup("namespace"); flag == nil || flag.Shorthand != "n" {
 		t.Fatalf("namespace flag = %#v, want -n shorthand", flag)
+	}
+}
+
+func TestRootHelpListsRolloutInspection(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	root := NewRootCmdWithFactory(factory.Static{NS: "default"}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &output, ErrOut: &output,
+	})
+	root.SetArgs([]string{"--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	help := output.String()
+	for _, text := range []string{"rollout", "Inspect InferenceService rollouts", "-n, --namespace"} {
+		if !strings.Contains(help, text) {
+			t.Fatalf("root help missing %q:\n%s", text, help)
+		}
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Adds a read-only `kubectl ome rollout status INFERENCESERVICE` command with
deterministic table, JSON, and YAML output. The implementation is contained in
the CLI command, report, projection, and root-registration paths under
`pkg/cli/`.

The command performs exactly one typed GET of the parent InferenceService. It
does not read child resources, write resources, start watches, or perform
rollout actions such as promote, pause, abort, or retry.

The report keeps current-epoch conclusions separate from validated status that
the parent reports:

- `STATE` is the current-parent-epoch conclusion.
- `REPORTED-STATE` is the bounded aggregate derived from structurally validated
  parent status.
- `EVIDENCE=Reported` and `EPOCH=Unverifiable` qualify the reported state,
  coordination readiness, and every status-derived group and component field.
- A status-derived report therefore keeps `STATE=Unknown`; even a terminal
  `REPORTED-STATE` does not claim that the current InferenceService generation
  has converged.
- `NotConfigured` is used only when per-component declarations positively
  prove that every declared component is non-OMENative and no rollout-status
  residue exists. Missing or defaulted evidence remains `Unknown`.

The projector and report also provide these closed semantics:

- Grouped components carry their declared Canary, BlueGreen, RollingUpdate, or
  Sequential strategy. Ungrouped OMENative components carry the typed
  Independent strategy. Strictly valid equal lifecycle revisions produce
  `Stable`; valid unequal revisions produce `Updating`; missing or malformed
  lifecycle evidence produces bounded diagnostics and `Unknown`.
- Sequential singleton groups are projected in declared order. An exact
  adjacent current/previous cursor with the controller's awaiting composite is
  `AwaitingNextComponent` and contributes `InProgress`, while preserving the
  controller's ready condition. The table repeats `CURRENT-COMPONENT` and
  `PREVIOUS-COMPONENT` on each component row.
- Canary projection validates phase, step, gate, capacity, traffic, promotion,
  and rollback residue as a coupled state. It accepts the controller's
  apply-traffic-then-advance window, including equal-weight final steps, without
  exposing promotion values.
- Analysis distinguishes clean `Unobserved` evidence from `Inconclusive`,
  validates timestamps, counters, finite numeric comparisons, and reported
  booleans, and aggregates Fail before Inconclusive before Pass.
- Table diagnostics are scoped to matching component rows. Any scoped issue
  without a matching component is retained once in a deterministic issue-only
  row; when no component rows exist, the summary row retains every issue.
- Output is closed to bounded enums, code-only warnings and issues, safe
  identities, timestamps, capacities, percentages, and validated lowercase
  eight-character revision hashes. Raw revision names, annotations,
  ResourceVersion, promotion values, condition text, analysis names, values,
  thresholds, queries, messages, and arbitrary maps are not emitted.

The production-reachable command-local help is exactly:

```text
Show rollout progress for an InferenceService

Usage:
  rollout status INFERENCESERVICE [flags]

Flags:
  -h, --help            help for status
  -o, --output string   Output format: table, json, or yaml (default "table")
```

The root command adds its inherited kubectl configuration flags around this
command-local help.

Representative Independent table stdout is exactly:

```text
STATE     REPORTED-STATE   EVIDENCE   EPOCH          GROUP   STRATEGY      GROUP-PHASE   CURRENT-COMPONENT   PREVIOUS-COMPONENT   COMPONENT   COMPONENT-PHASE   STEP   GATE   CAPACITY   TARGET-TRAFFIC   OBSERVED-TRAFFIC   ROLLED-OUT   READY   PREVIOUS   ISSUES
Unknown   Succeeded        Reported   Unverifiable   -       Independent   -             -                   -                    engine      Stable            -      -      -          -                -                  -            -       -          EpochUnverifiable
```

The same representative report in JSON is exactly:

```json
{
  "apiVersion": "cli.ome.io/v1alpha1",
  "kind": "RolloutStatusReport",
  "metadata": {
    "namespace": "prod",
    "name": "chat"
  },
  "collectedAt": "2026-08-31T18:30:00Z",
  "sources": [
    {
      "kind": "InferenceService",
      "namespace": "prod",
      "name": "chat",
      "uid": "isvc-uid",
      "generation": 7,
      "evidence": "Observed",
      "collectedAt": "2026-08-31T18:30:00Z"
    }
  ],
  "content": {
    "summary": {
      "state": "Unknown",
      "reportedState": "Succeeded",
      "evidence": "Reported",
      "epoch": "Unverifiable",
      "coordinationReady": "NotApplicable"
    },
    "groups": [],
    "components": [
      {
        "type": "engine",
        "strategy": "Independent",
        "phase": "Stable",
        "traffic": []
      }
    ],
    "issues": [
      {
        "code": "EpochUnverifiable"
      }
    ]
  },
  "warnings": [
    {
      "code": "PartialData"
    }
  ]
}
```

The same representative report in YAML is exactly:

```yaml
apiVersion: cli.ome.io/v1alpha1
collectedAt: "2026-08-31T18:30:00Z"
content:
  components:
  - phase: Stable
    strategy: Independent
    traffic: []
    type: engine
  groups: []
  issues:
  - code: EpochUnverifiable
  summary:
    coordinationReady: NotApplicable
    epoch: Unverifiable
    evidence: Reported
    reportedState: Succeeded
    state: Unknown
kind: RolloutStatusReport
metadata:
  name: chat
  namespace: prod
sources:
- collectedAt: "2026-08-31T18:30:00Z"
  evidence: Observed
  generation: 7
  kind: InferenceService
  name: chat
  namespace: prod
  uid: isvc-uid
warnings:
- code: PartialData
```

The help and three output blocks above are copied byte-for-byte from literal
equality fixtures at the final commit.

## Why we need it

OME exposes substantial rollout state on an InferenceService, but operators
otherwise have to inspect nested status and manually reconcile component
strategy, coordination cursors, canary steps, traffic, lifecycle revisions,
and analysis evidence.

This command turns one parent read into a bounded operational view without
inventing freshness. The split between current `STATE` and
`REPORTED-STATE` makes the upstream epoch-binding limitation visible, while
typed strategies, Sequential cursors, closed phase aggregation, scoped
diagnostics, and strict redaction make the reported evidence useful and safe
for terminal and automation consumers.

Fixes: N/A

## How to test

```shell
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go test -race ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
```

Fresh integrator verification at rebased commit `92459bc6` recorded:

- the full normal and race suites for `pkg/cli/...` and
  `cmd/kubectl-ome/...` passed;
- vet passed;
- statement coverage was 89.4% for `pkg/cli/rolloutprojection`, 88.5% for
  `pkg/cli/report/v1alpha1`, and 90.9% for `pkg/cli/cmd/rollout`;
- the host build and all six `CGO_ENABLED=0` cross-builds passed for Linux,
  Darwin, and Windows on amd64 and arm64; and
- gofmt, diff checks, and the changed-path scope audit were clean.

Focused tests cover the one-parent-GET boundary, invalid local names before
reads, request/response identity binding, all supported rollout strategies,
Sequential cursor/composite validation, canary transition edges, analysis
evidence, closed redaction, deterministic ordering, nonmutation, scoped and
issue-only diagnostics, and exact help/table/JSON/YAML output.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [ ] `make test` passes locally
