### PR TITLE
[Core] Add autoscale status command

### DIFF
--- a/pkg/cli/autoscaleprojection/project.go
+++ b/pkg/cli/autoscaleprojection/project.go
@@ -1,0 +1,450 @@
+// Package autoscaleprojection projects controller-reported autoscaling status
+// into the deliberately small, message-free CLI report contract.
+package autoscaleprojection
+
+import (
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+var (
+	ErrInferenceServiceRequired          = errors.New("autoscale projection requires an InferenceService")
+	ErrInferenceServiceNameRequired      = errors.New("autoscale projection requires an InferenceService name")
+	ErrInferenceServiceNamespaceRequired = errors.New("autoscale projection requires an InferenceService namespace")
+	ErrInferenceServiceUIDRequired       = errors.New("autoscale projection requires an InferenceService UID")
+)
+
+var knownComponents = []struct {
+	api    omev1beta1.ComponentType
+	report reportv1alpha1.RuntimeComponentType
+}{
+	{api: omev1beta1.EngineComponent, report: reportv1alpha1.RuntimeComponentEngine},
+	{api: omev1beta1.DecoderComponent, report: reportv1alpha1.RuntimeComponentDecoder},
+	{api: omev1beta1.RouterComponent, report: reportv1alpha1.RuntimeComponentRouter},
+}
+
+// Project reports only evidence already mirrored onto the parent
+// InferenceService. It performs no child-object reads and makes no freshness
+// claim about that evidence.
+func Project(
+	isvc *omev1beta1.InferenceService,
+	clock reportv1alpha1.Clock,
+) (reportv1alpha1.AutoscaleStatusReport, error) {
+	if isvc == nil {
+		return reportv1alpha1.AutoscaleStatusReport{}, ErrInferenceServiceRequired
+	}
+	if isvc.Name == "" {
+		return reportv1alpha1.AutoscaleStatusReport{}, ErrInferenceServiceNameRequired
+	}
+	if isvc.Namespace == "" {
+		return reportv1alpha1.AutoscaleStatusReport{}, ErrInferenceServiceNamespaceRequired
+	}
+	if isvc.UID == "" {
+		return reportv1alpha1.AutoscaleStatusReport{}, ErrInferenceServiceUIDRequired
+	}
+
+	content := reportv1alpha1.AutoscaleStatusContent{
+		Components: []reportv1alpha1.AutoscaleComponentStatus{},
+		Issues:     []reportv1alpha1.AutoscaleIssue{},
+	}
+	unknownComponent := false
+	for component := range isvc.Status.Components {
+		if !isKnownComponent(component) {
+			unknownComponent = true
+			content.Issues = append(content.Issues, reportv1alpha1.AutoscaleIssue{
+				Code: reportv1alpha1.AutoscaleIssueUnknownComponentStatus,
+			})
+		}
+	}
+	for _, component := range knownComponents {
+		status, ok := isvc.Status.Components[component.api]
+		if !ok {
+			continue
+		}
+		projected, issues := projectComponent(isvc.Namespace, component.report, status)
+		content.Components = append(content.Components, projected)
+		content.Issues = append(content.Issues, issues...)
+	}
+	content.Summary.State = summarize(content.Components, unknownComponent)
+
+	report := reportv1alpha1.NewAutoscaleStatusReport(
+		reportv1alpha1.Metadata{Namespace: isvc.Namespace, Name: isvc.Name},
+		content,
+		clock,
+	)
+	report.Sources = []reportv1alpha1.AutoscaleSourceReference{{
+		Kind:        reportv1alpha1.AutoscaleSourceInferenceService,
+		Namespace:   isvc.Namespace,
+		Name:        isvc.Name,
+		UID:         string(isvc.UID),
+		Generation:  isvc.Generation,
+		Evidence:    reportv1alpha1.EvidenceReported,
+		CollectedAt: report.CollectedAt,
+	}}
+	if content.Summary.State != reportv1alpha1.AutoscaleStateReported {
+		report.Warnings = []reportv1alpha1.AutoscaleWarning{{Code: reportv1alpha1.AutoscaleWarningPartialData}}
+	}
+	return report.Canonical(), nil
+}
+
+func projectComponent(
+	namespace string,
+	componentType reportv1alpha1.RuntimeComponentType,
+	status omev1beta1.ComponentStatusSpec,
+) (reportv1alpha1.AutoscaleComponentStatus, []reportv1alpha1.AutoscaleIssue) {
+	component := reportv1alpha1.AutoscaleComponentStatus{
+		Type:       componentType,
+		Class:      reportv1alpha1.AutoscaleClassUnknown,
+		ManagedBy:  reportv1alpha1.AutoscaleManagedByUnknown,
+		SpecSource: reportv1alpha1.AutoscaleSpecSourceUnknown,
+		Target:     reportv1alpha1.AutoscaleTarget{State: reportv1alpha1.AutoscaleTargetNotReported},
+		Replicas:   reportv1alpha1.AutoscaleReplicaStatus{State: reportv1alpha1.AutoscaleReplicasNotReported},
+		Conditions: reportv1alpha1.AutoscaleConditionsStatus{State: reportv1alpha1.AutoscaleConditionsNotReported, Items: []reportv1alpha1.AutoscaleCondition{}},
+	}
+	issues := []reportv1alpha1.AutoscaleIssue{}
+	addIssue := func(code reportv1alpha1.AutoscaleIssueCode) {
+		issues = append(issues, reportv1alpha1.AutoscaleIssue{Code: code, Component: componentType})
+	}
+
+	var targetIssue reportv1alpha1.AutoscaleIssueCode
+	component.Target, targetIssue = projectTarget(namespace, status.ScaleTargetRef)
+	if targetIssue != "" {
+		addIssue(targetIssue)
+	}
+
+	if status.Autoscaler == nil {
+		component.State = reportv1alpha1.AutoscaleComponentNotReported
+		if component.Target.State == reportv1alpha1.AutoscaleTargetInvalid {
+			component.State = reportv1alpha1.AutoscaleComponentInvalid
+		}
+		addIssue(reportv1alpha1.AutoscaleIssueAutoscalerNotReported)
+		return component, issues
+	}
+
+	autoscaler := status.Autoscaler
+	classOK := true
+	switch autoscaler.Class {
+	case omev1beta1.AutoscalerHPA:
+		component.Class = reportv1alpha1.AutoscaleClassHPA
+	case omev1beta1.AutoscalerKEDA:
+		component.Class = reportv1alpha1.AutoscaleClassKEDA
+	case omev1beta1.AutoscalerExternal:
+		component.Class = reportv1alpha1.AutoscaleClassExternal
+	case omev1beta1.AutoscalerNone:
+		component.Class = reportv1alpha1.AutoscaleClassNone
+	default:
+		classOK = false
+		addIssue(reportv1alpha1.AutoscaleIssueClassInvalid)
+	}
+
+	managedByOK := true
+	switch autoscaler.ManagedBy {
+	case omev1beta1.AutoscalerManagedByOME:
+		component.ManagedBy = reportv1alpha1.AutoscaleManagedByOME
+	case omev1beta1.AutoscalerManagedByExternal:
+		component.ManagedBy = reportv1alpha1.AutoscaleManagedByExternal
+	case omev1beta1.AutoscalerManagedByNone:
+		component.ManagedBy = reportv1alpha1.AutoscaleManagedByNone
+	default:
+		managedByOK = false
+		addIssue(reportv1alpha1.AutoscaleIssueManagedByInvalid)
+	}
+
+	specSourceOK := true
+	switch autoscaler.SpecSource {
+	case "isvc":
+		component.SpecSource = reportv1alpha1.AutoscaleSpecSourceISVC
+	case "runtime":
+		component.SpecSource = reportv1alpha1.AutoscaleSpecSourceRuntime
+	case "legacy":
+		component.SpecSource = reportv1alpha1.AutoscaleSpecSourceLegacy
+	case "default":
+		component.SpecSource = reportv1alpha1.AutoscaleSpecSourceDefault
+	default:
+		specSourceOK = false
+		addIssue(reportv1alpha1.AutoscaleIssueSpecSourceInvalid)
+	}
+
+	matrixOK := classOK && managedByOK && ownershipMatches(component.Class, component.ManagedBy)
+	if classOK && managedByOK && !matrixOK {
+		addIssue(reportv1alpha1.AutoscaleIssueOwnershipMismatch)
+	}
+	nonOMEClass := classOK && (component.Class == reportv1alpha1.AutoscaleClassExternal || component.Class == reportv1alpha1.AutoscaleClassNone)
+	unexpectedReplicas := nonOMEClass && (autoscaler.CurrentReplicas != 0 || autoscaler.DesiredReplicas != 0 || autoscaler.LastScaleTime != nil)
+	unexpectedConditions := nonOMEClass && len(autoscaler.Conditions) != 0
+
+	if !matrixOK {
+		component.Replicas.State = reportv1alpha1.AutoscaleReplicasInvalid
+		component.Conditions.State = reportv1alpha1.AutoscaleConditionsInvalid
+	} else {
+		switch component.ManagedBy {
+		case reportv1alpha1.AutoscaleManagedByOME:
+			component.Replicas, targetIssue = projectOMEReplicas(autoscaler)
+			if targetIssue != "" {
+				addIssue(targetIssue)
+			}
+			var conditionIssues []reportv1alpha1.AutoscaleIssueCode
+			component.Conditions, conditionIssues = projectOMEConditions(component.Class, autoscaler.Conditions)
+			for _, conditionIssue := range conditionIssues {
+				addIssue(conditionIssue)
+			}
+		case reportv1alpha1.AutoscaleManagedByExternal, reportv1alpha1.AutoscaleManagedByNone:
+			component.Replicas = reportv1alpha1.AutoscaleReplicaStatus{State: reportv1alpha1.AutoscaleReplicasUnavailable}
+			component.Conditions = reportv1alpha1.AutoscaleConditionsStatus{State: reportv1alpha1.AutoscaleConditionsUnavailable, Items: []reportv1alpha1.AutoscaleCondition{}}
+		}
+	}
+	if unexpectedReplicas {
+		component.Replicas.State = reportv1alpha1.AutoscaleReplicasInvalid
+		addIssue(reportv1alpha1.AutoscaleIssueUnexpectedScalerEvidence)
+	}
+	if unexpectedConditions {
+		component.Conditions.State = reportv1alpha1.AutoscaleConditionsInvalid
+		addIssue(reportv1alpha1.AutoscaleIssueUnexpectedScalerEvidence)
+	}
+
+	component.State = summarizeComponent(component, classOK && managedByOK && specSourceOK && matrixOK)
+	return component, issues
+}
+
+func projectTarget(
+	namespace string,
+	target *omev1beta1.ScaleTargetRef,
+) (reportv1alpha1.AutoscaleTarget, reportv1alpha1.AutoscaleIssueCode) {
+	if target == nil {
+		return reportv1alpha1.AutoscaleTarget{State: reportv1alpha1.AutoscaleTargetNotReported}, reportv1alpha1.AutoscaleIssueScaleTargetNotReported
+	}
+	if target.Name == "" || len(validation.IsDNS1123Subdomain(target.Name)) != 0 {
+		return reportv1alpha1.AutoscaleTarget{State: reportv1alpha1.AutoscaleTargetInvalid}, reportv1alpha1.AutoscaleIssueScaleTargetInvalid
+	}
+
+	projected := reportv1alpha1.AutoscaleTarget{
+		State: reportv1alpha1.AutoscaleTargetReported, Namespace: namespace, Name: target.Name,
+	}
+	switch {
+	case target.APIVersion == "apps/v1" && target.Kind == "Deployment":
+		projected.APIVersion = "apps/v1"
+		projected.Kind = reportv1alpha1.AutoscaleTargetDeployment
+	case target.APIVersion == "ome.io/v1beta1" && target.Kind == "InferenceReplica":
+		projected.APIVersion = "ome.io/v1beta1"
+		projected.Kind = reportv1alpha1.AutoscaleTargetInferenceReplica
+	default:
+		return reportv1alpha1.AutoscaleTarget{State: reportv1alpha1.AutoscaleTargetInvalid}, reportv1alpha1.AutoscaleIssueScaleTargetInvalid
+	}
+	return projected, ""
+}
+
+func projectOMEReplicas(status *omev1beta1.ComponentAutoscalerStatus) (reportv1alpha1.AutoscaleReplicaStatus, reportv1alpha1.AutoscaleIssueCode) {
+	if status.CurrentReplicas < 0 || status.DesiredReplicas < 0 || (status.LastScaleTime != nil && status.LastScaleTime.IsZero()) {
+		return reportv1alpha1.AutoscaleReplicaStatus{State: reportv1alpha1.AutoscaleReplicasInvalid}, reportv1alpha1.AutoscaleIssueReplicaEvidenceInvalid
+	}
+	current := status.CurrentReplicas
+	desired := status.DesiredReplicas
+	projected := reportv1alpha1.AutoscaleReplicaStatus{
+		State: reportv1alpha1.AutoscaleReplicasReported, CurrentReplicas: &current, DesiredReplicas: &desired,
+	}
+	if status.LastScaleTime != nil {
+		lastScaleTime := status.LastScaleTime.Time.UTC()
+		projected.LastScaleTime = &lastScaleTime
+	}
+	if current == 0 || desired == 0 {
+		projected.State = reportv1alpha1.AutoscaleReplicasAmbiguous
+		return projected, reportv1alpha1.AutoscaleIssueReplicaEvidenceAmbiguous
+	}
+	return projected, ""
+}
+
+func projectOMEConditions(
+	class reportv1alpha1.AutoscaleClass,
+	conditions []metav1.Condition,
+) (reportv1alpha1.AutoscaleConditionsStatus, []reportv1alpha1.AutoscaleIssueCode) {
+	if len(conditions) == 0 {
+		return reportv1alpha1.AutoscaleConditionsStatus{
+			State: reportv1alpha1.AutoscaleConditionsNotReported,
+			Items: []reportv1alpha1.AutoscaleCondition{},
+		}, nil
+	}
+
+	byType := map[reportv1alpha1.AutoscaleConditionType][]reportv1alpha1.AutoscaleCondition{}
+	invalid := false
+	for _, condition := range conditions {
+		typeValue, ok := conditionType(class, condition.Type)
+		if !ok || condition.LastTransitionTime.IsZero() {
+			invalid = true
+			continue
+		}
+		statusValue, ok := conditionStatus(condition.Status)
+		if !ok {
+			invalid = true
+			continue
+		}
+		projected := reportv1alpha1.AutoscaleCondition{
+			Type: typeValue, Status: statusValue, LastTransitionTime: condition.LastTransitionTime.Time.UTC(),
+		}
+		if !containsCondition(byType[typeValue], projected) {
+			byType[typeValue] = append(byType[typeValue], projected)
+		}
+	}
+
+	items := []reportv1alpha1.AutoscaleCondition{}
+	conflict := false
+	for _, conditionType := range conditionOrder(class) {
+		values := byType[conditionType]
+		switch len(values) {
+		case 0:
+			continue
+		case 1:
+			items = append(items, values[0])
+		default:
+			conflict = true
+		}
+	}
+	state := reportv1alpha1.AutoscaleConditionsReported
+	issues := []reportv1alpha1.AutoscaleIssueCode{}
+	if conflict {
+		state = reportv1alpha1.AutoscaleConditionsInvalid
+		issues = append(issues, reportv1alpha1.AutoscaleIssueConditionConflict)
+	}
+	if invalid {
+		state = reportv1alpha1.AutoscaleConditionsInvalid
+		issues = append(issues, reportv1alpha1.AutoscaleIssueConditionInvalid)
+	}
+	return reportv1alpha1.AutoscaleConditionsStatus{State: state, Items: items}, issues
+}
+
+func conditionType(class reportv1alpha1.AutoscaleClass, value string) (reportv1alpha1.AutoscaleConditionType, bool) {
+	if class == reportv1alpha1.AutoscaleClassHPA {
+		switch value {
+		case "AbleToScale":
+			return reportv1alpha1.AutoscaleConditionAbleToScale, true
+		case "ScalingActive":
+			return reportv1alpha1.AutoscaleConditionScalingActive, true
+		case "ScalingLimited":
+			return reportv1alpha1.AutoscaleConditionScalingLimited, true
+		}
+	}
+	if class == reportv1alpha1.AutoscaleClassKEDA {
+		switch value {
+		case "Ready":
+			return reportv1alpha1.AutoscaleConditionReady, true
+		case "Active":
+			return reportv1alpha1.AutoscaleConditionActive, true
+		case "Fallback":
+			return reportv1alpha1.AutoscaleConditionFallback, true
+		case "Paused":
+			return reportv1alpha1.AutoscaleConditionPaused, true
+		}
+	}
+	return "", false
+}
+
+func conditionStatus(value metav1.ConditionStatus) (reportv1alpha1.AutoscaleConditionStatus, bool) {
+	switch value {
+	case metav1.ConditionTrue:
+		return reportv1alpha1.AutoscaleConditionTrue, true
+	case metav1.ConditionFalse:
+		return reportv1alpha1.AutoscaleConditionFalse, true
+	case metav1.ConditionUnknown:
+		return reportv1alpha1.AutoscaleConditionUnknown, true
+	default:
+		return "", false
+	}
+}
+
+func conditionOrder(class reportv1alpha1.AutoscaleClass) []reportv1alpha1.AutoscaleConditionType {
+	if class == reportv1alpha1.AutoscaleClassHPA {
+		return []reportv1alpha1.AutoscaleConditionType{
+			reportv1alpha1.AutoscaleConditionAbleToScale,
+			reportv1alpha1.AutoscaleConditionScalingActive,
+			reportv1alpha1.AutoscaleConditionScalingLimited,
+		}
+	}
+	return []reportv1alpha1.AutoscaleConditionType{
+		reportv1alpha1.AutoscaleConditionReady,
+		reportv1alpha1.AutoscaleConditionActive,
+		reportv1alpha1.AutoscaleConditionFallback,
+		reportv1alpha1.AutoscaleConditionPaused,
+	}
+}
+
+func containsCondition(values []reportv1alpha1.AutoscaleCondition, candidate reportv1alpha1.AutoscaleCondition) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func ownershipMatches(class reportv1alpha1.AutoscaleClass, managedBy reportv1alpha1.AutoscaleManagedBy) bool {
+	switch class {
+	case reportv1alpha1.AutoscaleClassHPA, reportv1alpha1.AutoscaleClassKEDA:
+		return managedBy == reportv1alpha1.AutoscaleManagedByOME
+	case reportv1alpha1.AutoscaleClassExternal:
+		return managedBy == reportv1alpha1.AutoscaleManagedByExternal
+	case reportv1alpha1.AutoscaleClassNone:
+		return managedBy == reportv1alpha1.AutoscaleManagedByNone
+	default:
+		return false
+	}
+}
+
+func summarizeComponent(component reportv1alpha1.AutoscaleComponentStatus, enumsValid bool) reportv1alpha1.AutoscaleComponentState {
+	if !enumsValid ||
+		component.Target.State == reportv1alpha1.AutoscaleTargetInvalid ||
+		component.Replicas.State == reportv1alpha1.AutoscaleReplicasInvalid ||
+		component.Conditions.State == reportv1alpha1.AutoscaleConditionsInvalid {
+		return reportv1alpha1.AutoscaleComponentInvalid
+	}
+	if component.Target.State == reportv1alpha1.AutoscaleTargetNotReported ||
+		component.Replicas.State == reportv1alpha1.AutoscaleReplicasAmbiguous ||
+		component.Replicas.State == reportv1alpha1.AutoscaleReplicasNotReported ||
+		component.Conditions.State == reportv1alpha1.AutoscaleConditionsNotReported {
+		return reportv1alpha1.AutoscaleComponentPartial
+	}
+	return reportv1alpha1.AutoscaleComponentReported
+}
+
+func summarize(components []reportv1alpha1.AutoscaleComponentStatus, unknownComponent bool) reportv1alpha1.AutoscaleState {
+	if unknownComponent {
+		return reportv1alpha1.AutoscaleStateInvalid
+	}
+	if len(components) == 0 {
+		return reportv1alpha1.AutoscaleStateUnavailable
+	}
+	allNotReported := true
+	partial := false
+	for _, component := range components {
+		switch component.State {
+		case reportv1alpha1.AutoscaleComponentInvalid:
+			return reportv1alpha1.AutoscaleStateInvalid
+		case reportv1alpha1.AutoscaleComponentReported:
+			allNotReported = false
+		case reportv1alpha1.AutoscaleComponentPartial:
+			allNotReported = false
+			partial = true
+		case reportv1alpha1.AutoscaleComponentNotReported:
+			partial = true
+		}
+	}
+	if allNotReported {
+		return reportv1alpha1.AutoscaleStateUnavailable
+	}
+	if partial {
+		return reportv1alpha1.AutoscaleStatePartial
+	}
+	return reportv1alpha1.AutoscaleStateReported
+}
+
+func isKnownComponent(component omev1beta1.ComponentType) bool {
+	for _, known := range knownComponents {
+		if component == known.api {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cli/autoscaleprojection/project_test.go
+++ b/pkg/cli/autoscaleprojection/project_test.go
@@ -1,0 +1,796 @@
+package autoscaleprojection
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	kedav1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestProjectRejectsUnsafeInferenceServiceIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		isvc *omev1beta1.InferenceService
+		want error
+	}{
+		{name: "nil", want: ErrInferenceServiceRequired},
+		{name: "name omitted", isvc: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Namespace: "prod", UID: "uid"}}, want: ErrInferenceServiceNameRequired},
+		{name: "namespace omitted", isvc: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat", UID: "uid"}}, want: ErrInferenceServiceNamespaceRequired},
+		{name: "uid omitted", isvc: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "prod"}}, want: ErrInferenceServiceUIDRequired},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Project(test.isvc, fixedClock())
+			assert.ErrorIs(t, err, test.want)
+			assert.Equal(t, reportv1alpha1.AutoscaleStatusReport{}, got)
+		})
+	}
+
+	assert.EqualError(t, ErrInferenceServiceRequired, "autoscale projection requires an InferenceService")
+	assert.EqualError(t, ErrInferenceServiceNameRequired, "autoscale projection requires an InferenceService name")
+	assert.EqualError(t, ErrInferenceServiceNamespaceRequired, "autoscale projection requires an InferenceService namespace")
+	assert.EqualError(t, ErrInferenceServiceUIDRequired, "autoscale projection requires an InferenceService UID")
+}
+
+func TestProjectReportedHPAUsesOnlyParentReportedEvidence(t *testing.T) {
+	lastScale := metav1.NewTime(time.Date(2026, time.August, 31, 18, 20, 0, 0, time.FixedZone("secret-zone", -7*60*60)))
+	transition := metav1.NewTime(time.Date(2026, time.August, 31, 18, 15, 0, 0, time.FixedZone("secret-zone", -7*60*60)))
+	isvc := baseInferenceService()
+	isvc.Labels = map[string]string{"SECRET_OBJECT_LABEL": "SECRET_OBJECT_LABEL_VALUE"}
+	isvc.OwnerReferences = []metav1.OwnerReference{{Name: "SECRET_OWNER_REFERENCE"}}
+	isvc.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "SECRET_FIELD_MANAGER"}}
+	isvc.Spec.Engine = &omev1beta1.EngineSpec{ComponentExtensionSpec: omev1beta1.ComponentExtensionSpec{
+		Labels:      map[string]string{"SECRET_LABEL_KEY": "SECRET_LABEL_VALUE"},
+		Annotations: map[string]string{"SECRET_SPEC_ANNOTATION": "SECRET_SPEC_VALUE"},
+		Autoscaler: &omev1beta1.ComponentAutoscaler{
+			Class: omev1beta1.AutoscalerKEDA,
+			Keda: &omev1beta1.KedaAutoscaler{Triggers: []kedav1.ScaleTriggers{{
+				Type: "SECRET_TRIGGER", Metadata: map[string]string{"token": "SECRET_TRIGGER_TOKEN"},
+			}}},
+			HPA: &omev1beta1.HPAAutoscaler{Metrics: []autoscalingv2.MetricSpec{{
+				Type: autoscalingv2.ExternalMetricSourceType,
+				External: &autoscalingv2.ExternalMetricSource{
+					Metric: autoscalingv2.MetricIdentifier{Name: "SECRET_METRIC"},
+				},
+			}}},
+		},
+	}}
+	isvc.Status.ObservedGeneration = 999
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			RolloutPhase:              omev1beta1.RolloutPhase("SECRET_ROLLOUT_PHASE"),
+			LatestReadyRevision:       "SECRET_READY_REVISION",
+			LatestRolledoutRevision:   "SECRET_ROLLEDOUT_REVISION",
+			PreviousRolledoutRevision: "SECRET_PREVIOUS_REVISION",
+			Traffic: []omev1beta1.ComponentTrafficTarget{{
+				RevisionName: "SECRET_TRAFFIC_REVISION", Tag: "SECRET_TRAFFIC_TAG", Percent: 100,
+			}},
+			Autoscaler: &omev1beta1.ComponentAutoscalerStatus{
+				Class: omev1beta1.AutoscalerHPA, ManagedBy: omev1beta1.AutoscalerManagedByOME,
+				SpecSource: "default", CurrentReplicas: 2, DesiredReplicas: 3,
+				LastScaleTime: &lastScale,
+				Conditions: []metav1.Condition{
+					{Type: "ScalingActive", Status: metav1.ConditionTrue, Reason: "SECRET_REASON", Message: "SECRET_MESSAGE", ObservedGeneration: 998, LastTransitionTime: transition},
+					{Type: "AbleToScale", Status: metav1.ConditionTrue, Reason: "SECRET_REASON_2", Message: "SECRET_MESSAGE_2", ObservedGeneration: 997, LastTransitionTime: transition},
+				},
+			},
+			ScaleTargetRef: &omev1beta1.ScaleTargetRef{
+				APIVersion: "ome.io/v1beta1", Kind: "InferenceReplica", Name: "chat-engine",
+			},
+		},
+	}
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	current, desired := int32(2), int32(3)
+	assert.Equal(t, reportv1alpha1.AutoscaleSummary{State: reportv1alpha1.AutoscaleStateReported}, got.Content.Summary)
+	assert.Equal(t, []reportv1alpha1.AutoscaleSourceReference{{
+		Kind: reportv1alpha1.AutoscaleSourceInferenceService, Namespace: "prod", Name: "chat",
+		UID: "isvc-uid", Generation: 7, Evidence: reportv1alpha1.EvidenceReported,
+		CollectedAt: fixedClock().Now(),
+	}}, got.Sources)
+	assert.Equal(t, []reportv1alpha1.AutoscaleComponentStatus{{
+		Type: reportv1alpha1.RuntimeComponentEngine, State: reportv1alpha1.AutoscaleComponentReported,
+		Class: reportv1alpha1.AutoscaleClassHPA, ManagedBy: reportv1alpha1.AutoscaleManagedByOME,
+		SpecSource: reportv1alpha1.AutoscaleSpecSourceDefault,
+		Target: reportv1alpha1.AutoscaleTarget{
+			State: reportv1alpha1.AutoscaleTargetReported, APIVersion: "ome.io/v1beta1",
+			Kind: reportv1alpha1.AutoscaleTargetInferenceReplica, Namespace: "prod", Name: "chat-engine",
+		},
+		Replicas: reportv1alpha1.AutoscaleReplicaStatus{
+			State: reportv1alpha1.AutoscaleReplicasReported, CurrentReplicas: &current,
+			DesiredReplicas: &desired, LastScaleTime: ptrTime(lastScale.Time.UTC()),
+		},
+		Conditions: reportv1alpha1.AutoscaleConditionsStatus{
+			State: reportv1alpha1.AutoscaleConditionsReported,
+			Items: []reportv1alpha1.AutoscaleCondition{
+				{Type: reportv1alpha1.AutoscaleConditionAbleToScale, Status: reportv1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition.Time.UTC()},
+				{Type: reportv1alpha1.AutoscaleConditionScalingActive, Status: reportv1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition.Time.UTC()},
+			},
+		},
+	}}, got.Content.Components)
+	assert.Empty(t, got.Content.Issues)
+	assert.Empty(t, got.Warnings)
+
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		var output bytes.Buffer
+		require.NoError(t, report.Write(&output, format, got))
+		for _, secret := range []string{
+			"SECRET_RESOURCE_VERSION", "SECRET_ANNOTATION", "SECRET_STATUS_ANNOTATION",
+			"SECRET_REASON", "SECRET_MESSAGE", "observedGeneration", "resourceVersion",
+			"SECRET_LABEL", "SECRET_SPEC", "SECRET_TRIGGER", "SECRET_TRIGGER_TOKEN",
+			"SECRET_OBJECT_LABEL", "SECRET_OWNER_REFERENCE", "SECRET_FIELD_MANAGER",
+			"SECRET_METRIC", "metrics", "behavior",
+			"SECRET_ROLLOUT", "SECRET_READY", "SECRET_PREVIOUS", "SECRET_TRAFFIC",
+			"freshness", "syncToken", "lastRuntimeSyncToken", "continuationToken",
+		} {
+			assert.NotContains(t, output.String(), secret, "format %s", format)
+		}
+	}
+}
+
+func TestProjectNoComponentEvidenceIsUnavailable(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.Components = nil
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Equal(t, reportv1alpha1.AutoscaleStateUnavailable, got.Content.Summary.State)
+	assert.NotNil(t, got.Content.Components)
+	assert.Empty(t, got.Content.Components)
+	assert.NotNil(t, got.Content.Issues)
+	assert.Empty(t, got.Content.Issues)
+	assert.Equal(t, []reportv1alpha1.AutoscaleWarning{{Code: reportv1alpha1.AutoscaleWarningPartialData}}, got.Warnings)
+}
+
+func TestProjectKnownComponentWithoutAutoscalerIsNotReported(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			ScaleTargetRef: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "chat-engine"},
+		},
+	}
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	require.Len(t, got.Content.Components, 1)
+	component := got.Content.Components[0]
+	assert.Equal(t, reportv1alpha1.AutoscaleComponentNotReported, component.State)
+	assert.Equal(t, reportv1alpha1.AutoscaleClassUnknown, component.Class)
+	assert.Equal(t, reportv1alpha1.AutoscaleManagedByUnknown, component.ManagedBy)
+	assert.Equal(t, reportv1alpha1.AutoscaleSpecSourceUnknown, component.SpecSource)
+	assert.Equal(t, reportv1alpha1.AutoscaleTargetReported, component.Target.State)
+	assert.Equal(t, reportv1alpha1.AutoscaleReplicasNotReported, component.Replicas.State)
+	assert.NotNil(t, component.Conditions.Items)
+	assert.Equal(t, reportv1alpha1.AutoscaleConditionsNotReported, component.Conditions.State)
+	assert.Equal(t, []reportv1alpha1.AutoscaleIssue{{Code: reportv1alpha1.AutoscaleIssueAutoscalerNotReported, Component: reportv1alpha1.RuntimeComponentEngine}}, got.Content.Issues)
+	assert.Equal(t, reportv1alpha1.AutoscaleStateUnavailable, got.Content.Summary.State)
+}
+
+func TestProjectMalformedTargetCannotBeMaskedByMissingAutoscaler(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.EngineComponent: {
+			ScaleTargetRef: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment"},
+		},
+	}
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	require.Len(t, got.Content.Components, 1)
+	assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, got.Content.Components[0].State)
+	assert.Equal(t, reportv1alpha1.AutoscaleStateInvalid, got.Content.Summary.State)
+	assert.Equal(t, []reportv1alpha1.AutoscaleIssueCode{
+		reportv1alpha1.AutoscaleIssueAutoscalerNotReported,
+		reportv1alpha1.AutoscaleIssueScaleTargetInvalid,
+	}, issueCodes(got.Content.Issues))
+}
+
+func TestProjectClassOwnershipMatrix(t *testing.T) {
+	tests := []struct {
+		name           string
+		class          omev1beta1.AutoscalerClass
+		managedBy      omev1beta1.AutoscalerManagedBy
+		wantClass      reportv1alpha1.AutoscaleClass
+		wantManagedBy  reportv1alpha1.AutoscaleManagedBy
+		wantReplicas   reportv1alpha1.AutoscaleReplicaState
+		wantConditions reportv1alpha1.AutoscaleConditionsState
+		wantComponent  reportv1alpha1.AutoscaleComponentState
+		wantIssueCodes []reportv1alpha1.AutoscaleIssueCode
+	}{
+		{name: "HPA", class: omev1beta1.AutoscalerHPA, managedBy: omev1beta1.AutoscalerManagedByOME, wantClass: reportv1alpha1.AutoscaleClassHPA, wantManagedBy: reportv1alpha1.AutoscaleManagedByOME, wantReplicas: reportv1alpha1.AutoscaleReplicasAmbiguous, wantConditions: reportv1alpha1.AutoscaleConditionsNotReported, wantComponent: reportv1alpha1.AutoscaleComponentPartial, wantIssueCodes: []reportv1alpha1.AutoscaleIssueCode{reportv1alpha1.AutoscaleIssueReplicaEvidenceAmbiguous}},
+		{name: "KEDA", class: omev1beta1.AutoscalerKEDA, managedBy: omev1beta1.AutoscalerManagedByOME, wantClass: reportv1alpha1.AutoscaleClassKEDA, wantManagedBy: reportv1alpha1.AutoscaleManagedByOME, wantReplicas: reportv1alpha1.AutoscaleReplicasAmbiguous, wantConditions: reportv1alpha1.AutoscaleConditionsNotReported, wantComponent: reportv1alpha1.AutoscaleComponentPartial, wantIssueCodes: []reportv1alpha1.AutoscaleIssueCode{reportv1alpha1.AutoscaleIssueReplicaEvidenceAmbiguous}},
+		{name: "External", class: omev1beta1.AutoscalerExternal, managedBy: omev1beta1.AutoscalerManagedByExternal, wantClass: reportv1alpha1.AutoscaleClassExternal, wantManagedBy: reportv1alpha1.AutoscaleManagedByExternal, wantReplicas: reportv1alpha1.AutoscaleReplicasUnavailable, wantConditions: reportv1alpha1.AutoscaleConditionsUnavailable, wantComponent: reportv1alpha1.AutoscaleComponentReported},
+		{name: "None", class: omev1beta1.AutoscalerNone, managedBy: omev1beta1.AutoscalerManagedByNone, wantClass: reportv1alpha1.AutoscaleClassNone, wantManagedBy: reportv1alpha1.AutoscaleManagedByNone, wantReplicas: reportv1alpha1.AutoscaleReplicasUnavailable, wantConditions: reportv1alpha1.AutoscaleConditionsUnavailable, wantComponent: reportv1alpha1.AutoscaleComponentReported},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := baseInferenceService()
+			isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+				omev1beta1.EngineComponent: {
+					Autoscaler:     &omev1beta1.ComponentAutoscalerStatus{Class: test.class, ManagedBy: test.managedBy, SpecSource: "isvc"},
+					ScaleTargetRef: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "chat-engine"},
+				},
+			}
+
+			got, err := Project(isvc, fixedClock())
+			require.NoError(t, err)
+			require.Len(t, got.Content.Components, 1)
+			component := got.Content.Components[0]
+			assert.Equal(t, test.wantClass, component.Class)
+			assert.Equal(t, test.wantManagedBy, component.ManagedBy)
+			assert.Equal(t, test.wantReplicas, component.Replicas.State)
+			assert.Equal(t, test.wantConditions, component.Conditions.State)
+			assert.Equal(t, test.wantComponent, component.State)
+			assert.Equal(t, append([]reportv1alpha1.AutoscaleIssueCode{}, test.wantIssueCodes...), issueCodes(got.Content.Issues))
+		})
+	}
+}
+
+func TestProjectReplicaEvidenceStates(t *testing.T) {
+	tests := []struct {
+		name          string
+		current       int32
+		desired       int32
+		lastScaleTime *metav1.Time
+		wantState     reportv1alpha1.AutoscaleReplicaState
+		wantCurrent   *int32
+		wantDesired   *int32
+		wantLast      *time.Time
+		wantIssue     reportv1alpha1.AutoscaleIssueCode
+	}{
+		{name: "current zero is explicitly preserved but ambiguous", current: 0, desired: 3, wantState: reportv1alpha1.AutoscaleReplicasAmbiguous, wantCurrent: ptrInt32(0), wantDesired: ptrInt32(3), wantIssue: reportv1alpha1.AutoscaleIssueReplicaEvidenceAmbiguous},
+		{name: "desired zero is explicitly preserved but ambiguous", current: 2, desired: 0, wantState: reportv1alpha1.AutoscaleReplicasAmbiguous, wantCurrent: ptrInt32(2), wantDesired: ptrInt32(0), wantIssue: reportv1alpha1.AutoscaleIssueReplicaEvidenceAmbiguous},
+		{name: "negative current is invalid and omitted", current: -1, desired: 3, wantState: reportv1alpha1.AutoscaleReplicasInvalid, wantIssue: reportv1alpha1.AutoscaleIssueReplicaEvidenceInvalid},
+		{name: "negative desired is invalid and omitted", current: 2, desired: -1, wantState: reportv1alpha1.AutoscaleReplicasInvalid, wantIssue: reportv1alpha1.AutoscaleIssueReplicaEvidenceInvalid},
+		{name: "zero last-scale timestamp is invalid and omitted", current: 2, desired: 3, lastScaleTime: &metav1.Time{}, wantState: reportv1alpha1.AutoscaleReplicasInvalid, wantIssue: reportv1alpha1.AutoscaleIssueReplicaEvidenceInvalid},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, &omev1beta1.ComponentAutoscalerStatus{
+				Class: omev1beta1.AutoscalerHPA, ManagedBy: omev1beta1.AutoscalerManagedByOME,
+				SpecSource: "runtime", CurrentReplicas: test.current, DesiredReplicas: test.desired,
+				LastScaleTime: test.lastScaleTime, Conditions: []metav1.Condition{validHPACondition("AbleToScale")},
+			})
+
+			got, err := Project(isvc, fixedClock())
+			require.NoError(t, err)
+			component := got.Content.Components[0]
+			assert.Equal(t, test.wantState, component.Replicas.State)
+			assert.Equal(t, test.wantCurrent, component.Replicas.CurrentReplicas)
+			assert.Equal(t, test.wantDesired, component.Replicas.DesiredReplicas)
+			assert.Equal(t, test.wantLast, component.Replicas.LastScaleTime)
+			assert.Contains(t, issueCodes(got.Content.Issues), test.wantIssue)
+			if test.wantState == reportv1alpha1.AutoscaleReplicasInvalid {
+				assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, component.State)
+			} else {
+				assert.Equal(t, reportv1alpha1.AutoscaleComponentPartial, component.State)
+			}
+		})
+	}
+}
+
+func TestProjectValidatesTargetsWithoutReadingOrGuessing(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    *omev1beta1.ScaleTargetRef
+		wantState reportv1alpha1.AutoscaleTargetState
+		wantKind  reportv1alpha1.AutoscaleTargetKind
+		wantIssue reportv1alpha1.AutoscaleIssueCode
+	}{
+		{name: "deployment", target: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "chat-engine"}, wantState: reportv1alpha1.AutoscaleTargetReported, wantKind: reportv1alpha1.AutoscaleTargetDeployment},
+		{name: "inference replica", target: &omev1beta1.ScaleTargetRef{APIVersion: "ome.io/v1beta1", Kind: "InferenceReplica", Name: "chat-engine"}, wantState: reportv1alpha1.AutoscaleTargetReported, wantKind: reportv1alpha1.AutoscaleTargetInferenceReplica},
+		{name: "missing", wantState: reportv1alpha1.AutoscaleTargetNotReported, wantIssue: reportv1alpha1.AutoscaleIssueScaleTargetNotReported},
+		{name: "partial", target: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment"}, wantState: reportv1alpha1.AutoscaleTargetInvalid, wantIssue: reportv1alpha1.AutoscaleIssueScaleTargetInvalid},
+		{name: "wrong group", target: &omev1beta1.ScaleTargetRef{APIVersion: "evil.example/v1", Kind: "Deployment", Name: "chat-engine"}, wantState: reportv1alpha1.AutoscaleTargetInvalid, wantIssue: reportv1alpha1.AutoscaleIssueScaleTargetInvalid},
+		{name: "wrong kind", target: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "StatefulSet", Name: "chat-engine"}, wantState: reportv1alpha1.AutoscaleTargetInvalid, wantIssue: reportv1alpha1.AutoscaleIssueScaleTargetInvalid},
+		{name: "invalid name", target: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "SECRET/target"}, wantState: reportv1alpha1.AutoscaleTargetInvalid, wantIssue: reportv1alpha1.AutoscaleIssueScaleTargetInvalid},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, reportedHPA())
+			component := isvc.Status.Components[omev1beta1.EngineComponent]
+			component.ScaleTargetRef = test.target
+			isvc.Status.Components[omev1beta1.EngineComponent] = component
+
+			got, err := Project(isvc, fixedClock())
+			require.NoError(t, err)
+			projected := got.Content.Components[0]
+			assert.Equal(t, test.wantState, projected.Target.State)
+			assert.Equal(t, test.wantKind, projected.Target.Kind)
+			if test.wantState == reportv1alpha1.AutoscaleTargetReported {
+				assert.Equal(t, "prod", projected.Target.Namespace)
+				assert.Equal(t, "chat-engine", projected.Target.Name)
+				assert.NotContains(t, issueCodes(got.Content.Issues), test.wantIssue)
+			} else {
+				assert.Empty(t, projected.Target.APIVersion)
+				assert.Empty(t, projected.Target.Kind)
+				assert.Empty(t, projected.Target.Namespace)
+				assert.Empty(t, projected.Target.Name)
+				assert.Contains(t, issueCodes(got.Content.Issues), test.wantIssue)
+			}
+		})
+	}
+}
+
+func TestProjectRejectsClosedEnumAndOwnershipContradictions(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    *omev1beta1.ComponentAutoscalerStatus
+		wantClass reportv1alpha1.AutoscaleClass
+		wantOwner reportv1alpha1.AutoscaleManagedBy
+		wantSpec  reportv1alpha1.AutoscaleSpecSource
+		wantIssue reportv1alpha1.AutoscaleIssueCode
+	}{
+		{name: "unknown class", status: &omev1beta1.ComponentAutoscalerStatus{Class: "SECRET_CLASS", ManagedBy: omev1beta1.AutoscalerManagedByOME, SpecSource: "isvc"}, wantClass: reportv1alpha1.AutoscaleClassUnknown, wantOwner: reportv1alpha1.AutoscaleManagedByOME, wantSpec: reportv1alpha1.AutoscaleSpecSourceISVC, wantIssue: reportv1alpha1.AutoscaleIssueClassInvalid},
+		{name: "unknown manager", status: &omev1beta1.ComponentAutoscalerStatus{Class: omev1beta1.AutoscalerHPA, ManagedBy: "SECRET_MANAGER", SpecSource: "isvc"}, wantClass: reportv1alpha1.AutoscaleClassHPA, wantOwner: reportv1alpha1.AutoscaleManagedByUnknown, wantSpec: reportv1alpha1.AutoscaleSpecSourceISVC, wantIssue: reportv1alpha1.AutoscaleIssueManagedByInvalid},
+		{name: "unknown spec source", status: &omev1beta1.ComponentAutoscalerStatus{Class: omev1beta1.AutoscalerHPA, ManagedBy: omev1beta1.AutoscalerManagedByOME, SpecSource: "SECRET_SOURCE"}, wantClass: reportv1alpha1.AutoscaleClassHPA, wantOwner: reportv1alpha1.AutoscaleManagedByOME, wantSpec: reportv1alpha1.AutoscaleSpecSourceUnknown, wantIssue: reportv1alpha1.AutoscaleIssueSpecSourceInvalid},
+		{name: "ownership mismatch", status: &omev1beta1.ComponentAutoscalerStatus{Class: omev1beta1.AutoscalerKEDA, ManagedBy: omev1beta1.AutoscalerManagedByExternal, SpecSource: "runtime"}, wantClass: reportv1alpha1.AutoscaleClassKEDA, wantOwner: reportv1alpha1.AutoscaleManagedByExternal, wantSpec: reportv1alpha1.AutoscaleSpecSourceRuntime, wantIssue: reportv1alpha1.AutoscaleIssueOwnershipMismatch},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, test.status)
+			got, err := Project(isvc, fixedClock())
+			require.NoError(t, err)
+			component := got.Content.Components[0]
+			assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, component.State)
+			assert.Equal(t, test.wantClass, component.Class)
+			assert.Equal(t, test.wantOwner, component.ManagedBy)
+			assert.Equal(t, test.wantSpec, component.SpecSource)
+			assert.Contains(t, issueCodes(got.Content.Issues), test.wantIssue)
+			for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+				var output bytes.Buffer
+				require.NoError(t, report.Write(&output, format, got))
+				assert.NotContains(t, output.String(), "SECRET_", "format %s", format)
+			}
+		})
+	}
+}
+
+func TestProjectRejectsEveryKnownOwnershipMatrixMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		class     omev1beta1.AutoscalerClass
+		managedBy omev1beta1.AutoscalerManagedBy
+	}{
+		{name: "HPA/external", class: omev1beta1.AutoscalerHPA, managedBy: omev1beta1.AutoscalerManagedByExternal},
+		{name: "HPA/none", class: omev1beta1.AutoscalerHPA, managedBy: omev1beta1.AutoscalerManagedByNone},
+		{name: "KEDA/external", class: omev1beta1.AutoscalerKEDA, managedBy: omev1beta1.AutoscalerManagedByExternal},
+		{name: "KEDA/none", class: omev1beta1.AutoscalerKEDA, managedBy: omev1beta1.AutoscalerManagedByNone},
+		{name: "External/ome", class: omev1beta1.AutoscalerExternal, managedBy: omev1beta1.AutoscalerManagedByOME},
+		{name: "External/none", class: omev1beta1.AutoscalerExternal, managedBy: omev1beta1.AutoscalerManagedByNone},
+		{name: "None/ome", class: omev1beta1.AutoscalerNone, managedBy: omev1beta1.AutoscalerManagedByOME},
+		{name: "None/external", class: omev1beta1.AutoscalerNone, managedBy: omev1beta1.AutoscalerManagedByExternal},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := &omev1beta1.ComponentAutoscalerStatus{
+				Class: test.class, ManagedBy: test.managedBy, SpecSource: "default",
+			}
+			got, err := Project(inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status), fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, got.Content.Components[0].State)
+			assert.Equal(t, []reportv1alpha1.AutoscaleIssueCode{
+				reportv1alpha1.AutoscaleIssueOwnershipMismatch,
+			}, issueCodes(got.Content.Issues))
+		})
+	}
+}
+
+func TestProjectAcceptsEveryKnownSpecSource(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want reportv1alpha1.AutoscaleSpecSource
+	}{
+		{raw: "isvc", want: reportv1alpha1.AutoscaleSpecSourceISVC},
+		{raw: "runtime", want: reportv1alpha1.AutoscaleSpecSourceRuntime},
+		{raw: "legacy", want: reportv1alpha1.AutoscaleSpecSourceLegacy},
+		{raw: "default", want: reportv1alpha1.AutoscaleSpecSourceDefault},
+	}
+
+	for _, test := range tests {
+		t.Run(test.raw, func(t *testing.T) {
+			status := reportedHPA()
+			status.SpecSource = test.raw
+			got, err := Project(inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status), fixedClock())
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got.Content.Components[0].SpecSource)
+			assert.NotContains(t, issueCodes(got.Content.Issues), reportv1alpha1.AutoscaleIssueSpecSourceInvalid)
+		})
+	}
+}
+
+func TestProjectExternalAndNoneRejectUnexpectedScalerEvidence(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC))
+	tests := []struct {
+		name           string
+		mutate         func(*omev1beta1.ComponentAutoscalerStatus)
+		wantReplica    reportv1alpha1.AutoscaleReplicaState
+		wantConditions reportv1alpha1.AutoscaleConditionsState
+	}{
+		{name: "counter", mutate: func(status *omev1beta1.ComponentAutoscalerStatus) { status.CurrentReplicas = 1 }, wantReplica: reportv1alpha1.AutoscaleReplicasInvalid, wantConditions: reportv1alpha1.AutoscaleConditionsUnavailable},
+		{name: "last scale", mutate: func(status *omev1beta1.ComponentAutoscalerStatus) { status.LastScaleTime = &transition }, wantReplica: reportv1alpha1.AutoscaleReplicasInvalid, wantConditions: reportv1alpha1.AutoscaleConditionsUnavailable},
+		{name: "condition", mutate: func(status *omev1beta1.ComponentAutoscalerStatus) {
+			status.Conditions = []metav1.Condition{validHPACondition("AbleToScale")}
+		}, wantReplica: reportv1alpha1.AutoscaleReplicasUnavailable, wantConditions: reportv1alpha1.AutoscaleConditionsInvalid},
+	}
+
+	for _, classAndOwner := range []struct {
+		class omev1beta1.AutoscalerClass
+		owner omev1beta1.AutoscalerManagedBy
+	}{{omev1beta1.AutoscalerExternal, omev1beta1.AutoscalerManagedByExternal}, {omev1beta1.AutoscalerNone, omev1beta1.AutoscalerManagedByNone}} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s/%s", classAndOwner.class, test.name), func(t *testing.T) {
+				status := &omev1beta1.ComponentAutoscalerStatus{Class: classAndOwner.class, ManagedBy: classAndOwner.owner, SpecSource: "default"}
+				test.mutate(status)
+				got, err := Project(inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status), fixedClock())
+				require.NoError(t, err)
+				component := got.Content.Components[0]
+				assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, component.State)
+				assert.Equal(t, test.wantReplica, component.Replicas.State)
+				assert.Nil(t, component.Replicas.CurrentReplicas)
+				assert.Nil(t, component.Replicas.DesiredReplicas)
+				assert.Nil(t, component.Replicas.LastScaleTime)
+				assert.Equal(t, test.wantConditions, component.Conditions.State)
+				assert.Empty(t, component.Conditions.Items)
+				assert.Equal(t, []reportv1alpha1.AutoscaleIssueCode{reportv1alpha1.AutoscaleIssueUnexpectedScalerEvidence}, issueCodes(got.Content.Issues))
+			})
+		}
+	}
+}
+
+func TestProjectExternalAndNoneContradictionsSurviveOwnershipErrors(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC))
+	tests := []struct {
+		name      string
+		class     omev1beta1.AutoscalerClass
+		managedBy omev1beta1.AutoscalerManagedBy
+		want      []reportv1alpha1.AutoscaleIssueCode
+	}{
+		{
+			name: "external with mismatched OME manager", class: omev1beta1.AutoscalerExternal,
+			managedBy: omev1beta1.AutoscalerManagedByOME,
+			want: []reportv1alpha1.AutoscaleIssueCode{
+				reportv1alpha1.AutoscaleIssueOwnershipMismatch,
+				reportv1alpha1.AutoscaleIssueUnexpectedScalerEvidence,
+			},
+		},
+		{
+			name: "none with mismatched external manager", class: omev1beta1.AutoscalerNone,
+			managedBy: omev1beta1.AutoscalerManagedByExternal,
+			want: []reportv1alpha1.AutoscaleIssueCode{
+				reportv1alpha1.AutoscaleIssueOwnershipMismatch,
+				reportv1alpha1.AutoscaleIssueUnexpectedScalerEvidence,
+			},
+		},
+		{
+			name: "external with invalid manager", class: omev1beta1.AutoscalerExternal,
+			managedBy: "SECRET_MANAGER",
+			want: []reportv1alpha1.AutoscaleIssueCode{
+				reportv1alpha1.AutoscaleIssueManagedByInvalid,
+				reportv1alpha1.AutoscaleIssueUnexpectedScalerEvidence,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := &omev1beta1.ComponentAutoscalerStatus{
+				Class: test.class, ManagedBy: test.managedBy, SpecSource: "isvc",
+				CurrentReplicas: 1, DesiredReplicas: 2, LastScaleTime: &transition,
+				Conditions: []metav1.Condition{validHPACondition("AbleToScale")},
+			}
+
+			got, err := Project(inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status), fixedClock())
+			require.NoError(t, err)
+			component := got.Content.Components[0]
+			assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, component.State)
+			assert.Equal(t, reportv1alpha1.AutoscaleReplicasInvalid, component.Replicas.State)
+			assert.Nil(t, component.Replicas.CurrentReplicas)
+			assert.Nil(t, component.Replicas.DesiredReplicas)
+			assert.Nil(t, component.Replicas.LastScaleTime)
+			assert.Equal(t, reportv1alpha1.AutoscaleConditionsInvalid, component.Conditions.State)
+			assert.Empty(t, component.Conditions.Items)
+			assert.Equal(t, test.want, issueCodes(got.Content.Issues))
+		})
+	}
+}
+
+func TestProjectConditionsAreAllowlistedValidatedDedupedAndOrdered(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, 8, 31, 11, 0, 0, 0, time.FixedZone("input-zone", -7*60*60)))
+	duplicate := metav1.Condition{Type: "ScalingActive", Status: metav1.ConditionFalse, LastTransitionTime: transition, Reason: "SECRET_REASON", Message: "SECRET_MESSAGE"}
+	isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, &omev1beta1.ComponentAutoscalerStatus{
+		Class: omev1beta1.AutoscalerHPA, ManagedBy: omev1beta1.AutoscalerManagedByOME, SpecSource: "isvc",
+		CurrentReplicas: 2, DesiredReplicas: 3,
+		Conditions: []metav1.Condition{
+			duplicate,
+			{Type: "ScalingLimited", Status: metav1.ConditionUnknown, LastTransitionTime: transition},
+			{Type: "AbleToScale", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+			duplicate,
+		},
+	})
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	conditions := got.Content.Components[0].Conditions
+	assert.Equal(t, reportv1alpha1.AutoscaleConditionsReported, conditions.State)
+	assert.Equal(t, []reportv1alpha1.AutoscaleCondition{
+		{Type: reportv1alpha1.AutoscaleConditionAbleToScale, Status: reportv1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition.Time.UTC()},
+		{Type: reportv1alpha1.AutoscaleConditionScalingActive, Status: reportv1alpha1.AutoscaleConditionFalse, LastTransitionTime: transition.Time.UTC()},
+		{Type: reportv1alpha1.AutoscaleConditionScalingLimited, Status: reportv1alpha1.AutoscaleConditionUnknown, LastTransitionTime: transition.Time.UTC()},
+	}, conditions.Items)
+}
+
+func TestProjectKEDAConditionsUseTheirOwnFixedOrder(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC))
+	isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, &omev1beta1.ComponentAutoscalerStatus{
+		Class: omev1beta1.AutoscalerKEDA, ManagedBy: omev1beta1.AutoscalerManagedByOME,
+		SpecSource: "runtime", CurrentReplicas: 2, DesiredReplicas: 3,
+		Conditions: []metav1.Condition{
+			{Type: "Paused", Status: metav1.ConditionFalse, LastTransitionTime: transition},
+			{Type: "Fallback", Status: metav1.ConditionUnknown, LastTransitionTime: transition},
+			{Type: "Active", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+			{Type: "Ready", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+		},
+	})
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, []reportv1alpha1.AutoscaleConditionType{
+		reportv1alpha1.AutoscaleConditionReady,
+		reportv1alpha1.AutoscaleConditionActive,
+		reportv1alpha1.AutoscaleConditionFallback,
+		reportv1alpha1.AutoscaleConditionPaused,
+	}, conditionTypes(got.Content.Components[0].Conditions.Items))
+}
+
+func TestProjectInvalidAndConflictingConditionsAreOmitted(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC))
+	later := metav1.NewTime(transition.Add(time.Minute))
+	tests := []struct {
+		name       string
+		class      omev1beta1.AutoscalerClass
+		conditions []metav1.Condition
+		wantIssue  reportv1alpha1.AutoscaleIssueCode
+		wantItems  []reportv1alpha1.AutoscaleCondition
+	}{
+		{name: "foreign HPA condition", class: omev1beta1.AutoscalerHPA, conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue, LastTransitionTime: transition}}, wantIssue: reportv1alpha1.AutoscaleIssueConditionInvalid},
+		{name: "foreign KEDA condition", class: omev1beta1.AutoscalerKEDA, conditions: []metav1.Condition{{Type: "AbleToScale", Status: metav1.ConditionTrue, LastTransitionTime: transition}}, wantIssue: reportv1alpha1.AutoscaleIssueConditionInvalid},
+		{name: "unknown status", class: omev1beta1.AutoscalerHPA, conditions: []metav1.Condition{{Type: "AbleToScale", Status: "SECRET_STATUS", LastTransitionTime: transition}}, wantIssue: reportv1alpha1.AutoscaleIssueConditionInvalid},
+		{name: "zero transition", class: omev1beta1.AutoscalerHPA, conditions: []metav1.Condition{{Type: "AbleToScale", Status: metav1.ConditionTrue}}, wantIssue: reportv1alpha1.AutoscaleIssueConditionInvalid},
+		{name: "conflicting duplicate", class: omev1beta1.AutoscalerHPA, conditions: []metav1.Condition{
+			{Type: "AbleToScale", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+			{Type: "AbleToScale", Status: metav1.ConditionFalse, LastTransitionTime: later},
+			{Type: "ScalingActive", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+		}, wantIssue: reportv1alpha1.AutoscaleIssueConditionConflict, wantItems: []reportv1alpha1.AutoscaleCondition{{Type: reportv1alpha1.AutoscaleConditionScalingActive, Status: reportv1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition.Time}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := reportedHPA()
+			status.Class = test.class
+			status.Conditions = test.conditions
+			got, err := Project(inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status), fixedClock())
+			require.NoError(t, err)
+			component := got.Content.Components[0]
+			assert.Equal(t, reportv1alpha1.AutoscaleConditionsInvalid, component.Conditions.State)
+			assert.Equal(t, append([]reportv1alpha1.AutoscaleCondition{}, test.wantItems...), component.Conditions.Items)
+			assert.Contains(t, issueCodes(got.Content.Issues), test.wantIssue)
+			assert.Equal(t, reportv1alpha1.AutoscaleComponentInvalid, component.State)
+		})
+	}
+}
+
+func TestProjectReportsBothInvalidAndConflictingConditionAnomalies(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC))
+	later := metav1.NewTime(transition.Add(time.Minute))
+	status := reportedHPA()
+	status.Conditions = []metav1.Condition{
+		{Type: "AbleToScale", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+		{Type: "AbleToScale", Status: metav1.ConditionFalse, LastTransitionTime: later},
+		{Type: "SECRET_CONDITION", Status: metav1.ConditionTrue, LastTransitionTime: transition},
+	}
+
+	got, err := Project(inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status), fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, []reportv1alpha1.AutoscaleIssueCode{
+		reportv1alpha1.AutoscaleIssueConditionConflict,
+		reportv1alpha1.AutoscaleIssueConditionInvalid,
+	}, issueCodes(got.Content.Issues))
+	encoded, marshalErr := json.Marshal(got)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(encoded), "SECRET_CONDITION")
+}
+
+func TestProjectUnknownComponentAndHostileFieldsCannotLeak(t *testing.T) {
+	isvc := baseInferenceService()
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		omev1beta1.ComponentType("SECRET_COMPONENT"): {
+			Autoscaler:     &omev1beta1.ComponentAutoscalerStatus{Class: "SECRET_CLASS", ManagedBy: "SECRET_OWNER", SpecSource: "SECRET_SOURCE"},
+			ScaleTargetRef: &omev1beta1.ScaleTargetRef{APIVersion: "SECRET_API", Kind: "SECRET_KIND", Name: "SECRET_TARGET"},
+		},
+	}
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, reportv1alpha1.AutoscaleStateInvalid, got.Content.Summary.State)
+	assert.Empty(t, got.Content.Components)
+	assert.Equal(t, []reportv1alpha1.AutoscaleIssue{{Code: reportv1alpha1.AutoscaleIssueUnknownComponentStatus}}, got.Content.Issues)
+
+	for _, format := range []report.Format{report.FormatTable, report.FormatJSON, report.FormatYAML} {
+		var output bytes.Buffer
+		require.NoError(t, report.Write(&output, format, got))
+		assert.Contains(t, output.String(), string(reportv1alpha1.AutoscaleIssueUnknownComponentStatus))
+		assert.NotContains(t, output.String(), "SECRET_")
+	}
+}
+
+func TestProjectIsDeterministicAndDoesNotMutateInput(t *testing.T) {
+	components := []omev1beta1.ComponentType{omev1beta1.EngineComponent, omev1beta1.DecoderComponent, omev1beta1.RouterComponent}
+	var baseline reportv1alpha1.AutoscaleStatusReport
+	for seed := int64(0); seed < 20; seed++ {
+		rng := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic test permutation
+		permutation := rng.Perm(len(components))
+		isvc := baseInferenceService()
+		isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{}
+		for _, index := range permutation {
+			component := components[index]
+			autoscaler := reportedHPA()
+			autoscaler.Conditions = []metav1.Condition{
+				validHPACondition("ScalingLimited"),
+				validHPACondition("AbleToScale"),
+				validHPACondition("ScalingActive"),
+			}
+			rng.Shuffle(len(autoscaler.Conditions), func(left, right int) {
+				autoscaler.Conditions[left], autoscaler.Conditions[right] = autoscaler.Conditions[right], autoscaler.Conditions[left]
+			})
+			isvc.Status.Components[component] = omev1beta1.ComponentStatusSpec{
+				Autoscaler: autoscaler,
+				ScaleTargetRef: &omev1beta1.ScaleTargetRef{
+					APIVersion: "apps/v1", Kind: "Deployment", Name: "chat-" + string(component),
+				},
+			}
+		}
+		before := isvc.DeepCopy()
+
+		got, err := Project(isvc, fixedClock())
+		require.NoError(t, err)
+		assert.True(t, reflect.DeepEqual(before, isvc), "projection mutated input for seed %d", seed)
+		if seed == 0 {
+			baseline = got
+		} else {
+			assert.Equal(t, baseline, got)
+		}
+	}
+	assert.Equal(t, []reportv1alpha1.RuntimeComponentType{
+		reportv1alpha1.RuntimeComponentEngine,
+		reportv1alpha1.RuntimeComponentDecoder,
+		reportv1alpha1.RuntimeComponentRouter,
+	}, []reportv1alpha1.RuntimeComponentType{
+		baseline.Content.Components[0].Type,
+		baseline.Content.Components[1].Type,
+		baseline.Content.Components[2].Type,
+	})
+}
+
+func TestProjectOutputDoesNotAliasInput(t *testing.T) {
+	lastScale := metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC))
+	status := reportedHPA()
+	status.LastScaleTime = &lastScale
+	isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, status)
+
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	projected := &got.Content.Components[0]
+	*projected.Replicas.CurrentReplicas = 99
+	*projected.Replicas.DesiredReplicas = 100
+	*projected.Replicas.LastScaleTime = projected.Replicas.LastScaleTime.Add(time.Hour)
+	projected.Target.Name = "returned-target"
+	projected.Conditions.Items[0].Status = reportv1alpha1.AutoscaleConditionFalse
+
+	original := isvc.Status.Components[omev1beta1.EngineComponent]
+	assert.Equal(t, int32(2), original.Autoscaler.CurrentReplicas)
+	assert.Equal(t, int32(3), original.Autoscaler.DesiredReplicas)
+	assert.Equal(t, lastScale, *original.Autoscaler.LastScaleTime)
+	assert.Equal(t, "chat-engine", original.ScaleTargetRef.Name)
+	assert.Equal(t, metav1.ConditionTrue, original.Autoscaler.Conditions[0].Status)
+}
+
+func TestProjectWarningsAreOnlyPartialData(t *testing.T) {
+	isvc := inferenceServiceWithAutoscaler(omev1beta1.EngineComponent, reportedHPA())
+	got, err := Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Empty(t, got.Warnings)
+
+	component := isvc.Status.Components[omev1beta1.EngineComponent]
+	component.ScaleTargetRef = nil
+	isvc.Status.Components[omev1beta1.EngineComponent] = component
+	got, err = Project(isvc, fixedClock())
+	require.NoError(t, err)
+	assert.Equal(t, []reportv1alpha1.AutoscaleWarning{{Code: reportv1alpha1.AutoscaleWarningPartialData}}, got.Warnings)
+	for _, warning := range got.Warnings {
+		assert.Equal(t, reportv1alpha1.AutoscaleWarningPartialData, warning.Code)
+	}
+}
+
+func baseInferenceService() *omev1beta1.InferenceService {
+	return &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "prod", Name: "chat", UID: types.UID("isvc-uid"), Generation: 7,
+		ResourceVersion: "SECRET_RESOURCE_VERSION",
+		Annotations:     map[string]string{"secret": "SECRET_ANNOTATION"},
+	}}
+}
+
+func inferenceServiceWithAutoscaler(component omev1beta1.ComponentType, status *omev1beta1.ComponentAutoscalerStatus) *omev1beta1.InferenceService {
+	isvc := baseInferenceService()
+	isvc.Status.Components = map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+		component: {
+			Autoscaler:     status,
+			ScaleTargetRef: &omev1beta1.ScaleTargetRef{APIVersion: "apps/v1", Kind: "Deployment", Name: "chat-" + string(component)},
+		},
+	}
+	return isvc
+}
+
+func reportedHPA() *omev1beta1.ComponentAutoscalerStatus {
+	return &omev1beta1.ComponentAutoscalerStatus{
+		Class: omev1beta1.AutoscalerHPA, ManagedBy: omev1beta1.AutoscalerManagedByOME,
+		SpecSource: "default", CurrentReplicas: 2, DesiredReplicas: 3,
+		Conditions: []metav1.Condition{validHPACondition("AbleToScale")},
+	}
+}
+
+func validHPACondition(conditionType string) metav1.Condition {
+	return metav1.Condition{
+		Type: conditionType, Status: metav1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(time.Date(2026, 8, 31, 18, 0, 0, 0, time.UTC)),
+	}
+}
+
+func issueCodes(issues []reportv1alpha1.AutoscaleIssue) []reportv1alpha1.AutoscaleIssueCode {
+	result := make([]reportv1alpha1.AutoscaleIssueCode, len(issues))
+	for index := range issues {
+		result[index] = issues[index].Code
+	}
+	return result
+}
+
+func conditionTypes(conditions []reportv1alpha1.AutoscaleCondition) []reportv1alpha1.AutoscaleConditionType {
+	result := make([]reportv1alpha1.AutoscaleConditionType, len(conditions))
+	for index := range conditions {
+		result[index] = conditions[index].Type
+	}
+	return result
+}
+
+func ptrInt32(value int32) *int32 { return &value }
+
+func fixedClock() reportv1alpha1.Clock {
+	return reportv1alpha1.ClockFunc(func() time.Time {
+		return time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)
+	})
+}
+
+func ptrTime(value time.Time) *time.Time { return &value }

