### PR TITLE
[Core] Refresh Alfred before early decisions

### DIFF
--- a/oeps/0008-alfred-gpu-cluster-caretaker/README.md
+++ b/oeps/0008-alfred-gpu-cluster-caretaker/README.md
@@ -236,7 +236,7 @@ At the 2026-09-07 baseline, the source tree has the following status:
 | Observation and configuration | Implemented | Every replica builds snapshots and publishes gauges; configuration hot-reloads with last-known-good fallback. |
 | Defragmentation Policy #1 | Partially implemented | Scoring, candidate generation, arbitration, and reporting run; placement feasibility is not yet scheduler-complete. |
 | Arbiter and Reporter | Partially implemented | Core admission gates and outputs exist; positive-benefit/regression admission and dispatch/outcome-fed ledger state are not connected. |
-| Node-Health Policy #2 | Not implemented | Node conditions only exclude unhealthy nodes as defrag targets and enqueue a coalesced early decision request. That request currently reads the latest cached snapshot without first refreshing it; no evacuation candidates or remediation signals are produced. |
+| Node-Health Policy #2 | Not implemented | Node conditions only exclude unhealthy nodes as defrag targets and enqueue a coalesced early decision request. That request now forces a serialized snapshot refresh before policy evaluation without moving the regular decision deadline; no evacuation candidates or remediation signals are produced. |
 | Dispatcher | Not implemented | Alfred does not patch migration-request annotations and its current ClusterRole grants no InferenceService write. Both modes report Arbiter-admitted candidates as `withheld`: `RecommendOnly` in recommend-only mode and `DispatcherUnavailable` in execute mode. |
 | OMENative state | Implemented | Alfred validates dense `InferenceReplica.Status.InstanceStatuses` directly for stable Instance identity and lifecycle state, reads `Status.Migrations`, and joins live Pods by Instance index and incarnation for physical placement and readiness. Compatibility-only ready, scheduled, and nodes fields are not source-of-truth inputs. |
 | OMENative executor readiness | Not implemented | No capability producer or Alfred reader ships in the current implementation. The target design requires a fresh OMENative capability Lease; its producer, reader, and just-in-time pre-dispatch check are deferred with the Dispatcher. |
@@ -2675,8 +2675,11 @@ engine must not preclude them.
   Request annotations are a mailbox and the workload audit ledger retains
   durable history. A fresh capability Lease, not CRD/status presence alone,
   proves executor availability. RawDeployment and LWS are advisory-only until
-  their lifecycle owner implements the request contract. Current implementation
-  gaps (Node-Health and Dispatcher) are recorded explicitly.
+  their lifecycle owner implements the request contract. Condition-change early
+  passes now force a serialized snapshot refresh before policy evaluation
+  without moving the regular decision cadence. Current implementation gaps
+  (Node-Health evacuation, Dispatcher, and executor readiness) are recorded
+  explicitly.
 - 2026-09-07: The checked OMENative snapshot is implemented against dense
   `InferenceReplica.Status.InstanceStatuses` directly. Live Pods remain the
   source of truth for placement and readiness; compatibility-only ready,

--- a/oeps/0008-alfred-gpu-cluster-caretaker/README.md
+++ b/oeps/0008-alfred-gpu-cluster-caretaker/README.md
@@ -2675,16 +2675,15 @@ engine must not preclude them.
   Request annotations are a mailbox and the workload audit ledger retains
   durable history. A fresh capability Lease, not CRD/status presence alone,
   proves executor availability. RawDeployment and LWS are advisory-only until
-  their lifecycle owner implements the request contract. Condition-change early
-  passes now force a serialized snapshot refresh before policy evaluation
-  without moving the regular decision cadence. Current implementation gaps
-  (Node-Health evacuation, Dispatcher, and executor readiness) are recorded
-  explicitly.
+  their lifecycle owner implements the request contract.
 - 2026-09-07: The checked OMENative snapshot is implemented against dense
   `InferenceReplica.Status.InstanceStatuses` directly. Live Pods remain the
   source of truth for placement and readiness; compatibility-only ready,
   scheduled, and nodes fields are ignored. RawDeployment candidates are
-  advisory-only in current policy code.
+  advisory-only in current policy code. Condition-change early passes now force
+  a serialized snapshot refresh before policy evaluation without moving the
+  regular decision cadence. Current implementation gaps (Node-Health
+  evacuation, Dispatcher, and executor readiness) are recorded explicitly.
 - TBD: Complete Alpha implementation (capability Lease, Policy #2, Dispatcher,
   and outcome-fed safety ledger).
 - TBD: First Beta user.

