### PR TITLE
[Helm] policy webhooks, config parity, CRD gating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,18 @@ manifests: controller-gen yq ## 📄 Generate WebhookConfiguration, ClusterRole 
 
 	@echo "\n📁 Step 6: Copying manifests to Helm charts..."
 	@cp config/crd/full/ome* charts/ome-crd/templates/ && cp config/rbac/role.yaml charts/ome-resources/templates/ome-controller/rbac/role.yaml
+	@# The policy CRD templates are Helm-gated (each feature installs
+	@# CRD + controller + webhook together); the raw copy above drops the
+	@# wrapper, so re-wrap after every copy. The ome-crd render test fails
+	@# loudly if this ever regresses.
+	@f=charts/ome-crd/templates/ome.io_autoscalerpolicies.yaml; \
+	if ! head -1 $$f | grep -q 'autoscalerPolicy.enabled'; then \
+		{ echo '{{- if .Values.ome.autoscalerPolicy.enabled }}'; cat $$f; echo '{{- end }}'; } > $$f.tmp && mv $$f.tmp $$f; \
+	fi
+	@f=charts/ome-crd/templates/ome.io_rolloutpolicies.yaml; \
+	if ! head -1 $$f | grep -q 'rolloutPolicy.enabled'; then \
+		{ echo '{{- if .Values.ome.rolloutPolicy.enabled }}'; cat $$f; echo '{{- end }}'; } > $$f.tmp && mv $$f.tmp $$f; \
+	fi
 	@echo "✅ Manifests copied to Helm charts"
 
 	@echo "\n🎉 Manifest generation completed successfully!\n"
@@ -280,6 +292,14 @@ helm-lint: helm ## ⎈ Lint all charts
 	    exit 1; \
 	  fi \
 	done
+	@echo "🧪 Testing ome-crd chart contracts..."
+	@HELM_BIN="$(HELM)" bash $(CHARTS_DIR)/ome-crd/tests/render_test.sh
+	@echo "🧪 Testing ome-scheduler chart contracts..."
+	@HELM_BIN="$(HELM)" bash $(CHARTS_DIR)/ome-scheduler/tests/render_test.sh
+	@echo "🧪 Testing ome-resources chart contracts..."
+	@HELM_BIN="$(HELM)" bash $(CHARTS_DIR)/ome-resources/tests/render_test.sh
+	@echo "🧪 Testing ome-quota-manager chart contracts..."
+	@HELM_BIN="$(HELM)" bash $(CHARTS_DIR)/ome-quota-manager/tests/render_test.sh
 	@echo "✅ Helm lint complete"
 
 .PHONY: helm-doc

