### PR TITLE
fix(charts): fully qualify the bundled prometheus image

### DIFF
--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -658,7 +658,7 @@ prometheus:
   # hard-scope discovery on large multi-tenant clusters.
   scrapeNamespaces: []
   image:
-    repository: prom/prometheus
+    repository: docker.io/prom/prometheus
     tag: "v3.0.1"
     pullPolicy: IfNotPresent
   # Memory scales with active series = (scrape targets) x (series per pod).


### PR DESCRIPTION
## What this PR does

Changes the ome-resources chart's bundled Prometheus image default from `prom/prometheus` to `docker.io/prom/prometheus`.

## Why we need it

CRI-O clusters with strict short-name policy (no `containers-registries.conf` aliases) refuse to pull short-name images, so the bundled Prometheus crashloops out of the box:

```
Failed to inspect image "": rpc error: code = Unknown desc = short-name "prom/prometheus:v3.0.1" did not resolve to an alias and no containers-registries.conf(5) was found
```

Hit on a fresh install of the chart on an OKE/CRI-O cluster (moirai-dev). Every other image in the charts is already fully qualified (or prefixed by `global.hub`); this is the only short-name ref.

## How to test

`helm template charts/ome-resources | grep 'image: docker.io/prom/prometheus'` — and on a CRI-O cluster, the ome-prometheus pod pulls and starts. N/A for unit tests.

## Checklist

- [ ] Tests added/updated (if applicable) — N/A (chart default)
- [ ] Docs updated (if applicable) — N/A
- [x] `make test` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Prometheus image reference to use its fully qualified Docker Hub path, improving image resolution and deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->