### PR TITLE
[Core] Add runtime effective command

### DIFF
--- a/pkg/cli/cmd/runtime/effective.go
+++ b/pkg/cli/cmd/runtime/effective.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/namespace"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/cli/runtimeprojection"
+)
+
+type effectiveProjector func(
+	*v1beta1.InferenceService,
+	*effective.RuntimeState,
+	reportv1alpha1.Clock,
+) (reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent], error)
+
+type effectiveCommandDependencies struct {
+	clock     reportv1alpha1.Clock
+	limits    paging.Limits
+	projector effectiveProjector
+}
+
+type effectiveOptions struct {
+	genericiooptions.IOStreams
+	namespaceOptions *namespace.Options
+	dependencies     effectiveCommandDependencies
+	output           string
+	name             string
+	format           report.Format
+}
+
+func newEffectiveCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	return newEffectiveCmdWithDependencies(f, streams, effectiveCommandDependencies{
+		clock: reportv1alpha1.SystemClock{},
+		limits: paging.Limits{
+			PageSize:       paging.ChunkSize,
+			MaxItems:       1000,
+			MaxPages:       2,
+			RequestTimeout: 10 * time.Second,
+		},
+		projector: runtimeprojection.ProjectEffective,
+	})
+}
+
+func newEffectiveCmdWithDependencies(
+	f factory.Factory,
+	streams genericiooptions.IOStreams,
+	dependencies effectiveCommandDependencies,
+) *cobra.Command {
+	o := &effectiveOptions{
+		IOStreams: streams, namespaceOptions: namespace.NewOptions(), dependencies: dependencies,
+	}
+	cmd := &cobra.Command{
+		Use:   "effective INFERENCESERVICE",
+		Short: "Show effective runtime evidence for an InferenceService",
+		Long: `Shows allowlisted runtime selection, inheritance, pin, status, drift,
+and live-versus-controller-active evidence for an InferenceService.
+
+Current only means status.observedGeneration == metadata.generation in the
+fetched snapshot, never wall-clock freshness or rollout convergence. Raw
+runtime specs, ControllerRevision data, status messages, resource versions,
+and synchronization tokens are never printed.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.name = args[0]
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run(cmd.Context(), f)
+		},
+	}
+	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "Output format: table, json or yaml")
+	o.namespaceOptions.AddOMEFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *effectiveOptions) validate() error {
+	format, err := report.ParseFormat(o.output)
+	if err != nil {
+		return err
+	}
+	o.format = format
+	if problems := validation.IsDNS1123Subdomain(o.name); len(problems) > 0 {
+		return fmt.Errorf("InferenceService name %q is invalid: %s", o.name, strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func (o *effectiveOptions) run(ctx context.Context, f factory.Factory) error {
+	evidence, err := collectRuntimeEvidence(
+		ctx, f, o.namespaceOptions, o.name, o.dependencies.limits,
+		runtimeEvidenceOptions{IncludeHistory: false},
+	)
+	if err != nil {
+		return err
+	}
+	projected, err := o.dependencies.projector(
+		evidence.inferenceService, evidence.state, o.dependencies.clock,
+	)
+	if err != nil {
+		return fmt.Errorf("project effective runtime evidence: %w", err)
+	}
+	if err := report.Write(o.Out, o.format, projected); err != nil {
+		return fmt.Errorf("write effective runtime report: %w", err)
+	}
+	return nil
+}

--- a/pkg/cli/cmd/runtime/effective_errors_test.go
+++ b/pkg/cli/cmd/runtime/effective_errors_test.go
@@ -1,0 +1,325 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/cli/runtimeprojection"
+	"sigs.k8s.io/ome/pkg/client/clientset/versioned"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+)
+
+type failingFactory struct {
+	ome        versioned.Interface
+	kube       kubernetes.Interface
+	runtime    ctrlclient.Client
+	namespace  string
+	nsErr      error
+	omeErr     error
+	kubeErr    error
+	runtimeErr error
+}
+
+func (*failingFactory) RESTConfig() (*rest.Config, error)           { panic("unexpected RESTConfig call") }
+func (f *failingFactory) KubeClient() (kubernetes.Interface, error) { return f.kube, f.kubeErr }
+func (f *failingFactory) OMEClient() (versioned.Interface, error)   { return f.ome, f.omeErr }
+func (f *failingFactory) RuntimeClient() (ctrlclient.Client, error) { return f.runtime, f.runtimeErr }
+func (f *failingFactory) Namespace() (string, bool, error)          { return f.namespace, false, f.nsErr }
+
+func fixedEffectiveDependencies() effectiveCommandDependencies {
+	return effectiveCommandDependencies{
+		clock: reportv1alpha1.ClockFunc(func() time.Time {
+			return time.Date(2026, 8, 31, 12, 34, 56, 0, time.FixedZone("test", -7*60*60))
+		}),
+		limits: paging.Limits{
+			PageSize: paging.ChunkSize, MaxItems: 1000, MaxPages: 2, RequestTimeout: 10 * time.Second,
+		},
+		projector: runtimeprojection.ProjectEffective,
+	}
+}
+
+func boundISVC() *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "service", Namespace: "team-a", UID: types.UID("isvc-uid"), ResourceVersion: "17",
+	}}
+}
+
+func completeFactory(t *testing.T) *failingFactory {
+	t.Helper()
+	return &failingFactory{
+		ome: omefake.NewSimpleClientset(boundISVC()), kube: k8sfake.NewSimpleClientset(),
+		runtime: ctrlfake.NewClientBuilder().WithScheme(scheme(t)).Build(), namespace: "team-a",
+	}
+}
+
+func executeEffectiveWithDependencies(
+	t *testing.T,
+	f factory.Factory,
+	dependencies effectiveCommandDependencies,
+	out io.Writer,
+) (string, error) {
+	t.Helper()
+	var errOut bytes.Buffer
+	cmd := newEffectiveCmdWithDependencies(f, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: out, ErrOut: &errOut,
+	}, dependencies)
+	cmd.SetArgs([]string{"service"})
+	err := cmd.Execute()
+	return errOut.String(), err
+}
+
+// TestEffectivePreservesRequiredFailureCauses catches required acquisition
+// failures being downgraded, stringified without %w, or followed by output.
+func TestEffectivePreservesRequiredFailureCauses(t *testing.T) {
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "ome.io", Resource: "inferenceservices"}, "service")
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "ome.io", Resource: "inferenceservices"}, "service", errors.New("denied"))
+	namespaceFailure := errors.New("namespace failure")
+	omeClientFailure := errors.New("OME client failure")
+	kubeClientFailure := errors.New("Kubernetes client failure")
+	runtimeClientFailure := errors.New("runtime client failure")
+	tests := []struct {
+		name      string
+		configure func(*failingFactory)
+		want      error
+	}{
+		{name: "namespace", want: namespaceFailure, configure: func(f *failingFactory) { f.nsErr = namespaceFailure }},
+		{name: "OME client", want: omeClientFailure, configure: func(f *failingFactory) { f.omeErr = omeClientFailure }},
+		{name: "Kubernetes client", want: kubeClientFailure, configure: func(f *failingFactory) { f.kubeErr = kubeClientFailure }},
+		{name: "runtime client", want: runtimeClientFailure, configure: func(f *failingFactory) { f.runtimeErr = runtimeClientFailure }},
+		{name: "primary not found", want: notFound, configure: func(f *failingFactory) {
+			f.ome = primaryErrorClient(notFound)
+		}},
+		{name: "primary forbidden", want: forbidden, configure: func(f *failingFactory) {
+			f.ome = primaryErrorClient(forbidden)
+		}},
+		{name: "parent canceled", want: context.Canceled, configure: func(f *failingFactory) {
+			f.ome = primaryErrorClient(context.Canceled)
+		}},
+		{name: "parent deadline", want: context.DeadlineExceeded, configure: func(f *failingFactory) {
+			f.ome = primaryErrorClient(context.DeadlineExceeded)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := completeFactory(t)
+			test.configure(f)
+			var out bytes.Buffer
+			_, err := executeEffectiveWithDependencies(t, f, fixedEffectiveDependencies(), &out)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+			assert.Empty(t, out.String())
+		})
+	}
+}
+
+// TestEffectiveFriendlyCRDNotFound catches loss of the actionable
+// apierror.Friendly translation while retaining the Kubernetes status cause.
+func TestEffectiveFriendlyCRDNotFound(t *testing.T) {
+	cause := &apierrors.StatusError{ErrStatus: metav1.Status{
+		Status: metav1.StatusFailure, Reason: metav1.StatusReasonNotFound,
+		Message: "the server could not find the requested resource",
+	}}
+	f := completeFactory(t)
+	f.ome = primaryErrorClient(cause)
+	var out bytes.Buffer
+	_, err := executeEffectiveWithDependencies(t, f, fixedEffectiveDependencies(), &out)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cause)
+	assert.Contains(t, err.Error(), "OME does not appear to be installed on this cluster")
+	assert.Empty(t, out.String())
+}
+
+// TestEffectivePreservesParentContextFailure catches collection continuing as
+// success after the invoking command has already been canceled or expired.
+func TestEffectivePreservesParentContextFailure(t *testing.T) {
+	tests := []struct {
+		name    string
+		context func() (context.Context, context.CancelFunc)
+		want    error
+	}{
+		{name: "canceled", want: context.Canceled, context: func() (context.Context, context.CancelFunc) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			return ctx, func() {}
+		}},
+		{name: "deadline", want: context.DeadlineExceeded, context: func() (context.Context, context.CancelFunc) {
+			return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := test.context()
+			defer cancel()
+			var out, errOut bytes.Buffer
+			cmd := newEffectiveCmdWithDependencies(completeFactory(t), genericiooptions.IOStreams{
+				In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+			}, fixedEffectiveDependencies())
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"service"})
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+			assert.Empty(t, out.String())
+		})
+	}
+}
+
+func primaryErrorClient(cause error) versioned.Interface {
+	client := omefake.NewSimpleClientset()
+	client.PrependReactor("get", "inferenceservices", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, cause
+	})
+	return client
+}
+
+// TestEffectivePreservesProjectorFailure catches projection errors being
+// swallowed or rendered as a successful empty report.
+func TestEffectivePreservesProjectorFailure(t *testing.T) {
+	tests := []error{errors.New("projector sentinel"), runtimeprojection.ErrInvalidEvidence}
+	for _, sentinel := range tests {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			dependencies := fixedEffectiveDependencies()
+			dependencies.projector = func(
+				*v1beta1.InferenceService,
+				*effective.RuntimeState,
+				reportv1alpha1.Clock,
+			) (reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent], error) {
+				return reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent]{}, sentinel
+			}
+			var out bytes.Buffer
+			_, err := executeEffectiveWithDependencies(t, completeFactory(t), dependencies, &out)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, sentinel)
+			assert.Empty(t, out.String())
+		})
+	}
+}
+
+// TestEffectivePreservesResolverConstructionFailure catches invalid fixed
+// collection limits being ignored or converted into a successful report.
+func TestEffectivePreservesResolverConstructionFailure(t *testing.T) {
+	dependencies := fixedEffectiveDependencies()
+	dependencies.limits.PageSize = 0
+	var out bytes.Buffer
+	_, err := executeEffectiveWithDependencies(t, completeFactory(t), dependencies, &out)
+	require.Error(t, err)
+	assert.EqualError(t, err, "construct runtime evidence resolver: revision paging limits are invalid")
+	cause := errors.Unwrap(err)
+	require.Error(t, cause, "resolver-construction wrapping must retain a nonnil cause")
+	assert.EqualError(t, cause, "revision paging limits are invalid")
+	assert.NoError(t, errors.Unwrap(cause), "the exact lower-level constructor error is the terminal cause")
+	assert.Empty(t, out.String())
+}
+
+// TestEffectiveProjectsExactlyOnce catches duplicate projection or rendering
+// directly from internal evidence instead of the typed projected report.
+func TestEffectiveProjectsExactlyOnce(t *testing.T) {
+	dependencies := fixedEffectiveDependencies()
+	calls := 0
+	dependencies.projector = func(
+		isvc *v1beta1.InferenceService,
+		state *effective.RuntimeState,
+		clock reportv1alpha1.Clock,
+	) (reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeEffectiveContent], error) {
+		calls++
+		return runtimeprojection.ProjectEffective(isvc, state, clock)
+	}
+	var out bytes.Buffer
+	_, err := executeEffectiveWithDependencies(t, completeFactory(t), dependencies, &out)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.NotEmpty(t, out.String())
+}
+
+type failingWriter struct {
+	short bool
+	err   error
+}
+
+func (w failingWriter) Write(p []byte) (int, error) {
+	if w.short {
+		return len(p) - 1, nil
+	}
+	return 0, w.err
+}
+
+// TestEffectivePreservesWriterFailures catches successful exit on destination
+// errors, including io.Writer's short-write contract.
+func TestEffectivePreservesWriterFailures(t *testing.T) {
+	writerFailure := errors.New("writer sentinel")
+	tests := []struct {
+		name   string
+		writer io.Writer
+		want   error
+	}{
+		{name: "failure", writer: failingWriter{err: writerFailure}, want: writerFailure},
+		{name: "short write", writer: failingWriter{short: true}, want: io.ErrShortWrite},
+	}
+	for _, test := range tests {
+		for _, format := range []string{"table", "json", "yaml"} {
+			t.Run(test.name+"/"+format, func(t *testing.T) {
+				var errOut bytes.Buffer
+				cmd := newEffectiveCmdWithDependencies(completeFactory(t), genericiooptions.IOStreams{
+					In: &bytes.Buffer{}, Out: test.writer, ErrOut: &errOut,
+				}, fixedEffectiveDependencies())
+				cmd.SetArgs([]string{"service", "--output", format})
+				err := cmd.Execute()
+				require.Error(t, err)
+				assert.ErrorIs(t, err, test.want)
+			})
+		}
+	}
+}
+
+// TestEffectivePreservesMachineFormatMarshalFailures catches JSON/YAML
+// serialization failures being swallowed, flattened, or partially written.
+func TestEffectivePreservesMachineFormatMarshalFailures(t *testing.T) {
+	dependencies := fixedEffectiveDependencies()
+	dependencies.clock = reportv1alpha1.ClockFunc(func() time.Time {
+		return time.Date(10000, 1, 2, 3, 4, 5, 0, time.UTC)
+	})
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			cmd := newEffectiveCmdWithDependencies(completeFactory(t), genericiooptions.IOStreams{
+				In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+			}, dependencies)
+			cmd.SetArgs([]string{"service", "--output", format})
+
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "marshal report "+format)
+			assert.Contains(t, err.Error(), "year outside of range [0,9999]")
+			var marshalerError *json.MarshalerError
+			assert.ErrorAs(t, err, &marshalerError)
+			assert.Empty(t, out.String())
+			assert.Empty(t, errOut.String())
+		})
+	}
+}

--- a/pkg/cli/cmd/runtime/effective_render_test.go
+++ b/pkg/cli/cmd/runtime/effective_render_test.go
@@ -1,0 +1,1010 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	knapis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+const (
+	secretImage       = "private.registry.invalid/runtime:credential-canary"
+	secretEnvironment = "secret-environment-canary"
+	secretArgument    = "--token=secret-argument-canary"
+	secretLabel       = "secret-label-canary"
+	secretAnnotation  = "secret-annotation-canary"
+	secretRuntimeRV   = "secret-runtime-resource-version"
+	secretRevisionRV  = "secret-revision-resource-version"
+	secretISVCRV      = "secret-isvc-resource-version"
+	secretSyncToken   = "secret-sync-token-canary"
+	secretMessage     = "secret-status-message-canary"
+	secretKeyRefName  = "secret-key-ref-name-canary"
+	secretKeyRefKey   = "secret-key-ref-key-canary"
+	secretVolumeName  = "secret-volume-ref-name-canary"
+	secretNodeValue   = "secret-node-selector-value-canary"
+)
+
+func healthyPinnedFactory(t *testing.T) (*acquisitionFactory, string) {
+	return healthyPinnedFactoryVariant(t, false)
+}
+
+func orderedStringMap(reversed bool, entries ...[2]string) map[string]string {
+	result := make(map[string]string, len(entries))
+	if reversed {
+		for index := len(entries) - 1; index >= 0; index-- {
+			result[entries[index][0]] = entries[index][1]
+		}
+		return result
+	}
+	for _, entry := range entries {
+		result[entry[0]] = entry[1]
+	}
+	return result
+}
+
+type permutingRuntimeResponseClient struct {
+	ctrlclient.Client
+	reversed bool
+	gets     int
+}
+
+func (c *permutingRuntimeResponseClient) Get(
+	ctx context.Context,
+	key ctrlclient.ObjectKey,
+	object ctrlclient.Object,
+	options ...ctrlclient.GetOption,
+) error {
+	if err := c.Client.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	runtimeObject, ok := object.(*v1beta1.ClusterServingRuntime)
+	if !ok {
+		return nil
+	}
+	// Alternate equivalent map insertion order across resolver responses. The
+	// reversed fixture starts with the opposite response order.
+	reverseThisResponse := (c.gets%2 == 0) == c.reversed
+	c.gets++
+	runtimeObject.Labels = orderedStringMap(reverseThisResponse,
+		[2]string{"private-label", secretLabel}, [2]string{"second-label", "second-value"},
+	)
+	runtimeObject.Annotations = orderedStringMap(reverseThisResponse,
+		[2]string{"private-annotation", secretAnnotation}, [2]string{"second-annotation", "second-value"},
+	)
+	runtimeObject.Spec.NodeSelector = orderedStringMap(reverseThisResponse,
+		[2]string{"accelerator", "gpu"}, [2]string{"private-node", secretNodeValue},
+	)
+	return nil
+}
+
+func healthyPinnedFactoryVariant(t *testing.T, reversed bool) (*acquisitionFactory, string) {
+	t.Helper()
+	autoSync := false
+	kind := runtimeselector.KindClusterServingRuntime
+	runtimeSpec := v1beta1.ServingRuntimeSpec{
+		ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{NodeSelector: orderedStringMap(reversed,
+			[2]string{"accelerator", "gpu"}, [2]string{"private-node", secretNodeValue},
+		)},
+		EngineConfig: &v1beta1.EngineSpec{
+			PodSpec: v1beta1.PodSpec{Volumes: []corev1.Volume{{
+				Name: "runtime-secret", VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: secretVolumeName},
+				},
+			}}},
+			Runner: &v1beta1.RunnerSpec{Container: corev1.Container{
+				Name: "runner", Image: secretImage,
+				Env: []corev1.EnvVar{
+					{Name: "TOKEN", Value: secretEnvironment},
+					{Name: "SECRET_KEY", ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: secretKeyRefName},
+							Key:                  secretKeyRefKey,
+						},
+					}},
+				},
+				Args: []string{secretArgument},
+			}},
+		}}
+	_, shortHash, err := runtimerevision.Hash(&runtimeSpec)
+	require.NoError(t, err)
+	revisionName := runtimerevision.Name(
+		runtimerevision.KindClusterServingRuntime, "", "cluster-runtime", shortHash,
+	)
+	runtimeObject := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-runtime", UID: types.UID("runtime-uid"), Generation: 2,
+			ResourceVersion: secretRuntimeRV,
+			Labels: orderedStringMap(reversed,
+				[2]string{"private-label", secretLabel}, [2]string{"second-label", "second-value"},
+			),
+			Annotations: orderedStringMap(reversed,
+				[2]string{"private-annotation", secretAnnotation}, [2]string{"second-annotation", "second-value"},
+			),
+		},
+		Spec: runtimeSpec,
+	}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "service", Namespace: "team-a", UID: types.UID("isvc-uid"),
+			ResourceVersion: secretISVCRV, Generation: 4,
+			Labels: orderedStringMap(reversed,
+				[2]string{"private-label", secretLabel}, [2]string{"second-label", "second-value"},
+			),
+			Annotations: orderedStringMap(reversed,
+				[2]string{"private-annotation", secretAnnotation},
+				[2]string{constants.RuntimeSyncAnnotationKey, secretSyncToken},
+			),
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{
+				Name: "cluster-runtime", Kind: &kind, AutoSync: &autoSync, Revision: &revisionName,
+			},
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+	isvc.Status.ObservedGeneration = 4
+	isvc.Status.PinnedRevisionName = revisionName
+	isvc.Status.LastRuntimeSyncToken = secretSyncToken
+	isvc.Status.Conditions = duckv1.Conditions{{
+		Type:   knapis.ConditionType(constants.RuntimeDriftedConditionType),
+		Status: corev1.ConditionTrue, Reason: "RevisionMismatch", Message: secretMessage,
+	}}
+	raw, err := json.Marshal(&runtimeSpec)
+	require.NoError(t, err)
+	revision := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: revisionName, Namespace: "control-plane", UID: types.UID("revision-uid"),
+			ResourceVersion:   secretRevisionRV,
+			CreationTimestamp: metav1.NewTime(time.Date(2026, 8, 30, 1, 2, 3, 0, time.UTC)),
+			Labels: orderedStringMap(reversed,
+				[2]string{constants.RuntimeRevisionOfLabelKey, "cluster-runtime"},
+				[2]string{constants.RuntimeRevisionOfKindLabelKey, string(runtimerevision.KindClusterServingRuntime)},
+				[2]string{constants.RuntimeRevisionOfNamespaceLabelKey, ""},
+				[2]string{constants.RuntimeRevisionHashLabelKey, shortHash},
+				[2]string{"private-label", secretLabel},
+			),
+			Annotations: orderedStringMap(reversed,
+				[2]string{constants.RuntimeRevisionCreatedByKey, constants.RuntimeRevisionCreatedByOMEValue},
+				[2]string{"private-annotation", secretAnnotation},
+			),
+		},
+		Data: runtime.RawExtension{Raw: raw}, Revision: 1,
+	}
+	runtimeClient := &permutingRuntimeResponseClient{
+		Client:   ctrlfake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(runtimeObject).Build(),
+		reversed: reversed,
+	}
+	return &acquisitionFactory{
+		ome: omefake.NewSimpleClientset(isvc), kube: k8sfake.NewSimpleClientset(revision),
+		runtime:   runtimeClient,
+		namespace: "team-a",
+	}, shortHash
+}
+
+func renderHealthyPinned(t *testing.T, format string) string {
+	return renderHealthyPinnedVariant(t, format, false)
+}
+
+func renderHealthyPinnedVariant(t *testing.T, format string, reversed bool) string {
+	t.Helper()
+	f, _ := healthyPinnedFactoryVariant(t, reversed)
+	var out, errOut bytes.Buffer
+	cmd := newEffectiveCmdWithDependencies(f, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+	}, fixedEffectiveDependencies())
+	cmd.SetArgs([]string{"service", "--ome-namespace", "control-plane", "--output", format})
+	require.NoError(t, cmd.Execute())
+	require.Empty(t, errOut.String())
+	return out.String()
+}
+
+func renderStalePinned(t *testing.T, format string) string {
+	t.Helper()
+	f, _ := healthyPinnedFactory(t)
+	inferenceService, err := f.ome.OmeV1beta1().InferenceServices("team-a").Get(
+		context.Background(), "service", metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	inferenceService.Status.ObservedGeneration = 3
+	_, err = f.ome.OmeV1beta1().InferenceServices("team-a").Update(
+		context.Background(), inferenceService, metav1.UpdateOptions{},
+	)
+	require.NoError(t, err)
+
+	var out, errOut bytes.Buffer
+	cmd := newEffectiveCmdWithDependencies(f, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+	}, fixedEffectiveDependencies())
+	cmd.SetArgs([]string{"service", "--ome-namespace", "control-plane", "--output", format})
+	require.NoError(t, cmd.Execute())
+	require.Empty(t, errOut.String())
+	return out.String()
+}
+
+func renderNotConfigured(t *testing.T, format string) string {
+	t.Helper()
+	f := completeFactory(t)
+	var out, errOut bytes.Buffer
+	cmd := newEffectiveCmdWithDependencies(f, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+	}, fixedEffectiveDependencies())
+	cmd.SetArgs([]string{"service", "--output", format})
+	require.NoError(t, cmd.Execute())
+	require.Empty(t, errOut.String())
+	return out.String()
+}
+
+type erroringRuntimeClient struct {
+	ctrlclient.Client
+	err error
+}
+
+func (c erroringRuntimeClient) Get(
+	context.Context,
+	ctrlclient.ObjectKey,
+	ctrlclient.Object,
+	...ctrlclient.GetOption,
+) error {
+	return c.err
+}
+
+// TestEffectiveHealthyPinnedExactFormats catches command-level divergence
+// between table, JSON, and YAML or loss of the fixed collection timestamp.
+func TestEffectiveHealthyPinnedExactFormats(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{format: "table", want: `VIEW     STATE       REASON   RUNTIME                                 REVISION                      HASH       COMPONENT   MODE            MODE-SOURCE   PIN           PIN-STATE   SYNC           STATUS    DRIFT                           LIVE-RELATION   ISSUES
+Live     Available   -        ClusterServingRuntime/cluster-runtime   -                             e0e2b0d6   engine      RawDeployment   Default       ExplicitPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Equal           -
+Active   Available   -        ClusterServingRuntime/cluster-runtime   cr-cluster-runtime-e0e2b0d6   e0e2b0d6   engine      RawDeployment   Default       ExplicitPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Equal           -
+`},
+		{format: "json", want: `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "RuntimeEffectiveReport",
+  "metadata": {
+    "namespace": "team-a",
+    "name": "service"
+  },
+  "collectedAt": "2026-08-31T19:34:56Z",
+  "sources": [
+    {
+      "kind": "ClusterServingRuntime",
+      "name": "cluster-runtime",
+      "uid": "runtime-uid",
+      "generation": 2,
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    },
+    {
+      "kind": "ControllerRevision",
+      "namespace": "control-plane",
+      "name": "cr-cluster-runtime-e0e2b0d6",
+      "uid": "revision-uid",
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    },
+    {
+      "kind": "InferenceService",
+      "namespace": "team-a",
+      "name": "service",
+      "uid": "isvc-uid",
+      "generation": 4,
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    }
+  ],
+  "content": {
+    "selection": {
+      "source": "Explicit",
+      "runtime": {
+        "apiVersion": "ome.io/v1beta1",
+        "kind": "ClusterServingRuntime",
+        "name": "cluster-runtime",
+        "uid": "runtime-uid",
+        "generation": 2
+      }
+    },
+    "inheritance": {
+      "state": "Observed",
+      "sources": [
+        {
+          "apiVersion": "ome.io/v1beta1",
+          "kind": "ClusterServingRuntime",
+          "name": "cluster-runtime",
+          "uid": "runtime-uid",
+          "generation": 2
+        }
+      ]
+    },
+    "pin": {
+      "mode": "ExplicitPin",
+      "state": "Resolved",
+      "requestedRevision": "cr-cluster-runtime-e0e2b0d6",
+      "reportedRevision": "cr-cluster-runtime-e0e2b0d6",
+      "status": {
+        "generation": 4,
+        "observedGeneration": 4,
+        "freshness": "Current"
+      },
+      "reportedDrift": {
+        "state": "ReportedTrue",
+        "cause": "RevisionMismatch"
+      },
+      "syncState": "Acknowledged"
+    },
+    "live": {
+      "state": "Available",
+      "origin": "LiveRuntime",
+      "source": {
+        "apiVersion": "ome.io/v1beta1",
+        "kind": "ClusterServingRuntime",
+        "name": "cluster-runtime",
+        "uid": "runtime-uid",
+        "generation": 2
+      },
+      "hash": "e0e2b0d6",
+      "components": [
+        {
+          "type": "engine",
+          "deploymentMode": "RawDeployment",
+          "deploymentModeSource": "Default"
+        }
+      ]
+    },
+    "active": {
+      "state": "Available",
+      "origin": "ControllerRevision",
+      "source": {
+        "apiVersion": "ome.io/v1beta1",
+        "kind": "ClusterServingRuntime",
+        "name": "cluster-runtime",
+        "uid": "runtime-uid",
+        "generation": 2
+      },
+      "revision": {
+        "namespace": "control-plane",
+        "name": "cr-cluster-runtime-e0e2b0d6",
+        "uid": "revision-uid",
+        "createdAt": "2026-08-30T01:02:03Z"
+      },
+      "hash": "e0e2b0d6",
+      "components": [
+        {
+          "type": "engine",
+          "deploymentMode": "RawDeployment",
+          "deploymentModeSource": "Default"
+        }
+      ]
+    },
+    "liveToActive": "Equal",
+    "issues": []
+  },
+  "warnings": []
+}
+`},
+		{format: "yaml", want: `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T19:34:56Z"
+content:
+  active:
+    components:
+    - deploymentMode: RawDeployment
+      deploymentModeSource: Default
+      type: engine
+    hash: e0e2b0d6
+    origin: ControllerRevision
+    revision:
+      createdAt: "2026-08-30T01:02:03Z"
+      name: cr-cluster-runtime-e0e2b0d6
+      namespace: control-plane
+      uid: revision-uid
+    source:
+      apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    state: Available
+  inheritance:
+    sources:
+    - apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    state: Observed
+  issues: []
+  live:
+    components:
+    - deploymentMode: RawDeployment
+      deploymentModeSource: Default
+      type: engine
+    hash: e0e2b0d6
+    origin: LiveRuntime
+    source:
+      apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    state: Available
+  liveToActive: Equal
+  pin:
+    mode: ExplicitPin
+    reportedDrift:
+      cause: RevisionMismatch
+      state: ReportedTrue
+    reportedRevision: cr-cluster-runtime-e0e2b0d6
+    requestedRevision: cr-cluster-runtime-e0e2b0d6
+    state: Resolved
+    status:
+      freshness: Current
+      generation: 4
+      observedGeneration: 4
+    syncState: Acknowledged
+  selection:
+    runtime:
+      apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    source: Explicit
+kind: RuntimeEffectiveReport
+metadata:
+  name: service
+  namespace: team-a
+sources:
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  generation: 2
+  kind: ClusterServingRuntime
+  name: cluster-runtime
+  uid: runtime-uid
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  kind: ControllerRevision
+  name: cr-cluster-runtime-e0e2b0d6
+  namespace: control-plane
+  uid: revision-uid
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  generation: 4
+  kind: InferenceService
+  name: service
+  namespace: team-a
+  uid: isvc-uid
+warnings: []
+`},
+	}
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			assert.Equal(t, test.want, renderHealthyPinned(t, test.format))
+		})
+	}
+}
+
+// TestEffectiveStalePinnedExactFormats catches observedGeneration lag being
+// presented as current in any full-command output format.
+func TestEffectiveStalePinnedExactFormats(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{format: "table", want: `VIEW     STATE       REASON   RUNTIME                                 REVISION                      HASH       COMPONENT   MODE            MODE-SOURCE   PIN           PIN-STATE   SYNC           STATUS   DRIFT                           LIVE-RELATION   ISSUES
+Live     Available   -        ClusterServingRuntime/cluster-runtime   -                             e0e2b0d6   engine      RawDeployment   Default       ExplicitPin   Resolved    Acknowledged   Stale    ReportedTrue/RevisionMismatch   Equal           StatusStale
+Active   Available   -        ClusterServingRuntime/cluster-runtime   cr-cluster-runtime-e0e2b0d6   e0e2b0d6   engine      RawDeployment   Default       ExplicitPin   Resolved    Acknowledged   Stale    ReportedTrue/RevisionMismatch   Equal           StatusStale
+`},
+		{format: "json", want: `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "RuntimeEffectiveReport",
+  "metadata": {
+    "namespace": "team-a",
+    "name": "service"
+  },
+  "collectedAt": "2026-08-31T19:34:56Z",
+  "sources": [
+    {
+      "kind": "ClusterServingRuntime",
+      "name": "cluster-runtime",
+      "uid": "runtime-uid",
+      "generation": 2,
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    },
+    {
+      "kind": "ControllerRevision",
+      "namespace": "control-plane",
+      "name": "cr-cluster-runtime-e0e2b0d6",
+      "uid": "revision-uid",
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    },
+    {
+      "kind": "InferenceService",
+      "namespace": "team-a",
+      "name": "service",
+      "uid": "isvc-uid",
+      "generation": 4,
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    }
+  ],
+  "content": {
+    "selection": {
+      "source": "Explicit",
+      "runtime": {
+        "apiVersion": "ome.io/v1beta1",
+        "kind": "ClusterServingRuntime",
+        "name": "cluster-runtime",
+        "uid": "runtime-uid",
+        "generation": 2
+      }
+    },
+    "inheritance": {
+      "state": "Observed",
+      "sources": [
+        {
+          "apiVersion": "ome.io/v1beta1",
+          "kind": "ClusterServingRuntime",
+          "name": "cluster-runtime",
+          "uid": "runtime-uid",
+          "generation": 2
+        }
+      ]
+    },
+    "pin": {
+      "mode": "ExplicitPin",
+      "state": "Resolved",
+      "requestedRevision": "cr-cluster-runtime-e0e2b0d6",
+      "reportedRevision": "cr-cluster-runtime-e0e2b0d6",
+      "status": {
+        "generation": 4,
+        "observedGeneration": 3,
+        "freshness": "Stale"
+      },
+      "reportedDrift": {
+        "state": "ReportedTrue",
+        "cause": "RevisionMismatch"
+      },
+      "syncState": "Acknowledged"
+    },
+    "live": {
+      "state": "Available",
+      "origin": "LiveRuntime",
+      "source": {
+        "apiVersion": "ome.io/v1beta1",
+        "kind": "ClusterServingRuntime",
+        "name": "cluster-runtime",
+        "uid": "runtime-uid",
+        "generation": 2
+      },
+      "hash": "e0e2b0d6",
+      "components": [
+        {
+          "type": "engine",
+          "deploymentMode": "RawDeployment",
+          "deploymentModeSource": "Default"
+        }
+      ]
+    },
+    "active": {
+      "state": "Available",
+      "origin": "ControllerRevision",
+      "source": {
+        "apiVersion": "ome.io/v1beta1",
+        "kind": "ClusterServingRuntime",
+        "name": "cluster-runtime",
+        "uid": "runtime-uid",
+        "generation": 2
+      },
+      "revision": {
+        "namespace": "control-plane",
+        "name": "cr-cluster-runtime-e0e2b0d6",
+        "uid": "revision-uid",
+        "createdAt": "2026-08-30T01:02:03Z"
+      },
+      "hash": "e0e2b0d6",
+      "components": [
+        {
+          "type": "engine",
+          "deploymentMode": "RawDeployment",
+          "deploymentModeSource": "Default"
+        }
+      ]
+    },
+    "liveToActive": "Equal",
+    "issues": [
+      {
+        "code": "StatusStale"
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "code": "PartialData"
+    },
+    {
+      "code": "StaleEvidence"
+    }
+  ]
+}
+`},
+		{format: "yaml", want: `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T19:34:56Z"
+content:
+  active:
+    components:
+    - deploymentMode: RawDeployment
+      deploymentModeSource: Default
+      type: engine
+    hash: e0e2b0d6
+    origin: ControllerRevision
+    revision:
+      createdAt: "2026-08-30T01:02:03Z"
+      name: cr-cluster-runtime-e0e2b0d6
+      namespace: control-plane
+      uid: revision-uid
+    source:
+      apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    state: Available
+  inheritance:
+    sources:
+    - apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    state: Observed
+  issues:
+  - code: StatusStale
+  live:
+    components:
+    - deploymentMode: RawDeployment
+      deploymentModeSource: Default
+      type: engine
+    hash: e0e2b0d6
+    origin: LiveRuntime
+    source:
+      apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    state: Available
+  liveToActive: Equal
+  pin:
+    mode: ExplicitPin
+    reportedDrift:
+      cause: RevisionMismatch
+      state: ReportedTrue
+    reportedRevision: cr-cluster-runtime-e0e2b0d6
+    requestedRevision: cr-cluster-runtime-e0e2b0d6
+    state: Resolved
+    status:
+      freshness: Stale
+      generation: 4
+      observedGeneration: 3
+    syncState: Acknowledged
+  selection:
+    runtime:
+      apiVersion: ome.io/v1beta1
+      generation: 2
+      kind: ClusterServingRuntime
+      name: cluster-runtime
+      uid: runtime-uid
+    source: Explicit
+kind: RuntimeEffectiveReport
+metadata:
+  name: service
+  namespace: team-a
+sources:
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  generation: 2
+  kind: ClusterServingRuntime
+  name: cluster-runtime
+  uid: runtime-uid
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  kind: ControllerRevision
+  name: cr-cluster-runtime-e0e2b0d6
+  namespace: control-plane
+  uid: revision-uid
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  generation: 4
+  kind: InferenceService
+  name: service
+  namespace: team-a
+  uid: isvc-uid
+warnings:
+- code: PartialData
+- code: StaleEvidence
+`},
+	}
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			assert.Equal(t, test.want, renderStalePinned(t, test.format))
+		})
+	}
+}
+
+// TestEffectiveNotConfiguredExactFormats catches degraded evidence being
+// escalated to an error or rendered differently across the three formats.
+func TestEffectiveNotConfiguredExactFormats(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{format: "table", want: `VIEW     STATE         REASON          RUNTIME   REVISION   HASH   COMPONENT   MODE   MODE-SOURCE   PIN        PIN-STATE     SYNC     STATUS       DRIFT         LIVE-RELATION   ISSUES
+Live     Unavailable   NotConfigured   -         -          -      -           -      -             AutoSync   Unavailable   Absent   Unobserved   NotReported   Unknown         InheritanceUnavailable,StatusUnobserved
+Active   Unavailable   NotConfigured   -         -          -      -           -      -             AutoSync   Unavailable   Absent   Unobserved   NotReported   Unknown         InheritanceUnavailable,StatusUnobserved
+`},
+		{format: "json", want: `{
+  "apiVersion": "cli.ome.io/v1alpha1",
+  "kind": "RuntimeEffectiveReport",
+  "metadata": {
+    "namespace": "team-a",
+    "name": "service"
+  },
+  "collectedAt": "2026-08-31T19:34:56Z",
+  "sources": [
+    {
+      "kind": "InferenceService",
+      "namespace": "team-a",
+      "name": "service",
+      "uid": "isvc-uid",
+      "evidence": "Observed",
+      "collectedAt": "2026-08-31T19:34:56Z"
+    }
+  ],
+  "content": {
+    "selection": {
+      "source": "Selected"
+    },
+    "inheritance": {
+      "state": "Unavailable",
+      "sources": [],
+      "unavailableReason": "NotConfigured"
+    },
+    "pin": {
+      "mode": "AutoSync",
+      "state": "Unavailable",
+      "status": {
+        "generation": 0,
+        "observedGeneration": 0,
+        "freshness": "Unobserved"
+      },
+      "reportedDrift": {
+        "state": "NotReported"
+      },
+      "syncState": "Absent"
+    },
+    "live": {
+      "state": "Unavailable",
+      "components": [],
+      "unavailableReason": "NotConfigured"
+    },
+    "active": {
+      "state": "Unavailable",
+      "components": [],
+      "unavailableReason": "NotConfigured"
+    },
+    "liveToActive": "Unknown",
+    "issues": [
+      {
+        "code": "InheritanceUnavailable"
+      },
+      {
+        "code": "StatusUnobserved"
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "code": "PartialData"
+    }
+  ]
+}
+`},
+		{format: "yaml", want: `apiVersion: cli.ome.io/v1alpha1
+collectedAt: "2026-08-31T19:34:56Z"
+content:
+  active:
+    components: []
+    state: Unavailable
+    unavailableReason: NotConfigured
+  inheritance:
+    sources: []
+    state: Unavailable
+    unavailableReason: NotConfigured
+  issues:
+  - code: InheritanceUnavailable
+  - code: StatusUnobserved
+  live:
+    components: []
+    state: Unavailable
+    unavailableReason: NotConfigured
+  liveToActive: Unknown
+  pin:
+    mode: AutoSync
+    reportedDrift:
+      state: NotReported
+    state: Unavailable
+    status:
+      freshness: Unobserved
+      generation: 0
+      observedGeneration: 0
+    syncState: Absent
+  selection:
+    source: Selected
+kind: RuntimeEffectiveReport
+metadata:
+  name: service
+  namespace: team-a
+sources:
+- collectedAt: "2026-08-31T19:34:56Z"
+  evidence: Observed
+  kind: InferenceService
+  name: service
+  namespace: team-a
+  uid: isvc-uid
+warnings:
+- code: PartialData
+`},
+	}
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			assert.Equal(t, test.want, renderNotConfigured(t, test.format))
+		})
+	}
+}
+
+// TestEffectiveHealthyPinnedOutputIsDeterministic catches output depending on
+// map insertion or the order of semantically equivalent resolver responses.
+func TestEffectiveHealthyPinnedOutputIsDeterministic(t *testing.T) {
+	for _, format := range []string{"table", "json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			renderCounts := [2]int{}
+			var baseline string
+			for repetition := 0; repetition < 3; repetition++ {
+				forward := renderHealthyPinnedVariant(t, format, false)
+				renderCounts[0]++
+				reversed := renderHealthyPinnedVariant(t, format, true)
+				renderCounts[1]++
+				if repetition == 0 {
+					baseline = forward
+				}
+				assert.Equal(t, baseline, forward,
+					"forward semantic variant repetition %d must be byte-identical", repetition)
+				assert.Equal(t, baseline, reversed,
+					"reversed map insertion and resolver response ordering repetition %d must be byte-identical", repetition)
+			}
+			assert.Equal(t, [2]int{3, 3}, renderCounts,
+				"each semantic variant must be rendered exactly three times")
+		})
+	}
+}
+
+// TestEffectiveHealthyPinnedRedactsPrivateFields catches secret-bearing runtime
+// or revision content crossing the allowlisted report boundary in any format.
+func TestEffectiveHealthyPinnedRedactsPrivateFields(t *testing.T) {
+	canaries := []string{
+		secretImage, secretEnvironment, secretArgument, secretLabel, secretAnnotation,
+		secretRuntimeRV, secretRevisionRV, secretISVCRV, secretSyncToken, secretMessage,
+		secretKeyRefName, secretKeyRefKey, secretVolumeName, secretNodeValue,
+	}
+	for _, format := range []string{"table", "json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			output := renderHealthyPinned(t, format)
+			for _, canary := range canaries {
+				assert.NotContains(t, output, canary)
+			}
+		})
+	}
+}
+
+// TestEffectiveRedactsHostileConditionEnums catches arbitrary condition status
+// and reason strings escaping instead of their bounded classifications.
+func TestEffectiveRedactsHostileConditionEnums(t *testing.T) {
+	const hostileReason = "secret-hostile-reason-enum"
+	const hostileStatus = "secret-hostile-status-enum"
+	for _, format := range []string{"table", "json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			f, _ := healthyPinnedFactory(t)
+			client := f.ome.(*omefake.Clientset)
+			resource := v1beta1.SchemeGroupVersion.WithResource("inferenceservices")
+			object, err := client.Tracker().Get(resource, "team-a", "service")
+			require.NoError(t, err)
+			isvc := object.(*v1beta1.InferenceService).DeepCopy()
+			isvc.Status.Conditions[0].Reason = hostileReason
+			isvc.Status.Conditions[0].Status = corev1.ConditionStatus(hostileStatus)
+			require.NoError(t, client.Tracker().Update(resource, isvc, "team-a"))
+			var out, errOut bytes.Buffer
+			cmd := newEffectiveCmdWithDependencies(f, genericiooptions.IOStreams{
+				In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+			}, fixedEffectiveDependencies())
+			cmd.SetArgs([]string{"service", "--ome-namespace", "control-plane", "--output", format})
+			require.NoError(t, cmd.Execute())
+			assert.Contains(t, out.String(), "ReportedDriftConflict")
+			assert.NotContains(t, out.String(), hostileReason)
+			assert.NotContains(t, out.String(), hostileStatus)
+			assert.Empty(t, errOut.String())
+		})
+	}
+}
+
+// TestEffectiveOptionalFailuresRenderBoundedDiagnostics catches optional API
+// causes leaking to stdout/stderr or incorrectly turning degraded evidence into
+// a command failure.
+func TestEffectiveOptionalFailuresRenderBoundedDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		issue  string
+		canary string
+		mutate func(*acquisitionFactory)
+	}{
+		{
+			name: "exact revision", issue: "RevisionUnavailable", canary: "optional-revision-error-secret",
+			mutate: func(f *acquisitionFactory) {
+				client := k8sfake.NewSimpleClientset()
+				client.PrependReactor("get", "controllerrevisions", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("optional-revision-error-secret")
+				})
+				f.kube = client
+			},
+		},
+		{
+			name: "live runtime", issue: "LiveRuntimeUnavailable", canary: "optional-live-error-secret",
+			mutate: func(f *acquisitionFactory) {
+				f.runtime = erroringRuntimeClient{Client: f.runtime, err: errors.New("optional-live-error-secret")}
+			},
+		},
+	}
+	for _, test := range tests {
+		for _, format := range []string{"table", "json", "yaml"} {
+			t.Run(test.name+"/"+format, func(t *testing.T) {
+				f, _ := healthyPinnedFactory(t)
+				test.mutate(f)
+				var out, errOut bytes.Buffer
+				cmd := newEffectiveCmdWithDependencies(f, genericiooptions.IOStreams{
+					In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut,
+				}, fixedEffectiveDependencies())
+				cmd.SetArgs([]string{"service", "--ome-namespace", "control-plane", "--output", format})
+				require.NoError(t, cmd.Execute())
+				assert.Contains(t, out.String(), test.issue)
+				assert.NotContains(t, out.String(), test.canary)
+				assert.NotContains(t, errOut.String(), test.canary)
+				assert.Empty(t, errOut.String())
+			})
+		}
+	}
+}

--- a/pkg/cli/cmd/runtime/effective_test.go
+++ b/pkg/cli/cmd/runtime/effective_test.go
@@ -1,0 +1,609 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/client/clientset/versioned"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+	ometypedv1beta1 "sigs.k8s.io/ome/pkg/client/clientset/versioned/typed/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+type primaryGetContextObservation struct {
+	deadline    time.Time
+	hasDeadline bool
+	observedAt  time.Time
+}
+
+type deadlineRecordingOMEClient struct {
+	versioned.Interface
+	primaryGETs []primaryGetContextObservation
+}
+
+func (c *deadlineRecordingOMEClient) OmeV1beta1() ometypedv1beta1.OmeV1beta1Interface {
+	return &deadlineRecordingOmeV1beta1{
+		OmeV1beta1Interface: c.Interface.OmeV1beta1(),
+		parent:              c,
+	}
+}
+
+type deadlineRecordingOmeV1beta1 struct {
+	ometypedv1beta1.OmeV1beta1Interface
+	parent *deadlineRecordingOMEClient
+}
+
+func (c *deadlineRecordingOmeV1beta1) InferenceServices(namespace string) ometypedv1beta1.InferenceServiceInterface {
+	return &deadlineRecordingInferenceServices{
+		InferenceServiceInterface: c.OmeV1beta1Interface.InferenceServices(namespace),
+		parent:                    c.parent,
+	}
+}
+
+type deadlineRecordingInferenceServices struct {
+	ometypedv1beta1.InferenceServiceInterface
+	parent *deadlineRecordingOMEClient
+}
+
+func (c *deadlineRecordingInferenceServices) Get(
+	ctx context.Context,
+	name string,
+	options metav1.GetOptions,
+) (*v1beta1.InferenceService, error) {
+	observedAt := time.Now()
+	deadline, hasDeadline := ctx.Deadline()
+	c.parent.primaryGETs = append(c.parent.primaryGETs, primaryGetContextObservation{
+		deadline: deadline, hasDeadline: hasDeadline, observedAt: observedAt,
+	})
+	return c.InferenceServiceInterface.Get(ctx, name, options)
+}
+
+type runtimeClientOperation struct {
+	verb       string
+	objectType string
+	key        ctrlclient.ObjectKey
+}
+
+type recordingRuntimeClient struct {
+	ctrlclient.Client
+	operations []runtimeClientOperation
+}
+
+func (c *recordingRuntimeClient) record(verb string, object any, key ctrlclient.ObjectKey) {
+	c.operations = append(c.operations, runtimeClientOperation{
+		verb: verb, objectType: fmt.Sprintf("%T", object), key: key,
+	})
+}
+
+func (c *recordingRuntimeClient) Get(
+	ctx context.Context,
+	key ctrlclient.ObjectKey,
+	object ctrlclient.Object,
+	options ...ctrlclient.GetOption,
+) error {
+	c.record("get", object, key)
+	return c.Client.Get(ctx, key, object, options...)
+}
+
+func (c *recordingRuntimeClient) List(
+	ctx context.Context,
+	list ctrlclient.ObjectList,
+	options ...ctrlclient.ListOption,
+) error {
+	c.record("list", list, ctrlclient.ObjectKey{})
+	return c.Client.List(ctx, list, options...)
+}
+
+func (c *recordingRuntimeClient) Apply(
+	ctx context.Context,
+	configuration k8sruntime.ApplyConfiguration,
+	options ...ctrlclient.ApplyOption,
+) error {
+	c.record("apply", configuration, ctrlclient.ObjectKey{})
+	return c.Client.Apply(ctx, configuration, options...)
+}
+
+func (c *recordingRuntimeClient) Create(
+	ctx context.Context,
+	object ctrlclient.Object,
+	options ...ctrlclient.CreateOption,
+) error {
+	c.record("create", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.Client.Create(ctx, object, options...)
+}
+
+func (c *recordingRuntimeClient) Delete(
+	ctx context.Context,
+	object ctrlclient.Object,
+	options ...ctrlclient.DeleteOption,
+) error {
+	c.record("delete", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.Client.Delete(ctx, object, options...)
+}
+
+func (c *recordingRuntimeClient) Update(
+	ctx context.Context,
+	object ctrlclient.Object,
+	options ...ctrlclient.UpdateOption,
+) error {
+	c.record("update", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.Client.Update(ctx, object, options...)
+}
+
+func (c *recordingRuntimeClient) Patch(
+	ctx context.Context,
+	object ctrlclient.Object,
+	patch ctrlclient.Patch,
+	options ...ctrlclient.PatchOption,
+) error {
+	c.record("patch", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.Client.Patch(ctx, object, patch, options...)
+}
+
+func (c *recordingRuntimeClient) DeleteAllOf(
+	ctx context.Context,
+	object ctrlclient.Object,
+	options ...ctrlclient.DeleteAllOfOption,
+) error {
+	c.record("delete-all-of", object, ctrlclient.ObjectKey{})
+	return c.Client.DeleteAllOf(ctx, object, options...)
+}
+
+func (c *recordingRuntimeClient) Status() ctrlclient.SubResourceWriter {
+	return &recordingSubResourceWriter{
+		parent: c, name: "status", delegate: c.Client.Status(),
+	}
+}
+
+func (c *recordingRuntimeClient) SubResource(name string) ctrlclient.SubResourceClient {
+	return &recordingSubResourceClient{
+		parent: c, name: name, delegate: c.Client.SubResource(name),
+	}
+}
+
+type recordingSubResourceWriter struct {
+	parent   *recordingRuntimeClient
+	name     string
+	delegate ctrlclient.SubResourceWriter
+}
+
+func (c *recordingSubResourceWriter) Create(
+	ctx context.Context,
+	object ctrlclient.Object,
+	subResource ctrlclient.Object,
+	options ...ctrlclient.SubResourceCreateOption,
+) error {
+	c.parent.record(c.name+"-create", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Create(ctx, object, subResource, options...)
+}
+
+func (c *recordingSubResourceWriter) Update(
+	ctx context.Context,
+	object ctrlclient.Object,
+	options ...ctrlclient.SubResourceUpdateOption,
+) error {
+	c.parent.record(c.name+"-update", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Update(ctx, object, options...)
+}
+
+func (c *recordingSubResourceWriter) Patch(
+	ctx context.Context,
+	object ctrlclient.Object,
+	patch ctrlclient.Patch,
+	options ...ctrlclient.SubResourcePatchOption,
+) error {
+	c.parent.record(c.name+"-patch", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Patch(ctx, object, patch, options...)
+}
+
+type recordingSubResourceClient struct {
+	parent   *recordingRuntimeClient
+	name     string
+	delegate ctrlclient.SubResourceClient
+}
+
+func (c *recordingSubResourceClient) Get(
+	ctx context.Context,
+	object ctrlclient.Object,
+	subResource ctrlclient.Object,
+	options ...ctrlclient.SubResourceGetOption,
+) error {
+	c.parent.record(c.name+"-get", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Get(ctx, object, subResource, options...)
+}
+
+func (c *recordingSubResourceClient) Create(
+	ctx context.Context,
+	object ctrlclient.Object,
+	subResource ctrlclient.Object,
+	options ...ctrlclient.SubResourceCreateOption,
+) error {
+	c.parent.record(c.name+"-create", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Create(ctx, object, subResource, options...)
+}
+
+func (c *recordingSubResourceClient) Update(
+	ctx context.Context,
+	object ctrlclient.Object,
+	options ...ctrlclient.SubResourceUpdateOption,
+) error {
+	c.parent.record(c.name+"-update", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Update(ctx, object, options...)
+}
+
+func (c *recordingSubResourceClient) Patch(
+	ctx context.Context,
+	object ctrlclient.Object,
+	patch ctrlclient.Patch,
+	options ...ctrlclient.SubResourcePatchOption,
+) error {
+	c.parent.record(c.name+"-patch", object, ctrlclient.ObjectKeyFromObject(object))
+	return c.delegate.Patch(ctx, object, patch, options...)
+}
+
+// TestEffectiveCommandContract catches removing the effective command, changing
+// its operator-facing contract, or accidentally adding unsupported local flags.
+func TestEffectiveCommandContract(t *testing.T) {
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	parent := NewCmd(factory.Static{}, streams)
+
+	assert.Equal(t, "Inspect OME runtime selection and configuration", parent.Short)
+	cmd, _, err := parent.Find([]string{"effective"})
+	require.NoError(t, err)
+	require.NotSame(t, parent, cmd)
+	assert.Equal(t, "effective INFERENCESERVICE", cmd.Use)
+	assert.Equal(t, "Show effective runtime evidence for an InferenceService", cmd.Short)
+	assert.Equal(t, `Shows allowlisted runtime selection, inheritance, pin, status, drift,
+and live-versus-controller-active evidence for an InferenceService.
+
+Current only means status.observedGeneration == metadata.generation in the
+fetched snapshot, never wall-clock freshness or rollout convergence. Raw
+runtime specs, ControllerRevision data, status messages, resource versions,
+and synchronization tokens are never printed.`, cmd.Long)
+	assert.Contains(t, cmd.Long, "status.observedGeneration == metadata.generation")
+	assert.Contains(t, cmd.Long, "never wall-clock freshness or rollout convergence")
+	assert.Contains(t, cmd.Long, "Raw\nruntime specs")
+	assert.Contains(t, cmd.Long, "ControllerRevision data")
+	assert.Contains(t, cmd.Long, "synchronization tokens are never printed")
+
+	output := cmd.Flags().Lookup("output")
+	require.NotNil(t, output)
+	assert.Equal(t, "o", output.Shorthand)
+	assert.Equal(t, "table", output.DefValue)
+	assert.Equal(t, "Output format: table, json or yaml", output.Usage)
+	omeNamespace := cmd.Flags().Lookup("ome-namespace")
+	require.NotNil(t, omeNamespace)
+	assert.Equal(t, "ome", omeNamespace.DefValue)
+	assert.Equal(t, "Namespace where the OME control plane is installed", omeNamespace.Usage)
+	assert.Nil(t, cmd.Flags().Lookup("namespace"), "namespace must remain inherited from the root")
+
+	wantLocalFlags := map[string]bool{"ome-namespace": true, "output": true}
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		assert.Truef(t, wantLocalFlags[flag.Name], "unexpected local flag %q", flag.Name)
+		delete(wantLocalFlags, flag.Name)
+	})
+	assert.Empty(t, wantLocalFlags)
+}
+
+// TestEffectiveHelpOutput catches user-visible help drift that field-level
+// metadata assertions cannot see, including flag ordering and defaults.
+func TestEffectiveHelpOutput(t *testing.T) {
+	var out bytes.Buffer
+	parent := NewCmd(factory.Static{}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &out, ErrOut: &out,
+	})
+	parent.SetOut(&out)
+	parent.SetErr(&out)
+	parent.SetArgs([]string{"effective", "--help"})
+	require.NoError(t, parent.Execute())
+	assert.Equal(t, `Shows allowlisted runtime selection, inheritance, pin, status, drift,
+and live-versus-controller-active evidence for an InferenceService.
+
+Current only means status.observedGeneration == metadata.generation in the
+fetched snapshot, never wall-clock freshness or rollout convergence. Raw
+runtime specs, ControllerRevision data, status messages, resource versions,
+and synchronization tokens are never printed.
+
+Usage:
+  runtime effective INFERENCESERVICE [flags]
+
+Flags:
+  -h, --help                   help for effective
+      --ome-namespace string   Namespace where the OME control plane is installed (default "ome")
+  -o, --output string          Output format: table, json or yaml (default "table")
+`, out.String())
+}
+
+// TestEffectiveUsesOnlyBoundedReadRequests catches accidental history LISTs,
+// duplicate exact revision GETs, namespace cross-wiring, write verbs, or an
+// unbounded/excessive primary request timeout.
+func TestEffectiveUsesOnlyBoundedReadRequests(t *testing.T) {
+	tests := []struct {
+		name             string
+		reportedRevision string
+		wantRevisionGETs []string
+	}{
+		{name: "distinct revisions", reportedRevision: "reported-revision", wantRevisionGETs: []string{"requested-revision", "reported-revision"}},
+		{name: "deduplicated revision", reportedRevision: "requested-revision", wantRevisionGETs: []string{"requested-revision"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			autoSync := false
+			kind := runtimeselector.KindClusterServingRuntime
+			requestedRevision := "requested-revision"
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "service", Namespace: "team-a", UID: types.UID("isvc-uid"),
+					ResourceVersion: "17", Generation: 4,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name: "cluster-runtime", Kind: &kind, AutoSync: &autoSync, Revision: &requestedRevision,
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			}
+			isvc.Status.ObservedGeneration = 4
+			isvc.Status.PinnedRevisionName = test.reportedRevision
+			runtimeObject := &v1beta1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-runtime", UID: types.UID("runtime-uid"), ResourceVersion: "23", Generation: 2,
+				},
+				Spec: v1beta1.ServingRuntimeSpec{EngineConfig: &v1beta1.EngineSpec{
+					Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "runner", Image: "private.example/runtime:secret"}},
+				}},
+			}
+			omeFake := omefake.NewSimpleClientset(isvc)
+			ome := &deadlineRecordingOMEClient{Interface: omeFake}
+			kube := k8sfake.NewSimpleClientset()
+			runtimeClient := &recordingRuntimeClient{Client: ctrlfake.NewClientBuilder().
+				WithScheme(scheme(t)).WithObjects(runtimeObject).Build()}
+			f := &acquisitionFactory{
+				ome: ome, kube: kube,
+				runtime:   runtimeClient,
+				namespace: "team-a",
+			}
+			var out, errOut bytes.Buffer
+			cmd := NewCmd(f, genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut})
+			cmd.SetArgs([]string{"effective", "service", "--ome-namespace", "control-plane"})
+
+			err := cmd.Execute()
+
+			require.NoError(t, err)
+			require.Len(t, omeFake.Actions(), 1)
+			assert.Equal(t, "get", omeFake.Actions()[0].GetVerb())
+			assert.Equal(t, "inferenceservices", omeFake.Actions()[0].GetResource().Resource)
+			assert.Equal(t, "team-a", omeFake.Actions()[0].GetNamespace())
+			primaryGET, ok := omeFake.Actions()[0].(k8stesting.GetAction)
+			require.True(t, ok)
+			assert.Equal(t, "service", primaryGET.GetName())
+			require.Len(t, ome.primaryGETs, 1)
+			primaryContext := ome.primaryGETs[0]
+			require.True(t, primaryContext.hasDeadline, "primary GET must carry a deadline")
+			assert.WithinDuration(t,
+				primaryContext.observedAt.Add(10*time.Second), primaryContext.deadline, 100*time.Millisecond,
+				"primary GET deadline must use the production 10-second request limit",
+			)
+
+			var revisionGETs []string
+			for _, action := range kube.Actions() {
+				assert.Equal(t, "get", action.GetVerb(), "effective must not list revision history")
+				assert.Equal(t, "controllerrevisions", action.GetResource().Resource)
+				assert.Equal(t, "control-plane", action.GetNamespace())
+				get, ok := action.(k8stesting.GetAction)
+				require.True(t, ok)
+				revisionGETs = append(revisionGETs, get.GetName())
+			}
+			assert.Equal(t, test.wantRevisionGETs, revisionGETs)
+			assert.Equal(t, []runtimeClientOperation{
+				{
+					verb: "get", objectType: "*v1beta1.ClusterServingRuntime",
+					key: ctrlclient.ObjectKey{Name: "cluster-runtime"},
+				},
+				{
+					verb: "get", objectType: "*v1beta1.ClusterServingRuntime",
+					key: ctrlclient.ObjectKey{Name: "cluster-runtime"},
+				},
+				{
+					verb: "get", objectType: "*v1beta1.ClusterServingRuntime",
+					key: ctrlclient.ObjectKey{Name: "cluster-runtime"},
+				},
+			}, runtimeClient.operations)
+			assert.NotContains(t, out.String(), "private.example/runtime:secret")
+			assert.Contains(t, out.String(), "RevisionMissing")
+			assert.Empty(t, errOut.String())
+		})
+	}
+}
+
+// TestEffectiveRejectsUnboundPrimarySnapshots catches trusting a nil or
+// identity-incomplete server response and constructing later clients from it.
+func TestEffectiveRejectsUnboundPrimarySnapshots(t *testing.T) {
+	valid := func() *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+			Name: "service", Namespace: "team-a", UID: types.UID("isvc-uid"), ResourceVersion: "17",
+		}}
+	}
+	tests := []struct {
+		name string
+		got  func() *v1beta1.InferenceService
+		want error
+	}{
+		{name: "nil response", got: func() *v1beta1.InferenceService { return nil }, want: errNilInferenceService},
+		{name: "wrong name", got: func() *v1beta1.InferenceService { v := valid(); v.Name = "hostile-returned-name"; return v }, want: errInferenceServiceNameMismatch},
+		{name: "wrong namespace", got: func() *v1beta1.InferenceService { v := valid(); v.Namespace = "hostile-returned-namespace"; return v }, want: errInferenceServiceNamespaceMismatch},
+		{name: "empty UID", got: func() *v1beta1.InferenceService { v := valid(); v.UID = ""; return v }, want: errInferenceServiceUIDEmpty},
+		{name: "empty resource version", got: func() *v1beta1.InferenceService { v := valid(); v.ResourceVersion = ""; return v }, want: errInferenceServiceVersionEmpty},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ome := omefake.NewSimpleClientset()
+			ome.PrependReactor("get", "inferenceservices", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+				return true, test.got(), nil
+			})
+			f := &acquisitionFactory{
+				ome: ome, kube: k8sfake.NewSimpleClientset(),
+				runtime: ctrlfake.NewClientBuilder().WithScheme(scheme(t)).Build(), namespace: "team-a",
+			}
+			var out, errOut bytes.Buffer
+			cmd := NewCmd(f, genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut})
+			cmd.SetArgs([]string{"effective", "service"})
+
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+			assert.NotContains(t, err.Error(), "hostile-returned")
+			assert.Zero(t, f.kubeGet)
+			assert.Zero(t, f.runtimeGet)
+			assert.Empty(t, out.String())
+			assert.Empty(t, errOut.String())
+		})
+	}
+}
+
+type acquisitionFactory struct {
+	ome          versioned.Interface
+	kube         kubernetes.Interface
+	runtime      ctrlclient.Client
+	namespace    string
+	namespaceGet int
+	omeGet       int
+	kubeGet      int
+	runtimeGet   int
+}
+
+func (*acquisitionFactory) RESTConfig() (*rest.Config, error) { panic("unexpected RESTConfig call") }
+func (f *acquisitionFactory) KubeClient() (kubernetes.Interface, error) {
+	f.kubeGet++
+	return f.kube, nil
+}
+func (f *acquisitionFactory) OMEClient() (versioned.Interface, error) {
+	f.omeGet++
+	return f.ome, nil
+}
+func (f *acquisitionFactory) RuntimeClient() (ctrlclient.Client, error) {
+	f.runtimeGet++
+	return f.runtime, nil
+}
+func (f *acquisitionFactory) Namespace() (string, bool, error) {
+	f.namespaceGet++
+	return f.namespace, false, nil
+}
+
+// TestEffectiveAcquiresBoundSnapshotBeforeOptionalEvidence catches namespace
+// cross-wiring, duplicate primary GETs, and construction of later clients
+// before the primary snapshot has been acquired and bound.
+func TestEffectiveAcquiresBoundSnapshotBeforeOptionalEvidence(t *testing.T) {
+	isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "service", Namespace: "team-a", UID: types.UID("isvc-uid"), ResourceVersion: "17",
+	}}
+	ome := omefake.NewSimpleClientset(isvc)
+	kube := k8sfake.NewSimpleClientset()
+	f := &acquisitionFactory{
+		ome:       ome,
+		kube:      kube,
+		runtime:   ctrlfake.NewClientBuilder().WithScheme(scheme(t)).Build(),
+		namespace: "team-a",
+	}
+	var out, errOut bytes.Buffer
+	cmd := NewCmd(f, genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut})
+	cmd.SetArgs([]string{"effective", "service", "--ome-namespace", "control-plane"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, f.namespaceGet)
+	assert.Equal(t, 1, f.omeGet)
+	assert.Equal(t, 1, f.kubeGet)
+	assert.Equal(t, 1, f.runtimeGet)
+	require.Len(t, ome.Actions(), 1)
+	assert.Equal(t, "get", ome.Actions()[0].GetVerb())
+	assert.Equal(t, "inferenceservices", ome.Actions()[0].GetResource().Resource)
+	assert.Equal(t, "team-a", ome.Actions()[0].GetNamespace())
+	primaryGET, ok := ome.Actions()[0].(k8stesting.GetAction)
+	require.True(t, ok)
+	assert.Equal(t, "service", primaryGET.GetName())
+	assert.Empty(t, kube.Actions(), "no revision is named and history is disabled")
+	assert.Contains(t, out.String(), "VIEW")
+	assert.Contains(t, out.String(), "NotConfigured")
+	assert.Empty(t, errOut.String())
+}
+
+type validationFactory struct {
+	namespaceCalls int
+	namespace      string
+}
+
+func (*validationFactory) RESTConfig() (*rest.Config, error) { panic("unexpected RESTConfig call") }
+func (*validationFactory) KubeClient() (kubernetes.Interface, error) {
+	panic("unexpected KubeClient call")
+}
+func (*validationFactory) OMEClient() (versioned.Interface, error) {
+	panic("unexpected OMEClient call")
+}
+func (*validationFactory) RuntimeClient() (ctrlclient.Client, error) {
+	panic("unexpected RuntimeClient call")
+}
+func (f *validationFactory) Namespace() (string, bool, error) {
+	f.namespaceCalls++
+	return f.namespace, false, nil
+}
+
+// TestEffectiveValidationPrecedesAcquisition catches validation moving after
+// namespace resolution or client construction, which could issue API calls for
+// an invocation that is already known to be invalid.
+func TestEffectiveValidationPrecedesAcquisition(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		workloadNamespace  string
+		wantError          string
+		wantNamespaceCalls int
+	}{
+		{name: "zero arguments", wantError: "accepts 1 arg(s)"},
+		{name: "two arguments", args: []string{"one", "two"}, wantError: "accepts 1 arg(s)"},
+		{name: "invalid service name", args: []string{"Bad_Name"}, wantError: "InferenceService name", wantNamespaceCalls: 0},
+		{name: "invalid output", args: []string{"service", "--output", "xml"}, wantError: "unsupported output format", wantNamespaceCalls: 0},
+		{name: "invalid output before invalid service name", args: []string{"Bad_Name", "--output", "xml"}, wantError: "unsupported output format", wantNamespaceCalls: 0},
+		{name: "invalid workload namespace", args: []string{"service"}, workloadNamespace: "Bad_NS", wantError: "workload namespace", wantNamespaceCalls: 1},
+		{name: "invalid OME namespace", args: []string{"service", "--ome-namespace", "Bad_NS"}, workloadNamespace: "team-a", wantError: "OME namespace", wantNamespaceCalls: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := &validationFactory{namespace: test.workloadNamespace}
+			var out, errOut bytes.Buffer
+			cmd := NewCmd(f, genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &errOut})
+			cmd.SetArgs(append([]string{"effective"}, test.args...))
+
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.Truef(t, strings.Contains(err.Error(), test.wantError), "error %q does not contain %q", err, test.wantError)
+			assert.Equal(t, test.wantNamespaceCalls, f.namespaceCalls)
+			assert.Empty(t, out.String())
+			assert.Empty(t, errOut.String())
+		})
+	}
+}

--- a/pkg/cli/cmd/runtime/evidence.go
+++ b/pkg/cli/cmd/runtime/evidence.go
@@ -1,0 +1,106 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/apierror"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/namespace"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+)
+
+var (
+	errNilInferenceService               = errors.New("InferenceService GET returned no object")
+	errInferenceServiceNameMismatch      = errors.New("InferenceService GET returned a different name")
+	errInferenceServiceNamespaceMismatch = errors.New("InferenceService GET returned a different namespace")
+	errInferenceServiceUIDEmpty          = errors.New("InferenceService GET returned an empty UID")
+	errInferenceServiceVersionEmpty      = errors.New("InferenceService GET returned an empty resourceVersion")
+)
+
+type runtimeEvidenceOptions struct {
+	IncludeHistory bool
+}
+
+type runtimeEvidence struct {
+	inferenceService *v1beta1.InferenceService
+	state            *effective.RuntimeState
+}
+
+func collectRuntimeEvidence(
+	ctx context.Context,
+	f factory.Factory,
+	namespaceOptions *namespace.Options,
+	name string,
+	limits paging.Limits,
+	options runtimeEvidenceOptions,
+) (*runtimeEvidence, error) {
+	workloadNamespace, _, err := f.Namespace()
+	if err != nil {
+		return nil, fmt.Errorf("resolve workload namespace: %w", err)
+	}
+	resolved, err := namespaceOptions.Resolve(workloadNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	omeClient, err := f.OMEClient()
+	if err != nil {
+		return nil, fmt.Errorf("construct OME client: %w", err)
+	}
+	requestContext, cancel := context.WithTimeout(ctx, limits.RequestTimeout)
+	isvc, err := omeClient.OmeV1beta1().InferenceServices(resolved.WorkloadNamespace).
+		Get(requestContext, name, metav1.GetOptions{})
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("get InferenceService: %w", apierror.Friendly(err))
+	}
+	if err := bindInferenceService(isvc, resolved.WorkloadNamespace, name); err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := f.KubeClient()
+	if err != nil {
+		return nil, fmt.Errorf("construct Kubernetes client: %w", err)
+	}
+	runtimeClient, err := f.RuntimeClient()
+	if err != nil {
+		return nil, fmt.Errorf("construct runtime client: %w", err)
+	}
+	liveResolver := effective.NewRuntimeResolver(runtimeClient)
+	pinResolver, err := effective.NewRuntimePinResolver(
+		kubeClient.AppsV1(), liveResolver, resolved.OMENamespace, limits,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("construct runtime evidence resolver: %w", err)
+	}
+	state, err := pinResolver.Resolve(ctx, isvc, effective.RuntimeResolveOptions{
+		IncludeHistory: options.IncludeHistory,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect runtime evidence: %w", err)
+	}
+	return &runtimeEvidence{inferenceService: isvc, state: state}, nil
+}
+
+func bindInferenceService(isvc *v1beta1.InferenceService, wantNamespace, name string) error {
+	switch {
+	case isvc == nil:
+		return errNilInferenceService
+	case isvc.Name != name:
+		return errInferenceServiceNameMismatch
+	case isvc.Namespace != wantNamespace:
+		return errInferenceServiceNamespaceMismatch
+	case isvc.UID == "":
+		return errInferenceServiceUIDEmpty
+	case isvc.ResourceVersion == "":
+		return errInferenceServiceVersionEmpty
+	default:
+		return nil
+	}
+}

--- a/pkg/cli/cmd/runtime/runtime.go
+++ b/pkg/cli/cmd/runtime/runtime.go
@@ -11,8 +11,9 @@ import (
 func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "runtime",
-		Short: "Inspect OME runtime selection",
+		Short: "Inspect OME runtime selection and configuration",
 	}
 	cmd.AddCommand(newExplainCmd(f, streams))
+	cmd.AddCommand(newEffectiveCmd(f, streams))
 	return cmd
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -29,6 +29,7 @@ func TestRootCommandTree(t *testing.T) {
 		"ome get",
 		"ome logs",
 		"ome runtime",
+		"ome runtime effective",
 		"ome runtime explain",
 		"ome status",
 		"ome version",
@@ -38,6 +39,13 @@ func TestRootCommandTree(t *testing.T) {
 	}
 	if !root.SilenceErrors || !root.SilenceUsage {
 		t.Fatalf("root error policy = (SilenceErrors=%t, SilenceUsage=%t), want both true", root.SilenceErrors, root.SilenceUsage)
+	}
+	explain, _, err := root.Find([]string{"runtime", "explain"})
+	if err != nil {
+		t.Fatalf("find runtime explain: %v", err)
+	}
+	if explain.Use != "explain (--model NAME | --isvc NAME)" || explain.Short != "Explain which serving runtimes match a model and why" {
+		t.Fatalf("runtime explain contract changed: Use=%q Short=%q", explain.Use, explain.Short)
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Adds `kubectl ome runtime effective INFERENCESERVICE` as the first CLI
consumer of the runtime evidence, projection, and report stack. The command
shows allowlisted selection, inheritance, pin, status, drift, and
live-versus-controller-active evidence in table, JSON, or YAML form.

The command performs one primary InferenceService GET under a 10-second
deadline and binds the returned identity, UID, and resource version before
constructing later clients. It then collects only bounded optional evidence:
live runtime reads and deduplicated exact requested/reported
ControllerRevision GETs. `IncludeHistory` is false, so this command performs
no history LIST. A reusable command-local acquisition seam is included for a
later `runtime history` change, but no history command is implemented or
registered here.

Optional missing, disabled, stale, unobserved, or unreadable evidence becomes
a bounded typed diagnostic and exits successfully. Required acquisition,
validation, projection, serialization, and writer failures remain errors with
their causes preserved.

`Current` has the deliberately narrow snapshot meaning
`status.observedGeneration == metadata.generation`; it does not claim
wall-clock freshness or rollout convergence. Output passes only the typed,
allowlisted projection to the renderer, excluding raw runtime specs,
ControllerRevision payloads, status messages, labels, annotations, resource
versions, synchronization tokens, image/env/argument data, secret references,
and raw optional errors.

The change is scoped to seven files under `pkg/cli/**`: command registration,
the effective command and acquisition seam, focused command/render/error
tests, and the root command-tree assertion. It does not change factory
interfaces, dependencies, lower-layer report/projection APIs, or `runtime
explain` behavior.

**Exact command-local help**

Command: `kubectl ome runtime effective --help`

```text
Shows allowlisted runtime selection, inheritance, pin, status, drift,
and live-versus-controller-active evidence for an InferenceService.

Current only means status.observedGeneration == metadata.generation in the
fetched snapshot, never wall-clock freshness or rollout convergence. Raw
runtime specs, ControllerRevision data, status messages, resource versions,
and synchronization tokens are never printed.

Usage:
  runtime effective INFERENCESERVICE [flags]

Flags:
  -h, --help                   help for effective
      --ome-namespace string   Namespace where the OME control plane is installed (default "ome")
  -o, --output string          Output format: table, json or yaml (default "table")
```

**Representative table stdout: healthy pinned/drifted fixture**

```text
VIEW     STATE       REASON   RUNTIME                                 REVISION                      HASH       COMPONENT   MODE            MODE-SOURCE   PIN           PIN-STATE   SYNC           STATUS    DRIFT                           LIVE-RELATION   ISSUES
Live     Available   -        ClusterServingRuntime/cluster-runtime   -                             e0e2b0d6   engine      RawDeployment   Default       ExplicitPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Equal           -
Active   Available   -        ClusterServingRuntime/cluster-runtime   cr-cluster-runtime-e0e2b0d6   e0e2b0d6   engine      RawDeployment   Default       ExplicitPin   Resolved    Acknowledged   Current   ReportedTrue/RevisionMismatch   Equal           -
```

**Representative JSON stdout: not-configured degraded fixture**

```json
{
  "apiVersion": "cli.ome.io/v1alpha1",
  "kind": "RuntimeEffectiveReport",
  "metadata": {
    "namespace": "team-a",
    "name": "service"
  },
  "collectedAt": "2026-08-31T19:34:56Z",
  "sources": [
    {
      "kind": "InferenceService",
      "namespace": "team-a",
      "name": "service",
      "uid": "isvc-uid",
      "evidence": "Observed",
      "collectedAt": "2026-08-31T19:34:56Z"
    }
  ],
  "content": {
    "selection": {
      "source": "Selected"
    },
    "inheritance": {
      "state": "Unavailable",
      "sources": [],
      "unavailableReason": "NotConfigured"
    },
    "pin": {
      "mode": "AutoSync",
      "state": "Unavailable",
      "status": {
        "generation": 0,
        "observedGeneration": 0,
        "freshness": "Unobserved"
      },
      "reportedDrift": {
        "state": "NotReported"
      },
      "syncState": "Absent"
    },
    "live": {
      "state": "Unavailable",
      "components": [],
      "unavailableReason": "NotConfigured"
    },
    "active": {
      "state": "Unavailable",
      "components": [],
      "unavailableReason": "NotConfigured"
    },
    "liveToActive": "Unknown",
    "issues": [
      {
        "code": "InheritanceUnavailable"
      },
      {
        "code": "StatusUnobserved"
      }
    ]
  },
  "warnings": [
    {
      "code": "PartialData"
    }
  ]
}
```

**Representative YAML stdout: not-configured degraded fixture**

```yaml
apiVersion: cli.ome.io/v1alpha1
collectedAt: "2026-08-31T19:34:56Z"
content:
  active:
    components: []
    state: Unavailable
    unavailableReason: NotConfigured
  inheritance:
    sources: []
    state: Unavailable
    unavailableReason: NotConfigured
  issues:
  - code: InheritanceUnavailable
  - code: StatusUnobserved
  live:
    components: []
    state: Unavailable
    unavailableReason: NotConfigured
  liveToActive: Unknown
  pin:
    mode: AutoSync
    reportedDrift:
      state: NotReported
    state: Unavailable
    status:
      freshness: Unobserved
      generation: 0
      observedGeneration: 0
    syncState: Absent
  selection:
    source: Selected
kind: RuntimeEffectiveReport
metadata:
  name: service
  namespace: team-a
sources:
- collectedAt: "2026-08-31T19:34:56Z"
  evidence: Observed
  kind: InferenceService
  name: service
  namespace: team-a
  uid: isvc-uid
warnings:
- code: PartialData
```

## Why we need it

Operators need a deterministic, safe view of the runtime configuration that
OME selected and the revision the controller is actively reporting. Existing
low-level evidence and report packages had no production CLI consumer, so
diagnosing pinning, drift, inheritance, or stale status required inspecting
raw resources that can contain sensitive or noisy implementation details.

This command exposes the bounded facts needed for diagnosis while making
partial evidence explicit and preserving a strict redaction boundary.

Fixes: N/A

## How to test

Fresh integrator verification at final commit `eac7ec7a`:

- `go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1` passed the full scoped
  CLI and kubectl-ome command suites.

- `go test -race ./pkg/cli/... ./cmd/kubectl-ome/... -count=1` passed the full
  scoped CLI and kubectl-ome command suites with no race reports.

- `go vet ./pkg/cli/... ./cmd/...` passed with no output.

- `go test ./pkg/cli/cmd/runtime -coverprofile=... -count=1` reported 89.1%
  statement coverage; every new production function in `effective.go` and
  `evidence.go` is covered at 100%.

- The host `./cmd/kubectl-ome` build passed.

- Six `CGO_ENABLED=0` cross-builds passed: Darwin, Linux, and Windows on both
  `amd64` and `arm64`.

- `gofmt`, diff hygiene, and final scope checks were clean. The commit changes
  only the seven expected files under `pkg/cli/**`.

Focused tests also pin exact help and table/JSON/YAML bytes, validation and
request ordering, one primary GET, the 10-second primary deadline, exact-read
deduplication with zero history LISTs, optional degraded evidence, cause
preservation, deterministic rendering, redaction, and writer failures.

## Checklist

- [x] Tests added/updated (if applicable)

- [x] Docs updated (if applicable): command-local help documents freshness and
  redaction semantics; no separate documentation change is in scope.

- [ ] `make test` passes locally (not run; the scoped normal/race suites, vet,
  coverage, host build, and six cross-builds passed as listed above)