--- a/charts/ome-crd/templates/_helpers.tpl
+++ b/charts/ome-crd/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/*
+Chart name and version, suitable for use as a Kubernetes label value.
+*/}}
+{{- define "ome-crd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Standard Helm chart provenance labels.
+*/}}
+{{- define "ome-crd.labels" -}}
+helm.sh/chart: {{ include "ome-crd.chart" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ome
+{{- end -}}

--- a/charts/ome-crd/templates/ome.io_autoscalerpolicies.yaml
+++ b/charts/ome-crd/templates/ome.io_autoscalerpolicies.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ome.autoscalerPolicy.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -625,3 +626,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/ome-crd/templates/ome.io_rolloutpolicies.yaml
+++ b/charts/ome-crd/templates/ome.io_rolloutpolicies.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ome.rolloutPolicy.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -230,3 +231,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/ome-crd/templates/release-info.yaml
+++ b/charts/ome-crd/templates/release-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ome-crd-release
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-crd.labels" . | nindent 4 }}
+data:
+  chart-version: {{ .Chart.Version | quote }}
+  app-version: {{ .Chart.AppVersion | quote }}

--- a/charts/ome-crd/tests/render_test.sh
+++ b/charts/ome-crd/tests/render_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helm_bin="${HELM_BIN:-helm}"
+
+fail() {
+  echo "ome-crd chart test: $*" >&2
+  exit 1
+}
+
+"${helm_bin}" lint --strict "${chart_dir}" >/dev/null
+rendered="$("${helm_bin}" template ome-crd "${chart_dir}" --namespace ome)"
+
+grep -Fq 'helm.sh/chart: ome-crd-0.1.0' <<<"${rendered}" ||
+  fail "release marker chart version label was not rendered"
+grep -Fq 'name: ome-crd-release' <<<"${rendered}" ||
+  fail "release marker ConfigMap was not rendered"
+grep -Fq 'chart-version: "0.1.0"' <<<"${rendered}" ||
+  fail "release marker chart version was not rendered"
+grep -Fq 'app-version: "1.16.0"' <<<"${rendered}" ||
+  fail "release marker app version was not rendered"
+
+# The AutoscalerPolicy CRD installs only with the feature gate, so a cluster
+# never carries the CRD without the controller + webhook the ome-resources
+# chart gates on the same value.
+if grep -Fq 'name: autoscalerpolicies.ome.io' <<<"${rendered}"; then
+  fail "AutoscalerPolicy CRD was rendered with the feature gate off"
+fi
+
+autoscaler_enabled="$("${helm_bin}" template ome-crd "${chart_dir}" \
+  --namespace ome \
+  --set ome.autoscalerPolicy.enabled=true)"
+grep -Fq 'name: autoscalerpolicies.ome.io' <<<"${autoscaler_enabled}" ||
+  fail "AutoscalerPolicy CRD was not rendered with the feature gate on"
+
+# The RolloutPolicy CRD installs only with the feature gate, so a cluster
+# never carries the CRD without the webhook the ome-resources chart gates on
+# the same value.
+if grep -Fq 'name: rolloutpolicies.ome.io' <<<"${rendered}"; then
+  fail "RolloutPolicy CRD was rendered with the feature gate off"
+fi
+
+rollout_enabled="$("${helm_bin}" template ome-crd "${chart_dir}" \
+  --namespace ome \
+  --set ome.rolloutPolicy.enabled=true)"
+grep -Fq 'name: rolloutpolicies.ome.io' <<<"${rollout_enabled}" ||
+  fail "RolloutPolicy CRD was not rendered with the feature gate on"

--- a/charts/ome-crd/values.yaml
+++ b/charts/ome-crd/values.yaml
@@ -1,0 +1,14 @@
+ome:
+  # autoscalerPolicy gates the AutoscalerPolicy CRD. Deliberately the same
+  # values path as ome-resources' ome.autoscalerPolicy.enabled (which gates
+  # the manager RBAC, validating webhook, and config block): set both charts
+  # from one value so the CRD never installs without its controller and
+  # webhook, and vice versa. Alpha; default off.
+  autoscalerPolicy:
+    enabled: false
+  # rolloutPolicy gates the RolloutPolicy CRD. Deliberately the same values
+  # path as ome-resources' ome.rolloutPolicy.enabled (which gates the policy
+  # validating webhook): set both charts from one value so the CRD never
+  # installs without its webhook, and vice versa. Alpha; default off.
+  rolloutPolicy:
+    enabled: false

--- a/charts/ome-quota-manager/templates/deployment.yaml
+++ b/charts/ome-quota-manager/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.quotaManager.podSecurityContext | nindent 8 }}
       containers:
       - name: quota-manager
         image: {{ include "ome-quota-manager.image" (dict "values" .Values "repository" .Values.quotaManager.image.repository "tag" .Values.quotaManager.image.tag) }}
@@ -109,20 +109,33 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         securityContext:
+          # Asserted here rather than on the pod so it binds this container and
+          # nothing the platform injects alongside it.
+          runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
         resources:
           {{- toYaml .Values.quotaManager.resources | nindent 10 }}
-        {{- if .Values.quotaManager.webhook.enabled }}
+        {{- with .Values.quotaManager.extraEnv }}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if or .Values.quotaManager.webhook.enabled .Values.quotaManager.extraVolumeMounts }}
         volumeMounts:
+        {{- if .Values.quotaManager.webhook.enabled }}
         - name: webhook-cert
           mountPath: {{ include "ome-quota-manager.certDir" . }}
           readOnly: true
         {{- end }}
-      {{- if .Values.quotaManager.webhook.enabled }}
+        {{- with .Values.quotaManager.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+      {{- if or .Values.quotaManager.webhook.enabled .Values.quotaManager.extraVolumes }}
       volumes:
+      {{- if .Values.quotaManager.webhook.enabled }}
       # Read-only in both cert modes. With internal management the component
       # never writes this path: it writes the Secret, and the kubelet projects
       # the Secret back down here — which is also why a fresh pod stays unready
@@ -131,6 +144,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ .Values.quotaManager.name }}-webhook-cert
+      {{- end }}
+      {{- with .Values.quotaManager.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.quotaManager.nodeSelector }}
       nodeSelector:

--- a/charts/ome-quota-manager/tests/render_test.sh
+++ b/charts/ome-quota-manager/tests/render_test.sh
@@ -342,6 +342,61 @@ fi
 if grep -Fq -- '--allow-exec-credentials' <<<"${projectOn}"; then
   fail "exec credentials were enabled without being asked for"
 fi
