### PR TITLE
[Core] revision: keep queue labels out of the hash

### DIFF
--- a/pkg/controller/v1beta1/workload/revision/revision.go
+++ b/pkg/controller/v1beta1/workload/revision/revision.go
@@ -271,13 +271,63 @@ func TemplateMeta(src *metav1.ObjectMeta) *metav1.ObjectMeta {
 			filtered[k] = v
 		}
 	}
-	if len(src.Labels) == 0 && len(filtered) == 0 {
+	labels := src.Labels
+	if hasSchedulingLabel(src.Labels) {
+		labels = make(map[string]string, len(src.Labels))
+		for k, v := range src.Labels {
+			if isSchedulingLabel(k) {
+				continue
+			}
+			labels[k] = v
+		}
+	}
+	if len(labels) == 0 && len(filtered) == 0 {
 		return nil
 	}
 	return &metav1.ObjectMeta{
-		Labels:      src.Labels,
+		Labels:      labels,
 		Annotations: filtered,
 	}
+}
+
+// Labels naming the queue a pod is admitted against, and the priority it is
+// admitted at. Duplicated as literals to keep this package a leaf, like the
+// rollout verbs above.
+const (
+	kueueQueueNameLabel     = "kueue.x-k8s.io/queue-name"
+	kueuePriorityClassLabel = "kueue.x-k8s.io/priority-class"
+)
+
+// isSchedulingLabel reports whether the label is one the admission plane owns
+// rather than the user, and therefore must not feed the pod-template revision
+// hash — the label mirror of isLifecycleAnnotation.
+//
+// A queue assignment is derived from cluster state, not from the spec: it moves
+// when quota is re-authored or when the operator turns queue stamping on or off.
+// Hashing it makes each of those a full rollout of every workload, which is a
+// steep price for a value the running pods cannot act on anyway. Kueue reads
+// these at admission, so a pod already admitted keeps its queue whatever the
+// label later says, and the new value takes effect when the pod is next created.
+//
+// The consequence to know: re-pointing a workload at another queue does not
+// recreate its pods on its own. It takes effect on the next rollout.
+func isSchedulingLabel(key string) bool {
+	switch key {
+	case kueueQueueNameLabel, kueuePriorityClassLabel:
+		return true
+	}
+	return false
+}
+
+// hasSchedulingLabel reports whether any key is admission-plane owned. Fast path
+// so the common case skips the copy in TemplateMeta.
+func hasSchedulingLabel(labels map[string]string) bool {
+	for k := range labels {
+		if isSchedulingLabel(k) {
+			return true
+		}
+	}
+	return false
 }
 
 // hasLifecycleAnnotation reports whether any key in annotations is a

--- a/pkg/controller/v1beta1/workload/revision/revision_test.go
+++ b/pkg/controller/v1beta1/workload/revision/revision_test.go
@@ -467,6 +467,76 @@ func TestRevisionHash_PausedRolloutAnnotationDoesNotDriftHash(t *testing.T) {
 	}
 }
 
+// A queue assignment is derived from cluster state, not from the spec: it moves
+// when quota is re-authored, and it appears or disappears wholesale when the
+// operator turns queue stamping on or off. Hashing it makes each of those a
+// rollout of every workload on the cluster.
+func TestRevisionHash_SchedulingLabelsDoNotDriftHash(t *testing.T) {
+	ps := basicPodSpecForRevision()
+	base := &metav1.ObjectMeta{Labels: map[string]string{"app": "llama"}}
+
+	for _, tc := range []struct {
+		name   string
+		labels map[string]string
+	}{
+		{
+			name:   "queue stamped where there was none",
+			labels: map[string]string{"app": "llama", "kueue.x-k8s.io/queue-name": "team-a"},
+		},
+		{
+			name:   "queue re-pointed at another leaf",
+			labels: map[string]string{"app": "llama", "kueue.x-k8s.io/queue-name": "team-b"},
+		},
+		{
+			name: "priority class alongside the queue",
+			labels: map[string]string{
+				"app":                           "llama",
+				"kueue.x-k8s.io/queue-name":     "team-a",
+				"kueue.x-k8s.io/priority-class": "high",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hBase, _, _ := Hash(ps, base, nil, "")
+			hWith, _, _ := Hash(ps, &metav1.ObjectMeta{Labels: tc.labels}, nil, "")
+			if hBase != hWith {
+				t.Errorf("admission-owned labels must not reach the revision hash: base=%s with=%s", hBase, hWith)
+			}
+		})
+	}
+}
+
+// The exclusion is scoped to the admission plane's own keys. A user label is
+// spec the user wrote, and changing it is a rollout they asked for.
+func TestRevisionHash_UserLabelsStillDriftHash(t *testing.T) {
+	ps := basicPodSpecForRevision()
+	a := &metav1.ObjectMeta{Labels: map[string]string{"app": "llama", "tier": "gold"}}
+	b := &metav1.ObjectMeta{Labels: map[string]string{"app": "llama", "tier": "silver"}}
+
+	hA, _, _ := Hash(ps, a, nil, "")
+	hB, _, _ := Hash(ps, b, nil, "")
+	if hA == hB {
+		t.Errorf("a user label change must still bump the hash, got %s for both", hA)
+	}
+}
+
+// A template carrying nothing but admission-owned labels has to hash as though
+// it carried no metadata at all, or the exclusion just moves the drift: such a
+// workload would differ from one that never had labels.
+func TestRevisionHash_OnlySchedulingLabelsEqualsNoMeta(t *testing.T) {
+	ps := basicPodSpecForRevision()
+	only := &metav1.ObjectMeta{Labels: map[string]string{"kueue.x-k8s.io/queue-name": "team-a"}}
+
+	hNil, _, _ := Hash(ps, nil, nil, "")
+	hOnly, _, _ := Hash(ps, only, nil, "")
+	if hNil != hOnly {
+		t.Errorf("a template with only admission labels must hash as empty: nil=%s only=%s", hNil, hOnly)
+	}
+	if got := TemplateMeta(only); got != nil {
+		t.Errorf("TemplateMeta should collapse to nil, got %+v", got)
+	}
+}
+
 // The canary operator verbs (rollout-promote / rollout-rollback) are
 // added to and removed from the ISVC mid-rollout. They must NOT feed the
 // revision hash: otherwise an operator promoting revision X would mint a


### PR DESCRIPTION
## Summary

The pod-template revision hash now ignores the admission-plane labels
kueue.x-k8s.io/queue-name and kueue.x-k8s.io/priority-class. A queue
assignment is derived from cluster state rather than authored in the
spec: it moves when quota is re-authored, and it appears or disappears
wholesale when queue stamping is toggled. Hashing it turned each of
those into a full rollout of every workload, for a value running pods
cannot act on anyway. Kueue reads these labels at admission, so an
admitted pod keeps its queue regardless of later label changes and the
new value applies when the pod is next created. Re-pointing a workload
at another queue therefore takes effect on the next rollout rather than
recreating pods on its own.

TemplateMeta strips these keys from the hashed labels, mirroring the
existing lifecycle-annotation exclusion, and collapses to nil when the
template carries nothing else so a queue-only template hashes the same
as one with no metadata.

Tests pin that stamping a queue, re-pointing it, and adding a priority
class alongside it all leave the hash unchanged; that a user-authored
label change still bumps the hash; and that a template with only
admission-owned labels hashes identically to a nil template and
collapses to nil in TemplateMeta.

## Verification

`go build`, `go vet` and `go test` on the affected packages; codespell clean.
