### PR TITLE
[Helm] ome-resources: extra env/volumes on controller

### DIFF
--- a/charts/ome-resources/templates/ome-controller/deployment.yaml
+++ b/charts/ome-resources/templates/ome-controller/deployment.yaml
@@ -100,6 +100,9 @@ spec:
                 fieldPath: metadata.namespace
           - name: SECRET_NAME
             value: ome-webhook-server-cert
+          {{- with .Values.ome.controller.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         livenessProbe:
           failureThreshold: 5
           initialDelaySeconds: 10
@@ -130,9 +133,15 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- with .Values.ome.controller.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
         secret:
           defaultMode: 420
           secretName: ome-webhook-server-cert
+      {{- with .Values.ome.controller.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -115,6 +115,12 @@ ome:
     memoryLimit: "2Gi"
 
   controller:
+    # Extension points for injecting deployment-specific configuration into the
+    # controller pod (mirrors the modelAgent extension points). All default to
+    # empty, so the rendered output is unchanged when unset.
+    extraEnv: []
+    extraVolumes: []
+    extraVolumeMounts: []
     replicaCount: 3
     # Additional annotations applied to the controller pod template.
     # Merged after the chart's default annotations (prometheus.io/scrape, etc.).


### PR DESCRIPTION
## What this PR does

Adds `ome.controller.extraEnv`, `ome.controller.extraVolumes`, and
`ome.controller.extraVolumeMounts` extension points to the `ome-resources`
controller Deployment, mirroring the extension points that already exist for
`modelAgent`.

## Why we need it

The controller Deployment had no extension points, so an operator cannot inject
deployment-specific environment variables, volumes, or mounts (e.g. an
environment-specific credential/trust-store sidecar or host mount) without
forking the chart. This adds a supported, generic way to express that.

## How to test

- `helm template` with defaults → volumes `[cert]`, env `[POD_NAMESPACE,
  SECRET_NAME]`; output is byte-identical to before (all three fields default to
  `[]`).
- `helm template` with the three fields set → the extra env vars, volumes, and
  mounts render into the controller pod spec at the expected indentation.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm configuration options for supplying additional controller environment variables, volume mounts, and volumes.
  * These options default to empty lists and can be customized during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->