+
+# --- the platform escape hatches an exec plugin needs ---
+#
+# An exec-credential binary runs inside this pod and authenticates with material
+# the chart cannot know about, so extraEnv/extraVolumes/extraVolumeMounts have to
+# reach the container. The case worth pinning is with the webhook OFF: the
+# volumes and volumeMounts blocks used to exist only for the webhook cert, so a
+# mount added while the webhook is disabled is the one that silently vanishes.
+# The three markers share no substring: env renders outside the webhook guard,
+# so a value that merely contained the mount path would satisfy the mount's
+# assertion too and hide exactly the regression this is here to catch.
+extras=(
+  --set-json 'quotaManager.extraEnv=[{"name":"PLUGIN_CERT","value":"/var/run/plugin/combined.pem"}]'
+  --set-json 'quotaManager.extraVolumes=[{"name":"creds","hostPath":{"path":"/etc/creds","type":"Directory"}}]'
+  --set-json 'quotaManager.extraVolumeMounts=[{"name":"creds","mountPath":"/opt/creds","readOnly":true}]'
+)
+for webhook in true false; do
+  out="$(render --set quotaManager.mode=management \
+    --set quotaManager.webhook.enabled="${webhook}" "${extras[@]}" \
+    --show-only templates/deployment.yaml)"
+  for needle in 'name: PLUGIN_CERT' 'path: /etc/creds' 'mountPath: /opt/creds'; do
+    if ! grep -Fq -- "${needle}" <<<"${out}"; then
+      fail "extra '${needle}' dropped with webhook.enabled=${webhook}"
+    fi
+  done
+done
+
+# --- runAsNonRoot binds the container, not the pod ---
+#
+# A pod-level runAsNonRoot also binds every container the platform injects, and
+# an injected initContainer carries no securityContext of its own. One that runs
+# as root then fails with "container has runAsNonRoot and image will run as
+# root" and takes the pod with it -- which is how an exec-credential install
+# breaks. The workload's own guarantee is unchanged either way.
+ctx="$(render --set quotaManager.mode=management --show-only templates/deployment.yaml)"
+python3 - "$ctx" <<'PY' || fail "runAsNonRoot is not scoped to the container"
+import sys, re
+doc = sys.argv[1]
+spec = doc.split('    spec:', 1)[1]
+pod_ctx = spec.split('      containers:', 1)[0]
+if 'runAsNonRoot' in pod_ctx:
+    raise SystemExit("pod-level securityContext still sets runAsNonRoot")
+ctr = spec.split('      containers:', 1)[1]
+if 'runAsNonRoot: true' not in ctr:
+    raise SystemExit("container securityContext lost runAsNonRoot")
+PY
+
+# And absent, they add nothing: an empty env/volumes block is invalid, not inert.
+bare="$(render --set quotaManager.mode=management \
+  --set quotaManager.webhook.enabled=false --show-only templates/deployment.yaml)"
+for empty in 'env:' 'volumes:' 'volumeMounts:'; do
+  if grep -Eq "^[[:space:]]*${empty}[[:space:]]*$" <<<"${bare}"; then
+    fail "rendered an empty ${empty} block with no webhook and no extras"
+  fi
+done
 # --- remote access is off unless asked for, grants narrowly, and mints no
 # --- non-expiring credential unless explicitly told to ---
 

--- a/charts/ome-quota-manager/values.yaml
+++ b/charts/ome-quota-manager/values.yaml
@@ -207,6 +207,32 @@ quotaManager:
   podAnnotations: {}
   podLabels: {}
 
+  # Pod-level securityContext, which containers that set none inherit. Empty by
+  # default, and the workload's own guarantee is asserted on its container
+  # instead — see securityContext below.
+  #
+  # The distinction matters when the platform injects a container. An injected
+  # initContainer carries no securityContext of its own, so a pod-level
+  # runAsNonRoot applies to it: an image that runs as root then fails to start
+  # with "container has runAsNonRoot and image will run as root", taking the pod
+  # with it. Constraining the pod constrains whatever the platform adds, which
+  # is not the thing this chart is trying to constrain.
+  podSecurityContext: {}
+
+  # Escape hatches for what the platform, rather than this chart, has to supply.
+  # The case they exist for is an exec-credential kubeconfig: the plugin binary
+  # runs inside this pod, so whatever it needs to authenticate -- a trust store
+  # on a host path, the environment variables naming its client certificate --
+  # has to be mounted here, and none of it is knowable from the chart.
+  #
+  # Enabling projection.execCredentials without these is the common mistake. It
+  # gets the plugin past the transport's policy check and no further: the binary
+  # then runs and fails on its own missing configuration, which reads as a
+  # certificate error rather than a chart one.
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
   # A single-replica install cannot satisfy a PDB, so it is off by default and
   # only meaningful alongside replicaCount > 1.
   podDisruptionBudget:

--- a/charts/ome-resources/templates/ome-controller/configmap.yaml
+++ b/charts/ome-resources/templates/ome-controller/configmap.yaml
@@ -33,7 +33,8 @@ data:
   deploy: |-
     {
       "defaultDeploymentMode": "{{ .Values.ome.controller.deploymentMode }}"{{- with .Values.ome.controller.replicas }},
-      "replicas": {{ toJson . }}{{- end }}
+      "replicas": {{ toJson . }}{{- end }}{{- with .Values.ome.controller.terminationGracePeriodSeconds }},
+      "terminationGracePeriodSeconds": {{ . }}{{- end }}
     }
 {{- with .Values.ome.controller.podDisruptionBudget }}
   podDisruptionBudget: |-