--- a/pkg/alfred/config/config.go
+++ b/pkg/alfred/config/config.go
@@ -46,8 +46,9 @@ type Config struct {
 
 	DecisionLoopInterval    metav1.Duration `json:"decisionLoopInterval"`
 	ObservationLoopInterval metav1.Duration `json:"observationLoopInterval"`
-	// EarlyTickOn advances the next decision tick on the named events;
-	// empty disables advancement. A pass is never interrupted.
+	// EarlyTickOn requests a supplemental fresh decision pass on the named
+	// events without moving the regular cadence; empty disables these passes.
+	// A running pass is never interrupted.
 	EarlyTickOn []string `json:"earlyTickOn"`
 
 	Policies Policies `json:"policies"`

--- a/pkg/alfred/engine/earlytick.go
+++ b/pkg/alfred/engine/earlytick.go
@@ -13,13 +13,12 @@ import (
 	"sigs.k8s.io/ome/pkg/alfred/config"
 )
 
-// EarlyTicker turns node-condition changes into decision-loop tick
-// advancements (earlyTickOn: [NodeConditionChange]): health evacuation
-// starts within seconds while defragmentation stays lazily periodic. The
-// signal advances the timer feeding a non-reentrant loop, so it can shorten
-// waiting but never introduce concurrency. It runs on every replica — the
-// channel is only consumed by the leader's decision loop, and a non-leader's
-// signals are cheap.
+// EarlyTicker turns node-condition changes into supplemental decision passes
+// (earlyTickOn: [NodeConditionChange]): health evacuation starts within seconds
+// while defragmentation stays lazily periodic. The signal requests a fresh pass
+// from the non-reentrant loop without moving its regular cadence. It runs on
+// every replica — the channel is only consumed by the leader's decision loop,
+// and a non-leader's signals are cheap.
 type EarlyTicker struct {
 	Cache ctrlcache.Cache
 	Store *config.Store
@@ -27,7 +26,7 @@ type EarlyTicker struct {
 
 	// C carries the tick signal; buffered with capacity 1 so a signal
 	// landing mid-pass waits there instead of being lost, and a storm of
-	// changes collapses into one advancement.
+	// changes collapses into one supplemental pass.
 	C chan struct{}
 }
 
@@ -73,7 +72,7 @@ func (e *EarlyTicker) observe(oldObj, newObj interface{}) {
 	}
 	select {
 	case e.C <- struct{}{}:
-		e.Log.V(1).Info("node condition change; advancing decision tick", "node", newNode.Name)
+		e.Log.V(1).Info("node condition change; requesting supplemental decision pass", "node", newNode.Name)
 	default:
 		// A signal is already pending; the next pass covers this change.
 	}

--- a/pkg/alfred/engine/earlytick.go
+++ b/pkg/alfred/engine/earlytick.go
@@ -14,11 +14,11 @@ import (
 )
 
 // EarlyTicker turns node-condition changes into supplemental decision passes
-// (earlyTickOn: [NodeConditionChange]): health evacuation starts within seconds
-// while defragmentation stays lazily periodic. The signal requests a fresh pass
-// from the non-reentrant loop without moving its regular cadence. It runs on
-// every replica — the channel is only consumed by the leader's decision loop,
-// and a non-leader's signals are cheap.
+// (earlyTickOn: [NodeConditionChange]): relevant condition changes prompt a
+// fresh policy evaluation while the regular cadence remains periodic. The
+// signal requests a fresh pass from the non-reentrant loop without moving its
+// regular cadence. It runs on every replica — the channel is only consumed by
+// the leader's decision loop, and a non-leader's signals are cheap.
 type EarlyTicker struct {
 	Cache ctrlcache.Cache
 	Store *config.Store

--- a/pkg/alfred/engine/loop.go
+++ b/pkg/alfred/engine/loop.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/ome/pkg/alfred/config"
@@ -17,6 +19,13 @@ import (
 // the first pass. observer.Loop implements it.
 type SnapshotSource interface {
 	Latest() *snapshot.ClusterSnapshot
+}
+
+// snapshotRefresher is kept internal so Latest-only SnapshotSource
+// implementations remain source-compatible. Early decisions fail closed when
+// the configured source cannot also coordinate a refresh.
+type snapshotRefresher interface {
+	Refresh(context.Context) error
 }
 
 // DecisionLoop is the leader-only decision Runnable: policies → arbiter →
@@ -33,11 +42,14 @@ type DecisionLoop struct {
 	Metrics   *metrics.Metrics
 	Log       logr.Logger
 
-	// EarlyTick advances the next tick when a subscribed event (a node
-	// condition change) arrives; it never interrupts a running pass. The
-	// channel must be buffered (capacity 1): a signal landing mid-pass
-	// waits there and fires the next select immediately.
+	// EarlyTick requests a supplemental pass when a subscribed event (a node
+	// condition change) arrives; it never interrupts a running pass or resets
+	// the regular timer. The channel must be buffered (capacity 1): a signal
+	// landing mid-pass waits there and fires the next select immediately.
 	EarlyTick <-chan struct{}
+
+	// timerClock drives the regular decision timer. Nil uses the real clock.
+	timerClock clock.Clock
 
 	// Now overrides the clock in tests.
 	Now func() time.Time
@@ -49,23 +61,72 @@ var _ manager.LeaderElectionRunnable = &DecisionLoop{}
 // NeedLeaderElection returns true: exactly one replica decides and acts.
 func (l *DecisionLoop) NeedLeaderElection() bool { return true }
 
-// Start runs an immediate first pass, then ticks at decisionLoopInterval,
-// re-reading the interval every pass so a config reload takes effect without
-// a restart.
+// Start runs an immediate first pass, then regular passes at
+// decisionLoopInterval. Early signals add fresh, serialized passes without
+// moving the current regular deadline. The interval is reloaded only when a
+// regular deadline is consumed, including a deadline coincident with an early
+// signal.
 func (l *DecisionLoop) Start(ctx context.Context) error {
 	l.RunOnce(ctx)
+	timer := l.decisionClock().NewTimer(l.Store.Get().DecisionLoopInterval.Duration)
+	defer timer.Stop()
 	for {
-		timer := time.NewTimer(l.Store.Get().DecisionLoopInterval.Duration)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return nil
-		case <-timer.C:
+		case <-timer.C():
+			// If an early signal is already pending at the regular deadline,
+			// fold both into one fresh pass. A failed refresh skips that pass,
+			// but the consumed regular deadline still resets normal cadence.
+			if l.takeEarlyTick() {
+				l.runFreshDecisionLogged(ctx)
+			} else {
+				l.RunOnce(ctx)
+			}
+			timer.Reset(l.Store.Get().DecisionLoopInterval.Duration)
 		case <-l.EarlyTick:
-			timer.Stop()
+			// The timer may have become ready at the same instant as the early
+			// signal. Drain it if so and count this as the regular pass; otherwise
+			// leave the still-running timer completely untouched.
+			regularDue := false
+			select {
+			case <-timer.C():
+				regularDue = true
+			default:
+			}
+			l.runFreshDecisionLogged(ctx)
+			if regularDue {
+				timer.Reset(l.Store.Get().DecisionLoopInterval.Duration)
+			}
 		}
-		l.RunOnce(ctx)
 	}
+}
+
+func (l *DecisionLoop) takeEarlyTick() bool {
+	select {
+	case <-l.EarlyTick:
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *DecisionLoop) runFreshDecisionLogged(ctx context.Context) {
+	if err := l.runFreshDecision(ctx); err != nil {
+		l.Log.Error(err, "snapshot refresh failed; skipping decision pass")
+	}
+}
+
+func (l *DecisionLoop) runFreshDecision(ctx context.Context) error {
+	refresher, ok := l.Snapshots.(snapshotRefresher)
+	if !ok {
+		return fmt.Errorf("snapshot source does not support refresh")
+	}
+	if err := refresher.Refresh(ctx); err != nil {
+		return fmt.Errorf("refresh snapshot: %w", err)
+	}
+	l.RunOnce(ctx)
+	return nil
 }
 
 // RunOnce executes one decision pass against the latest snapshot. Exported
@@ -105,4 +166,11 @@ func (l *DecisionLoop) now() time.Time {
 		return time.Now()
 	}
 	return l.Now()
+}
+
+func (l *DecisionLoop) decisionClock() clock.Clock {
+	if l.timerClock == nil {
+		return clock.RealClock{}
+	}
+	return l.timerClock
 }

--- a/pkg/alfred/engine/loop.go
+++ b/pkg/alfred/engine/loop.go
@@ -85,9 +85,10 @@ func (l *DecisionLoop) Start(ctx context.Context) error {
 			}
 			timer.Reset(l.Store.Get().DecisionLoopInterval.Duration)
 		case <-l.EarlyTick:
-			// The timer may have become ready at the same instant as the early
-			// signal. Drain it if so and count this as the regular pass; otherwise
-			// leave the still-running timer completely untouched.
+			// The timer may become ready either just before the early signal or
+			// while its refresh is in flight. Drain it in either case and count the
+			// fresh attempt as the regular pass; otherwise leave the still-running
+			// timer completely untouched.
 			regularDue := false
 			select {
 			case <-timer.C():
@@ -95,6 +96,13 @@ func (l *DecisionLoop) Start(ctx context.Context) error {
 			default:
 			}
 			l.runFreshDecisionLogged(ctx)
+			if !regularDue {
+				select {
+				case <-timer.C():
+					regularDue = true
+				default:
+				}
+			}
 			if regularDue {
 				timer.Reset(l.Store.Get().DecisionLoopInterval.Duration)
 			}

--- a/pkg/alfred/engine/loop_test.go
+++ b/pkg/alfred/engine/loop_test.go
@@ -424,7 +424,7 @@ func TestEarlyTickerObserve(t *testing.T) {
 
 func waitForPolicyCalls(t *testing.T, p *stubPolicy, want int64) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for atomic.LoadInt64(&p.calls) < want {
 		if time.Now().After(deadline) {
 			t.Fatalf("policy calls = %d, want at least %d", atomic.LoadInt64(&p.calls), want)
@@ -435,7 +435,7 @@ func waitForPolicyCalls(t *testing.T, p *stubPolicy, want int64) {
 
 func waitForFakeTimer(t *testing.T, fakeClock *clocktesting.FakeClock) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for !fakeClock.HasWaiters() {
 		if time.Now().After(deadline) {
 			t.Fatal("decision loop did not arm its regular timer")

--- a/pkg/alfred/engine/loop_test.go
+++ b/pkg/alfred/engine/loop_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,24 +11,51 @@ import (
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/ome/pkg/alfred/config"
 	"sigs.k8s.io/ome/pkg/alfred/policy"
 	"sigs.k8s.io/ome/pkg/alfred/snapshot"
 )
 
-type stubSource struct{ snap *snapshot.ClusterSnapshot }
+type stubSource struct {
+	snap      *snapshot.ClusterSnapshot
+	refresh   func(context.Context) error
+	onLatest  func()
+	refreshed atomic.Int64
+}
 
-func (s *stubSource) Latest() *snapshot.ClusterSnapshot { return s.snap }
+type latestOnlySource struct{ snap *snapshot.ClusterSnapshot }
+
+func (s *latestOnlySource) Latest() *snapshot.ClusterSnapshot { return s.snap }
+
+func (s *stubSource) Latest() *snapshot.ClusterSnapshot {
+	if s.onLatest != nil {
+		s.onLatest()
+	}
+	return s.snap
+}
+
+func (s *stubSource) Refresh(ctx context.Context) error {
+	s.refreshed.Add(1)
+	if s.refresh == nil {
+		return nil
+	}
+	return s.refresh(ctx)
+}
 
 type stubPolicy struct {
-	calls int64
-	out   []policy.Candidate
+	calls      int64
+	out        []policy.Candidate
+	onEvaluate func()
 }
 
 func (p *stubPolicy) Name() string { return "stub" }
 func (p *stubPolicy) Evaluate(*snapshot.ClusterSnapshot, *config.Config) []policy.Candidate {
 	atomic.AddInt64(&p.calls, 1)
+	if p.onEvaluate != nil {
+		p.onEvaluate()
+	}
 	return p.out
 }
 
@@ -106,6 +134,75 @@ func TestRunOnceWithoutSnapshotSkips(t *testing.T) {
 	}
 }
 
+func TestFreshDecisionOrdersRefreshLatestEvaluate(t *testing.T) {
+	steps := make(chan string, 3)
+	source := &stubSource{
+		snap: scenario().Build(),
+		refresh: func(context.Context) error {
+			steps <- "refresh"
+			return nil
+		},
+		onLatest: func() { steps <- "latest" },
+	}
+	p := &stubPolicy{onEvaluate: func() { steps <- "evaluate" }}
+	loop, _, _ := newTestLoop(t, source.snap, p)
+	loop.Snapshots = source
+
+	if err := loop.runFreshDecision(context.Background()); err != nil {
+		t.Fatalf("runFreshDecision() error = %v", err)
+	}
+
+	for i, want := range []string{"refresh", "latest", "evaluate"} {
+		select {
+		case got := <-steps:
+			if got != want {
+				t.Fatalf("step %d = %q, want %q", i, got, want)
+			}
+		default:
+			t.Fatalf("missing step %d (%s)", i, want)
+		}
+	}
+}
+
+func TestFreshDecisionRefreshFailureSkipsEvaluationAndReporting(t *testing.T) {
+	wantErr := errors.New("snapshot refresh failed")
+	source := &stubSource{
+		snap:    scenario().Build(),
+		refresh: func(context.Context) error { return wantErr },
+	}
+	p := &stubPolicy{}
+	loop, reporter, _ := newTestLoop(t, source.snap, p)
+	loop.Snapshots = source
+
+	err := loop.runFreshDecision(context.Background())
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runFreshDecision() error = %v, want %v", err, wantErr)
+	}
+	if got := atomic.LoadInt64(&p.calls); got != 0 {
+		t.Fatalf("policy evaluations = %d, want 0", got)
+	}
+	if reporter.omenativeSeeded {
+		t.Fatal("refresh failure reached reporter")
+	}
+}
+
+func TestFreshDecisionLatestOnlySourceFailsClosed(t *testing.T) {
+	p := &stubPolicy{}
+	loop, reporter, _ := newTestLoop(t, scenario().Build(), p)
+	loop.Snapshots = &latestOnlySource{snap: scenario().Build()}
+
+	if err := loop.runFreshDecision(context.Background()); err == nil {
+		t.Fatal("runFreshDecision() error = nil, want unsupported refresh error")
+	}
+	if got := atomic.LoadInt64(&p.calls); got != 0 {
+		t.Fatalf("policy evaluations = %d, want 0", got)
+	}
+	if reporter.omenativeSeeded {
+		t.Fatal("missing refresh support reached reporter")
+	}
+}
+
 func TestBreakerGaugeFollowsLedger(t *testing.T) {
 	snap := scenario().Build()
 	loop, reporter, _ := newTestLoop(t, snap, &stubPolicy{})
@@ -118,9 +215,9 @@ func TestBreakerGaugeFollowsLedger(t *testing.T) {
 	}
 }
 
-// TestStartEarlyTickAdvances: with a 5-minute interval, only the early-tick
-// signal can trigger the second pass inside the test timeout.
-func TestStartEarlyTickAdvances(t *testing.T) {
+// TestStartEarlyTickRunsSupplementalPass verifies that, with a five-minute
+// interval, the early signal can request a second pass inside the test timeout.
+func TestStartEarlyTickRunsSupplementalPass(t *testing.T) {
 	p := &stubPolicy{}
 	loop, _, early := newTestLoop(t, scenario().Build(), p)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -141,7 +238,131 @@ func TestStartEarlyTickAdvances(t *testing.T) {
 	}
 	waitFor(1) // immediate first pass
 	early <- struct{}{}
-	waitFor(2) // advanced by the early tick, not the 5m timer
+	waitFor(2) // requested by the early signal, not the 5m timer
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error on shutdown: %v", err)
+	}
+}
+
+func TestStartEarlyTickDoesNotResetRegularCadence(t *testing.T) {
+	p := &stubPolicy{}
+	loop, _, early := newTestLoop(t, scenario().Build(), p)
+	source := loop.Snapshots.(*stubSource)
+	fakeClock := clocktesting.NewFakeClock(testNow)
+	loop.timerClock = fakeClock
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loop.Start(ctx) }()
+
+	waitForPolicyCalls(t, p, 1)
+	waitForFakeTimer(t, fakeClock)
+	fakeClock.Step(2 * time.Minute)
+	early <- struct{}{}
+	waitForPolicyCalls(t, p, 2)
+	if got := source.refreshed.Load(); got != 1 {
+		t.Fatalf("early refreshes = %d, want 1", got)
+	}
+
+	// The original five-minute deadline remains at t=5m. Resetting it in the
+	// early branch would postpone this pass until t=7m.
+	fakeClock.Step(3 * time.Minute)
+	waitForPolicyCalls(t, p, 3)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error on shutdown: %v", err)
+	}
+}
+
+func TestStartRegularTickReloadsInterval(t *testing.T) {
+	p := &stubPolicy{}
+	loop, _, _ := newTestLoop(t, scenario().Build(), p)
+	fakeClock := clocktesting.NewFakeClock(testNow)
+	loop.timerClock = fakeClock
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loop.Start(ctx) }()
+
+	waitForPolicyCalls(t, p, 1)
+	waitForFakeTimer(t, fakeClock)
+	if _, err := loop.Store.Update([]byte("schemaVersion: 1\ndecisionLoopInterval: 1m")); err != nil {
+		t.Fatal(err)
+	}
+	fakeClock.Step(5 * time.Minute)
+	waitForPolicyCalls(t, p, 2)
+	waitForFakeTimer(t, fakeClock)
+	fakeClock.Step(time.Minute)
+	waitForPolicyCalls(t, p, 3)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error on shutdown: %v", err)
+	}
+}
+
+func TestStartCoincidentRegularAndEarlyTickRefreshesOnce(t *testing.T) {
+	p := &stubPolicy{}
+	loop, _, early := newTestLoop(t, scenario().Build(), p)
+	fakeClock := clocktesting.NewFakeClock(testNow)
+	loop.timerClock = fakeClock
+	wantErr := errors.New("coincident refresh failed")
+	firstRefreshEntered := make(chan struct{})
+	releaseFirstRefresh := make(chan struct{})
+	secondRefresh := make(chan struct{})
+	source := loop.Snapshots.(*stubSource)
+	source.refresh = func(ctx context.Context) error {
+		switch source.refreshed.Load() {
+		case 1:
+			close(firstRefreshEntered)
+			select {
+			case <-releaseFirstRefresh:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		case 2:
+			close(secondRefresh)
+			return wantErr
+		default:
+			return nil
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- loop.Start(ctx) }()
+
+	waitForPolicyCalls(t, p, 1)
+	waitForFakeTimer(t, fakeClock)
+	early <- struct{}{}
+	select {
+	case <-firstRefreshEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first early refresh did not start")
+	}
+
+	// Hold the first early pass so both the regular deadline and another
+	// coalesced early signal are pending when the loop returns to select.
+	early <- struct{}{}
+	fakeClock.Step(5 * time.Minute)
+	close(releaseFirstRefresh)
+	waitForPolicyCalls(t, p, 2)
+	select {
+	case <-secondRefresh:
+	case <-time.After(time.Second):
+		t.Fatal("coincident tick did not refresh")
+	}
+	if got := atomic.LoadInt64(&p.calls); got != 2 {
+		t.Fatalf("refresh failure allowed coincident decision: calls = %d, want 2", got)
+	}
+
+	// The failed coincident pass still consumed the regular deadline and reset
+	// the normal cadence. It must not immediately run a stale regular decision.
+	waitForFakeTimer(t, fakeClock)
+	fakeClock.Step(5 * time.Minute)
+	waitForPolicyCalls(t, p, 3)
 
 	cancel()
 	if err := <-done; err != nil {
@@ -169,14 +390,14 @@ func TestEarlyTickerObserve(t *testing.T) {
 	select {
 	case <-ticker.C:
 	default:
-		t.Fatal("a condition flip must advance the tick")
+		t.Fatal("a condition flip must request a supplemental pass")
 	}
 
 	// A heartbeat-only update does not.
 	ticker.observe(node(corev1.ConditionTrue), node(corev1.ConditionTrue))
 	select {
 	case <-ticker.C:
-		t.Fatal("heartbeat updates must not advance the tick")
+		t.Fatal("heartbeat updates must not request a supplemental pass")
 	default:
 	}
 
@@ -198,5 +419,27 @@ func TestEarlyTickerObserve(t *testing.T) {
 	case <-ticker.C:
 		t.Fatal("a disabled trigger must not signal")
 	default:
+	}
+}
+
+func waitForPolicyCalls(t *testing.T, p *stubPolicy, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for atomic.LoadInt64(&p.calls) < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("policy calls = %d, want at least %d", atomic.LoadInt64(&p.calls), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func waitForFakeTimer(t *testing.T, fakeClock *clocktesting.FakeClock) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for !fakeClock.HasWaiters() {
+		if time.Now().After(deadline) {
+			t.Fatal("decision loop did not arm its regular timer")
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/pkg/alfred/engine/loop_test.go
+++ b/pkg/alfred/engine/loop_test.go
@@ -53,7 +53,10 @@ type notifyingTimer struct {
 
 func (t *notifyingTimer) C() <-chan time.Time {
 	if t.reads != nil {
-		t.reads <- struct{}{}
+		select {
+		case t.reads <- struct{}{}:
+		default:
+		}
 	}
 	return t.Timer.C()
 }

--- a/pkg/alfred/engine/loop_test.go
+++ b/pkg/alfred/engine/loop_test.go
@@ -439,7 +439,8 @@ func TestStartCoincidentRegularAndEarlyTickRefreshesOnce(t *testing.T) {
 	p := &stubPolicy{}
 	loop, _, early := newTestLoop(t, scenario().Build(), p)
 	fakeClock := clocktesting.NewFakeClock(testNow)
-	loop.timerClock = fakeClock
+	timerReads := make(chan struct{}, 8)
+	loop.timerClock = &notifyingClock{Clock: fakeClock, reads: timerReads}
 	wantErr := errors.New("coincident refresh failed")
 	firstRefreshEntered := make(chan struct{})
 	releaseFirstRefresh := make(chan struct{})
@@ -468,32 +469,38 @@ func TestStartCoincidentRegularAndEarlyTickRefreshesOnce(t *testing.T) {
 	go func() { done <- loop.Start(ctx) }()
 
 	waitForPolicyCalls(t, p, 1)
-	waitForFakeTimer(t, fakeClock)
+	receiveSignal(t, timerReads, "initial outer timer select")
 	early <- struct{}{}
 	select {
 	case <-firstRefreshEntered:
 	case <-time.After(time.Second):
 		t.Fatal("first early refresh did not start")
 	}
+	receiveSignal(t, timerReads, "first early pre-refresh timer check")
 
 	// Hold the first early pass so both the regular deadline and another
 	// coalesced early signal are pending when the loop returns to select.
 	early <- struct{}{}
 	fakeClock.Step(5 * time.Minute)
 	close(releaseFirstRefresh)
+	receiveSignal(t, timerReads, "first early post-refresh timer check")
+	receiveSignal(t, timerReads, "outer timer select after first early pass")
+	receiveSignal(t, timerReads, "second early pre-refresh timer check")
 	waitForPolicyCalls(t, p, 2)
 	select {
 	case <-secondRefresh:
 	case <-time.After(time.Second):
 		t.Fatal("coincident tick did not refresh")
 	}
+	receiveSignal(t, timerReads, "second early post-refresh timer check")
+	receiveSignal(t, timerReads, "final outer timer select")
 	if got := atomic.LoadInt64(&p.calls); got != 2 {
 		t.Fatalf("refresh failure allowed coincident decision: calls = %d, want 2", got)
 	}
 
-	// The failed coincident pass still consumed the regular deadline and reset
-	// the normal cadence. It must not immediately run a stale regular decision.
-	waitForFakeTimer(t, fakeClock)
+	// The first fresh pass consumed the coincident regular deadline and reset
+	// normal cadence before the queued second refresh failed. The failure must
+	// not immediately run a stale regular decision.
 	fakeClock.Step(5 * time.Minute)
 	waitForPolicyCalls(t, p, 3)
 

--- a/pkg/alfred/engine/loop_test.go
+++ b/pkg/alfred/engine/loop_test.go
@@ -11,6 +11,7 @@ import (
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/ome/pkg/alfred/config"
@@ -28,6 +29,42 @@ type stubSource struct {
 type latestOnlySource struct{ snap *snapshot.ClusterSnapshot }
 
 func (s *latestOnlySource) Latest() *snapshot.ClusterSnapshot { return s.snap }
+
+type notifyingClock struct {
+	clock.Clock
+	created chan<- time.Duration
+	resets  chan<- time.Duration
+	reads   chan<- struct{}
+}
+
+func (c *notifyingClock) NewTimer(d time.Duration) clock.Timer {
+	timer := c.Clock.NewTimer(d)
+	if c.created != nil {
+		c.created <- d
+	}
+	return &notifyingTimer{Timer: timer, resets: c.resets, reads: c.reads}
+}
+
+type notifyingTimer struct {
+	clock.Timer
+	resets chan<- time.Duration
+	reads  chan<- struct{}
+}
+
+func (t *notifyingTimer) C() <-chan time.Time {
+	if t.reads != nil {
+		t.reads <- struct{}{}
+	}
+	return t.Timer.C()
+}
+
+func (t *notifyingTimer) Reset(d time.Duration) bool {
+	active := t.Timer.Reset(d)
+	if t.resets != nil {
+		t.resets <- d
+	}
+	return active
+}
 
 func (s *stubSource) Latest() *snapshot.ClusterSnapshot {
 	if s.onLatest != nil {
@@ -251,18 +288,30 @@ func TestStartEarlyTickDoesNotResetRegularCadence(t *testing.T) {
 	loop, _, early := newTestLoop(t, scenario().Build(), p)
 	source := loop.Snapshots.(*stubSource)
 	fakeClock := clocktesting.NewFakeClock(testNow)
-	loop.timerClock = fakeClock
+	created := make(chan time.Duration, 1)
+	timerReads := make(chan struct{}, 8)
+	loop.timerClock = &notifyingClock{
+		Clock:   fakeClock,
+		created: created,
+		reads:   timerReads,
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- loop.Start(ctx) }()
 
 	waitForPolicyCalls(t, p, 1)
-	waitForFakeTimer(t, fakeClock)
+	receiveDuration(t, created, "regular timer creation")
 	fakeClock.Step(2 * time.Minute)
 	early <- struct{}{}
 	waitForPolicyCalls(t, p, 2)
 	if got := source.refreshed.Load(); got != 1 {
 		t.Fatalf("early refreshes = %d, want 1", got)
+	}
+	// Wait until the early branch has checked the timer before and after the
+	// refresh, then returned to the outer select. Advancing at policy evaluation
+	// alone can race the post-refresh drain and turn this into a coincident pass.
+	for range 4 {
+		receiveSignal(t, timerReads, "supplemental pass timer check")
 	}
 
 	// The original five-minute deadline remains at t=5m. Resetting it in the
@@ -299,6 +348,90 @@ func TestStartRegularTickReloadsInterval(t *testing.T) {
 	cancel()
 	if err := <-done; err != nil {
 		t.Fatalf("Start returned error on shutdown: %v", err)
+	}
+}
+
+func TestStartElapsedDeadlineDuringFailedEarlyRefreshSkipsStaleDecision(t *testing.T) {
+	advisory := cand("prod/b", "node3")
+	advisory.Executable = false
+	advisory.AdvisoryReason = policy.AdvisoryNoSurgeHeadroom
+	p := &stubPolicy{out: []policy.Candidate{advisory}}
+	loop, reporter, early := newTestLoop(t, scenario().Build(), p)
+	source := loop.Snapshots.(*stubSource)
+	refreshEntered := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	wantErr := errors.New("blocked early refresh failed")
+	source.refresh = func(ctx context.Context) error {
+		close(refreshEntered)
+		select {
+		case <-releaseRefresh:
+			return wantErr
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	fakeClock := clocktesting.NewFakeClock(testNow)
+	created := make(chan time.Duration, 1)
+	resets := make(chan time.Duration, 2)
+	loop.timerClock = &notifyingClock{
+		Clock:   fakeClock,
+		created: created,
+		resets:  resets,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loop.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Start returned error on shutdown: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Error("Start did not stop after cancellation")
+		}
+	})
+
+	if got := receiveDuration(t, created, "regular timer creation"); got != 5*time.Minute {
+		t.Fatalf("initial decision interval = %v, want 5m", got)
+	}
+	early <- struct{}{}
+	select {
+	case <-refreshEntered:
+	case <-time.After(time.Second):
+		t.Fatal("early refresh did not start")
+	}
+
+	// The regular deadline expires only after the early refresh is in flight.
+	// No second early signal is queued: this specifically exercises the timer
+	// that becomes ready while Refresh is blocked.
+	fakeClock.Step(5 * time.Minute)
+	close(releaseRefresh)
+	if got := receiveDuration(t, resets, "elapsed deadline reset"); got != 5*time.Minute {
+		t.Fatalf("reset decision interval = %v, want 5m", got)
+	}
+
+	produced := reporter.Metrics.RecommendationsProduced.WithLabelValues(
+		"defragmentation", "prod/b", "engine", policy.ReasonFragmentation, "false")
+	if got := atomic.LoadInt64(&p.calls); got != 1 {
+		t.Fatalf("policy evaluations after failed refresh = %d, want 1 initial evaluation", got)
+	}
+	if got := promtestutil.ToFloat64(produced); got != 1 {
+		t.Fatalf("reported cycles after failed refresh = %v, want 1 initial report", got)
+	}
+
+	// Consuming the elapsed deadline must reset, not shift or discard, cadence.
+	fakeClock.Step(5 * time.Minute)
+	if got := receiveDuration(t, resets, "next regular deadline reset"); got != 5*time.Minute {
+		t.Fatalf("next decision interval = %v, want 5m", got)
+	}
+	if got := atomic.LoadInt64(&p.calls); got != 2 {
+		t.Fatalf("policy evaluations after next regular deadline = %d, want 2", got)
+	}
+	if got := promtestutil.ToFloat64(produced); got != 2 {
+		t.Fatalf("reported cycles after next regular deadline = %v, want 2", got)
 	}
 }
 
@@ -441,5 +574,25 @@ func waitForFakeTimer(t *testing.T, fakeClock *clocktesting.FakeClock) {
 			t.Fatal("decision loop did not arm its regular timer")
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+func receiveDuration(t *testing.T, ch <-chan time.Duration, event string) time.Duration {
+	t.Helper()
+	select {
+	case duration := <-ch:
+		return duration
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", event)
+		return 0
+	}
+}
+
+func receiveSignal(t *testing.T, ch <-chan struct{}, event string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", event)
 	}
 }

--- a/pkg/alfred/observer/loop.go
+++ b/pkg/alfred/observer/loop.go
@@ -8,6 +8,7 @@ package observer
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,7 +41,8 @@ type Loop struct {
 	// Now overrides the clock in tests.
 	Now func() time.Time
 
-	latest atomic.Pointer[snapshot.ClusterSnapshot]
+	refreshMu sync.Mutex
+	latest    atomic.Pointer[snapshot.ClusterSnapshot]
 }
 
 var _ manager.Runnable = &Loop{}
@@ -60,7 +62,7 @@ func (l *Loop) Latest() *snapshot.ClusterSnapshot {
 // observation interval, re-reading the interval every pass so a config
 // reload takes effect without a restart.
 func (l *Loop) Start(ctx context.Context) error {
-	if err := l.RunOnce(ctx); err != nil {
+	if err := l.Refresh(ctx); err != nil {
 		// The first pass may race informer sync; log and keep ticking.
 		l.Log.Error(err, "initial observation pass failed")
 	}
@@ -70,16 +72,25 @@ func (l *Loop) Start(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-time.After(interval):
-			if err := l.RunOnce(ctx); err != nil {
+			if err := l.Refresh(ctx); err != nil {
 				l.Log.Error(err, "observation pass failed")
 			}
 		}
 	}
 }
 
-// RunOnce builds one snapshot and publishes gauges. Exported so tests (and a
-// forced pre-decision refresh) can drive passes directly.
+// RunOnce is the compatibility name for one serialized refresh.
 func (l *Loop) RunOnce(ctx context.Context) error {
+	return l.Refresh(ctx)
+}
+
+// Refresh builds and publishes one snapshot. The whole pass is serialized so
+// a periodic observation and a forced pre-decision refresh cannot interleave
+// snapshot publication, gauge resets, or scorer output.
+func (l *Loop) Refresh(ctx context.Context) error {
+	l.refreshMu.Lock()
+	defer l.refreshMu.Unlock()
+
 	started := l.now()
 	cfg := l.Store.Get()
 

--- a/pkg/alfred/observer/loop_test.go
+++ b/pkg/alfred/observer/loop_test.go
@@ -242,7 +242,10 @@ func TestRefreshSerializesConcurrentBuildAndPublication(t *testing.T) {
 					break
 				}
 			}
-			entered <- struct{}{}
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
 			select {
 			case <-release:
 			case <-ctx.Done():

--- a/pkg/alfred/observer/loop_test.go
+++ b/pkg/alfred/observer/loop_test.go
@@ -2,6 +2,8 @@ package observer
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,7 +15,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"sigs.k8s.io/ome/pkg/alfred/config"
 	"sigs.k8s.io/ome/pkg/alfred/metrics"
@@ -209,5 +213,75 @@ func TestRunOnceRecordsOMENativeExecutorState(t *testing.T) {
 				t.Fatalf("omenative_unavailable = %v, want %v", got, tc.gauge)
 			}
 		})
+	}
+}
+
+func TestRefreshSerializesConcurrentBuildAndPublication(t *testing.T) {
+	loop, _ := newTestLoop(t)
+	base, ok := loop.Reader.(client.WithWatch)
+	if !ok {
+		t.Fatalf("test reader type = %T, want client.WithWatch", loop.Reader)
+	}
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseBuilds := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseBuilds)
+	var active, maxActive atomic.Int32
+	loop.Reader = interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*corev1.NodeList); !ok {
+				return c.List(ctx, list, opts...)
+			}
+			current := active.Add(1)
+			defer active.Add(-1)
+			for {
+				old := maxActive.Load()
+				if current <= old || maxActive.CompareAndSwap(old, current) {
+					break
+				}
+			}
+			entered <- struct{}{}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			return c.List(ctx, list, opts...)
+		},
+	})
+
+	done := make(chan error, 2)
+	go func() { done <- loop.Refresh(context.Background()) }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("first refresh never entered snapshot build")
+	}
+	secondStarted := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		done <- loop.Refresh(context.Background())
+	}()
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second refresh goroutine did not start")
+	}
+	select {
+	case <-entered:
+		t.Fatal("second refresh overlapped the first snapshot build")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseBuilds()
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatalf("Refresh() error = %v", err)
+		}
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("max concurrent snapshot builds = %d, want 1", got)
 	}
 }

--- a/pkg/alfred/observer/loop_test.go
+++ b/pkg/alfred/observer/loop_test.go
@@ -2,8 +2,6 @@ package observer
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -216,75 +214,44 @@ func TestRunOnceRecordsOMENativeExecutorState(t *testing.T) {
 	}
 }
 
-func TestRefreshSerializesConcurrentBuildAndPublication(t *testing.T) {
+func TestRefreshHoldsSerializationLockDuringBuildAndPublication(t *testing.T) {
 	loop, _ := newTestLoop(t)
 	base, ok := loop.Reader.(client.WithWatch)
 	if !ok {
 		t.Fatalf("test reader type = %T, want client.WithWatch", loop.Reader)
 	}
 
-	entered := make(chan struct{}, 2)
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseBuilds := func() { releaseOnce.Do(func() { close(release) }) }
-	t.Cleanup(releaseBuilds)
-	var active, maxActive atomic.Int32
+	assertLocked := func(phase string) {
+		t.Helper()
+		if loop.refreshMu.TryLock() {
+			loop.refreshMu.Unlock()
+			t.Errorf("refresh serialization lock is not held during %s", phase)
+		}
+	}
+	checkedBuild := false
+	checkedPublication := false
 	loop.Reader = interceptor.NewClient(base, interceptor.Funcs{
 		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 			if _, ok := list.(*corev1.NodeList); !ok {
 				return c.List(ctx, list, opts...)
 			}
-			current := active.Add(1)
-			defer active.Add(-1)
-			for {
-				old := maxActive.Load()
-				if current <= old || maxActive.CompareAndSwap(old, current) {
-					break
-				}
-			}
-			select {
-			case entered <- struct{}{}:
-			default:
-			}
-			select {
-			case <-release:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			assertLocked("snapshot build")
+			checkedBuild = true
 			return c.List(ctx, list, opts...)
 		},
 	})
-
-	done := make(chan error, 2)
-	go func() { done <- loop.Refresh(context.Background()) }()
-	select {
-	case <-entered:
-	case <-time.After(time.Second):
-		t.Fatal("first refresh never entered snapshot build")
-	}
-	secondStarted := make(chan struct{})
-	go func() {
-		close(secondStarted)
-		done <- loop.Refresh(context.Background())
-	}()
-	select {
-	case <-secondStarted:
-	case <-time.After(time.Second):
-		t.Fatal("second refresh goroutine did not start")
-	}
-	select {
-	case <-entered:
-		t.Fatal("second refresh overlapped the first snapshot build")
-	case <-time.After(50 * time.Millisecond):
+	loop.Scorer = func(*snapshot.ClusterSnapshot, *config.Config, *metrics.Metrics) {
+		assertLocked("snapshot publication")
+		checkedPublication = true
 	}
 
-	releaseBuilds()
-	for range 2 {
-		if err := <-done; err != nil {
-			t.Fatalf("Refresh() error = %v", err)
-		}
+	if err := loop.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
 	}
-	if got := maxActive.Load(); got != 1 {
-		t.Fatalf("max concurrent snapshot builds = %d, want 1", got)
+	if !checkedBuild {
+		t.Error("snapshot build lock assertion was not reached")
+	}
+	if !checkedPublication {
+		t.Error("snapshot publication lock assertion was not reached")
 	}
 }


### PR DESCRIPTION
## Summary

- Serialize complete Alfred observation refreshes so periodic and forced
  passes cannot interleave snapshot publication, gauge resets, or scoring.
- Force a fresh snapshot before each node-condition supplemental decision and
  skip evaluation when refresh is unavailable or fails.
- Keep supplemental passes independent of the regular decision cadence.
- Fold coincident early/regular signals even when the regular deadline becomes
  ready while an early refresh is in flight, preventing stale fallback after a
  failed refresh.
- Cover cadence, collision, failure, and serialization behavior with
  deterministic tests and update OEP-0008's node-condition early-pass status.

## Scope

This PR is stacked on #827 and is groundwork for Node-Health Policy #2.

It does not add evacuation candidates, remediation signals, capability
machinery, a Dispatcher, migration writes, a new migration package, or
workload-package changes.

## Verification

```text
go test ./pkg/alfred/... ./cmd/alfred/... -count=1
go test -race ./pkg/alfred/engine ./pkg/alfred/observer -count=1
go vet ./pkg/alfred/... ./cmd/alfred/...
go test ./pkg/alfred/engine -run '^TestStartElapsedDeadlineDuringFailedEarlyRefreshSkipsStaleDecision$' -count=100
go test -race ./pkg/alfred/engine -run '^TestStartCoincidentRegularAndEarlyTickRefreshesOnce$' -count=1000
go test ./pkg/alfred/observer -run '^TestRefreshHoldsSerializationLockDuringBuildAndPublication$' -count=100
pre-commit run --all-files --show-diff-on-failure
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supplemental decision passes triggered by configured events without changing the regular decision schedule.
  * Supplemental passes now refresh snapshots before evaluation to ensure decisions use current data.
  * Regular intervals are reloaded after scheduled passes, preserving updated timing.

* **Bug Fixes**
  * Prevented scheduled and event-triggered refreshes from running concurrently.
  * Failed or unsupported refreshes now skip evaluation instead of producing decisions from stale data.
  * Combined simultaneous triggers into a single refresh and decision pass.

* **Documentation**
  * Updated configuration and implementation guidance to describe supplemental passes and current readiness considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->