### PR TITLE
ci: add express mode to dev-images and publish ome-scheduler

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -5,6 +5,16 @@ name: Dev Images
 # images are unaffected (release.yaml builds on tags).
 on:
   workflow_dispatch:
+    inputs:
+      express:
+        description: 'amd64-only fast build (skips the QEMU-emulated arm64 half; does not move the floating :dev tag)'
+        type: boolean
+        default: false
+
+# An express run never queues behind (or cancels) a comprehensive build.
+concurrency:
+  group: dev-images-${{ inputs.express && 'express' || 'full' }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -33,6 +43,9 @@ jobs:
           - name: ome-agent
             dockerfile: dockerfiles/ome-agent.Dockerfile
             image: ome-agent
+          - name: ome-scheduler
+            dockerfile: dockerfiles/ome-scheduler.Dockerfile
+            image: ome-scheduler
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -44,6 +57,7 @@ jobs:
           cache: true
 
       - name: Set up QEMU
+        if: ${{ !inputs.express }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -68,6 +82,18 @@ jobs:
           DEV_VERSION="dev-${TIMESTAMP}-${SHORT_SHA}"
           echo "version=${DEV_VERSION}" >> $GITHUB_OUTPUT
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}"
+          if [ "${{ inputs.express }}" = "true" ]; then
+            # Express pins only the SHA tag; :dev stays multi-arch.
+            echo "tags=${IMAGE}:dev-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          else
+            {
+              echo "tags<<EOF"
+              echo "${IMAGE}:dev"
+              echo "${IMAGE}:dev-${SHORT_SHA}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          fi
           echo "📦 Building dev version: ${DEV_VERSION}"
 
       - name: Build and push ${{ matrix.component.name }}
@@ -76,11 +102,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.component.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.express && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}:dev
-            ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}:dev-${{ steps.version.outputs.short_sha }}
+          tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha,scope=${{ matrix.component.image }}
           cache-to: type=gha,scope=${{ matrix.component.image }},mode=max,ignore-error=true
           build-args: |


### PR DESCRIPTION
## What this PR does

Adds an `express` boolean input to the `dev-images` dispatch (amd64-only build: skips the QEMU-emulated arm64 half, pins only the `dev-<sha>` tag so the floating `:dev` stays multi-arch, and runs in its own concurrency lane so it never queues behind a comprehensive build). Also adds `ome-scheduler` to the build matrix, giving it its first publish path.

## Why we need it

A full dev-images run takes 70+ minutes, almost entirely in the QEMU arm64 legs (measured on run [33477254399](https://github.com/ome-projects/ome/actions/runs/33477254399)) — far too slow for iterate-on-main workflows. The pattern is lifted from smg's nightly express lane, which builds in ~15 minutes. The scheduler half: `charts/ome-scheduler` shipped without any image pipeline, so the chart's default `ome-scheduler:latest` is unpullable.

Fixes #830

## How to test

Dispatch `dev-images.yaml` with `express=true`: expect amd64-only manifests, only `dev-<sha>` tags moved, and an `ome-scheduler` package created. Dispatch with defaults: behavior identical to today plus the scheduler leg. Workflow-only change — `make test` unaffected.

## Checklist

- [ ] Tests added/updated (if applicable) — N/A (workflow-only)
- [ ] Docs updated (if applicable) — N/A
- [x] `make test` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fast, amd64-only development image builds.
  - Express builds publish a commit-specific image without changing the floating development image.
  - Added development image support for the scheduler component.

- **Improvements**
  - Full development image builds continue to support both amd64 and arm64 platforms.
  - Separate build handling helps fast builds run independently from full builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->