@@ -43,10 +44,22 @@ data:
   canaryAnalysis: |-
     {
       "bundledPrometheusAddress": "{{ .Values.ome.controller.canaryAnalysis.bundledPrometheusAddress | default (printf "http://ome-prometheus.%s.svc:%v" .Release.Namespace .Values.prometheus.service.port) }}",
+      "defaultProvider": "{{ .Values.ome.controller.canaryAnalysis.defaultProvider | default "" }}",
       "queryTimeout": "{{ .Values.ome.controller.canaryAnalysis.queryTimeout | default "5s" }}",
       "maxConcurrency": {{ .Values.ome.controller.canaryAnalysis.maxConcurrency | default 8 }},
       "cacheTTL": "{{ .Values.ome.controller.canaryAnalysis.cacheTTL | default "2m" }}"
     }
+
+  rollout: |-
+    {
+      "maxPinnedPlanBytes": {{ .Values.ome.controller.rollout.maxPinnedPlanBytes | default 0 }},
+      "defaultReadyTimeout": "{{ .Values.ome.controller.rollout.defaultReadyTimeout | default "" }}"
+    }
+{{- with .Values.ome.metricProviders }}
+
+  metricProviders: |-
+    {{- toJson . | nindent 4 }}
+{{- end }}
 
   coordination: |-
     {
@@ -129,6 +142,17 @@ data:
         "backendPort": {{ .Values.ome.multicluster.config.endpoint.backendPort | default 0 }}
       }
     }