--- a/pkg/cli/cmd/autoscale/autoscale.go
+++ b/pkg/cli/cmd/autoscale/autoscale.go
@@ -1,0 +1,24 @@
+// Package autoscale implements `kubectl ome autoscale` subcommands.
+package autoscale
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/autoscaleprojection"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+// NewCmd builds the autoscale command family.
+func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "autoscale",
+		Short: "Inspect controller-reported autoscaling evidence",
+	}
+	cmd.AddCommand(newStatusCmd(f, streams, statusDependencies{
+		clock:   reportv1alpha1.SystemClock{},
+		project: autoscaleprojection.Project,
+	}))
+	return cmd
+}

--- a/pkg/cli/cmd/autoscale/autoscale_test.go
+++ b/pkg/cli/cmd/autoscale/autoscale_test.go
@@ -1,0 +1,75 @@
+package autoscale
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+)
+
+func TestNewCmdRegistersStatusSubcommand(t *testing.T) {
+	cmd := NewCmd(factory.Static{}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{},
+	})
+
+	assert.Equal(t, "autoscale", cmd.Use)
+	found, args, err := cmd.Find([]string{"status"})
+	require.NoError(t, err)
+	assert.Empty(t, args)
+	assert.Equal(t, "autoscale status", found.CommandPath())
+	assert.Equal(t, "status INFERENCESERVICE", found.Use)
+}
+
+func TestAutoscaleHelpExplainsReportedEvidence(t *testing.T) {
+	var output bytes.Buffer
+	cmd := NewCmd(factory.Static{}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &output, ErrOut: &output,
+	})
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--help"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, `Inspect controller-reported autoscaling evidence
+
+Usage:
+  autoscale [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  status      Show controller-reported autoscaling status
+
+Flags:
+  -h, --help   help for autoscale
+
+Use "autoscale [command] --help" for more information about a command.
+`, output.String())
+}
+
+func TestStatusHelpDefinesTheReportedEvidenceBoundary(t *testing.T) {
+	var output bytes.Buffer
+	cmd := NewCmd(factory.Static{}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &output, ErrOut: &output,
+	})
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"status", "--help"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, `Show autoscaling evidence already reported on the InferenceService parent.
+It does not query HPA, KEDA ScaledObject, Deployment, or InferenceReplica
+objects, so "Reported" describes controller-reported evidence, not freshness.
+
+Usage:
+  autoscale status INFERENCESERVICE [flags]
+
+Flags:
+  -h, --help            help for status
+  -o, --output string   Output format: table, json or yaml (default "table")
+`, output.String())
+}

--- a/pkg/cli/cmd/autoscale/status.go
+++ b/pkg/cli/cmd/autoscale/status.go
@@ -1,0 +1,119 @@
+package autoscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/apierror"
+	"sigs.k8s.io/ome/pkg/cli/autoscaleprojection"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+var (
+	// ErrReturnedInferenceServiceNameMismatch rejects a response that is not
+	// bound to the requested resource name.
+	ErrReturnedInferenceServiceNameMismatch = errors.New("returned inference service name does not match request")
+	// ErrReturnedInferenceServiceNamespaceMismatch rejects a response that is
+	// not bound to the resolved request namespace.
+	ErrReturnedInferenceServiceNamespaceMismatch = errors.New("returned inference service namespace does not match request")
+	// ErrReturnedInferenceServiceUIDMissing rejects a response that cannot be
+	// durably bound to the requested Kubernetes object.
+	ErrReturnedInferenceServiceUIDMissing = errors.New("returned inference service has no UID")
+)
+
+type statusProjector func(
+	*omev1beta1.InferenceService,
+	reportv1alpha1.Clock,
+) (reportv1alpha1.AutoscaleStatusReport, error)
+
+type statusDependencies struct {
+	clock   reportv1alpha1.Clock
+	project statusProjector
+}
+
+type statusOptions struct {
+	genericiooptions.IOStreams
+	output string
+	deps   statusDependencies
+}
+
+func newStatusCmd(
+	f factory.Factory,
+	streams genericiooptions.IOStreams,
+	deps statusDependencies,
+) *cobra.Command {
+	o := &statusOptions{IOStreams: streams, deps: deps}
+	cmd := &cobra.Command{
+		Use:   "status INFERENCESERVICE",
+		Short: "Show controller-reported autoscaling status",
+		Long: `Show autoscaling evidence already reported on the InferenceService parent.
+It does not query HPA, KEDA ScaledObject, Deployment, or InferenceReplica
+objects, so "Reported" describes controller-reported evidence, not freshness.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(cmd.Context(), f, args[0])
+		},
+	}
+	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "Output format: table, json or yaml")
+	return cmd
+}
+
+func (o *statusOptions) run(ctx context.Context, f factory.Factory, name string) error {
+	format, err := report.ParseFormat(o.output)
+	if err != nil {
+		return err
+	}
+	if problems := utilvalidation.IsDNS1123Subdomain(name); len(problems) > 0 {
+		return fmt.Errorf("invalid InferenceService name %q: %s", name, strings.Join(problems, "; "))
+	}
+
+	namespace, _, err := f.Namespace()
+	if err != nil {
+		return fmt.Errorf("resolve namespace: %w", err)
+	}
+	if namespace == "" {
+		return fmt.Errorf("resolved namespace must not be empty")
+	}
+	if problems := utilvalidation.IsDNS1123Label(namespace); len(problems) > 0 {
+		return fmt.Errorf("invalid resolved namespace: %s", strings.Join(problems, "; "))
+	}
+	client, err := f.OMEClient()
+	if err != nil {
+		return fmt.Errorf("create OME client: %w", err)
+	}
+	isvc, err := client.OmeV1beta1().InferenceServices(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get InferenceService %q: %w", namespace+"/"+name, apierror.Friendly(err))
+	}
+	if isvc == nil {
+		return autoscaleprojection.ErrInferenceServiceRequired
+	}
+	if isvc.Name != name {
+		return ErrReturnedInferenceServiceNameMismatch
+	}
+	if isvc.Namespace != namespace {
+		return ErrReturnedInferenceServiceNamespaceMismatch
+	}
+	if isvc.UID == "" {
+		return ErrReturnedInferenceServiceUIDMissing
+	}
+
+	reportValue, err := o.deps.project(isvc, o.deps.clock)
+	if err != nil {
+		return fmt.Errorf("project autoscale status for InferenceService %q: %w", namespace+"/"+name, err)
+	}
+	if err := report.Write(o.Out, format, reportValue); err != nil {
+		return fmt.Errorf("write autoscale status: %w", err)
+	}
+	return nil
+}

