### PR TITLE
[Bugfix] Wait for PodReady after recreate

### DIFF
--- a/pkg/controller/v1beta1/workload/ops/update_recreate.go
+++ b/pkg/controller/v1beta1/workload/ops/update_recreate.go
@@ -150,7 +150,10 @@ func recreateUpdate(ctx context.Context, deps workload.Deps, input workload.Reco
 		return false, nil
 	}
 
-	// Phase C: flip serving, promote Ready+RunningRevision.
+	// Phase C: flip serving, then wait for kubelet to incorporate the
+	// controller readiness gate into PodReady before promoting the Instance.
+	// ContainersReady alone only proves that the runtime probe passed; the Pod
+	// is not eligible for its Service until PodReady also observes serving=True.
 	if !query.AllPodsRuntimeReady(newPods) {
 		return false, nil
 	}
@@ -162,6 +165,11 @@ func recreateUpdate(ctx context.Context, deps workload.Deps, input workload.Reco
 		// lived on the now-deleted old pods.
 		if err := podreadiness.MarkPodServing(ctx, deps.Client, deps.Reader(), pod, podreadiness.WriterLifecycle, podreadiness.KeyLifecycleInstanceReady); err != nil {
 			return false, fmt.Errorf("mark serving (instance=%d, pod=%s): %w", inst.Index, pod.Name, err)
+		}
+	}
+	for _, pod := range newPods {
+		if !podreadiness.IsPodReady(pod) {
+			return false, nil
 		}
 	}
 	if err := patchInstanceStatusReadyOnRevision(ctx, input, inst.Index, target.Name); err != nil {

--- a/pkg/controller/v1beta1/workload/ops/update_recreate_readiness_test.go
+++ b/pkg/controller/v1beta1/workload/ops/update_recreate_readiness_test.go
@@ -1,0 +1,94 @@
+package ops
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	workload "sigs.k8s.io/ome/pkg/controller/v1beta1/workload/types"
+)
+
+func TestRecreateUpdateWaitsForPodReadyAfterEnablingServing(t *testing.T) {
+	tests := []struct {
+		name      string
+		podReady  bool
+		wantDone  bool
+		wantPhase workload.InstancePhase
+	}{
+		{
+			name:      "serving gate set but pod ready not observed",
+			podReady:  false,
+			wantDone:  false,
+			wantPhase: workload.InstancePhaseUpdating,
+		},
+		{
+			name:      "pod ready observed",
+			podReady:  true,
+			wantDone:  true,
+			wantPhase: workload.InstancePhaseReady,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			legacyResetExpectations(t)
+			isvc, ir := legacyISVCReadyAtIncarnation("llama-70b", "prod", 1)
+			client := legacyNewFakeClient(t, isvc, ir)
+			targetSpec := legacyTargetSpecImage("llama:v2")
+			target := legacyEnsureTargetCR(t, client, isvc, targetSpec)
+
+			if err := legacyMutateInstance(client, isvc, workload.ComponentEngine)(context.Background(), 0, func(status *workload.InstanceStatus) bool {
+				status.Incarnation = 2
+				status.Phase = workload.InstancePhaseUpdating
+				status.TargetRevision = target.Name
+				status.Operation = &workload.InstanceOperation{
+					Type:           workload.InstanceOperationUpdate,
+					Step:           updateStepDrain,
+					TargetRevision: target.Name,
+				}
+				return true
+			}); err != nil {
+				t.Fatalf("seed in-flight recreate: %v", err)
+			}
+
+			pod := legacyPodAtIncarnation(isvc, 0, 2, true, true)
+			pod.Spec = *targetSpec.DeepCopy()
+			if test.podReady {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				})
+			}
+			if err := client.Create(context.Background(), pod); err != nil {
+				t.Fatalf("create replacement pod: %v", err)
+			}
+
+			input := legacyTestInput(isvc, client, workload.ComponentEngine)
+			plan := legacyComponentPlan(workload.UpdateStrategyRecreatePod, nil)
+			done, err := recreateUpdate(
+				context.Background(),
+				legacyTestDeps(client),
+				input,
+				plan,
+				plan.Instances[0],
+				target,
+				[]*corev1.Pod{pod},
+			)
+			if err != nil {
+				t.Fatalf("recreateUpdate: %v", err)
+			}
+			if done != test.wantDone {
+				t.Fatalf("done: got %t, want %t", done, test.wantDone)
+			}
+
+			statuses := legacyInstanceStatusesOnIR(client, isvc, workload.ComponentEngine)
+			if len(statuses) != 1 {
+				t.Fatalf("instance statuses: got %d, want 1", len(statuses))
+			}
+			if got := workload.InstancePhase(statuses[0].Phase); got != test.wantPhase {
+				t.Fatalf("phase: got %q, want %q", got, test.wantPhase)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

- keeps a recreated Instance in Updating after enabling its serving readiness gate
- waits until kubelet reports PodReady before promoting the Instance to Ready
- adds regression coverage for both the waiting and completed states

## Why we need it

The recreate path currently marks the replacement Instance Ready immediately after ContainersReady is true and the controller sets the serving readiness gate. PodReady may still reflect the previous gate value at that point, so the replacement is not yet eligible for Service traffic.

With a zero-surge rollout, prematurely promoting that Instance allows the unavailable budget to drain the next old Instance. This can leave no routable backend even though the controller reports a ready Instance.

## How to test

- go test ./pkg/controller/v1beta1/workload/... -count=1
- additional local Kind validation with maxSurge=0 and an API-compatible SMG mock completed a compatible rollout with 0 backend-unavailable responses; the unpatched controller produced 6

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (not applicable: behavior-only bug fix)
- [ ] make test passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload update readiness handling by waiting for replacement pods to report ready before marking the instance as ready.
  * Prevented instances from being promoted prematurely while new pods are still becoming ready.

* **Tests**
  * Added coverage for update behavior when replacement pods are ready or not yet ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->