+{{- if .Values.ome.autoscalerPolicy.enabled }}
+
+  autoscalerPolicy: |-
+    {
+      "metricProviders": {{ .Values.ome.autoscalerPolicy.metricProviders | default dict | toJson }},
+      "preflight": {
+        "memberGetTimeoutSeconds": {{ .Values.ome.autoscalerPolicy.preflight.memberGetTimeoutSeconds | default 0 }},
+        "skewDeadlineSeconds": {{ .Values.ome.autoscalerPolicy.preflight.skewDeadlineSeconds | default 0 }}
+      }
+    }
+{{- end }}
 
   metricsAggregator: |-
     {
@@ -138,6 +162,10 @@ data:
 {{- if .Values.ome.podMonitor }}
   podMonitor: |-
     {{- toJson .Values.ome.podMonitor | nindent 4 }}
+{{- end }}
+{{- if .Values.ome.controller.acceleratorResources }}
+  acceleratorResources: |-
+    {{- toJson .Values.ome.controller.acceleratorResources | nindent 4 }}
 {{- end }}
   servingSidecar: |-
     {

--- a/charts/ome-resources/templates/ome-controller/webhooks/autoscalerpolicyvalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/autoscalerpolicyvalidator.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ome.autoscalerPolicy.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: autoscalerpolicy.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: ome/serving-cert
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-ome-io-v1beta1-autoscalerpolicy
+    failurePolicy: Fail
+    name: autoscalerpolicy.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    # Skip spec re-validation on objects already being deleted, but DELETE
+    # itself must always reach the handler (it denies in-use deletion). A
+    # DELETE review carries no `object`, so evaluating the deletionTimestamp
+    # guard there would error and failurePolicy would reject every delete —
+    # the operation check must short-circuit first.
+    matchConditions:
+      - name: skip-deletion
+        expression: "request.operation == 'DELETE' || !has(object.metadata.deletionTimestamp)"
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - autoscalerpolicies
+{{- end }}

--- a/charts/ome-resources/templates/ome-controller/webhooks/rolloutpolicyvalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/rolloutpolicyvalidator.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ome.rolloutPolicy.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: rolloutpolicy.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: ome/serving-cert
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-ome-io-v1beta1-rolloutpolicy
+    failurePolicy: Fail
+    name: rolloutpolicy.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    # Skip spec re-validation on objects already being deleted, but DELETE
+    # itself must always reach the handler (it denies in-use deletion). A
+    # DELETE review carries no `object`, so evaluating the deletionTimestamp
+    # guard there would error and failurePolicy would reject every delete —
+    # the operation check must short-circuit first.
+    matchConditions:
+      - name: skip-deletion
+        expression: "request.operation == 'DELETE' || !has(object.metadata.deletionTimestamp)"
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - rolloutpolicies
+{{- end }}

--- a/charts/ome-resources/tests/render_test.sh
+++ b/charts/ome-resources/tests/render_test.sh
@@ -312,3 +312,141 @@ multicluster_access="$("${helm_bin}" template ome-resources "${chart_dir}" \
   --show-only templates/ome-controller/rbac/multicluster_access.yaml)"
 grep -Fqx '  - inferencereplicas' <<<"${multicluster_access}" ||
   fail "multicluster-access ClusterRole does not grant inferencereplicas"
+
+# acceleratorResources has no in-code default: the chart default is the only
+# source of any non-nvidia recognition. It stays nvidia-only so upgrading the
+# chart cannot change which pods get a PARALLELISM_SIZE env var — recognizing
+# a resource an existing multi-node Component already requests would change
+# that Component's hashed OMENative revision payload and roll it (see
+# controllerconfig.InferenceServicesConfig.AcceleratorResourceNames).
+grep -Fq '["nvidia.com/gpu"]' <<<"${controller_config}" ||
+  fail "default accelerator resources list was not rendered"
+if grep -Fq -e 'amd.com/gpu' -e 'google.com/tpu' <<<"${controller_config}"; then
+  fail "chart default recognized a non-nvidia accelerator without an explicit override"
+fi
+
+accelerator_resources_overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-json 'ome.controller.acceleratorResources=["nvidia.com/gpu","amd.com/gpu","google.com/tpu"]' \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '["nvidia.com/gpu","amd.com/gpu","google.com/tpu"]' <<<"${accelerator_resources_overridden}" ||
+  fail "accelerator resources override was not rendered"
+
+accelerator_resources_cleared="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-json 'ome.controller.acceleratorResources=[]' \
+  --show-only templates/ome-controller/configmap.yaml)"
+if grep -Fq 'acceleratorResources' <<<"${accelerator_resources_cleared}"; then
+  fail "acceleratorResources key was rendered when the list was cleared"
+fi
+
+# ome.autoscalerPolicy.enabled gates the policy validating webhook and the
+# config block. Manager RBAC stays ungated in the generated role (the
+# optional-CRD precedent: grants on absent CRDs are inert), so the gate-off
+# render checks the webhook, not RBAC rule names.
+if grep -Fq 'path: /validate-ome-io-v1beta1-autoscalerpolicy' <<<"${rendered}"; then
+  fail "AutoscalerPolicy webhook was rendered with the feature gate off"
+fi
+if grep -Fq 'autoscalerPolicy:' <<<"${controller_config}"; then
+  fail "autoscalerPolicy config block was rendered with the feature gate off"
+fi
+
+autoscaler_enabled="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.autoscalerPolicy.enabled=true)"
+# The autoscalerpolicies / triggerauthentications RBAC lives ungated in the
+# generated manager role (the optional-CRD precedent: grants on absent CRDs
+# are inert), so it must render regardless of the feature gate.
+grep -Fq -- '- triggerauthentications' <<<"${autoscaler_enabled}" ||
+  fail "KEDA TriggerAuthentication RBAC was not rendered"
+grep -Fq -- '- autoscalerpolicies/status' <<<"${autoscaler_enabled}" ||
+  fail "AutoscalerPolicy status RBAC was not rendered"
+grep -Fq 'name: autoscalerpolicy.ome.io' <<<"${autoscaler_enabled}" ||
+  fail "AutoscalerPolicy validating webhook was not rendered with the gate on"
+grep -Fq 'path: /validate-ome-io-v1beta1-autoscalerpolicy' <<<"${autoscaler_enabled}" ||
+  fail "AutoscalerPolicy webhook path was not rendered with the gate on"
+# In-use deletion denial happens at admission, so the webhook must both
+# register the DELETE operation and pass DELETE through its skip-deletion
+# matchCondition (a DELETE review has no `object` to guard on).
+grep -Fq -- '- DELETE' <<<"${autoscaler_enabled}" ||
+  fail "AutoscalerPolicy webhook does not register the DELETE operation"
+grep -Fq "request.operation == 'DELETE'" <<<"${autoscaler_enabled}" ||
+  fail "AutoscalerPolicy skip-deletion matchCondition does not pass DELETE through"
+
+autoscaler_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.autoscalerPolicy.enabled=true \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"metricProviders": {}' <<<"${autoscaler_config}" ||
+  fail "empty autoscalerPolicy provider map was not rendered with the gate on"
+grep -Fq '"memberGetTimeoutSeconds": 0' <<<"${autoscaler_config}" ||
+  fail "autoscalerPolicy preflight member GET timeout default was not rendered"
+grep -Fq '"skewDeadlineSeconds": 0' <<<"${autoscaler_config}" ||
+  fail "autoscalerPolicy preflight skew deadline default was not rendered"
+
+autoscaler_provider_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.autoscalerPolicy.enabled=true \
+  --set-string 'ome.autoscalerPolicy.metricProviders.cluster-prometheus.serverAddress=http://ome-prometheus.ome.svc:9090' \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"cluster-prometheus":{"serverAddress":"http://ome-prometheus.ome.svc:9090"}' <<<"${autoscaler_provider_config}" ||
+  fail "autoscalerPolicy metric provider binding was not rendered"
+# The nested map is the deprecated alias: it must never also render the
+# authoritative top-level key, which would mask the alias in the loader.
+if grep -Eq '^  metricProviders:' <<<"${autoscaler_provider_config}"; then
+  fail "nested autoscalerPolicy providers leaked into the top-level metricProviders key"
+fi
+
+# ome.rolloutPolicy.enabled gates the policy validating webhook. Manager RBAC
+# stays ungated in the generated role (the optional-CRD precedent: grants on
+# absent CRDs are inert), and the rollout config block stays ungated too —
+# inline rollout plans exist on every cluster, policy CRD or not.
+if grep -Fq 'path: /validate-ome-io-v1beta1-rolloutpolicy' <<<"${rendered}"; then
+  fail "RolloutPolicy webhook was rendered with the feature gate off"
+fi
+
+rollout_enabled="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.rolloutPolicy.enabled=true)"
+grep -Fq -- '- rolloutpolicies/status' <<<"${rollout_enabled}" ||
+  fail "RolloutPolicy status RBAC was not rendered"
+grep -Fq 'name: rolloutpolicy.ome.io' <<<"${rollout_enabled}" ||
+  fail "RolloutPolicy validating webhook was not rendered with the gate on"
+grep -Fq 'path: /validate-ome-io-v1beta1-rolloutpolicy' <<<"${rollout_enabled}" ||
+  fail "RolloutPolicy webhook path was not rendered with the gate on"
+# In-use deletion denial happens at admission, so the webhook must both
+# register the DELETE operation and pass DELETE through its skip-deletion
+# matchCondition (a DELETE review has no `object` to guard on).
+rollout_webhook="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.rolloutPolicy.enabled=true \
+  --show-only templates/ome-controller/webhooks/rolloutpolicyvalidator.yaml)"
+grep -Fq -- '- DELETE' <<<"${rollout_webhook}" ||
+  fail "RolloutPolicy webhook does not register the DELETE operation"
+grep -Fq "request.operation == 'DELETE'" <<<"${rollout_webhook}" ||
+  fail "RolloutPolicy skip-deletion matchCondition does not pass DELETE through"
+
+# The rollout block and the canaryAnalysis default provider render ungated,
+# and the chart values are the only source of their defaults (the OME binary
+# deliberately has none).
+grep -Fq '"maxPinnedPlanBytes": 16384' <<<"${controller_config}" ||
+  fail "rollout pinned-plan size cap default was not rendered"
+grep -Fq '"defaultReadyTimeout": "15m"' <<<"${controller_config}" ||
+  fail "rollout default ready timeout was not rendered"
+grep -Fq '"defaultProvider": ""' <<<"${controller_config}" ||
+  fail "canaryAnalysis default provider was not rendered"
+# The loader treats a present top-level metricProviders key — even {} — as
+# authoritative, so the chart must omit it entirely when no bindings are set.
+if grep -Eq '^  metricProviders:' <<<"${controller_config}"; then
+  fail "top-level metricProviders key was rendered with no bindings configured"
+fi
+
+metric_providers_config="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set-string 'ome.metricProviders.cluster-prometheus.serverAddress=http://ome-prometheus.ome.svc:9090' \
+  --set-string 'ome.metricProviders.cluster-prometheus.headers.X-Scope-OrgID=tenant-a' \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Eq '^  metricProviders:' <<<"${metric_providers_config}" ||
+  fail "top-level metricProviders key was not rendered when bindings are set"
+grep -Fq '"cluster-prometheus":{"headers":{"X-Scope-OrgID":"tenant-a"},"serverAddress":"http://ome-prometheus.ome.svc:9090"}' <<<"${metric_providers_config}" ||
+  fail "top-level metric provider binding was not rendered"

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -106,6 +106,78 @@ ome:
         globalGateway: ""       # "namespace/name" of the global Gateway ("" => publisher is a no-op)
         routeNamespace: ""      # namespace for the published HTTPRoute + Service ("" => the ISVC's namespace)
         backendPort: 0          # port on the winner's ingress the global host forwards to
+  # autoscalerPolicy is the single gate for the reusable AutoscalerPolicy
+  # feature: the manager's policy RBAC, the policy validating webhook, and the
+  # autoscalerPolicy config block all install together on this one value —
+  # never install-but-dormant. Alpha; default off. Deliberately the same
+  # values path as the ome-crd chart's ome.autoscalerPolicy.enabled: set both
+  # charts from one value so the CRD and its controller + webhook always ship
+  # as a unit.
+  autoscalerPolicy:
+    enabled: false
+    # metricProviders binds the logical provider names policies reference
+    # (providerRef on endpoint triggers) to this cluster's metric endpoints.
+    # Deprecated alias: prefer the top-level ome.metricProviders map, which
+    # is authoritative whenever it is set; the loader reads this nested map
+    # only when the top-level key is absent.
+    # Cluster-admin owned and the ONLY source of endpoints: a policy can only
+    # NAME a provider, an unbound name is a render error (fail closed), and
+    # the OME binary has NO built-in addresses — this map is the source of
+    # truth. Per provider: serverAddress (required) is injected as the
+    # rendered trigger's serverAddress; authSecretRef ({name, key}, optional)
+    # points at a Secret key in each consumer namespace holding a bearer
+    # token, materialized as a KEDA TriggerAuthentication and never rendered
+    # into policies, status, or digests.
+    # Example, pointing at the bundled Prometheus this chart deploys (same
+    # address canaryAnalysis defaults to):
+    # metricProviders:
+    #   cluster-prometheus:
+    #     serverAddress: "http://ome-prometheus.ome.svc:9090"
+    #     # authSecretRef:
+    #     #   name: prometheus-bearer
+    #     #   key: token
+    metricProviders: {}
+    # preflight tunes the control-plane placement preflight for
+    # policy-referencing InferenceServices. 0 => the manager's built-in
+    # default (memberGetTimeoutSeconds 5, skewDeadlineSeconds 900).
+    preflight:
+      # Deadline for each per-candidate live policy GET; a timed-out member
+      # is ineligible for that placement.
+      memberGetTimeoutSeconds: 0
+      # How long a home may hold a derived policy-referencing ISVC without
+      # reporting a resolved digest before the control plane flags it.
+      skewDeadlineSeconds: 0
+  # rolloutPolicy is the single gate for the reusable RolloutPolicy feature:
+  # the policy validating webhook installs on this one value — never
+  # install-but-dormant. Alpha; default off. Deliberately the same values path
+  # as the ome-crd chart's ome.rolloutPolicy.enabled: set both charts from one
+  # value so the CRD and its webhook always ship as a unit. Manager RBAC stays
+  # ungated in the generated role (grants on an absent CRD are inert), and the
+  # ome.controller.rollout config block below stays ungated too — inline
+  # rollout plans exist on every cluster, policy CRD or not.
+  rolloutPolicy:
+    enabled: false
+  # metricProviders binds the logical provider names consumers reference (a
+  # policy trigger's providerRef, canaryAnalysis.defaultProvider) to this
+  # cluster's metric endpoints, rendered as the top-level metricProviders key
+  # of inferenceservice-config. Cluster-admin owned and the ONLY source of
+  # endpoints: consumers name providers, the OME binary has NO built-in
+  # addresses. Per provider: serverAddress (required); authSecretRef
+  # ({name, key}, optional) names a Secret key in each consumer namespace
+  # holding a bearer token; headers (optional map) are fleet-default HTTP
+  # headers attached to provider requests. Whenever this map is set it is
+  # authoritative and the deprecated nested ome.autoscalerPolicy.metricProviders
+  # alias is ignored by the loader.
+  # Example:
+  # metricProviders:
+  #   cluster-prometheus:
+  #     serverAddress: "http://ome-prometheus.ome.svc:9090"
+  #     # authSecretRef:
+  #     #   name: prometheus-bearer
+  #     #   key: token
+  #     # headers:
+  #     #   X-Scope-OrgID: tenant-a
+  metricProviders: {}
   benchmarkJob:
     image: genai-bench
     tag: 0.1.113
@@ -141,6 +213,15 @@ ome:
         engine: 3
         decoder: 3
         router: 2
+    # Admission-time pod termination grace stamped by the same webhook on any
+    # component that does not author terminationGracePeriodSeconds. Bounds how
+    # long a component has to finish in-flight requests after SIGTERM; a
+    # serving component whose requests outlive it loses them on every restart.
+    # Same contract as replicas above: the binary has no built-in default, and
+    # an authored component value always wins. Size it above the tier's
+    # longest expected request, and keep any in-process drain the runtime
+    # performs strictly under it so the runtime finishes first.
+    terminationGracePeriodSeconds: 600
     # Max reconciles each controller runs in parallel (distinct objects only —
     # controller-runtime serializes per object key, so independent objects
     # reconcile concurrently). Source of truth for these values (the OME binary
@@ -166,6 +247,28 @@ ome:
     # window; kept short so ConfigMap edits apply without a restart. Set to "0" to
     # disable caching (read the apiserver on every load).
     configCacheTTL: "30s"
+    # AcceleratorResources lists the extended resource names OME recognizes as
+    # GPU/accelerator capacity when inspecting a container's resources (GPU-enabled
+    # checks, per-pod accelerator counts feeding multi-node PARALLELISM_SIZE
+    # sizing). Exact names, no patterns. The OME binary has NO built-in default
+    # list; omitting this key (or setting an empty list) falls back to
+    # recognizing only "nvidia.com/gpu" — the sole resource name OME recognized
+    # before this field existed — so an unconfigured/upgraded cluster's behavior
+    # is unchanged. The chart default below preserves that same nvidia-only
+    # behavior for every existing install.
+    #
+    # Adding a resource name here is a template-affecting change, not a config
+    # tweak: for any multi-node Engine/Decoder Component whose runner container
+    # requests that resource, recognizing it materializes the PARALLELISM_SIZE
+    # env var onto the pod template where it was previously absent (0 GPUs
+    # detected). That changes the hashed OMENative revision payload, which mints
+    # a new revision and rolls every such Component still running. Schedule
+    # adding a vendor here like any other pod-template change, not like a
+    # config-only edit.
+    acceleratorResources:
+      - nvidia.com/gpu
+      # - amd.com/gpu
+      # - google.com/tpu
     # canaryAnalysis tunes metric-gated canary promotion (spec.rollout.canary).
     canaryAnalysis:
       # Default Prometheus the analysis queries when a canary does not set its own
@@ -173,11 +276,27 @@ ome:
       # ome-prometheus Service at prometheus.service.port. Set to your own
       # Prometheus/Thanos for production.
       bundledPrometheusAddress: ""
+      # Name of an ome.metricProviders binding used as the analysis source when
+      # a canary names neither a providerRef nor its own serverAddress. Empty
+      # keeps the bundledPrometheusAddress fallback; a name with no binding is
+      # a config error surfaced when a run opens, never a silent fallback.
+      defaultProvider: ""
       # Per-sample query timeout, max background query concurrency, and how long a
       # sampled result stays usable in the controller's cache.
       queryTimeout: "5s"
       maxConcurrency: 8
       cacheTTL: "2m"
+    # rollout tunes rollout runs (inline plans and RolloutPolicy-backed alike),
+    # so it applies regardless of ome.rolloutPolicy.enabled. Source of truth
+    # for these values: the OME binary has NO built-in defaults.
+    rollout:
+      # Cap on the JSON-rendered size of a policy/inline plan body pinned into
+      # a run's status. 0 means uncapped.
+      maxPinnedPlanBytes: 16384
+      # Fleet-default readiness deadline applied when a rollout does not set
+      # its own. Empty means no configured default (each consumer keeps its
+      # documented fallback).
+      defaultReadyTimeout: "15m"
     # coordination tunes the OMENative cross-Component coordination layer.
     coordination:
       # Per-revision hysteresis band (percent) for the pod-proportional traffic


### PR DESCRIPTION
## Summary

Wires the AutoscalerPolicy and RolloutPolicy features through the Helm charts and makes the chart render tests part of `make helm-lint`.

**ome-resources**
- ValidatingWebhookConfigurations for `AutoscalerPolicy` and `RolloutPolicy`, gated on `ome.autoscalerPolicy.enabled` / `ome.rolloutPolicy.enabled`.
- `inferenceservice-config` gains the `acceleratorResources`, `autoscalerPolicy`, `rolloutPolicy` and `metricProviders` blocks, with matching `values.yaml` entries.
- `deploy.terminationGracePeriodSeconds: 600` is now rendered into the config. The binary carries no built-in default and an authored component value always wins; set the value to empty to fall back to the Kubernetes default.

**ome-crd**
- The two policy CRD templates are wrapped in the same gates, so one value enables the CRD, the controller wiring and the webhook together. `make manifests` re-applies the wrapper after every regeneration.
- A release marker (`release-info.yaml` + helpers) and a render test pin the contract.

**ome-quota-manager**
- Pod-level `runAsNonRoot` moves to the container `securityContext` and is configurable via `quotaManager.podSecurityContext`. PSA `restricted` remains satisfied because the only container sets it.

**Makefile**
- `helm-lint` now runs every chart's `tests/render_test.sh`, so the chart contracts are enforced in CI rather than only when invoked by hand.

## Behavior to note

- Both policy gates default to `false`: the policy CRDs and webhooks are not installed unless enabled. Set `ome.autoscalerPolicy.enabled` / `ome.rolloutPolicy.enabled` to the same value in both `ome-crd` and `ome-resources`.
- Components that do not author `terminationGracePeriodSeconds` now receive 600s instead of the Kubernetes default of 30s.

## Verification

- `make helm-lint` (lint + all four render tests) passes.
- Strict duplicate-key YAML load of every `charts/*/values.yaml` passes.
- `helm template` for `ome-crd` renders the policy CRDs only when the gates are on.

Stacked on #844.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added feature gates for optional AutoscalerPolicy and RolloutPolicy CRDs and validation webhooks.
  - Added configurable autoscaler, rollout, metric provider, accelerator resource, canary, and controller settings.
  - Added release metadata reporting for the CRD chart.
  - Added configurable pod security contexts, environment variables, volumes, and volume mounts for the quota manager.
  - Added optional termination grace period and policy configuration rendering.

- **Tests**
  - Added Helm render validation covering feature gates, defaults, overrides, metadata, security settings, and optional resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->