--- a/pkg/cli/cmd/autoscale/status_test.go
+++ b/pkg/cli/cmd/autoscale/status_test.go
@@ -1,0 +1,549 @@
+package autoscale
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	ktesting "k8s.io/client-go/testing"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/autoscaleprojection"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+)
+
+func TestStatusGetsOneInferenceServiceAndWritesExactTable(t *testing.T) {
+	isvc := &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "chat", Namespace: "prod", UID: types.UID("uid-chat"), Generation: 7,
+	}}
+	client := omefake.NewSimpleClientset(isvc)
+	var projected *omev1beta1.InferenceService
+	deps := statusDependencies{
+		clock: fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+		project: func(got *omev1beta1.InferenceService, _ reportv1alpha1.Clock) (reportv1alpha1.AutoscaleStatusReport, error) {
+			projected = got
+			return commandReportFixture(), nil
+		},
+	}
+
+	out, err := executeStatus(t, factory.Static{OME: client, NS: "prod"}, deps, "chat")
+
+	require.NoError(t, err)
+	require.NotNil(t, projected)
+	assert.Equal(t, isvc.ObjectMeta, projected.ObjectMeta)
+	assert.Equal(t,
+		"STATE      COMPONENT   COMPONENT-STATE   CLASS   MANAGED-BY   SPEC-SOURCE   TARGET                              TARGET-EVIDENCE   CURRENT   DESIRED   REPLICA-EVIDENCE   LAST-SCALE             CONDITION-EVIDENCE   CONDITIONS                            ISSUES\n"+
+			"Reported   engine      Reported          HPA     ome          default       InferenceReplica/prod/chat-engine   Reported          2         3         Reported           2026-08-31T18:20:00Z   Reported             AbleToScale=True,ScalingActive=True   -\n",
+		out,
+	)
+	require.Len(t, client.Actions(), 1)
+	action := client.Actions()[0]
+	assert.Equal(t, "get", action.GetVerb())
+	assert.Equal(t, "inferenceservices", action.GetResource().Resource)
+	getAction, ok := action.(ktesting.GetAction)
+	require.True(t, ok)
+	assert.Equal(t, "prod", getAction.GetNamespace())
+	assert.Equal(t, "chat", getAction.GetName())
+}
+
+func TestStatusValidatesArgumentsBeforeFactoryAccess(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing name", want: "accepts 1 arg(s), received 0"},
+		{name: "extra name", args: []string{"chat", "other"}, want: "accepts 1 arg(s), received 2"},
+		{name: "unsupported output", args: []string{"chat", "--output", "wide"}, want: `unsupported output format "wide"`},
+		{name: "invalid name", args: []string{"Bad_Name"}, want: `invalid InferenceService name "Bad_Name"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := executeStatus(t, panicFactory{}, statusDependencies{}, tt.args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestStatusRejectsUnboundInferenceServiceResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		object *omev1beta1.InferenceService
+		want   string
+		kind   error
+	}{
+		{
+			name: "nil response",
+			want: autoscaleprojection.ErrInferenceServiceRequired.Error(),
+			kind: autoscaleprojection.ErrInferenceServiceRequired,
+		},
+		{
+			name: "different name",
+			object: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+				Name: "other", Namespace: "prod", UID: types.UID("uid-other"),
+			}},
+			want: ErrReturnedInferenceServiceNameMismatch.Error(),
+			kind: ErrReturnedInferenceServiceNameMismatch,
+		},
+		{
+			name: "different namespace",
+			object: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+				Name: "chat", Namespace: "other", UID: types.UID("uid-chat"),
+			}},
+			want: ErrReturnedInferenceServiceNamespaceMismatch.Error(),
+			kind: ErrReturnedInferenceServiceNamespaceMismatch,
+		},
+		{
+			name: "missing UID",
+			object: &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+				Name: "chat", Namespace: "prod",
+			}},
+			want: ErrReturnedInferenceServiceUIDMissing.Error(),
+			kind: ErrReturnedInferenceServiceUIDMissing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := omefake.NewSimpleClientset()
+			client.PrependReactor("get", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+				if tt.object == nil {
+					var typedNil *omev1beta1.InferenceService
+					return true, typedNil, nil
+				}
+				return true, tt.object.DeepCopy(), nil
+			})
+			deps := statusDependencies{project: func(
+				*omev1beta1.InferenceService,
+				reportv1alpha1.Clock,
+			) (reportv1alpha1.AutoscaleStatusReport, error) {
+				panic("projection must not run for an unbound response")
+			}}
+
+			out, err := executeStatus(t, factory.Static{OME: client, NS: "prod"}, deps, "chat")
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.kind)
+			assert.Contains(t, err.Error(), tt.want)
+			assert.Empty(t, out)
+			require.Len(t, client.Actions(), 1)
+		})
+	}
+}
+
+func TestStatusStopsAtInvalidNamespaceResolution(t *testing.T) {
+	wantErr := errors.New("namespace backend failed")
+	tests := []struct {
+		name      string
+		namespace string
+		err       error
+		want      string
+	}{
+		{name: "resolver error", err: wantErr, want: wantErr.Error()},
+		{name: "empty namespace", want: "resolved namespace must not be empty"},
+		{name: "invalid namespace", namespace: "Bad_Namespace", want: "invalid resolved namespace"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := namespaceResultFactory{namespace: tt.namespace, err: tt.err}
+			_, err := executeStatus(t, f, statusDependencies{}, "chat")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+			if tt.err != nil {
+				assert.Contains(t, err.Error(), "resolve namespace")
+			}
+		})
+	}
+}
+
+func TestStatusReturnsAcquisitionErrorsWithoutRendering(t *testing.T) {
+	t.Run("client construction", func(t *testing.T) {
+		out, err := executeStatus(t, factory.Static{NS: "prod"}, statusDependencies{}, "chat")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "create OME client")
+		assert.Contains(t, err.Error(), "static factory: no OME client configured")
+		assert.Empty(t, out)
+	})
+
+	tests := []struct {
+		name       string
+		reactorErr error
+		assertErr  func(*testing.T, error)
+	}{
+		{
+			name: "not found",
+			reactorErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: "ome.io", Resource: "inferenceservices"}, "chat",
+			),
+			assertErr: func(t *testing.T, err error) { assert.True(t, apierrors.IsNotFound(err)) },
+		},
+		{
+			name: "forbidden",
+			reactorErr: apierrors.NewForbidden(
+				schema.GroupResource{Group: "ome.io", Resource: "inferenceservices"}, "chat", errors.New("denied"),
+			),
+			assertErr: func(t *testing.T, err error) { assert.True(t, apierrors.IsForbidden(err)) },
+		},
+		{
+			name:       "canceled",
+			reactorErr: context.Canceled,
+			assertErr:  func(t *testing.T, err error) { assert.ErrorIs(t, err, context.Canceled) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := omefake.NewSimpleClientset()
+			client.PrependReactor("get", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tt.reactorErr
+			})
+
+			out, err := executeStatus(t, factory.Static{OME: client, NS: "prod"}, statusDependencies{}, "chat")
+
+			require.Error(t, err)
+			tt.assertErr(t, err)
+			assert.Contains(t, err.Error(), `get InferenceService "prod/chat"`)
+			assert.Empty(t, out)
+			require.Len(t, client.Actions(), 1)
+		})
+	}
+}
+
+func TestStatusReturnsProjectionAndWriterErrors(t *testing.T) {
+	isvc := &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "chat", Namespace: "prod", UID: types.UID("uid-chat"),
+	}}
+
+	t.Run("projection", func(t *testing.T) {
+		wantErr := errors.New("projection failed")
+		deps := statusDependencies{
+			project: func(*omev1beta1.InferenceService, reportv1alpha1.Clock) (reportv1alpha1.AutoscaleStatusReport, error) {
+				return reportv1alpha1.AutoscaleStatusReport{}, wantErr
+			},
+		}
+
+		out, err := executeStatus(t, factory.Static{OME: omefake.NewSimpleClientset(isvc), NS: "prod"}, deps, "chat")
+
+		require.ErrorIs(t, err, wantErr)
+		assert.Contains(t, err.Error(), `project autoscale status for InferenceService "prod/chat"`)
+		assert.Empty(t, out)
+	})
+
+	t.Run("writer", func(t *testing.T) {
+		wantErr := errors.New("writer failed")
+		cmd := newStatusCmd(
+			factory.Static{OME: omefake.NewSimpleClientset(isvc), NS: "prod"},
+			genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: errorWriter{err: wantErr}, ErrOut: &bytes.Buffer{}},
+			statusDependencies{project: func(
+				*omev1beta1.InferenceService,
+				reportv1alpha1.Clock,
+			) (reportv1alpha1.AutoscaleStatusReport, error) {
+				return commandReportFixture(), nil
+			}},
+		)
+		cmd.SetArgs([]string{"chat"})
+
+		err := cmd.Execute()
+
+		require.ErrorIs(t, err, wantErr)
+		assert.Contains(t, err.Error(), "write autoscale status")
+	})
+}
+
+func TestStatusDegradedReportExitsSuccessfully(t *testing.T) {
+	isvc := &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "chat", Namespace: "prod", UID: types.UID("uid-chat"),
+	}}
+	reportValue := commandReportFixture()
+	reportValue.Content.Summary.State = reportv1alpha1.AutoscaleStatePartial
+	reportValue.Content.Components[0].State = reportv1alpha1.AutoscaleComponentPartial
+	reportValue.Warnings = []reportv1alpha1.AutoscaleWarning{{Code: reportv1alpha1.AutoscaleWarningPartialData}}
+	deps := statusDependencies{project: func(
+		*omev1beta1.InferenceService,
+		reportv1alpha1.Clock,
+	) (reportv1alpha1.AutoscaleStatusReport, error) {
+		return reportValue, nil
+	}}
+
+	out, err := executeStatus(t, factory.Static{OME: omefake.NewSimpleClientset(isvc), NS: "prod"}, deps, "chat")
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "Partial")
+}
+
+func TestStatusWritesExactJSONAndYAML(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{name: "json", format: "json", want: `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "AutoscaleStatusReport",
+  "metadata": {
+    "namespace": "prod",
+    "name": "chat"
+  },
+  "collectedAt": "2026-08-31T18:30:00Z",
+  "sources": [
+    {
+      "kind": "InferenceService",
+      "namespace": "prod",
+      "name": "chat",
+      "uid": "uid-chat",
+      "generation": 7,
+      "evidence": "Reported",
+      "collectedAt": "2026-08-31T18:30:00Z"
+    }
+  ],
+  "content": {
+    "summary": {
+      "state": "Reported"
+    },
+    "components": [
+      {
+        "type": "engine",
+        "state": "Reported",
+        "class": "HPA",
+        "managedBy": "ome",
+        "specSource": "default",
+        "target": {
+          "state": "Reported",
+          "apiVersion": "ome.io/v1beta1",
+          "kind": "InferenceReplica",
+          "namespace": "prod",
+          "name": "chat-engine"
+        },
+        "replicas": {
+          "state": "Reported",
+          "currentReplicas": 2,
+          "desiredReplicas": 3,
+          "lastScaleTime": "2026-08-31T18:20:00Z"
+        },
+        "conditions": {
+          "state": "Reported",
+          "items": [
+            {
+              "type": "AbleToScale",
+              "status": "True",
+              "lastTransitionTime": "2026-08-31T18:15:00Z"
+            },
+            {
+              "type": "ScalingActive",
+              "status": "True",
+              "lastTransitionTime": "2026-08-31T18:15:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "issues": []
+  },
+  "warnings": []
+}
+`},
+		{name: "yaml", format: "yaml", want: `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T18:30:00Z"
+content:
+  components:
+  - class: HPA
+    conditions:
+      items:
+      - lastTransitionTime: "2026-08-31T18:15:00Z"
+        status: "True"
+        type: AbleToScale
+      - lastTransitionTime: "2026-08-31T18:15:00Z"
+        status: "True"
+        type: ScalingActive
+      state: Reported
+    managedBy: ome
+    replicas:
+      currentReplicas: 2
+      desiredReplicas: 3
+      lastScaleTime: "2026-08-31T18:20:00Z"
+      state: Reported
+    specSource: default
+    state: Reported
+    target:
+      apiVersion: ome.io/v1beta1
+      kind: InferenceReplica
+      name: chat-engine
+      namespace: prod
+      state: Reported
+    type: engine
+  issues: []
+  summary:
+    state: Reported
+kind: AutoscaleStatusReport
+metadata:
+  name: chat
+  namespace: prod
+sources:
+- collectedAt: "2026-08-31T18:30:00Z"
+  evidence: Reported
+  generation: 7
+  kind: InferenceService
+  name: chat
+  namespace: prod
+  uid: uid-chat
+warnings: []
+`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := &omev1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+				Name: "chat", Namespace: "prod", UID: types.UID("uid-chat"),
+			}}
+			deps := statusDependencies{project: func(
+				*omev1beta1.InferenceService,
+				reportv1alpha1.Clock,
+			) (reportv1alpha1.AutoscaleStatusReport, error) {
+				return commandReportFixture(), nil
+			}}
+
+			out, err := executeStatus(
+				t, factory.Static{OME: omefake.NewSimpleClientset(isvc), NS: "prod"},
+				deps, "chat", "--output", tt.format,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestStatusProductionWiringProjectsTheSingleFetchedParent(t *testing.T) {
+	transition := metav1.NewTime(time.Date(2026, time.August, 31, 18, 15, 0, 0, time.UTC))
+	isvc := &omev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "chat", Namespace: "prod", UID: types.UID("uid-chat"), Generation: 7,
+		},
+		Status: omev1beta1.InferenceServiceStatus{Components: map[omev1beta1.ComponentType]omev1beta1.ComponentStatusSpec{
+			omev1beta1.EngineComponent: {
+				Autoscaler: &omev1beta1.ComponentAutoscalerStatus{
+					Class: omev1beta1.AutoscalerHPA, ManagedBy: omev1beta1.AutoscalerManagedByOME,
+					SpecSource: "default", CurrentReplicas: 2, DesiredReplicas: 3,
+					Conditions: []metav1.Condition{{
+						Type: "AbleToScale", Status: metav1.ConditionTrue, LastTransitionTime: transition,
+					}},
+				},
+				ScaleTargetRef: &omev1beta1.ScaleTargetRef{
+					APIVersion: "ome.io/v1beta1", Kind: "InferenceReplica", Name: "chat-engine",
+				},
+			},
+		}},
+	}
+	client := omefake.NewSimpleClientset(isvc)
+	var output bytes.Buffer
+	cmd := NewCmd(factory.Static{OME: client, NS: "prod"}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &output, ErrOut: &output,
+	})
+	cmd.SetArgs([]string{"status", "chat", "--output", "json"})
+
+	require.NoError(t, cmd.Execute())
+	var got reportv1alpha1.AutoscaleStatusReport
+	require.NoError(t, json.Unmarshal(output.Bytes(), &got))
+	assert.Equal(t, reportv1alpha1.Metadata{Namespace: "prod", Name: "chat"}, got.Metadata)
+	assert.Equal(t, reportv1alpha1.AutoscaleStateReported, got.Content.Summary.State)
+	require.Len(t, got.Sources, 1)
+	assert.Equal(t, "uid-chat", got.Sources[0].UID)
+	assert.Equal(t, int64(7), got.Sources[0].Generation)
+	assert.Equal(t, reportv1alpha1.EvidenceReported, got.Sources[0].Evidence)
+	require.Len(t, client.Actions(), 1)
+	action, ok := client.Actions()[0].(ktesting.GetAction)
+	require.True(t, ok)
+	assert.Equal(t, "prod", action.GetNamespace())
+	assert.Equal(t, "chat", action.GetName())
+}
+
+func executeStatus(t *testing.T, f factory.Factory, deps statusDependencies, args ...string) (string, error) {
+	t.Helper()
+	var output bytes.Buffer
+	cmd := newStatusCmd(f, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &output, ErrOut: &output,
+	}, deps)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return output.String(), err
+}
+
+func commandReportFixture() reportv1alpha1.AutoscaleStatusReport {
+	current, desired := int32(2), int32(3)
+	lastScale := time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)
+	transition := time.Date(2026, time.August, 31, 18, 15, 0, 0, time.UTC)
+	result := reportv1alpha1.NewAutoscaleStatusReport(
+		reportv1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		reportv1alpha1.AutoscaleStatusContent{
+			Summary: reportv1alpha1.AutoscaleSummary{State: reportv1alpha1.AutoscaleStateReported},
+			Components: []reportv1alpha1.AutoscaleComponentStatus{{
+				Type: reportv1alpha1.RuntimeComponentEngine, State: reportv1alpha1.AutoscaleComponentReported,
+				Class: reportv1alpha1.AutoscaleClassHPA, ManagedBy: reportv1alpha1.AutoscaleManagedByOME,
+				SpecSource: reportv1alpha1.AutoscaleSpecSourceDefault,
+				Target: reportv1alpha1.AutoscaleTarget{
+					State: reportv1alpha1.AutoscaleTargetReported, APIVersion: "ome.io/v1beta1",
+					Kind: reportv1alpha1.AutoscaleTargetInferenceReplica, Namespace: "prod", Name: "chat-engine",
+				},
+				Replicas: reportv1alpha1.AutoscaleReplicaStatus{
+					State: reportv1alpha1.AutoscaleReplicasReported, CurrentReplicas: &current,
+					DesiredReplicas: &desired, LastScaleTime: &lastScale,
+				},
+				Conditions: reportv1alpha1.AutoscaleConditionsStatus{
+					State: reportv1alpha1.AutoscaleConditionsReported,
+					Items: []reportv1alpha1.AutoscaleCondition{{
+						Type:   reportv1alpha1.AutoscaleConditionAbleToScale,
+						Status: reportv1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition,
+					}, {
+						Type:   reportv1alpha1.AutoscaleConditionScalingActive,
+						Status: reportv1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition,
+					}},
+				},
+			}},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+	result.Sources = []reportv1alpha1.AutoscaleSourceReference{{
+		Kind: reportv1alpha1.AutoscaleSourceInferenceService, Namespace: "prod", Name: "chat",
+		UID: "uid-chat", Generation: 7, Evidence: reportv1alpha1.EvidenceReported,
+		CollectedAt: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC),
+	}}
+	return result.Canonical()
+}
+
+type fixedClock struct{ now time.Time }
+
+func (clock fixedClock) Now() time.Time { return clock.now }
+
+// panicFactory makes any factory access fail the test through a panic. It is
+// intentionally backed by a nil embedded interface so preflight tests prove
+// validation happens before namespace resolution or client construction.
+type panicFactory struct{ factory.Factory }
+
+type namespaceResultFactory struct {
+	factory.Factory
+	namespace string
+	err       error
+}
+
+func (f namespaceResultFactory) Namespace() (string, bool, error) {
+	return f.namespace, false, f.err
+}
+
+type errorWriter struct{ err error }
+
+func (writer errorWriter) Write([]byte) (int, error) { return 0, writer.err }

--- a/pkg/cli/report/v1alpha1/autoscale_status.go
+++ b/pkg/cli/report/v1alpha1/autoscale_status.go
@@ -1,0 +1,562 @@
+package v1alpha1
+
+import (
+	"cmp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+)
+
+const AutoscaleStatusReportKind = "AutoscaleStatusReport"
+
+type AutoscaleSourceKind string
+
+const AutoscaleSourceInferenceService AutoscaleSourceKind = "InferenceService"
+
+type AutoscaleState string
+
+const (
+	AutoscaleStateReported    AutoscaleState = "Reported"
+	AutoscaleStatePartial     AutoscaleState = "Partial"
+	AutoscaleStateUnavailable AutoscaleState = "Unavailable"
+	AutoscaleStateInvalid     AutoscaleState = "Invalid"
+)
+
+type AutoscaleComponentState string
+
+const (
+	AutoscaleComponentReported    AutoscaleComponentState = "Reported"
+	AutoscaleComponentPartial     AutoscaleComponentState = "Partial"
+	AutoscaleComponentNotReported AutoscaleComponentState = "NotReported"
+	AutoscaleComponentInvalid     AutoscaleComponentState = "Invalid"
+)
+
+type AutoscaleClass string
+
+const (
+	AutoscaleClassHPA      AutoscaleClass = "HPA"
+	AutoscaleClassKEDA     AutoscaleClass = "KEDA"
+	AutoscaleClassExternal AutoscaleClass = "External"
+	AutoscaleClassNone     AutoscaleClass = "None"
+	AutoscaleClassUnknown  AutoscaleClass = "Unknown"
+)
+
+type AutoscaleManagedBy string
+
+const (
+	AutoscaleManagedByOME      AutoscaleManagedBy = "ome"
+	AutoscaleManagedByExternal AutoscaleManagedBy = "external"
+	AutoscaleManagedByNone     AutoscaleManagedBy = "none"
+	AutoscaleManagedByUnknown  AutoscaleManagedBy = "Unknown"
+)
+
+type AutoscaleSpecSource string
+
+const (
+	AutoscaleSpecSourceISVC    AutoscaleSpecSource = "isvc"
+	AutoscaleSpecSourceRuntime AutoscaleSpecSource = "runtime"
+	AutoscaleSpecSourceLegacy  AutoscaleSpecSource = "legacy"
+	AutoscaleSpecSourceDefault AutoscaleSpecSource = "default"
+	AutoscaleSpecSourceUnknown AutoscaleSpecSource = "Unknown"
+)
+
+type AutoscaleTargetState string
+
+const (
+	AutoscaleTargetReported    AutoscaleTargetState = "Reported"
+	AutoscaleTargetNotReported AutoscaleTargetState = "NotReported"
+	AutoscaleTargetInvalid     AutoscaleTargetState = "Invalid"
+)
+
+type AutoscaleTargetKind string
+
+const (
+	AutoscaleTargetDeployment       AutoscaleTargetKind = "Deployment"
+	AutoscaleTargetInferenceReplica AutoscaleTargetKind = "InferenceReplica"
+)
+
+type AutoscaleReplicaState string
+
+const (
+	AutoscaleReplicasReported    AutoscaleReplicaState = "Reported"
+	AutoscaleReplicasAmbiguous   AutoscaleReplicaState = "Ambiguous"
+	AutoscaleReplicasNotReported AutoscaleReplicaState = "NotReported"
+	AutoscaleReplicasUnavailable AutoscaleReplicaState = "Unavailable"
+	AutoscaleReplicasInvalid     AutoscaleReplicaState = "Invalid"
+)
+
+type AutoscaleConditionType string
+
+const (
+	AutoscaleConditionAbleToScale    AutoscaleConditionType = "AbleToScale"
+	AutoscaleConditionScalingActive  AutoscaleConditionType = "ScalingActive"
+	AutoscaleConditionScalingLimited AutoscaleConditionType = "ScalingLimited"
+	AutoscaleConditionReady          AutoscaleConditionType = "Ready"
+	AutoscaleConditionActive         AutoscaleConditionType = "Active"
+	AutoscaleConditionFallback       AutoscaleConditionType = "Fallback"
+	AutoscaleConditionPaused         AutoscaleConditionType = "Paused"
+)
+
+type AutoscaleConditionStatus string
+
+const (
+	AutoscaleConditionTrue    AutoscaleConditionStatus = "True"
+	AutoscaleConditionFalse   AutoscaleConditionStatus = "False"
+	AutoscaleConditionUnknown AutoscaleConditionStatus = "Unknown"
+)
+
+type AutoscaleConditionsState string
+
+const (
+	AutoscaleConditionsReported    AutoscaleConditionsState = "Reported"
+	AutoscaleConditionsNotReported AutoscaleConditionsState = "NotReported"
+	AutoscaleConditionsUnavailable AutoscaleConditionsState = "Unavailable"
+	AutoscaleConditionsInvalid     AutoscaleConditionsState = "Invalid"
+)
+
+type AutoscaleIssueCode string
+
+const (
+	AutoscaleIssueUnknownComponentStatus   AutoscaleIssueCode = "UnknownComponentStatus"
+	AutoscaleIssueAutoscalerNotReported    AutoscaleIssueCode = "AutoscalerNotReported"
+	AutoscaleIssueScaleTargetNotReported   AutoscaleIssueCode = "ScaleTargetNotReported"
+	AutoscaleIssueClassInvalid             AutoscaleIssueCode = "ClassInvalid"
+	AutoscaleIssueManagedByInvalid         AutoscaleIssueCode = "ManagedByInvalid"
+	AutoscaleIssueOwnershipMismatch        AutoscaleIssueCode = "OwnershipMismatch"
+	AutoscaleIssueSpecSourceInvalid        AutoscaleIssueCode = "SpecSourceInvalid"
+	AutoscaleIssueUnexpectedScalerEvidence AutoscaleIssueCode = "UnexpectedScalerEvidence"
+	AutoscaleIssueReplicaEvidenceAmbiguous AutoscaleIssueCode = "ReplicaEvidenceAmbiguous"
+	AutoscaleIssueReplicaEvidenceInvalid   AutoscaleIssueCode = "ReplicaEvidenceInvalid"
+	AutoscaleIssueScaleTargetInvalid       AutoscaleIssueCode = "ScaleTargetInvalid"
+	AutoscaleIssueConditionInvalid         AutoscaleIssueCode = "ConditionInvalid"
+	AutoscaleIssueConditionConflict        AutoscaleIssueCode = "ConditionConflict"
+)
+
+type AutoscaleWarningCode string
+
+const (
+	AutoscaleWarningPartialData AutoscaleWarningCode = "PartialData"
+)
+
+// AutoscaleSourceReference identifies the one allowlisted parent object used
+// to build a status report. It deliberately omits Kubernetes versioning and
+// metadata fields that are not part of the evidence contract.
+type AutoscaleSourceReference struct {
+	Kind        AutoscaleSourceKind `json:"kind"`
+	Namespace   string              `json:"namespace"`
+	Name        string              `json:"name"`
+	UID         string              `json:"uid"`
+	Generation  int64               `json:"generation"`
+	Evidence    EvidenceLevel       `json:"evidence"`
+	CollectedAt time.Time           `json:"collectedAt"`
+}
+
+type AutoscaleSummary struct {
+	State AutoscaleState `json:"state"`
+}
+
+type AutoscaleTarget struct {
+	State      AutoscaleTargetState `json:"state"`
+	APIVersion string               `json:"apiVersion,omitempty"`
+	Kind       AutoscaleTargetKind  `json:"kind,omitempty"`
+	Namespace  string               `json:"namespace,omitempty"`
+	Name       string               `json:"name,omitempty"`
+}
+
+type AutoscaleReplicaStatus struct {
+	State           AutoscaleReplicaState `json:"state"`
+	CurrentReplicas *int32                `json:"currentReplicas,omitempty"`
+	DesiredReplicas *int32                `json:"desiredReplicas,omitempty"`
+	LastScaleTime   *time.Time            `json:"lastScaleTime,omitempty"`
+}
+
+type AutoscaleCondition struct {
+	Type               AutoscaleConditionType   `json:"type"`
+	Status             AutoscaleConditionStatus `json:"status"`
+	LastTransitionTime time.Time                `json:"lastTransitionTime"`
+}
+
+type AutoscaleConditionsStatus struct {
+	State AutoscaleConditionsState `json:"state"`
+	Items []AutoscaleCondition     `json:"items"`
+}
+
+type AutoscaleComponentStatus struct {
+	Type       RuntimeComponentType      `json:"type"`
+	State      AutoscaleComponentState   `json:"state"`
+	Class      AutoscaleClass            `json:"class"`
+	ManagedBy  AutoscaleManagedBy        `json:"managedBy"`
+	SpecSource AutoscaleSpecSource       `json:"specSource"`
+	Target     AutoscaleTarget           `json:"target"`
+	Replicas   AutoscaleReplicaStatus    `json:"replicas"`
+	Conditions AutoscaleConditionsStatus `json:"conditions"`
+}
+
+type AutoscaleIssue struct {
+	Code      AutoscaleIssueCode   `json:"code"`
+	Component RuntimeComponentType `json:"component,omitempty"`
+}
+
+type AutoscaleWarning struct {
+	Code AutoscaleWarningCode `json:"code"`
+}
+
+type AutoscaleStatusContent struct {
+	Summary    AutoscaleSummary           `json:"summary"`
+	Components []AutoscaleComponentStatus `json:"components"`
+	Issues     []AutoscaleIssue           `json:"issues"`
+}
+
+// AutoscaleStatusReport is a dedicated message-free status contract. Values
+// in it are controller-reported evidence, never a claim about current cluster
+// state.
+type AutoscaleStatusReport struct {
+	APIVersion  string                     `json:"apiVersion"`
+	Kind        string                     `json:"kind"`
+	Metadata    Metadata                   `json:"metadata"`
+	CollectedAt time.Time                  `json:"collectedAt"`
+	Sources     []AutoscaleSourceReference `json:"sources"`
+	Content     AutoscaleStatusContent     `json:"content"`
+	Warnings    []AutoscaleWarning         `json:"warnings"`
+}
+
+func NewAutoscaleStatusReport(metadata Metadata, content AutoscaleStatusContent, clock Clock) AutoscaleStatusReport {
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	return (AutoscaleStatusReport{
+		APIVersion: APIVersion, Kind: AutoscaleStatusReportKind, Metadata: metadata,
+		CollectedAt: clock.Now().UTC(), Sources: []AutoscaleSourceReference{},
+		Content: content, Warnings: []AutoscaleWarning{},
+	}).Canonical()
+}
+
+func (r AutoscaleStatusReport) Canonical() AutoscaleStatusReport {
+	result := r
+	result.APIVersion = APIVersion
+	result.Kind = AutoscaleStatusReportKind
+	result.CollectedAt = r.CollectedAt.UTC()
+	result.Sources = append([]AutoscaleSourceReference{}, r.Sources...)
+	for i := range result.Sources {
+		if result.Sources[i].CollectedAt.IsZero() {
+			result.Sources[i].CollectedAt = result.CollectedAt
+		} else {
+			result.Sources[i].CollectedAt = result.Sources[i].CollectedAt.UTC()
+		}
+	}
+	sort.Slice(result.Sources, func(i, j int) bool { return autoscaleSourceLess(result.Sources[i], result.Sources[j]) })
+	result.Content = r.Content.Canonical()
+	result.Warnings = append([]AutoscaleWarning{}, r.Warnings...)
+	sort.Slice(result.Warnings, func(i, j int) bool { return result.Warnings[i].Code < result.Warnings[j].Code })
+	result.Warnings = dedupeAutoscaleWarnings(result.Warnings)
+	return result
+}
+
+func (r AutoscaleStatusReport) Table() report.Table { return r.Canonical().Content.Table() }
+
+func (c AutoscaleStatusContent) Canonical() AutoscaleStatusContent {
+	result := c
+	result.Components = make([]AutoscaleComponentStatus, len(c.Components))
+	for i := range c.Components {
+		result.Components[i] = canonicalAutoscaleComponent(c.Components[i])
+	}
+	sort.Slice(result.Components, func(i, j int) bool {
+		return compareAutoscaleComponents(result.Components[i], result.Components[j]) < 0
+	})
+	result.Issues = append([]AutoscaleIssue{}, c.Issues...)
+	sort.Slice(result.Issues, func(i, j int) bool {
+		if autoscaleComponentRank(result.Issues[i].Component) != autoscaleComponentRank(result.Issues[j].Component) {
+			return autoscaleComponentRank(result.Issues[i].Component) < autoscaleComponentRank(result.Issues[j].Component)
+		}
+		if result.Issues[i].Component != result.Issues[j].Component {
+			return result.Issues[i].Component < result.Issues[j].Component
+		}
+		return result.Issues[i].Code < result.Issues[j].Code
+	})
+	result.Issues = dedupeAutoscaleIssues(result.Issues)
+	return result
+}
+
+func (c AutoscaleStatusContent) Table() report.Table {
+	canonical := c.Canonical()
+	table := report.Table{Headers: []string{
+		"STATE", "COMPONENT", "COMPONENT-STATE", "CLASS", "MANAGED-BY", "SPEC-SOURCE",
+		"TARGET", "TARGET-EVIDENCE", "CURRENT", "DESIRED", "REPLICA-EVIDENCE", "LAST-SCALE", "CONDITION-EVIDENCE", "CONDITIONS", "ISSUES",
+	}, Rows: [][]string{}}
+	if len(canonical.Components) == 0 {
+		table.Rows = append(table.Rows, []string{
+			string(canonical.Summary.State), "-", "-", "-", "-", "-", "-",
+			"-", "-", "-", "-", "-", "-", "-", autoscaleIssuesCell("", canonical.Issues),
+		})
+		return table
+	}
+	for _, component := range canonical.Components {
+		table.Rows = append(table.Rows, []string{
+			string(canonical.Summary.State), string(component.Type), string(component.State),
+			string(component.Class), string(component.ManagedBy), string(component.SpecSource),
+			autoscaleTargetCell(component.Target), string(component.Target.State), autoscaleInt32Cell(component.Replicas.CurrentReplicas),
+			autoscaleInt32Cell(component.Replicas.DesiredReplicas), string(component.Replicas.State),
+			autoscaleTimeCell(component.Replicas.LastScaleTime), string(component.Conditions.State),
+			autoscaleConditionsCell(component.Conditions.Items),
+			autoscaleIssuesCell(component.Type, canonical.Issues),
+		})
+	}
+	return table
+}
+
+func canonicalAutoscaleComponent(component AutoscaleComponentStatus) AutoscaleComponentStatus {
+	result := component
+	result.Replicas.CurrentReplicas = copyInt32(component.Replicas.CurrentReplicas)
+	result.Replicas.DesiredReplicas = copyInt32(component.Replicas.DesiredReplicas)
+	if component.Replicas.LastScaleTime != nil {
+		value := component.Replicas.LastScaleTime.UTC()
+		result.Replicas.LastScaleTime = &value
+	}
+	result.Conditions = component.Conditions
+	result.Conditions.Items = append([]AutoscaleCondition{}, component.Conditions.Items...)
+	for i := range result.Conditions.Items {
+		result.Conditions.Items[i].LastTransitionTime = result.Conditions.Items[i].LastTransitionTime.UTC()
+	}
+	sort.Slice(result.Conditions.Items, func(i, j int) bool {
+		if autoscaleConditionRank(result.Conditions.Items[i].Type) != autoscaleConditionRank(result.Conditions.Items[j].Type) {
+			return autoscaleConditionRank(result.Conditions.Items[i].Type) < autoscaleConditionRank(result.Conditions.Items[j].Type)
+		}
+		if result.Conditions.Items[i].Type != result.Conditions.Items[j].Type {
+			return result.Conditions.Items[i].Type < result.Conditions.Items[j].Type
+		}
+		if result.Conditions.Items[i].Status != result.Conditions.Items[j].Status {
+			return result.Conditions.Items[i].Status < result.Conditions.Items[j].Status
+		}
+		return result.Conditions.Items[i].LastTransitionTime.Before(result.Conditions.Items[j].LastTransitionTime)
+	})
+	result.Conditions.Items = dedupeAutoscaleConditions(result.Conditions.Items)
+	return result
+}
+
+func autoscaleSourceLess(a, b AutoscaleSourceReference) bool {
+	for _, result := range []int{
+		cmp.Compare(a.Kind, b.Kind),
+		cmp.Compare(a.Namespace, b.Namespace),
+		cmp.Compare(a.Name, b.Name),
+		cmp.Compare(a.UID, b.UID),
+		cmp.Compare(a.Generation, b.Generation),
+		cmp.Compare(a.Evidence, b.Evidence),
+		a.CollectedAt.Compare(b.CollectedAt),
+	} {
+		if result != 0 {
+			return result < 0
+		}
+	}
+	return false
+}
+
+func compareAutoscaleComponents(a, b AutoscaleComponentStatus) int {
+	for _, result := range []int{
+		cmp.Compare(autoscaleComponentRank(a.Type), autoscaleComponentRank(b.Type)),
+		cmp.Compare(a.Type, b.Type),
+		cmp.Compare(a.State, b.State),
+		cmp.Compare(a.Class, b.Class),
+		cmp.Compare(a.ManagedBy, b.ManagedBy),
+		cmp.Compare(a.SpecSource, b.SpecSource),
+		compareAutoscaleTargets(a.Target, b.Target),
+		compareAutoscaleReplicas(a.Replicas, b.Replicas),
+		compareAutoscaleConditions(a.Conditions, b.Conditions),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareAutoscaleTargets(a, b AutoscaleTarget) int {
+	for _, result := range []int{
+		cmp.Compare(a.State, b.State), cmp.Compare(a.APIVersion, b.APIVersion),
+		cmp.Compare(a.Kind, b.Kind), cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareAutoscaleReplicas(a, b AutoscaleReplicaStatus) int {
+	for _, result := range []int{
+		cmp.Compare(a.State, b.State), compareAutoscaleInt32Pointers(a.CurrentReplicas, b.CurrentReplicas),
+		compareAutoscaleInt32Pointers(a.DesiredReplicas, b.DesiredReplicas),
+		compareAutoscaleTimePointers(a.LastScaleTime, b.LastScaleTime),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareAutoscaleConditions(a, b AutoscaleConditionsStatus) int {
+	if result := cmp.Compare(a.State, b.State); result != 0 {
+		return result
+	}
+	return slices.CompareFunc(a.Items, b.Items, compareAutoscaleCondition)
+}
+
+func compareAutoscaleCondition(a, b AutoscaleCondition) int {
+	for _, result := range []int{
+		cmp.Compare(autoscaleConditionRank(a.Type), autoscaleConditionRank(b.Type)),
+		cmp.Compare(a.Type, b.Type), cmp.Compare(a.Status, b.Status),
+		a.LastTransitionTime.Compare(b.LastTransitionTime),
+	} {
+		if result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareAutoscaleInt32Pointers(a, b *int32) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return cmp.Compare(*a, *b)
+	}
+}
+
+func compareAutoscaleTimePointers(a, b *time.Time) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return a.Compare(*b)
+	}
+}
+
+func autoscaleConditionRank(condition AutoscaleConditionType) int {
+	switch condition {
+	case AutoscaleConditionAbleToScale:
+		return 0
+	case AutoscaleConditionScalingActive:
+		return 1
+	case AutoscaleConditionScalingLimited:
+		return 2
+	case AutoscaleConditionReady:
+		return 3
+	case AutoscaleConditionActive:
+		return 4
+	case AutoscaleConditionFallback:
+		return 5
+	case AutoscaleConditionPaused:
+		return 6
+	default:
+		return 7
+	}
+}
+
+func autoscaleComponentRank(component RuntimeComponentType) int {
+	switch component {
+	case RuntimeComponentEngine:
+		return 0
+	case RuntimeComponentDecoder:
+		return 1
+	case RuntimeComponentRouter:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func copyInt32(value *int32) *int32 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func dedupeAutoscaleConditions(values []AutoscaleCondition) []AutoscaleCondition {
+	result := values[:0]
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func dedupeAutoscaleIssues(values []AutoscaleIssue) []AutoscaleIssue {
+	result := values[:0]
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func dedupeAutoscaleWarnings(values []AutoscaleWarning) []AutoscaleWarning {
+	result := values[:0]
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func autoscaleTargetCell(target AutoscaleTarget) string {
+	if target.State != AutoscaleTargetReported {
+		return "-"
+	}
+	return string(target.Kind) + "/" + target.Namespace + "/" + target.Name
+}
+
+func autoscaleInt32Cell(value *int32) string {
+	if value == nil {
+		return "-"
+	}
+	return strconv.FormatInt(int64(*value), 10)
+}
+
+func autoscaleTimeCell(value *time.Time) string {
+	if value == nil {
+		return "-"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func autoscaleConditionsCell(conditions []AutoscaleCondition) string {
+	if len(conditions) == 0 {
+		return "-"
+	}
+	values := make([]string, len(conditions))
+	for i, condition := range conditions {
+		values[i] = string(condition.Type) + "=" + string(condition.Status)
+	}
+	return strings.Join(values, ",")
+}
+
+func autoscaleIssuesCell(component RuntimeComponentType, issues []AutoscaleIssue) string {
+	values := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Component == "" || issue.Component == component {
+			values = append(values, string(issue.Code))
+		}
+	}
+	if len(values) == 0 {
+		return "-"
+	}
+	return strings.Join(values, ",")
+}

--- a/pkg/cli/report/v1alpha1/autoscale_status_test.go
+++ b/pkg/cli/report/v1alpha1/autoscale_status_test.go
@@ -1,0 +1,466 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/cli/report"
+	"sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+)
+
+func TestAutoscaleStatusEnumsAreClosedAndStable(t *testing.T) {
+	got := []string{
+		string(v1alpha1.AutoscaleSourceInferenceService),
+		string(v1alpha1.AutoscaleStateReported), string(v1alpha1.AutoscaleStatePartial),
+		string(v1alpha1.AutoscaleStateUnavailable), string(v1alpha1.AutoscaleStateInvalid),
+		string(v1alpha1.AutoscaleComponentReported), string(v1alpha1.AutoscaleComponentPartial),
+		string(v1alpha1.AutoscaleComponentNotReported), string(v1alpha1.AutoscaleComponentInvalid),
+		string(v1alpha1.AutoscaleClassHPA), string(v1alpha1.AutoscaleClassKEDA),
+		string(v1alpha1.AutoscaleClassExternal), string(v1alpha1.AutoscaleClassNone),
+		string(v1alpha1.AutoscaleClassUnknown),
+		string(v1alpha1.AutoscaleManagedByOME), string(v1alpha1.AutoscaleManagedByExternal),
+		string(v1alpha1.AutoscaleManagedByNone), string(v1alpha1.AutoscaleManagedByUnknown),
+		string(v1alpha1.AutoscaleSpecSourceISVC), string(v1alpha1.AutoscaleSpecSourceRuntime),
+		string(v1alpha1.AutoscaleSpecSourceLegacy), string(v1alpha1.AutoscaleSpecSourceDefault),
+		string(v1alpha1.AutoscaleSpecSourceUnknown),
+		string(v1alpha1.AutoscaleTargetReported), string(v1alpha1.AutoscaleTargetNotReported),
+		string(v1alpha1.AutoscaleTargetInvalid), string(v1alpha1.AutoscaleTargetDeployment),
+		string(v1alpha1.AutoscaleTargetInferenceReplica),
+		string(v1alpha1.AutoscaleReplicasReported), string(v1alpha1.AutoscaleReplicasAmbiguous),
+		string(v1alpha1.AutoscaleReplicasNotReported), string(v1alpha1.AutoscaleReplicasUnavailable),
+		string(v1alpha1.AutoscaleReplicasInvalid),
+		string(v1alpha1.AutoscaleConditionAbleToScale), string(v1alpha1.AutoscaleConditionScalingActive),
+		string(v1alpha1.AutoscaleConditionScalingLimited), string(v1alpha1.AutoscaleConditionReady),
+		string(v1alpha1.AutoscaleConditionActive), string(v1alpha1.AutoscaleConditionFallback),
+		string(v1alpha1.AutoscaleConditionPaused),
+		string(v1alpha1.AutoscaleConditionTrue), string(v1alpha1.AutoscaleConditionFalse),
+		string(v1alpha1.AutoscaleConditionUnknown),
+		string(v1alpha1.AutoscaleConditionsReported), string(v1alpha1.AutoscaleConditionsNotReported),
+		string(v1alpha1.AutoscaleConditionsUnavailable), string(v1alpha1.AutoscaleConditionsInvalid),
+	}
+	want := []string{
+		"InferenceService",
+		"Reported", "Partial", "Unavailable", "Invalid",
+		"Reported", "Partial", "NotReported", "Invalid",
+		"HPA", "KEDA", "External", "None", "Unknown",
+		"ome", "external", "none", "Unknown",
+		"isvc", "runtime", "legacy", "default", "Unknown",
+		"Reported", "NotReported", "Invalid", "Deployment", "InferenceReplica",
+		"Reported", "Ambiguous", "NotReported", "Unavailable", "Invalid",
+		"AbleToScale", "ScalingActive", "ScalingLimited", "Ready", "Active", "Fallback", "Paused",
+		"True", "False", "Unknown",
+		"Reported", "NotReported", "Unavailable", "Invalid",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestAutoscaleStatusIssueAndWarningCodesAreStable(t *testing.T) {
+	issues := []string{
+		string(v1alpha1.AutoscaleIssueUnknownComponentStatus),
+		string(v1alpha1.AutoscaleIssueAutoscalerNotReported),
+		string(v1alpha1.AutoscaleIssueScaleTargetNotReported),
+		string(v1alpha1.AutoscaleIssueClassInvalid),
+		string(v1alpha1.AutoscaleIssueManagedByInvalid),
+		string(v1alpha1.AutoscaleIssueOwnershipMismatch),
+		string(v1alpha1.AutoscaleIssueSpecSourceInvalid),
+		string(v1alpha1.AutoscaleIssueUnexpectedScalerEvidence),
+		string(v1alpha1.AutoscaleIssueReplicaEvidenceAmbiguous),
+		string(v1alpha1.AutoscaleIssueReplicaEvidenceInvalid),
+		string(v1alpha1.AutoscaleIssueScaleTargetInvalid),
+		string(v1alpha1.AutoscaleIssueConditionInvalid),
+		string(v1alpha1.AutoscaleIssueConditionConflict),
+	}
+	assert.Equal(t, []string{
+		"UnknownComponentStatus", "AutoscalerNotReported", "ScaleTargetNotReported",
+		"ClassInvalid", "ManagedByInvalid", "OwnershipMismatch", "SpecSourceInvalid",
+		"UnexpectedScalerEvidence", "ReplicaEvidenceAmbiguous", "ReplicaEvidenceInvalid",
+		"ScaleTargetInvalid", "ConditionInvalid", "ConditionConflict",
+	}, issues)
+
+	warnings := []string{string(v1alpha1.AutoscaleWarningPartialData)}
+	assert.Equal(t, []string{"PartialData"}, warnings)
+}
+
+func TestAutoscaleStatusSchemaIsTypedAndRedacted(t *testing.T) {
+	for _, typ := range []reflect.Type{
+		reflect.TypeOf(v1alpha1.AutoscaleStatusReport{}),
+		reflect.TypeOf(v1alpha1.AutoscaleSourceReference{}),
+		reflect.TypeOf(v1alpha1.AutoscaleStatusContent{}),
+		reflect.TypeOf(v1alpha1.AutoscaleComponentStatus{}),
+		reflect.TypeOf(v1alpha1.AutoscaleTarget{}),
+		reflect.TypeOf(v1alpha1.AutoscaleReplicaStatus{}),
+		reflect.TypeOf(v1alpha1.AutoscaleConditionsStatus{}),
+		reflect.TypeOf(v1alpha1.AutoscaleCondition{}),
+		reflect.TypeOf(v1alpha1.AutoscaleIssue{}),
+	} {
+		assertAutoscaleSchema(t, typ, map[reflect.Type]bool{})
+	}
+	warningType := reflect.TypeOf(v1alpha1.AutoscaleWarning{})
+	require.Equal(t, 1, warningType.NumField())
+	assert.Equal(t, "Code", warningType.Field(0).Name)
+	generation, ok := reflect.TypeOf(v1alpha1.AutoscaleSourceReference{}).FieldByName("Generation")
+	require.True(t, ok)
+	assert.Equal(t, "generation", generation.Tag.Get("json"), "source generation is required evidence, not optional freshness")
+}
+
+func TestNewAutoscaleStatusReportAcceptsDefaultSystemClock(t *testing.T) {
+	before := time.Now().UTC()
+	got := v1alpha1.NewAutoscaleStatusReport(
+		v1alpha1.Metadata{Name: "chat"},
+		v1alpha1.AutoscaleStatusContent{Components: []v1alpha1.AutoscaleComponentStatus{}, Issues: []v1alpha1.AutoscaleIssue{}},
+		nil,
+	)
+	after := time.Now().UTC()
+
+	assert.False(t, got.CollectedAt.Before(before))
+	assert.False(t, got.CollectedAt.After(after))
+	assert.Equal(t, time.UTC, got.CollectedAt.Location())
+}
+
+func TestAutoscaleStatusCanonicalizesWithoutMutatingCaller(t *testing.T) {
+	collectedAt := time.Date(2026, time.August, 31, 11, 30, 0, 0, time.FixedZone("test", -7*60*60))
+	lastScale := time.Date(2026, time.August, 31, 11, 20, 0, 0, time.FixedZone("test", -7*60*60))
+	transition := time.Date(2026, time.August, 31, 11, 10, 0, 0, time.FixedZone("test", -7*60*60))
+	current, desired := int32(2), int32(3)
+	reportValue := v1alpha1.NewAutoscaleStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.AutoscaleStatusContent{
+			Summary: v1alpha1.AutoscaleSummary{State: v1alpha1.AutoscaleStatePartial},
+			Components: []v1alpha1.AutoscaleComponentStatus{
+				{Type: v1alpha1.RuntimeComponentRouter, State: v1alpha1.AutoscaleComponentNotReported,
+					Class: v1alpha1.AutoscaleClassUnknown, ManagedBy: v1alpha1.AutoscaleManagedByUnknown,
+					SpecSource: v1alpha1.AutoscaleSpecSourceUnknown,
+					Target:     v1alpha1.AutoscaleTarget{State: v1alpha1.AutoscaleTargetNotReported},
+					Replicas:   v1alpha1.AutoscaleReplicaStatus{State: v1alpha1.AutoscaleReplicasNotReported},
+					Conditions: v1alpha1.AutoscaleConditionsStatus{State: v1alpha1.AutoscaleConditionsNotReported}},
+				{Type: v1alpha1.RuntimeComponentEngine, State: v1alpha1.AutoscaleComponentReported,
+					Class: v1alpha1.AutoscaleClassHPA, ManagedBy: v1alpha1.AutoscaleManagedByOME,
+					SpecSource: v1alpha1.AutoscaleSpecSourceDefault,
+					Target: v1alpha1.AutoscaleTarget{State: v1alpha1.AutoscaleTargetReported,
+						APIVersion: "ome.io/v1beta1", Kind: v1alpha1.AutoscaleTargetInferenceReplica,
+						Namespace: "prod", Name: "chat-engine"},
+					Replicas: v1alpha1.AutoscaleReplicaStatus{State: v1alpha1.AutoscaleReplicasReported,
+						CurrentReplicas: &current, DesiredReplicas: &desired, LastScaleTime: &lastScale},
+					Conditions: v1alpha1.AutoscaleConditionsStatus{State: v1alpha1.AutoscaleConditionsReported, Items: []v1alpha1.AutoscaleCondition{
+						{Type: v1alpha1.AutoscaleConditionScalingActive, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition},
+						{Type: v1alpha1.AutoscaleConditionAbleToScale, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition},
+						{Type: v1alpha1.AutoscaleConditionScalingActive, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition},
+					}}},
+			},
+			Issues: []v1alpha1.AutoscaleIssue{
+				{Code: v1alpha1.AutoscaleIssueScaleTargetNotReported, Component: v1alpha1.RuntimeComponentRouter},
+				{Code: v1alpha1.AutoscaleIssueAutoscalerNotReported, Component: v1alpha1.RuntimeComponentRouter},
+			},
+		},
+		fixedClock{now: collectedAt},
+	)
+	reportValue.Sources = []v1alpha1.AutoscaleSourceReference{
+		{Kind: v1alpha1.AutoscaleSourceInferenceService, Namespace: "prod", Name: "z", UID: "z", Generation: 8, Evidence: v1alpha1.EvidenceReported},
+		{Kind: v1alpha1.AutoscaleSourceInferenceService, Namespace: "prod", Name: "chat", UID: "uid", Generation: 7, Evidence: v1alpha1.EvidenceReported},
+	}
+	reportValue.Warnings = []v1alpha1.AutoscaleWarning{{Code: v1alpha1.AutoscaleWarningPartialData}}
+
+	canonical := reportValue.Canonical()
+
+	assert.Equal(t, v1alpha1.APIVersion, canonical.APIVersion)
+	assert.Equal(t, v1alpha1.AutoscaleStatusReportKind, canonical.Kind)
+	assert.Equal(t, "2026-08-31T18:30:00Z", canonical.CollectedAt.Format(time.RFC3339))
+	assert.Equal(t, "chat", canonical.Sources[0].Name)
+	assert.Equal(t, canonical.CollectedAt, canonical.Sources[0].CollectedAt)
+	assert.Equal(t, v1alpha1.RuntimeComponentEngine, canonical.Content.Components[0].Type)
+	assert.Equal(t, int64(7), canonical.Sources[0].Generation)
+	assert.Equal(t, []v1alpha1.AutoscaleCondition{
+		{Type: v1alpha1.AutoscaleConditionAbleToScale, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition.UTC()},
+		{Type: v1alpha1.AutoscaleConditionScalingActive, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition.UTC()},
+	}, canonical.Content.Components[0].Conditions.Items)
+	assert.Equal(t, time.UTC, canonical.Content.Components[0].Replicas.LastScaleTime.Location())
+	assert.Equal(t, v1alpha1.AutoscaleIssueAutoscalerNotReported, canonical.Content.Issues[0].Code)
+	assert.Equal(t, v1alpha1.AutoscaleWarningPartialData, canonical.Warnings[0].Code)
+
+	*canonical.Content.Components[0].Replicas.CurrentReplicas = 99
+	canonical.Content.Components[0].Conditions.Items[0].Status = v1alpha1.AutoscaleConditionFalse
+	canonical.Sources[0].Name = "returned"
+	assert.Equal(t, int32(2), *reportValue.Content.Components[0].Replicas.CurrentReplicas)
+	assert.Equal(t, v1alpha1.AutoscaleConditionTrue, reportValue.Content.Components[0].Conditions.Items[0].Status)
+	assert.Equal(t, "z", reportValue.Sources[0].Name)
+}
+
+func TestAutoscaleStatusCanonicalOrderingIsTotal(t *testing.T) {
+	transitionA := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	transitionB := transitionA.Add(time.Second)
+	componentA := v1alpha1.AutoscaleComponentStatus{
+		Type: v1alpha1.RuntimeComponentEngine, State: v1alpha1.AutoscaleComponentReported,
+		Class: v1alpha1.AutoscaleClassHPA, ManagedBy: v1alpha1.AutoscaleManagedByOME,
+		SpecSource: v1alpha1.AutoscaleSpecSourceDefault,
+		Target: v1alpha1.AutoscaleTarget{State: v1alpha1.AutoscaleTargetReported,
+			APIVersion: "apps/v1", Kind: v1alpha1.AutoscaleTargetDeployment, Namespace: "prod", Name: "a"},
+		Replicas: v1alpha1.AutoscaleReplicaStatus{State: v1alpha1.AutoscaleReplicasAmbiguous},
+		Conditions: v1alpha1.AutoscaleConditionsStatus{State: v1alpha1.AutoscaleConditionsReported,
+			Items: []v1alpha1.AutoscaleCondition{{Type: v1alpha1.AutoscaleConditionScalingActive,
+				Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transitionA}}},
+	}
+	componentB := componentA
+	componentB.Conditions.Items = []v1alpha1.AutoscaleCondition{{Type: v1alpha1.AutoscaleConditionScalingActive,
+		Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transitionB}}
+	left := v1alpha1.AutoscaleStatusContent{
+		Components: []v1alpha1.AutoscaleComponentStatus{componentA, componentB},
+	}.Canonical()
+	right := v1alpha1.AutoscaleStatusContent{
+		Components: []v1alpha1.AutoscaleComponentStatus{componentB, componentA},
+	}.Canonical()
+	assert.Equal(t, left, right)
+}
+
+func TestAutoscaleStatusTableUsesOnlyTypedReportedEvidence(t *testing.T) {
+	reportValue := autoscaleStatusFixture()
+
+	assert.Equal(t, report.Table{
+		Headers: []string{
+			"STATE", "COMPONENT", "COMPONENT-STATE", "CLASS", "MANAGED-BY", "SPEC-SOURCE",
+			"TARGET", "TARGET-EVIDENCE", "CURRENT", "DESIRED", "REPLICA-EVIDENCE", "LAST-SCALE", "CONDITION-EVIDENCE", "CONDITIONS", "ISSUES",
+		},
+		Rows: [][]string{{
+			"Reported", "engine", "Reported", "HPA", "ome", "default",
+			"InferenceReplica/prod/chat-engine", "Reported", "2", "3", "Reported", "2026-08-31T18:20:00Z",
+			"Reported", "AbleToScale=True,ScalingActive=True", "-",
+		}},
+	}, reportValue.Table())
+
+	var output bytes.Buffer
+	require.NoError(t, report.Write(&output, report.FormatTable, reportValue))
+	assert.Equal(t,
+		"STATE      COMPONENT   COMPONENT-STATE   CLASS   MANAGED-BY   SPEC-SOURCE   TARGET                              TARGET-EVIDENCE   CURRENT   DESIRED   REPLICA-EVIDENCE   LAST-SCALE             CONDITION-EVIDENCE   CONDITIONS                            ISSUES\n"+
+			"Reported   engine      Reported          HPA     ome          default       InferenceReplica/prod/chat-engine   Reported          2         3         Reported           2026-08-31T18:20:00Z   Reported             AbleToScale=True,ScalingActive=True   -\n",
+		output.String())
+}
+
+func TestAutoscaleStatusTableSurfacesGlobalIssuesWithoutEchoingUnknownComponents(t *testing.T) {
+	content := v1alpha1.AutoscaleStatusContent{
+		Summary: v1alpha1.AutoscaleSummary{State: v1alpha1.AutoscaleStateInvalid},
+		Components: []v1alpha1.AutoscaleComponentStatus{{
+			Type: v1alpha1.RuntimeComponentEngine, State: v1alpha1.AutoscaleComponentPartial,
+			Class: v1alpha1.AutoscaleClassHPA, ManagedBy: v1alpha1.AutoscaleManagedByOME,
+			SpecSource: v1alpha1.AutoscaleSpecSourceDefault,
+			Target:     v1alpha1.AutoscaleTarget{State: v1alpha1.AutoscaleTargetNotReported},
+			Replicas:   v1alpha1.AutoscaleReplicaStatus{State: v1alpha1.AutoscaleReplicasAmbiguous},
+			Conditions: v1alpha1.AutoscaleConditionsStatus{State: v1alpha1.AutoscaleConditionsNotReported, Items: []v1alpha1.AutoscaleCondition{}},
+		}},
+		Issues: []v1alpha1.AutoscaleIssue{
+			{Code: v1alpha1.AutoscaleIssueUnknownComponentStatus},
+			{Code: v1alpha1.AutoscaleIssueScaleTargetNotReported, Component: v1alpha1.RuntimeComponentEngine},
+		},
+	}
+
+	table := content.Table()
+	require.Len(t, table.Rows, 1)
+	assert.Equal(t, "ScaleTargetNotReported,UnknownComponentStatus", table.Rows[0][14])
+	assert.NotContains(t, strings.Join(table.Rows[0], " "), "SECRET_COMPONENT")
+}
+
+func TestAutoscaleStatusTableShowsUnavailableSummaryWithoutComponents(t *testing.T) {
+	content := v1alpha1.AutoscaleStatusContent{
+		Summary:    v1alpha1.AutoscaleSummary{State: v1alpha1.AutoscaleStateUnavailable},
+		Components: []v1alpha1.AutoscaleComponentStatus{},
+		Issues:     []v1alpha1.AutoscaleIssue{},
+	}
+
+	table := content.Table()
+	assert.Equal(t, [][]string{{
+		"Unavailable", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-",
+	}}, table.Rows)
+}
+
+func autoscaleStatusFixture() v1alpha1.AutoscaleStatusReport {
+	current, desired := int32(2), int32(3)
+	lastScale := time.Date(2026, time.August, 31, 18, 20, 0, 0, time.UTC)
+	transition := time.Date(2026, time.August, 31, 18, 15, 0, 0, time.UTC)
+	result := v1alpha1.NewAutoscaleStatusReport(
+		v1alpha1.Metadata{Namespace: "prod", Name: "chat"},
+		v1alpha1.AutoscaleStatusContent{
+			Summary: v1alpha1.AutoscaleSummary{State: v1alpha1.AutoscaleStateReported},
+			Components: []v1alpha1.AutoscaleComponentStatus{{
+				Type: v1alpha1.RuntimeComponentEngine, State: v1alpha1.AutoscaleComponentReported,
+				Class: v1alpha1.AutoscaleClassHPA, ManagedBy: v1alpha1.AutoscaleManagedByOME,
+				SpecSource: v1alpha1.AutoscaleSpecSourceDefault,
+				Target: v1alpha1.AutoscaleTarget{State: v1alpha1.AutoscaleTargetReported,
+					APIVersion: "ome.io/v1beta1", Kind: v1alpha1.AutoscaleTargetInferenceReplica,
+					Namespace: "prod", Name: "chat-engine"},
+				Replicas: v1alpha1.AutoscaleReplicaStatus{State: v1alpha1.AutoscaleReplicasReported,
+					CurrentReplicas: &current, DesiredReplicas: &desired, LastScaleTime: &lastScale},
+				Conditions: v1alpha1.AutoscaleConditionsStatus{State: v1alpha1.AutoscaleConditionsReported, Items: []v1alpha1.AutoscaleCondition{
+					{Type: v1alpha1.AutoscaleConditionScalingActive, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition},
+					{Type: v1alpha1.AutoscaleConditionAbleToScale, Status: v1alpha1.AutoscaleConditionTrue, LastTransitionTime: transition},
+				}},
+			}},
+		},
+		fixedClock{now: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC)},
+	)
+	result.Sources = []v1alpha1.AutoscaleSourceReference{{
+		Kind: v1alpha1.AutoscaleSourceInferenceService, Namespace: "prod", Name: "chat",
+		UID: "isvc-uid", Generation: 7, Evidence: v1alpha1.EvidenceReported,
+		CollectedAt: time.Date(2026, time.August, 31, 18, 30, 0, 0, time.UTC),
+	}}
+	return result
+}
+
+func TestAutoscaleStatusMachineOutputIsExact(t *testing.T) {
+	tests := []struct {
+		name   string
+		format report.Format
+		want   string
+	}{
+		{name: "json", format: report.FormatJSON, want: `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "AutoscaleStatusReport",
+  "metadata": {
+    "namespace": "prod",
+    "name": "chat"
+  },
+  "collectedAt": "2026-08-31T18:30:00Z",
+  "sources": [
+    {
+      "kind": "InferenceService",
+      "namespace": "prod",
+      "name": "chat",
+      "uid": "isvc-uid",
+      "generation": 7,
+      "evidence": "Reported",
+      "collectedAt": "2026-08-31T18:30:00Z"
+    }
+  ],
+  "content": {
+    "summary": {
+      "state": "Reported"
+    },
+    "components": [
+      {
+        "type": "engine",
+        "state": "Reported",
+        "class": "HPA",
+        "managedBy": "ome",
+        "specSource": "default",
+        "target": {
+          "state": "Reported",
+          "apiVersion": "ome.io/v1beta1",
+          "kind": "InferenceReplica",
+          "namespace": "prod",
+          "name": "chat-engine"
+        },
+        "replicas": {
+          "state": "Reported",
+          "currentReplicas": 2,
+          "desiredReplicas": 3,
+          "lastScaleTime": "2026-08-31T18:20:00Z"
+        },
+        "conditions": {
+          "state": "Reported",
+          "items": [
+            {
+              "type": "AbleToScale",
+              "status": "True",
+              "lastTransitionTime": "2026-08-31T18:15:00Z"
+            },
+            {
+              "type": "ScalingActive",
+              "status": "True",
+              "lastTransitionTime": "2026-08-31T18:15:00Z"
+            }
+          ]
+        }
+      }
+    ],
+    "issues": []
+  },
+  "warnings": []
+}
+`},
+		{name: "yaml", format: report.FormatYAML, want: `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T18:30:00Z"
+content:
+  components:
+  - class: HPA
+    conditions:
+      items:
+      - lastTransitionTime: "2026-08-31T18:15:00Z"
+        status: "True"
+        type: AbleToScale
+      - lastTransitionTime: "2026-08-31T18:15:00Z"
+        status: "True"
+        type: ScalingActive
+      state: Reported
+    managedBy: ome
+    replicas:
+      currentReplicas: 2
+      desiredReplicas: 3
+      lastScaleTime: "2026-08-31T18:20:00Z"
+      state: Reported
+    specSource: default
+    state: Reported
+    target:
+      apiVersion: ome.io/v1beta1
+      kind: InferenceReplica
+      name: chat-engine
+      namespace: prod
+      state: Reported
+    type: engine
+  issues: []
+  summary:
+    state: Reported
+kind: AutoscaleStatusReport
+metadata:
+  name: chat
+  namespace: prod
+sources:
+- collectedAt: "2026-08-31T18:30:00Z"
+  evidence: Reported
+  generation: 7
+  kind: InferenceService
+  name: chat
+  namespace: prod
+  uid: isvc-uid
+warnings: []
+`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.NoError(t, report.Write(&output, test.format, autoscaleStatusFixture()))
+			assert.Equal(t, test.want, output.String())
+		})
+	}
+}
+
+func assertAutoscaleSchema(t *testing.T, typ reflect.Type, seen map[reflect.Type]bool) {
+	t.Helper()
+	for typ.Kind() == reflect.Pointer || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array {
+		typ = typ.Elem()
+	}
+	if typ.PkgPath() == "time" || seen[typ] {
+		return
+	}
+	seen[typ] = true
+	require.NotEqual(t, reflect.Interface, typ.Kind(), "schema contains interface field at %s", typ)
+	require.NotEqual(t, reflect.Map, typ.Kind(), "schema contains map field at %s", typ)
+	if typ.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		name := strings.ToLower(field.Name + " " + strings.Split(field.Tag.Get("json"), ",")[0])
+		for _, forbidden := range []string{
+			"resourceversion", "annotation", "ownerreference", "managedfield", "observedgeneration",
+			"trigger", "fallback", "metric", "behavior", "template", "reason", "message", "error",
+			"freshness", "synctoken", "continuationtoken", "synchronizationtoken",
+		} {
+			assert.NotContains(t, name, forbidden, "unsafe field %s.%s", typ, field.Name)
+		}
+		assertAutoscaleSchema(t, field.Type, seen)
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"sigs.k8s.io/ome/pkg/cli/cmd/autoscale"
 	"sigs.k8s.io/ome/pkg/cli/cmd/get"
 	"sigs.k8s.io/ome/pkg/cli/cmd/logs"
 	runtimecmd "sigs.k8s.io/ome/pkg/cli/cmd/runtime"
@@ -37,8 +38,8 @@ func newRootCmd(f factory.Factory, configFlags *genericclioptions.ConfigFlags, s
   kubectl ome <command>
 
 It provides model-centric visibility into OME resources: rich listings,
-InferenceService readiness diagnosis, runtime-selection explanations and
-component-aware log streaming.`,
+controller-reported autoscaling evidence, InferenceService readiness diagnosis,
+runtime-selection explanations and component-aware log streaming.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -48,6 +49,7 @@ component-aware log streaming.`,
 	configFlags.AddFlags(cmd.PersistentFlags())
 
 	// Command families. Keep alphabetical.
+	cmd.AddCommand(autoscale.NewCmd(f, streams))
 	cmd.AddCommand(get.NewCmd(f, streams))
 	cmd.AddCommand(logs.NewCmd(f, streams))
 	cmd.AddCommand(runtimecmd.NewCmd(f, streams))

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -24,6 +24,8 @@ func TestRootCommandTree(t *testing.T) {
 	})
 	got := commandPaths(root)
 	want := []string{
+		"ome autoscale",
+		"ome autoscale status",
 		"ome get",
 		"ome logs",
 		"ome runtime",
@@ -36,6 +38,23 @@ func TestRootCommandTree(t *testing.T) {
 	}
 	if !root.SilenceErrors || !root.SilenceUsage {
 		t.Fatalf("root error policy = (SilenceErrors=%t, SilenceUsage=%t), want both true", root.SilenceErrors, root.SilenceUsage)
+	}
+}
+
+func TestRootHelpListsAutoscaleEvidenceCommand(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	root := NewRootCmdWithFactory(factory.Static{NS: "default"}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &output, ErrOut: &output,
+	})
+	root.SetArgs([]string{"--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !bytes.Contains(output.Bytes(), []byte("  autoscale   Inspect controller-reported autoscaling evidence\n")) {
+		t.Fatalf("root help does not list autoscale command:\n%s", output.String())
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Adds a read-only autoscaling inspection command for operators:

```text
kubectl ome autoscale status INFERENCESERVICE [-n NAMESPACE] [-o table|json|yaml]
```

The command performs exactly one typed `InferenceService` GET and projects the autoscaling evidence already mirrored into `status.components[*].autoscaler` and `scaleTargetRef`. It does not read an HPA, KEDA `ScaledObject`, `Deployment`, or `InferenceReplica`.

The new CLI-owned `AutoscaleStatusReport` provides:

- deterministic table, JSON, and YAML output;
- fixed `engine`, `decoder`, `router` component ordering;
- closed states for the report, component, target reference, replica evidence, and condition evidence;
- closed mappings for HPA, KEDA, External, and None classes; `ome`, `external`, and `none` managers; and `isvc`, `runtime`, `legacy`, and `default` spec sources;
- validated references only for `apps/v1 Deployment` and `ome.io/v1beta1 InferenceReplica` targets;
- HPA condition allowlisting for `AbleToScale`, `ScalingActive`, and `ScalingLimited`;
- KEDA condition allowlisting for `Ready`, `Active`, `Fallback`, and `Paused`;
- bounded, code-only issues and the single `PartialData` warning code;
- a safe summary row when no component evidence is reported; and
- root registration under `kubectl ome autoscale status`.

The command-local help is pinned exactly as:

```text
Show autoscaling evidence already reported on the InferenceService parent.
It does not query HPA, KEDA ScaledObject, Deployment, or InferenceReplica
objects, so "Reported" describes controller-reported evidence, not freshness.

Usage:
  autoscale status INFERENCESERVICE [flags]

Flags:
  -h, --help            help for status
  -o, --output string   Output format: table, json or yaml (default "table")
```

Representative table stdout, pinned by tests:

```text
STATE      COMPONENT   COMPONENT-STATE   CLASS   MANAGED-BY   SPEC-SOURCE   TARGET                              TARGET-EVIDENCE   CURRENT   DESIRED   REPLICA-EVIDENCE   LAST-SCALE             CONDITION-EVIDENCE   CONDITIONS                            ISSUES
Reported   engine      Reported          HPA     ome          default       InferenceReplica/prod/chat-engine   Reported          2         3         Reported           2026-08-31T18:20:00Z   Reported             AbleToScale=True,ScalingActive=True   -
```

Representative JSON stdout, pinned by tests:

```json
{
  "apiVersion": "cli.ome.io/v1alpha1",
  "kind": "AutoscaleStatusReport",
  "metadata": {
    "namespace": "prod",
    "name": "chat"
  },
  "collectedAt": "2026-08-31T18:30:00Z",
  "sources": [
    {
      "kind": "InferenceService",
      "namespace": "prod",
      "name": "chat",
      "uid": "uid-chat",
      "generation": 7,
      "evidence": "Reported",
      "collectedAt": "2026-08-31T18:30:00Z"
    }
  ],
  "content": {
    "summary": {
      "state": "Reported"
    },
    "components": [
      {
        "type": "engine",
        "state": "Reported",
        "class": "HPA",
        "managedBy": "ome",
        "specSource": "default",
        "target": {
          "state": "Reported",
          "apiVersion": "ome.io/v1beta1",
          "kind": "InferenceReplica",
          "namespace": "prod",
          "name": "chat-engine"
        },
        "replicas": {
          "state": "Reported",
          "currentReplicas": 2,
          "desiredReplicas": 3,
          "lastScaleTime": "2026-08-31T18:20:00Z"
        },
        "conditions": {
          "state": "Reported",
          "items": [
            {
              "type": "AbleToScale",
              "status": "True",
              "lastTransitionTime": "2026-08-31T18:15:00Z"
            },
            {
              "type": "ScalingActive",
              "status": "True",
              "lastTransitionTime": "2026-08-31T18:15:00Z"
            }
          ]
        }
      }
    ],
    "issues": []
  },
  "warnings": []
}
```

Representative YAML stdout, pinned by tests:

```yaml
apiVersion: cli.ome.io/v1alpha1
collectedAt: "2026-08-31T18:30:00Z"
content:
  components:
  - class: HPA
    conditions:
      items:
      - lastTransitionTime: "2026-08-31T18:15:00Z"
        status: "True"
        type: AbleToScale
      - lastTransitionTime: "2026-08-31T18:15:00Z"
        status: "True"
        type: ScalingActive
      state: Reported
    managedBy: ome
    replicas:
      currentReplicas: 2
      desiredReplicas: 3
      lastScaleTime: "2026-08-31T18:20:00Z"
      state: Reported
    specSource: default
    state: Reported
    target:
      apiVersion: ome.io/v1beta1
      kind: InferenceReplica
      name: chat-engine
      namespace: prod
      state: Reported
    type: engine
  issues: []
  summary:
    state: Reported
kind: AutoscaleStatusReport
metadata:
  name: chat
  namespace: prod
sources:
- collectedAt: "2026-08-31T18:30:00Z"
  evidence: Reported
  generation: 7
  kind: InferenceService
  name: chat
  namespace: prod
  uid: uid-chat
warnings: []
```

## Why we need it

Autoscaling diagnosis currently forces operators to chase component targets, identify the scaler implementation, and correlate multiple child objects. That is slow during an incident and often requires broader RBAC than reading the owning `InferenceService`. This command turns the parent status into one stable, scriptable operational view while using only one parent read.

The evidence boundary is intentionally strict:

- `Reported` means the value was present on the fetched `InferenceService`; it never means the child scaler was read, exists now, or is fresh.
- `collectedAt` records when the CLI collected the parent object, not when an HPA or KEDA object was last observed.
- The top-level `status.observedGeneration` is not used as autoscaler freshness evidence.
- A reported target is a validated parent-reported reference, not a claim that the target exists.
- Zero replica counters from an OME-managed HPA or KEDA scaler remain present numerically but are marked `Ambiguous`, because a single parent read cannot distinguish a real zero from scaler status that has not reported yet.
- Replica and condition evidence for External and None classes is `Unavailable`; contradictory counters, timestamps, or conditions are omitted and reported as `UnexpectedScalerEvidence`.
- Invalid classes, managers, spec sources, ownership combinations, target references, counters, condition types, condition states, and timestamps fail closed into bounded `Invalid` or `Unknown` states.
- Partial, unavailable, or invalid diagnostic reports still render successfully for operators. Acquisition, identity binding, projection, and writer failures return an error.

The report never serializes resource versions, observed generations, freshness or synchronization tokens, labels, annotations, owner references, managed fields, condition reasons or messages, raw errors, URLs, pod or scaler names, autoscaler metrics or behavior, KEDA triggers or metadata, fallback configuration, templates, or unrelated component rollout fields. Unknown component keys and hostile enum values produce bounded issue codes without echoing their raw values.

The fetched object is also bound to the requested name and resolved namespace and must carry a non-empty UID before projection, preventing a mismatched response from being rendered as evidence for the requested service. Argument, output-format, and resource-name validation happens before namespace resolution, client construction, or API access.

Fixes # (no linked issue)

## How to test

The implementation was developed test-first and verified with:

```bash
go test ./pkg/cli/report/v1alpha1 ./pkg/cli/autoscaleprojection ./pkg/cli/cmd/autoscale ./pkg/cli -count=1
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go test -race ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
go test ./pkg/cli/autoscaleprojection -coverprofile=/tmp/autoscaleprojection-final.cover -count=1
go test ./pkg/cli/cmd/autoscale -coverprofile=/tmp/autoscalecmd-final.cover -count=1
go test ./pkg/cli/autoscaleprojection -run 'TestProject(ReportedHPAUsesOnlyParentReportedEvidence|UnknownComponentAndHostileFieldsCannotLeak|RejectsClosedEnumAndOwnershipContradictions|IsDeterministicAndDoesNotMutateInput)$' -shuffle=on -count=20
```

Results:

- autoscale projection coverage: 99.5%;
- autoscale command coverage: 100.0%;
- full scoped normal and race suites passed;
- `go vet` passed;
- host build passed;
- Linux amd64/arm64, Darwin amd64/arm64, and Windows amd64/arm64 cross-builds passed;
- `gofmt -l` produced no output; and
- `git diff --check` passed.

The tests cover the full class/manager matrix, all spec sources, both target kinds and malformed references, absent evidence, ambiguous zero and invalid negative counters, all HPA and KEDA condition types, duplicate/conflicting/foreign conditions, unknown components and enums, response identity and UID binding, pre-read validation, API and writer failures, degraded success, randomized ordering, input non-mutation, exact help, exact table/JSON/YAML stdout, root registration, and end-to-end secret canaries in all three output formats.

`make test` was not run. The scoped CLI test, race, vet, coverage, formatting, diff, host-build, and six cross-build gates above were run instead.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (not applicable: the command includes tested user-facing help; no standalone docs changed)
- [ ] `make test` passes locally (not run; see the scoped verification above)
