### PR TITLE
[Core] quota accounting and placement fleet metrics

### DIFF
--- a/cmd/ome-quota-manager/main.go
+++ b/cmd/ome-quota-manager/main.go
@@ -327,6 +327,7 @@ func main() {
 			MaxDepth: opts.maxTreeDepth,
 		},
 		ResyncInterval: opts.resyncInterval,
+		Mode:           mode,
 	}
 	// Workload mode only. A management-mode manager holds the authored fleet
 	// tree; the nodes it would measure belong to members it reaches over a

--- a/pkg/controller/v1beta1/acceleratorquota/capacity.go
+++ b/pkg/controller/v1beta1/acceleratorquota/capacity.go
@@ -157,6 +157,11 @@ func (r *Reconciler) reconcileCapacity(ctx context.Context, root *v1beta1.Accele
 		return fmt.Errorf("summing node capacity: %w", err)
 	}
 
+	// Publish before merging. mergeCapacity folds the observation into the
+	// high-water marks and only the merged figure reaches status, so the
+	// unattributed slice and the raw node counts have no other reader.
+	recordCapacity(observed)
+
 	updated := root.DeepCopy()
 	updated.Status.Capacity = mergeCapacity(
 		root.Status.Capacity, observed.Capacities, r.Capacity.HysteresisPercent, metav1.Now())

--- a/pkg/controller/v1beta1/acceleratorquota/controller.go
+++ b/pkg/controller/v1beta1/acceleratorquota/controller.go
@@ -115,6 +115,13 @@ type Reconciler struct {
 	// management-mode shape and the way a workload cluster runs before an
 	// operator opts into writing Kueue objects.
 	Materialize MaterializeOptions
+
+	// Mode is which half of the plane this manager runs, carried here only so
+	// the budget metrics can say which. The option structs above already encode
+	// the behavioural difference; this names it for a reader of the series,
+	// where the same metric means the authored fleet total in one mode and one
+	// cluster's share in the other.
+	Mode Mode
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -228,12 +235,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.V(1).Info("consumption not read this pass", "reason", err.Error())
 	}
 
+	inTree := make(map[string]struct{}, len(built.Nodes()))
 	for _, node := range built.Nodes() {
+		inTree[node.Name()] = struct{}{}
 		if err := r.reconcileStatus(ctx, node, frozen, outcomes[node.Name()], reading,
 			fleet[node.Name()], fleetRollup[node.Name()]); err != nil {
 			errs = append(errs, fmt.Errorf("writing status for node %s: %w", node.Name(), err))
 		}
 	}
+	// The pass holds the authoritative node set, so a node that left the tree
+	// without going through its finalizer -- force-stripped, or deleted while
+	// this manager was down -- loses its series here rather than reporting a
+	// deleted tenant's accelerators forever.
+	sweepBudgets(inTree)
 	if len(errs) > 0 {
 		// One node's failure must not skip the rest, so they are collected and
 		// the whole pass retried. Each carries the stage it came from: claiming,
@@ -308,6 +322,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, node *tree.Node, froze
 	// only one of them is safe to publish on a failed read.
 	if totals, ok := reading.forNode(node.Name()); ok {
 		updated.Status.Budgets = budgetStatus(node, totals)
+		recordBudgets(string(r.Mode), node.Name(), node.Path, string(node.Role()), updated.Status.Budgets)
 	}
 
 	// Only a projecting plane has members to report, and only it should clear

--- a/pkg/controller/v1beta1/acceleratorquota/materialize.go
+++ b/pkg/controller/v1beta1/acceleratorquota/materialize.go
@@ -78,7 +78,9 @@ func (r *Reconciler) finalize(ctx context.Context, quota *v1beta1.AcceleratorQuo
 			Sweep(context.Context, sets.Set[string]) (int, error)
 		})
 		if ok {
-			if _, err := sweeper.Sweep(ctx, keep); err != nil {
+			swept, err := sweeper.Sweep(ctx, keep)
+			recordSwept(SweepTriggerFinalize, swept)
+			if err != nil {
 				return fmt.Errorf("reaping objects for %s: %w", quota.Name, err)
 			}
 		}
@@ -89,6 +91,11 @@ func (r *Reconciler) finalize(ctx context.Context, quota *v1beta1.AcceleratorQuo
 			return fmt.Errorf("reaping projections for %s: %w", quota.Name, err)
 		}
 	}
+
+	// The node's enforcement objects are gone; its accelerator figures describe
+	// nothing now, and a gauge left behind would keep reporting a deleted
+	// tenant's allowance.
+	deleteQuotaSeries(quota.Name)
 
 	updated := quota.DeepCopy()
 	controllerutil.RemoveFinalizer(updated, v1beta1.AcceleratorQuotaFinalizer)
@@ -131,11 +138,14 @@ func (r *Reconciler) materialize(ctx context.Context, built *tree.Tree, frozen m
 	if err != nil {
 		return nil, fmt.Errorf("materializing the quota tree: %w", err)
 	}
+	recordApplied(result.Applied)
 
 	if sweeper, ok := r.Materialize.Backend.(interface {
 		Sweep(context.Context, sets.Set[string]) (int, error)
 	}); ok {
-		if _, err := sweeper.Sweep(ctx, keep); err != nil {
+		swept, err := sweeper.Sweep(ctx, keep)
+		recordSwept(SweepTriggerMaterialize, swept)
+		if err != nil {
 			return result.Nodes, fmt.Errorf("sweeping orphaned objects: %w", err)
 		}
 	}

--- a/pkg/controller/v1beta1/acceleratorquota/metrics.go
+++ b/pkg/controller/v1beta1/acceleratorquota/metrics.go
@@ -1,0 +1,303 @@
+package acceleratorquota
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/quota/capacity"
+)
+
+// Collectors for the numbers the quota passes already compute. Every one is
+// observed at the controller call site that produced it, so pkg/quota stays a
+// library with no metrics dependency of its own.
+//
+// The capacity and backend families below carry no plane label. Capacity
+// derivation and materialization both run in workload mode only -- r.Capacity
+// and r.Materialize are populated on that branch alone -- so a mode label could
+// only ever hold one value, and a constant label is a column that costs
+// cardinality and answers nothing. The budget family further down does carry
+// it, because both modes publish budgets and mean different things by them.
+//
+// The capacity gauges are a full snapshot of the last pass, so each is Reset
+// before it is repopulated: a flavor being added has to drive the series it
+// used to own back to zero, and a stale series that merely stops updating
+// would read as a fleet that still has unattributed accelerators.
+var (
+	capacityAllocatable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_capacity_allocatable",
+		Help: "Allocatable accelerators on nodes that could accept work at the last capacity pass, by resource and ResourceFlavor. Allocatable, not capacity, so it will not reconcile against kube_node_status_capacity.",
+	}, []string{"resource", "flavor"})
+
+	capacityUnavailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_capacity_unavailable",
+		Help: "Accelerators on nodes that matched a ResourceFlavor but were cordoned or not Ready. Budgets are sized against allocatable, so this is the parked remainder.",
+	}, []string{"resource", "flavor"})
+
+	capacityNodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_capacity_nodes",
+		Help: "Nodes behind the accelerator totals, by resource, ResourceFlavor and whether they can accept work. This is what separates a one-machine shortfall from a rack.",
+	}, []string{"resource", "flavor", "state"})
+
+	capacityUnattributed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_capacity_unattributed",
+		Help: "Allocatable accelerators on nodes that no ResourceFlavor claims, so they contribute zero capacity to every budget. Non-zero means a missing or ambiguous ResourceFlavor, not a shrinking fleet.",
+	}, []string{"resource", "reason"})
+
+	capacityUnattributedNodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_capacity_unattributed_nodes",
+		Help: "Distinct nodes whose accelerators could not be attributed to a ResourceFlavor. Counts nodes, not node-resource pairs, so a node advertising two unclaimed resources is counted once.",
+	}, []string{"reason"})
+
+	backendAppliedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ome_quota_backend_applied_total",
+		Help: "Kueue objects written by the materializer. Writes are server-side applies issued unconditionally, so this tracks pass frequency times render size, not how often the tree changed.",
+	})
+
+	backendSweptTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ome_quota_backend_swept_total",
+		Help: "Kueue objects reaped as orphans, by what triggered the sweep: a materialization pass finding objects the tree no longer names, or a node being deleted.",
+	}, []string{"trigger"})
+)
+
+// Per-node accelerator accounting, written from the same pass that builds
+// status.budgets so the series and the CR cannot disagree.
+//
+// The identifying label is quota, not node: this package already reports
+// ome_quota_capacity_nodes, which counts machines, and one word meaning both a
+// Kubernetes node and a quota-tree node three panels apart is a trap. quota is
+// the AcceleratorQuota object name, which is cluster-scoped and
+// webhook-validated, so it needs no namespace and cannot run unbounded.
+//
+// These do carry plane. Both modes publish budgets and the same series means a
+// different thing in each: on a workload plane nominal is this cluster's share
+// and admitted is what its Kueue queues hold, while on a management plane
+// nominal is the authored fleet total and usage arrives only through the
+// member-status funnel. A fleet-wide query that mixed them would be summing
+// two different quantities.
+//
+// path carries the root-to-node position alongside quota, because a bare object
+// name does not say where in the tree a budget sits and two tenants under
+// different parents can be told apart only by their ancestry. It is derived from
+// quota rather than independent of it, so it multiplies no cardinality -- a node
+// has exactly one path -- but it does change when a node is reparented, which
+// recordBudgets handles rather than leaving two live series for one node. Empty
+// means the tree could not reach the node from the root, matching status.path.
+//
+// Lent is deliberately absent. The model has no lent figure -- an ancestor's
+// borrowed is recomputed rather than summed from its children, because a loan
+// between two siblings is internal to the subtree that contains them. Adding a
+// Go-side lent would invent a number the tree does not have; it is derivable in
+// PromQL over a subtree for anyone who wants it.
+var (
+	budgetNominal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_budget_nominal",
+		Help: "Accelerators allowed for this node and flavor: the fleet total where the tree is authored, this cluster's share on a projection.",
+	}, budgetLabels)
+
+	budgetAdmitted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_budget_admitted",
+		Help: "Accelerators currently admitted against the materialized queues, including anything borrowed.",
+	}, budgetLabels)
+
+	budgetReserved = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_budget_reserved",
+		Help: "Accelerators held by workloads carrying a quota reservation, admitted or not. Never below admitted; the gap is work that owns accelerators but has not started, so a tenant at its ceiling reads as idle unless this is read too.",
+	}, budgetLabels)
+
+	budgetBorrowed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_quota_budget_borrowed",
+		Help: "Accelerators admitted above this node's own nominal, taken from idle siblings and reclaimable on contention.",
+	}, budgetLabels)
+)
+
+var budgetLabels = []string{"plane", "quota", "path", "role", "resource", "flavor"}
+
+// budgetVectors is every vector keyed by quota, so a sweep cannot miss one that
+// was added later.
+func budgetVectors() []*prometheus.GaugeVec {
+	return []*prometheus.GaugeVec{budgetNominal, budgetAdmitted, budgetReserved, budgetBorrowed}
+}
+
+// recorded maps each quota name with live budget series to the path it was last
+// published under, so a pass can drop the ones the tree no longer names and
+// spot the ones that moved. The reconcile is whole-tree and serialised on one
+// key, but the mutex costs nothing and removes the assumption.
+var (
+	recordedMu sync.Mutex
+	recorded   = map[string]string{}
+)
+
+// Sweep triggers. Stable strings -- dashboards and alerts key off them.
+const (
+	// SweepTriggerMaterialize is a sweep at the end of a materialization pass,
+	// removing objects the current tree no longer names.
+	SweepTriggerMaterialize = "materialize"
+	// SweepTriggerFinalize is a sweep while releasing a deleted node's
+	// finalizer, removing that node's own objects.
+	SweepTriggerFinalize = "finalize"
+)
+
+// Node states behind a capacity total. Stable strings.
+const (
+	// NodeStateSchedulable counts nodes that could accept work.
+	NodeStateSchedulable = "schedulable"
+	// NodeStateUnavailable counts nodes that matched the flavor but were
+	// cordoned or not Ready.
+	NodeStateUnavailable = "unavailable"
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		capacityAllocatable,
+		capacityUnavailable,
+		capacityNodes,
+		capacityUnattributed,
+		capacityUnattributedNodes,
+		backendAppliedTotal,
+		backendSweptTotal,
+		budgetNominal,
+		budgetAdmitted,
+		budgetReserved,
+		budgetBorrowed,
+	)
+}
+
+// recordBudgets publishes one node's accelerator accounting.
+//
+// Called where status.budgets is computed rather than after the write lands,
+// and deliberately so: most passes change nothing, and a manager that only
+// published on change would come back from a restart with every budget series
+// missing until someone edited a spec. The gauge reports what the controller
+// resolved this pass, which is what the CR carries whenever the write succeeds.
+func recordBudgets(plane, quota, path, role string, budgets []v1beta1.AcceleratorBudgetStatus) {
+	if plane == "" || quota == "" {
+		return
+	}
+
+	// Reparenting moves a node without renaming it, and path is part of the key,
+	// so the series it used to occupy would keep reporting alongside its
+	// replacement and double the node in any sum. Drop the old one first.
+	recordedMu.Lock()
+	previous, seen := recorded[quota]
+	moved := seen && previous != path
+	recorded[quota] = path
+	recordedMu.Unlock()
+
+	if moved {
+		dropSeriesFor(quota)
+	}
+
+	for _, b := range budgets {
+		labels := []string{plane, quota, path, role, b.ResourceName, b.ResourceFlavor}
+		budgetNominal.WithLabelValues(labels...).Set(b.Nominal.AsApproximateFloat64())
+		budgetAdmitted.WithLabelValues(labels...).Set(b.Admitted.AsApproximateFloat64())
+		budgetReserved.WithLabelValues(labels...).Set(b.Reserved.AsApproximateFloat64())
+		budgetBorrowed.WithLabelValues(labels...).Set(b.Borrowed.AsApproximateFloat64())
+	}
+}
+
+// deleteQuotaSeries drops every budget series for one node, on the path that
+// removes it from the tree.
+func deleteQuotaSeries(quota string) {
+	recordedMu.Lock()
+	delete(recorded, quota)
+	recordedMu.Unlock()
+
+	dropSeriesFor(quota)
+}
+
+// dropSeriesFor removes every budget series carrying one quota name, whatever
+// path it was published under. Matching on quota alone is what lets it clean up
+// after a node that moved, whose stale series is keyed on a path no caller still
+// holds.
+func dropSeriesFor(quota string) {
+	for _, v := range budgetVectors() {
+		v.DeletePartialMatch(prometheus.Labels{"quota": quota})
+	}
+}
+
+// sweepBudgets drops series for nodes the tree no longer names.
+//
+// The finalizer path is the ordinary way a node's series go away; this catches
+// the rest -- a finalizer force-stripped by hand, or a delete that landed while
+// this manager was down. Cheap here because the pass already holds the
+// authoritative node set, which a per-object reconciler never does.
+func sweepBudgets(live map[string]struct{}) {
+	recordedMu.Lock()
+	var stale []string
+	for name := range recorded {
+		if _, ok := live[name]; !ok {
+			stale = append(stale, name)
+			delete(recorded, name)
+		}
+	}
+	recordedMu.Unlock()
+
+	for _, name := range stale {
+		dropSeriesFor(name)
+	}
+}
+
+// recordCapacity publishes one whole capacity pass.
+//
+// Takes the full result rather than the two slices separately, because the
+// gauges are a snapshot: partial publication would leave the unattributed
+// series describing one pass and the allocatable series another.
+func recordCapacity(observed capacity.Result) {
+	capacityAllocatable.Reset()
+	capacityUnavailable.Reset()
+	capacityNodes.Reset()
+	capacityUnattributed.Reset()
+	capacityUnattributedNodes.Reset()
+
+	for _, c := range observed.Capacities {
+		capacityAllocatable.WithLabelValues(c.ResourceName, c.ResourceFlavor).
+			Set(c.Allocatable.AsApproximateFloat64())
+		capacityUnavailable.WithLabelValues(c.ResourceName, c.ResourceFlavor).
+			Set(c.Unavailable.AsApproximateFloat64())
+		capacityNodes.WithLabelValues(c.ResourceName, c.ResourceFlavor, NodeStateSchedulable).
+			Set(float64(c.Nodes))
+		capacityNodes.WithLabelValues(c.ResourceName, c.ResourceFlavor, NodeStateUnavailable).
+			Set(float64(c.UnavailableNodes))
+	}
+
+	// Unattributed carries one entry per (node, resource). Accelerators sum across
+	// those entries, but nodes must not: a node advertising two unclaimed
+	// resources is one node, and counting entries would double it.
+	accelerators := map[[2]string]float64{}
+	nodes := map[string]map[string]struct{}{}
+	for _, u := range observed.Unattributed {
+		accelerators[[2]string{u.ResourceName, u.Reason}] += u.Quantity.AsApproximateFloat64()
+		if nodes[u.Reason] == nil {
+			nodes[u.Reason] = map[string]struct{}{}
+		}
+		nodes[u.Reason][u.Node] = struct{}{}
+	}
+	for key, total := range accelerators {
+		capacityUnattributed.WithLabelValues(key[0], key[1]).Set(total)
+	}
+	for reason, set := range nodes {
+		capacityUnattributedNodes.WithLabelValues(reason).Set(float64(len(set)))
+	}
+}
+
+// recordApplied counts the objects one materialization pass wrote.
+func recordApplied(objects int) {
+	if objects <= 0 {
+		return
+	}
+	backendAppliedTotal.Add(float64(objects))
+}
+
+// recordSwept counts the objects one sweep reaped. A sweep that finds nothing
+// is the steady state, so it is not recorded -- the counter would otherwise be
+// indistinguishable from one that never ran.
+func recordSwept(trigger string, objects int) {
+	if objects <= 0 {
+		return
+	}
+	backendSweptTotal.WithLabelValues(trigger).Add(float64(objects))
+}

--- a/pkg/controller/v1beta1/acceleratorquota/metrics_test.go
+++ b/pkg/controller/v1beta1/acceleratorquota/metrics_test.go
@@ -1,0 +1,432 @@
+package acceleratorquota
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/quota/capacity"
+)
+
+// Unit tests for the collectors registered at package init in metrics.go.
+// Nothing here needs envtest or a reconciler: the recorders are pure functions
+// of a capacity.Result or an int, which is the whole reason instrumentation
+// lives at the controller call site rather than inside pkg/quota.
+
+// sampleFor reads one sample out of the controller-runtime registry by metric
+// name and label subset. Returns 0 when the family exists but no sample
+// matches, and -1 only when Gather itself fails, so a missing metric is
+// distinguishable from a metric sitting at zero.
+// seriesFor counts the series matching a label subset. sampleFor reads the
+// first match and so cannot see a duplicate whose value happens to agree.
+func seriesFor(t *testing.T, name string, labels prometheus.Labels) int {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		return -1
+	}
+	count := 0
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			matched := true
+			for _, l := range m.GetLabel() {
+				if want, ok := labels[l.GetName()]; ok && want != l.GetValue() {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func sampleFor(t *testing.T, name string, labels prometheus.Labels) float64 {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		return -1
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			matched := true
+			for _, l := range m.GetLabel() {
+				if want, ok := labels[l.GetName()]; ok && want != l.GetValue() {
+					matched = false
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+			if m.Gauge != nil {
+				return m.Gauge.GetValue()
+			}
+			if m.Counter != nil {
+				return m.Counter.GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// The registration itself is the contract the scrape path depends on: a metric
+// that is declared but never registered is served by nothing, which is the
+// failure this whole package exists to stop repeating.
+func TestMetricsAreRegistered(t *testing.T) {
+	recordCapacity(capacity.Result{
+		Capacities: []capacity.Capacity{{
+			ResourceName: "example.com/accelerator", ResourceFlavor: "flavor-a",
+			Allocatable: qty("1"),
+		}},
+		Unattributed: []capacity.Unattributed{{
+			Node: "node-a", ResourceName: "example.com/accelerator",
+			Quantity: qty("1"), Reason: capacity.ReasonNoFlavor,
+		}},
+	})
+	recordApplied(1)
+	recordSwept(SweepTriggerMaterialize, 1)
+
+	for _, name := range []string{
+		"ome_quota_capacity_allocatable",
+		"ome_quota_capacity_unavailable",
+		"ome_quota_capacity_nodes",
+		"ome_quota_capacity_unattributed",
+		"ome_quota_capacity_unattributed_nodes",
+		"ome_quota_backend_applied_total",
+		"ome_quota_backend_swept_total",
+	} {
+		families, err := ctrlmetrics.Registry.Gather()
+		if err != nil {
+			t.Fatalf("gathering: %v", err)
+		}
+		found := false
+		for _, mf := range families {
+			if mf.GetName() == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s is not registered in the controller-runtime registry", name)
+		}
+	}
+}
+
+func TestRecordCapacitySplitsSchedulableFromParked(t *testing.T) {
+	recordCapacity(capacity.Result{Capacities: []capacity.Capacity{{
+		ResourceName:     "example.com/gpu",
+		ResourceFlavor:   "flavor-split",
+		Allocatable:      qty("24"),
+		Unavailable:      qty("8"),
+		Nodes:            3,
+		UnavailableNodes: 1,
+	}}})
+
+	l := prometheus.Labels{"resource": "example.com/gpu", "flavor": "flavor-split"}
+	if got := sampleFor(t, "ome_quota_capacity_allocatable", l); got != 24 {
+		t.Errorf("allocatable accelerators = %v, want 24", got)
+	}
+	if got := sampleFor(t, "ome_quota_capacity_unavailable", l); got != 8 {
+		t.Errorf("unavailable accelerators = %v, want 8", got)
+	}
+
+	sched := prometheus.Labels{"resource": "example.com/gpu", "flavor": "flavor-split", "state": NodeStateSchedulable}
+	if got := sampleFor(t, "ome_quota_capacity_nodes", sched); got != 3 {
+		t.Errorf("schedulable nodes = %v, want 3", got)
+	}
+	parked := prometheus.Labels{"resource": "example.com/gpu", "flavor": "flavor-split", "state": NodeStateUnavailable}
+	if got := sampleFor(t, "ome_quota_capacity_nodes", parked); got != 1 {
+		t.Errorf("unavailable nodes = %v, want 1", got)
+	}
+}
+
+// Unattributed carries one entry per (node, resource). Accelerators sum across those
+// entries; nodes must not, or a node advertising two unclaimed resources is
+// counted twice and the fleet looks bigger than it is.
+func TestRecordCapacityCountsNodesOnceAcrossResources(t *testing.T) {
+	recordCapacity(capacity.Result{Unattributed: []capacity.Unattributed{
+		{Node: "dual", ResourceName: "example.com/a", Quantity: qty("4"), Reason: capacity.ReasonNoFlavor},
+		{Node: "dual", ResourceName: "example.com/b", Quantity: qty("2"), Reason: capacity.ReasonNoFlavor},
+		{Node: "single", ResourceName: "example.com/a", Quantity: qty("4"), Reason: capacity.ReasonNoFlavor},
+	}})
+
+	if got := sampleFor(t, "ome_quota_capacity_unattributed_nodes",
+		prometheus.Labels{"reason": capacity.ReasonNoFlavor}); got != 2 {
+		t.Errorf("unattributed nodes = %v, want 2 (dual counted once)", got)
+	}
+	if got := sampleFor(t, "ome_quota_capacity_unattributed",
+		prometheus.Labels{"resource": "example.com/a", "reason": capacity.ReasonNoFlavor}); got != 8 {
+		t.Errorf("unattributed accelerators for resource a = %v, want 8 (summed across nodes)", got)
+	}
+}
+
+// The two reasons must not be merged: a missing ResourceFlavor and an ambiguous
+// one need different fixes, and the whole point of the metric is to say which.
+func TestRecordCapacitySeparatesUnattributedReasons(t *testing.T) {
+	recordCapacity(capacity.Result{Unattributed: []capacity.Unattributed{
+		{Node: "n1", ResourceName: "example.com/r", Quantity: qty("1"), Reason: capacity.ReasonNoFlavor},
+		{Node: "n2", ResourceName: "example.com/r", Quantity: qty("5"), Reason: capacity.ReasonAmbiguous},
+	}})
+
+	if got := sampleFor(t, "ome_quota_capacity_unattributed",
+		prometheus.Labels{"resource": "example.com/r", "reason": capacity.ReasonNoFlavor}); got != 1 {
+		t.Errorf("no-flavor accelerators = %v, want 1", got)
+	}
+	if got := sampleFor(t, "ome_quota_capacity_unattributed",
+		prometheus.Labels{"resource": "example.com/r", "reason": capacity.ReasonAmbiguous}); got != 5 {
+		t.Errorf("ambiguous accelerators = %v, want 5", got)
+	}
+}
+
+// A flavor being added has to drive the series it used to own back to zero. A
+// gauge that merely stops updating keeps reporting unattributed accelerators on a
+// cluster that has just been fixed.
+func TestRecordCapacityClearsResolvedSeries(t *testing.T) {
+	recordCapacity(capacity.Result{Unattributed: []capacity.Unattributed{
+		{Node: "n1", ResourceName: "example.com/transient", Quantity: qty("9"), Reason: capacity.ReasonNoFlavor},
+	}})
+	if got := sampleFor(t, "ome_quota_capacity_unattributed",
+		prometheus.Labels{"resource": "example.com/transient", "reason": capacity.ReasonNoFlavor}); got != 9 {
+		t.Fatalf("precondition: accelerators = %v, want 9", got)
+	}
+
+	// The operator adds the flavor; the next pass attributes everything.
+	recordCapacity(capacity.Result{Capacities: []capacity.Capacity{{
+		ResourceName: "example.com/transient", ResourceFlavor: "now-claimed", Allocatable: qty("9"),
+	}}})
+
+	if got := sampleFor(t, "ome_quota_capacity_unattributed",
+		prometheus.Labels{"resource": "example.com/transient", "reason": capacity.ReasonNoFlavor}); got != 0 {
+		t.Errorf("accelerators after the flavor was added = %v, want the series gone", got)
+	}
+}
+
+// A sweep that finds nothing is the steady state. Recording it would make a
+// counter that never moves indistinguishable from one whose sweep never ran.
+func TestRecordSweptIgnoresEmptySweeps(t *testing.T) {
+	l := prometheus.Labels{"trigger": SweepTriggerFinalize}
+	before := sampleFor(t, "ome_quota_backend_swept_total", l)
+
+	recordSwept(SweepTriggerFinalize, 0)
+	if got := sampleFor(t, "ome_quota_backend_swept_total", l); got != before {
+		t.Errorf("an empty sweep moved the counter: %v -> %v", before, got)
+	}
+
+	recordSwept(SweepTriggerFinalize, 3)
+	if got := sampleFor(t, "ome_quota_backend_swept_total", l); got != before+3 {
+		t.Errorf("swept counter = %v, want %v", got, before+3)
+	}
+}
+
+// The two triggers answer different questions -- routine orphan collection
+// versus a node being deleted -- so they must not share a series.
+func TestRecordSweptSeparatesTriggers(t *testing.T) {
+	mat := prometheus.Labels{"trigger": SweepTriggerMaterialize}
+	fin := prometheus.Labels{"trigger": SweepTriggerFinalize}
+	beforeMat := sampleFor(t, "ome_quota_backend_swept_total", mat)
+	beforeFin := sampleFor(t, "ome_quota_backend_swept_total", fin)
+
+	recordSwept(SweepTriggerMaterialize, 2)
+
+	if got := sampleFor(t, "ome_quota_backend_swept_total", mat); got != beforeMat+2 {
+		t.Errorf("materialize sweeps = %v, want %v", got, beforeMat+2)
+	}
+	if got := sampleFor(t, "ome_quota_backend_swept_total", fin); got != beforeFin {
+		t.Errorf("a materialize sweep leaked into the finalize series: %v -> %v", beforeFin, got)
+	}
+}
+
+func TestRecordAppliedIgnoresEmptyPasses(t *testing.T) {
+	before := sampleFor(t, "ome_quota_backend_applied_total", nil)
+
+	recordApplied(0)
+	if got := sampleFor(t, "ome_quota_backend_applied_total", nil); got != before {
+		t.Errorf("an empty pass moved the counter: %v -> %v", before, got)
+	}
+
+	recordApplied(7)
+	if got := sampleFor(t, "ome_quota_backend_applied_total", nil); got != before+7 {
+		t.Errorf("applied counter = %v, want %v", got, before+7)
+	}
+}
+
+func budgetLabelsFor(quota, resource string) prometheus.Labels {
+	return prometheus.Labels{"quota": quota, "resource": resource}
+}
+
+func oneBudget(t *testing.T, nominal, admitted, reserved, borrowed string) []v1beta1.AcceleratorBudgetStatus {
+	t.Helper()
+	return []v1beta1.AcceleratorBudgetStatus{{
+		ResourceName:   "google.com/tpu",
+		ResourceFlavor: "tpu7x",
+		Nominal:        qty(nominal),
+		Admitted:       qty(admitted),
+		Reserved:       qty(reserved),
+		Borrowed:       qty(borrowed),
+	}}
+}
+
+// The four figures must land on four distinct series. Collapsing any pair would
+// make "at its ceiling" and "holding accelerators it has not started using" read the
+// same.
+func TestRecordBudgetsPublishesEveryFigure(t *testing.T) {
+	recordBudgets(string(ModeWorkload), "tenant-a", "/root/team/tenant-a",
+		string(v1beta1.AcceleratorQuotaRoleClusterQueue), oneBudget(t, "16", "8", "8", "0"))
+
+	l := budgetLabelsFor("tenant-a", "google.com/tpu")
+	for _, tc := range []struct {
+		metric string
+		want   float64
+	}{
+		{"ome_quota_budget_nominal", 16},
+		{"ome_quota_budget_admitted", 8},
+		{"ome_quota_budget_reserved", 8},
+		{"ome_quota_budget_borrowed", 0},
+	} {
+		if got := sampleFor(t, tc.metric, l); got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.metric, got, tc.want)
+		}
+	}
+}
+
+// The same series name means the authored fleet total on one plane and one
+// cluster's share on the other, so the two must not merge.
+func TestRecordBudgetsSeparatesPlanes(t *testing.T) {
+	recordBudgets(string(ModeWorkload), "shared", "/shared", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "16", "0", "0", "0"))
+	recordBudgets(string(ModeManagement), "shared", "/shared", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "64", "0", "0", "0"))
+
+	wl := prometheus.Labels{"quota": "shared", "plane": string(ModeWorkload)}
+	mg := prometheus.Labels{"quota": "shared", "plane": string(ModeManagement)}
+	if got := sampleFor(t, "ome_quota_budget_nominal", wl); got != 16 {
+		t.Errorf("workload nominal = %v, want 16", got)
+	}
+	if got := sampleFor(t, "ome_quota_budget_nominal", mg); got != 64 {
+		t.Errorf("management nominal = %v, want 64", got)
+	}
+}
+
+// A blank plane or quota would land a series keyed on nothing, which no
+// dashboard can select and no sweep can find again.
+func TestRecordBudgetsDropsUnlabelledSamples(t *testing.T) {
+	recordBudgets("", "no-plane", "/no-plane", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "1", "0", "0", "0"))
+	recordBudgets(string(ModeWorkload), "", "", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "1", "0", "0", "0"))
+
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"quota": "no-plane"}); got != 0 {
+		t.Errorf("a sample with no plane was published: %v", got)
+	}
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"plane": string(ModeWorkload), "quota": ""}); got != 0 {
+		t.Errorf("a sample with no quota name was published: %v", got)
+	}
+}
+
+// Deleting a node has to take its series with it, or a deleted tenant's
+// allowance is reported forever.
+func TestDeleteQuotaSeriesDropsEveryVector(t *testing.T) {
+	recordBudgets(string(ModeWorkload), "doomed", "/doomed", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "8", "4", "4", "0"))
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"quota": "doomed"}); got != 8 {
+		t.Fatalf("precondition: nominal = %v, want 8", got)
+	}
+
+	deleteQuotaSeries("doomed")
+
+	for _, m := range []string{
+		"ome_quota_budget_nominal", "ome_quota_budget_admitted",
+		"ome_quota_budget_reserved", "ome_quota_budget_borrowed",
+	} {
+		if got := sampleFor(t, m, prometheus.Labels{"quota": "doomed"}); got != 0 {
+			t.Errorf("%s survived the delete: %v", m, got)
+		}
+	}
+}
+
+// The finalizer is the ordinary path; this is the one that catches a node
+// force-stripped, or deleted while the manager was down.
+func TestSweepBudgetsDropsNodesNoLongerInTheTree(t *testing.T) {
+	recordBudgets(string(ModeWorkload), "stays", "/stays", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "8", "0", "0", "0"))
+	recordBudgets(string(ModeWorkload), "vanished", "/vanished", string(v1beta1.AcceleratorQuotaRoleClusterQueue),
+		oneBudget(t, "4", "0", "0", "0"))
+
+	sweepBudgets(map[string]struct{}{"stays": {}})
+
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"quota": "vanished"}); got != 0 {
+		t.Errorf("a node absent from the tree kept its series: %v", got)
+	}
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"quota": "stays"}); got != 8 {
+		t.Errorf("the sweep removed a node that is still in the tree: %v", got)
+	}
+}
+
+// A bare object name does not say where in the tree a budget sits, and two
+// tenants under different parents are distinguishable only by ancestry.
+func TestRecordBudgetsPublishesTheTreePath(t *testing.T) {
+	recordBudgets(string(ModeWorkload), "nested", "/root/team/nested",
+		string(v1beta1.AcceleratorQuotaRoleClusterQueue), oneBudget(t, "12", "0", "0", "0"))
+
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"path": "/root/team/nested"}); got != 12 {
+		t.Errorf("nominal selected by path = %v, want 12", got)
+	}
+}
+
+// Reparenting moves a node without renaming it. path is part of the series key,
+// so the position it vacated has to stop reporting -- otherwise one node is
+// counted twice in every sum until the stale series ages out of the store.
+func TestRecordBudgetsReparentLeavesOneSeries(t *testing.T) {
+	const quota = "movable"
+	recordBudgets(string(ModeWorkload), quota, "/root/before",
+		string(v1beta1.AcceleratorQuotaRoleClusterQueue), oneBudget(t, "8", "0", "0", "0"))
+	recordBudgets(string(ModeWorkload), quota, "/root/after",
+		string(v1beta1.AcceleratorQuotaRoleClusterQueue), oneBudget(t, "8", "0", "0", "0"))
+
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"path": "/root/before"}); got != 0 {
+		t.Errorf("the vacated path kept reporting: %v", got)
+	}
+	if got := sampleFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"path": "/root/after"}); got != 8 {
+		t.Errorf("nominal at the new path = %v, want 8", got)
+	}
+	// Counted, not sampled: two series each reading 8 are indistinguishable from
+	// one by value, and it is the second series that does the damage in a sum.
+	if got := seriesFor(t, "ome_quota_budget_nominal",
+		prometheus.Labels{"quota": quota}); got != 1 {
+		t.Errorf("the node has %d series, want 1 -- the move left the old path behind", got)
+	}
+}
+
+// Republishing a node that has not moved must not disturb its series, since
+// that is what every resync tick does.
+func TestRecordBudgetsRepublishesInPlace(t *testing.T) {
+	const path = "/root/steady"
+	recordBudgets(string(ModeWorkload), "steady", path,
+		string(v1beta1.AcceleratorQuotaRoleClusterQueue), oneBudget(t, "8", "2", "2", "0"))
+	recordBudgets(string(ModeWorkload), "steady", path,
+		string(v1beta1.AcceleratorQuotaRoleClusterQueue), oneBudget(t, "8", "6", "6", "0"))
+
+	if got := sampleFor(t, "ome_quota_budget_admitted",
+		prometheus.Labels{"path": path}); got != 6 {
+		t.Errorf("admitted = %v, want 6", got)
+	}
+}

--- a/pkg/controller/v1beta1/placement/controller.go
+++ b/pkg/controller/v1beta1/placement/controller.go
@@ -1278,6 +1278,9 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, isvc *v1beta1.Inferenc
 	if f, ok := r.nominate().(forgetRoundState); ok {
 		f.forget(isvc.UID)
 	}
+	// Likewise the placement metrics, so a deleted ISVC stops reporting a phase
+	// and a winning cluster.
+	DeleteForISVC(isvc.Namespace, isvc.Name)
 	return ctrl.Result{}, nil
 }
 
@@ -1336,6 +1339,9 @@ func (r *Reconciler) writePlacement(ctx context.Context, isvc *v1beta1.Inference
 		}
 		return ctrl.Result{}, err
 	}
+	// Publish only after the status write landed, so the gauges never advertise
+	// a placement the API server rejected.
+	recordPlacement(isvc, res)
 	return ctrl.Result{RequeueAfter: r.safetyRequeue()}, nil
 }
 

--- a/pkg/controller/v1beta1/placement/metrics.go
+++ b/pkg/controller/v1beta1/placement/metrics.go
@@ -1,0 +1,171 @@
+package placement
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// Per-ISVC placement metrics. Every vector carries "namespace" and "isvc" so
+// same-named ISVCs cannot collide and the series set can be dropped on teardown,
+// bounding cardinality to the live ISVC count.
+//
+// Enum state is a label on an always-1 gauge, which makes phase="Failed"
+// directly alertable but only holds if stale label values are removed — hence
+// the reset-before-write in recordPlacement.
+var (
+	placementPhase = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_phase",
+		Help: "Always 1, labelled with the InferenceService's current multi-cluster placement phase (Pending, Racing, Placed, Failed). Exactly one series per ISVC.",
+	}, []string{"namespace", "isvc", "phase"})
+
+	placementWinner = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_winner",
+		Help: "Always 1, labelled with the WorkloadCluster the InferenceService is currently placed on. Absent while no cluster has won the race.",
+	}, []string{"namespace", "isvc", "cluster"})
+
+	placementCandidate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_candidate",
+		Help: "Always 1 per (ISVC, candidate cluster) the control plane has fanned out to, labelled with that candidate's phase (Placed, Admitted).",
+	}, []string{"namespace", "isvc", "cluster", "phase"})
+
+	placementCandidateAdmitted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_candidate_admitted_replicas",
+		Help: "Replicas this candidate cluster's Kueue has admitted. Meaningful in Split mode, where the control plane sums it across homes to decide whether the desired count is met.",
+	}, []string{"namespace", "isvc", "cluster"})
+
+	placementCandidateReady = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_candidate_ready_replicas",
+		Help: "Replicas serving traffic on this candidate cluster. In Split mode this is the weight an external LB uses to split traffic across homes.",
+	}, []string{"namespace", "isvc", "cluster"})
+
+	// Policy is spec-derived, not status-derived: it answers "what was asked
+	// for" so it can be compared against where the workload actually landed.
+	// The selector strings are free-form, but they vary per ISVC rather than per
+	// scrape, so the series count still tracks the live ISVC count.
+	placementPolicyInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_policy_info",
+		Help: "Always 1, labelled with the InferenceService's declared placement policy: mode, accelerator requirements, cluster selector, and Split spread. Exactly one series per ISVC that declares a placement.",
+	}, []string{"namespace", "isvc", "mode", "requirements", "cluster_selector", "spread"})
+
+	placementSplitReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_split_replicas",
+		Help: "Desired total replicas to distribute across homes, from spec.placement.split.replicas.",
+	}, []string{"namespace", "isvc"})
+
+	placementSplitMaxPerCluster = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_split_max_replicas_per_cluster",
+		Help: "Per-cluster replica ceiling from spec.placement.split.maxReplicasPerCluster (0 = uncapped).",
+	}, []string{"namespace", "isvc"})
+
+	placementSplitMinPerCluster = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_isvc_placement_split_min_replicas_per_cluster",
+		Help: "Per-cluster replica floor from spec.placement.split.minReplicasPerCluster (0 = unset).",
+	}, []string{"namespace", "isvc"})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		placementPhase, placementWinner, placementCandidate,
+		placementCandidateAdmitted, placementCandidateReady,
+		placementPolicyInfo, placementSplitReplicas,
+		placementSplitMaxPerCluster, placementSplitMinPerCluster,
+	)
+}
+
+// recordPlacement publishes the placement metrics for one source ISVC from the
+// status this pass just persisted, plus its declared policy. Called from
+// writePlacement after a successful status update so the gauges never advertise
+// a placement the API server rejected.
+func recordPlacement(isvc *v1beta1.InferenceService, res placementResult) {
+	if isvc == nil || isvc.Name == "" {
+		return
+	}
+	ns, name := isvc.Namespace, isvc.Name
+	match := prometheus.Labels{"namespace": ns, "isvc": name}
+
+	// Phase: reset so only the current phase reports 1.
+	placementPhase.DeletePartialMatch(match)
+	if res.phase != "" {
+		placementPhase.WithLabelValues(ns, name, string(res.phase)).Set(1)
+	}
+
+	// Winner: reset so a re-placement onto a different cluster does not leave
+	// the previous home reporting 1 alongside the new one.
+	placementWinner.DeletePartialMatch(match)
+	if res.winner != "" {
+		placementWinner.WithLabelValues(ns, name, res.winner).Set(1)
+	}
+
+	// Candidates: reset all three vectors so a cluster dropped from the race
+	// (loser sweep) stops reporting.
+	placementCandidate.DeletePartialMatch(match)
+	placementCandidateAdmitted.DeletePartialMatch(match)
+	placementCandidateReady.DeletePartialMatch(match)
+	for _, c := range res.candidates {
+		if c.Cluster == "" {
+			continue
+		}
+		placementCandidate.WithLabelValues(ns, name, c.Cluster, string(c.Phase)).Set(1)
+		placementCandidateAdmitted.WithLabelValues(ns, name, c.Cluster).Set(float64(c.AdmittedReplicas))
+		placementCandidateReady.WithLabelValues(ns, name, c.Cluster).Set(float64(c.ReadyReplicas))
+	}
+
+	recordPolicy(isvc)
+}
+
+// recordPolicy publishes the spec-side placement policy. Split-only numeric
+// fields are cleared for a non-Split (or absent) policy so a mode change does
+// not leave a stale replica band behind.
+func recordPolicy(isvc *v1beta1.InferenceService) {
+	ns, name := isvc.Namespace, isvc.Name
+	match := prometheus.Labels{"namespace": ns, "isvc": name}
+
+	placementPolicyInfo.DeletePartialMatch(match)
+	placementSplitReplicas.DeletePartialMatch(match)
+	placementSplitMaxPerCluster.DeletePartialMatch(match)
+	placementSplitMinPerCluster.DeletePartialMatch(match)
+
+	p := isvc.Spec.Placement
+	if p == nil {
+		return
+	}
+
+	spread := false
+	if p.Split != nil {
+		spread = p.Split.Spread
+	}
+	placementPolicyInfo.WithLabelValues(
+		ns, name, string(p.Mode), p.Requirements, p.ClusterSelector, strconv.FormatBool(spread),
+	).Set(1)
+
+	if p.Split == nil {
+		return
+	}
+	if p.Split.Replicas != nil {
+		placementSplitReplicas.WithLabelValues(ns, name).Set(float64(*p.Split.Replicas))
+	}
+	placementSplitMaxPerCluster.WithLabelValues(ns, name).Set(float64(p.Split.MaxReplicasPerCluster))
+	placementSplitMinPerCluster.WithLabelValues(ns, name).Set(float64(p.Split.MinReplicasPerCluster))
+}
+
+// DeleteForISVC drops every placement series for an ISVC. Called on teardown so
+// a deleted ISVC does not keep reporting a phase and a winning cluster.
+func DeleteForISVC(namespace, isvc string) {
+	if isvc == "" {
+		return
+	}
+	match := prometheus.Labels{"namespace": namespace, "isvc": isvc}
+	placementPhase.DeletePartialMatch(match)
+	placementWinner.DeletePartialMatch(match)
+	placementCandidate.DeletePartialMatch(match)
+	placementCandidateAdmitted.DeletePartialMatch(match)
+	placementCandidateReady.DeletePartialMatch(match)
+	placementPolicyInfo.DeletePartialMatch(match)
+	placementSplitReplicas.DeletePartialMatch(match)
+	placementSplitMaxPerCluster.DeletePartialMatch(match)
+	placementSplitMinPerCluster.DeletePartialMatch(match)
+}

--- a/pkg/controller/v1beta1/placement/metrics_test.go
+++ b/pkg/controller/v1beta1/placement/metrics_test.go
@@ -1,0 +1,192 @@
+package placement
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// resetPlacementMetrics clears every vector so whole-vector counts are
+// deterministic. Required because other tests in this package reconcile ISVCs
+// into these same globals, and CollectAndCount sizes the whole vector rather
+// than one label set.
+func resetPlacementMetrics() {
+	placementPhase.Reset()
+	placementWinner.Reset()
+	placementCandidate.Reset()
+	placementCandidateAdmitted.Reset()
+	placementCandidateReady.Reset()
+	placementPolicyInfo.Reset()
+	placementSplitReplicas.Reset()
+	placementSplitMaxPerCluster.Reset()
+	placementSplitMinPerCluster.Reset()
+}
+
+func splitISVC(ns, name string, replicas int32) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: v1beta1.InferenceServiceSpec{
+			Placement: &v1beta1.PlacementSpec{
+				Mode:            v1beta1.PlacementModeSplit,
+				Requirements:    "accelerator=tpu7x",
+				ClusterSelector: "region=us-east",
+				Split: &v1beta1.SplitSpec{
+					Replicas:              &replicas,
+					Spread:                true,
+					MaxReplicasPerCluster: 4,
+					MinReplicasPerCluster: 1,
+				},
+			},
+		},
+	}
+}
+
+// TestRecordPlacement_PublishesPhaseWinnerAndCandidates: one pass emits exactly
+// one phase series, one winner series, and per-candidate state plus replica
+// counts.
+func TestRecordPlacement_PublishesPhaseWinnerAndCandidates(t *testing.T) {
+	resetPlacementMetrics()
+
+	isvc := splitISVC("ns", "svc", 8)
+	res := placementResult{
+		winner: "cluster-a",
+		phase:  v1beta1.PlacementPhasePlaced,
+		candidates: []v1beta1.CandidatePlacement{
+			{Cluster: "cluster-a", Phase: v1beta1.CandidatePhaseAdmitted, AdmittedReplicas: 5, ReadyReplicas: 4},
+			{Cluster: "cluster-b", Phase: v1beta1.CandidatePhasePlaced, AdmittedReplicas: 3, ReadyReplicas: 0},
+		},
+	}
+	recordPlacement(isvc, res)
+
+	if got := testutil.CollectAndCount(placementPhase); got != 1 {
+		t.Fatalf("phase series = %d, want exactly 1", got)
+	}
+	if got := testutil.ToFloat64(placementPhase.WithLabelValues("ns", "svc", "Placed")); got != 1 {
+		t.Errorf("phase{Placed} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(placementWinner.WithLabelValues("ns", "svc", "cluster-a")); got != 1 {
+		t.Errorf("winner{cluster-a} = %v, want 1", got)
+	}
+	if got := testutil.CollectAndCount(placementCandidate); got != 2 {
+		t.Errorf("candidate series = %d, want 2", got)
+	}
+	if got := testutil.ToFloat64(placementCandidateAdmitted.WithLabelValues("ns", "svc", "cluster-a")); got != 5 {
+		t.Errorf("admitted{cluster-a} = %v, want 5", got)
+	}
+	if got := testutil.ToFloat64(placementCandidateReady.WithLabelValues("ns", "svc", "cluster-b")); got != 0 {
+		t.Errorf("ready{cluster-b} = %v, want 0", got)
+	}
+}
+
+// TestRecordPlacement_NoStaleSeriesOnTransition is the reason every vector is
+// reset before it is written: an ISVC that moves Racing -> Placed, changes
+// winner, and drops a candidate must not keep reporting the old label values.
+func TestRecordPlacement_NoStaleSeriesOnTransition(t *testing.T) {
+	resetPlacementMetrics()
+
+	isvc := splitISVC("ns", "svc", 8)
+	recordPlacement(isvc, placementResult{
+		winner: "cluster-a",
+		phase:  v1beta1.PlacementPhaseRacing,
+		candidates: []v1beta1.CandidatePlacement{
+			{Cluster: "cluster-a", Phase: v1beta1.CandidatePhasePlaced},
+			{Cluster: "cluster-b", Phase: v1beta1.CandidatePhasePlaced},
+		},
+	})
+	recordPlacement(isvc, placementResult{
+		winner: "cluster-b",
+		phase:  v1beta1.PlacementPhasePlaced,
+		candidates: []v1beta1.CandidatePlacement{
+			{Cluster: "cluster-b", Phase: v1beta1.CandidatePhaseAdmitted},
+		},
+	})
+
+	if got := testutil.CollectAndCount(placementPhase); got != 1 {
+		t.Errorf("phase series = %d, want 1 (Racing must not linger)", got)
+	}
+	if got := testutil.ToFloat64(placementPhase.WithLabelValues("ns", "svc", "Placed")); got != 1 {
+		t.Errorf("phase{Placed} = %v, want 1", got)
+	}
+	if got := testutil.CollectAndCount(placementWinner); got != 1 {
+		t.Errorf("winner series = %d, want 1 (cluster-a must not linger)", got)
+	}
+	if got := testutil.CollectAndCount(placementCandidate); got != 1 {
+		t.Errorf("candidate series = %d, want 1 (swept loser must not linger)", got)
+	}
+}
+
+// TestRecordPolicy_SplitFieldsAndModeChange: Split publishes the replica band;
+// switching to a non-Split mode clears it rather than leaving a stale band.
+func TestRecordPolicy_SplitFieldsAndModeChange(t *testing.T) {
+	resetPlacementMetrics()
+
+	isvc := splitISVC("ns", "svc", 8)
+	recordPolicy(isvc)
+
+	if got := testutil.ToFloat64(placementPolicyInfo.WithLabelValues(
+		"ns", "svc", "Split", "accelerator=tpu7x", "region=us-east", "true")); got != 1 {
+		t.Errorf("policy_info = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(placementSplitReplicas.WithLabelValues("ns", "svc")); got != 8 {
+		t.Errorf("split_replicas = %v, want 8", got)
+	}
+	if got := testutil.ToFloat64(placementSplitMaxPerCluster.WithLabelValues("ns", "svc")); got != 4 {
+		t.Errorf("max_per_cluster = %v, want 4", got)
+	}
+
+	isvc.Spec.Placement = &v1beta1.PlacementSpec{Mode: v1beta1.PlacementModeSingle}
+	recordPolicy(isvc)
+
+	if got := testutil.CollectAndCount(placementSplitReplicas); got != 0 {
+		t.Errorf("split_replicas series = %d, want 0 after switching to Single", got)
+	}
+	if got := testutil.CollectAndCount(placementPolicyInfo); got != 1 {
+		t.Errorf("policy_info series = %d, want 1 (Split labels must not linger)", got)
+	}
+}
+
+// TestRecordPolicy_NoPlacementEmitsNothing: an ISVC with no placement block is
+// not a multi-cluster ISVC and must not appear in the policy metrics.
+func TestRecordPolicy_NoPlacementEmitsNothing(t *testing.T) {
+	resetPlacementMetrics()
+
+	recordPolicy(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "plain"},
+	})
+
+	if got := testutil.CollectAndCount(placementPolicyInfo); got != 0 {
+		t.Errorf("policy_info series = %d, want 0", got)
+	}
+}
+
+// TestDeleteForISVC_DropsEverything: teardown must leave no series behind, or a
+// deleted ISVC keeps reporting a phase and a winning cluster forever.
+func TestDeleteForISVC_DropsEverything(t *testing.T) {
+	resetPlacementMetrics()
+
+	recordPlacement(splitISVC("ns", "svc", 8), placementResult{
+		winner:     "cluster-a",
+		phase:      v1beta1.PlacementPhasePlaced,
+		candidates: []v1beta1.CandidatePlacement{{Cluster: "cluster-a", Phase: v1beta1.CandidatePhaseAdmitted}},
+	})
+	DeleteForISVC("ns", "svc")
+
+	for name, n := range map[string]int{
+		"phase":           testutil.CollectAndCount(placementPhase),
+		"winner":          testutil.CollectAndCount(placementWinner),
+		"candidate":       testutil.CollectAndCount(placementCandidate),
+		"admitted":        testutil.CollectAndCount(placementCandidateAdmitted),
+		"ready":           testutil.CollectAndCount(placementCandidateReady),
+		"policy_info":     testutil.CollectAndCount(placementPolicyInfo),
+		"split_replicas":  testutil.CollectAndCount(placementSplitReplicas),
+		"max_per_cluster": testutil.CollectAndCount(placementSplitMaxPerCluster),
+		"min_per_cluster": testutil.CollectAndCount(placementSplitMinPerCluster),
+	} {
+		if n != 0 {
+			t.Errorf("%s series = %d, want 0 after DeleteForISVC", name, n)
+		}
+	}
+}

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -112,6 +112,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 			r.clearFailure(req.Name)
 			r.clearRetry(req.Name)
+			// The member is gone: drop its series so it stops counting toward
+			// the fleet size reported by ome_workload_cluster_ready.
+			deleteForCluster(req.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -202,6 +205,9 @@ func (r *Reconciler) finish(ctx context.Context, wc *v1beta1.WorkloadCluster, re
 		}
 		return ctrl.Result{}, fmt.Errorf("workloadcluster %s: update status: %w", wc.Name, err)
 	}
+	// Publish only after the status write landed, so the gauges track the
+	// condition that was actually persisted.
+	recordWorkloadCluster(wc)
 	return ctrl.Result{RequeueAfter: requeue}, nil
 }
 

--- a/pkg/controller/v1beta1/workloadcluster/metrics.go
+++ b/pkg/controller/v1beta1/workloadcluster/metrics.go
@@ -1,0 +1,77 @@
+package workloadcluster
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// Fleet-level membership metrics, keyed by cluster name (cardinality is bounded
+// by the WorkloadCluster count).
+//
+// clusterReady is a plain 0/1 gauge so fleet aggregates are trivial in PromQL;
+// clusterStatus adds the condition Reason to answer "why not ready". Reason
+// churns, so a cluster's prior series is dropped before the current one is set.
+var (
+	clusterReady = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_workload_cluster_ready",
+		Help: "1 if the WorkloadCluster's Ready condition is True, else 0. Present for every WorkloadCluster known to this control plane, so count() is the fleet size and sum() the ready count.",
+	}, []string{"cluster"})
+
+	clusterStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ome_workload_cluster_status",
+		Help: "Always 1, labelled with the WorkloadCluster's current Ready condition status and reason. Exactly one series per cluster.",
+	}, []string{"cluster", "status", "reason"})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(clusterReady, clusterStatus)
+}
+
+// recordWorkloadCluster publishes the membership metrics for one cluster from
+// its Ready condition. Called on every status write funnel pass, so the gauges
+// track the condition the control plane just persisted.
+//
+// A WorkloadCluster whose condition has not been set yet reports Unknown rather
+// than being omitted: an unassessed member is still a member, and dropping it
+// would make count() understate the fleet.
+func recordWorkloadCluster(wc *v1beta1.WorkloadCluster) {
+	if wc == nil || wc.Name == "" {
+		return
+	}
+
+	status, reason := string(metav1.ConditionUnknown), "NotAssessed"
+	if c := apimeta.FindStatusCondition(wc.Status.Conditions, v1beta1.WorkloadClusterReady); c != nil {
+		status = string(c.Status)
+		if c.Reason != "" {
+			reason = c.Reason
+		} else {
+			reason = "Unset"
+		}
+	}
+
+	ready := 0.0
+	if status == string(metav1.ConditionTrue) {
+		ready = 1.0
+	}
+	clusterReady.WithLabelValues(wc.Name).Set(ready)
+
+	// Reset first so a cluster only ever carries its current (status, reason).
+	clusterStatus.DeletePartialMatch(prometheus.Labels{"cluster": wc.Name})
+	clusterStatus.WithLabelValues(wc.Name, status, reason).Set(1)
+}
+
+// deleteForCluster drops every series for a WorkloadCluster that no longer
+// exists, so a removed member stops counting toward the fleet size.
+func deleteForCluster(name string) {
+	if name == "" {
+		return
+	}
+	match := prometheus.Labels{"cluster": name}
+	clusterReady.DeletePartialMatch(match)
+	clusterStatus.DeletePartialMatch(match)
+}

--- a/pkg/controller/v1beta1/workloadcluster/metrics_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/metrics_test.go
@@ -1,0 +1,101 @@
+package workloadcluster
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// resetClusterMetrics clears both vectors so whole-vector counts are
+// deterministic. Required because other tests in this package reconcile
+// WorkloadClusters into these same globals.
+func resetClusterMetrics() {
+	clusterReady.Reset()
+	clusterStatus.Reset()
+}
+
+func wcWithReady(name string, status metav1.ConditionStatus, reason string) *v1beta1.WorkloadCluster {
+	wc := &v1beta1.WorkloadCluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if status != "" {
+		wc.Status.Conditions = []metav1.Condition{{
+			Type:   v1beta1.WorkloadClusterReady,
+			Status: status,
+			Reason: reason,
+		}}
+	}
+	return wc
+}
+
+// TestRecordWorkloadCluster_ReadyAndNotReady: the 0/1 gauge is what makes
+// count() the fleet size and sum() the ready count, so both states must be
+// present rather than the unready cluster being omitted.
+func TestRecordWorkloadCluster_ReadyAndNotReady(t *testing.T) {
+	resetClusterMetrics()
+
+	recordWorkloadCluster(wcWithReady("a", metav1.ConditionTrue, "Connected"))
+	recordWorkloadCluster(wcWithReady("b", metav1.ConditionFalse, "ConnectionFailed"))
+
+	if got := testutil.ToFloat64(clusterReady.WithLabelValues("a")); got != 1 {
+		t.Errorf("ready{a} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(clusterReady.WithLabelValues("b")); got != 0 {
+		t.Errorf("ready{b} = %v, want 0", got)
+	}
+	if got := testutil.CollectAndCount(clusterReady); got != 2 {
+		t.Errorf("ready series = %d, want 2 (fleet size)", got)
+	}
+	if got := testutil.ToFloat64(clusterStatus.WithLabelValues("b", "False", "ConnectionFailed")); got != 1 {
+		t.Errorf("status{b,False,ConnectionFailed} = %v, want 1", got)
+	}
+}
+
+// TestRecordWorkloadCluster_ReasonChurnDoesNotAccumulate: Reason is a churning
+// label, so a cluster must carry exactly one status series at any time.
+func TestRecordWorkloadCluster_ReasonChurnDoesNotAccumulate(t *testing.T) {
+	resetClusterMetrics()
+
+	recordWorkloadCluster(wcWithReady("a", metav1.ConditionFalse, "ConnectionFailed"))
+	recordWorkloadCluster(wcWithReady("a", metav1.ConditionTrue, "ProbeFailedRetrying"))
+	recordWorkloadCluster(wcWithReady("a", metav1.ConditionTrue, "Connected"))
+
+	if got := testutil.CollectAndCount(clusterStatus); got != 1 {
+		t.Fatalf("status series = %d, want 1 (prior reasons must not linger)", got)
+	}
+	if got := testutil.ToFloat64(clusterStatus.WithLabelValues("a", "True", "Connected")); got != 1 {
+		t.Errorf("status{a,True,Connected} = %v, want 1", got)
+	}
+}
+
+// TestRecordWorkloadCluster_UnassessedCounts: a member whose condition has not
+// been written yet is still a member; dropping it would understate the fleet.
+func TestRecordWorkloadCluster_UnassessedCounts(t *testing.T) {
+	resetClusterMetrics()
+
+	recordWorkloadCluster(wcWithReady("fresh", "", ""))
+
+	if got := testutil.ToFloat64(clusterReady.WithLabelValues("fresh")); got != 0 {
+		t.Errorf("ready{fresh} = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(clusterStatus.WithLabelValues("fresh", "Unknown", "NotAssessed")); got != 1 {
+		t.Errorf("status{fresh,Unknown,NotAssessed} = %v, want 1", got)
+	}
+}
+
+// TestDeleteForCluster_DropsEverything: a removed member must stop counting
+// toward the fleet size.
+func TestDeleteForCluster_DropsEverything(t *testing.T) {
+	resetClusterMetrics()
+
+	recordWorkloadCluster(wcWithReady("gone", metav1.ConditionTrue, "Connected"))
+	deleteForCluster("gone")
+
+	if got := testutil.CollectAndCount(clusterReady); got != 0 {
+		t.Errorf("ready series = %d, want 0", got)
+	}
+	if got := testutil.CollectAndCount(clusterStatus); got != 0 {
+		t.Errorf("status series = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Publish the numbers the quota, placement and workload-cluster passes
already compute as Prometheus series on the controller-runtime
registry, recorded at the controller call site so pkg/quota stays a
library with no metrics dependency.

Per-tenant accounting (acceleratorquota):
  ome_quota_budget_nominal / _admitted / _reserved / _borrowed
  labels: plane, quota, path, role, resource, flavor
The series are written from the same pass that computes
status.budgets, so the gauge and the CR cannot disagree, and are
republished every pass so a restarted manager does not come back
with the family missing. `plane` distinguishes a management plane
(nominal = authored fleet total) from a workload plane (nominal =
this cluster's share); the Reconciler gains a Mode field for that
label and cmd/ome-quota-manager wires it. `path` is the node's
root-to-node tree position, mirroring status.path: reparenting a
node drops its old series before publishing under the new path,
the finalizer removes a deleted node's series, and each whole-tree
pass sweeps series for nodes the tree no longer contains (covers
force-stripped finalizers and deletes that landed while the
manager was down).

Capacity and materializer (workload mode only, so no plane label):
  ome_quota_capacity_allocatable / _unavailable   {resource, flavor}
  ome_quota_capacity_nodes          {resource, flavor, state}
  ome_quota_capacity_unattributed   {resource, reason}
  ome_quota_capacity_unattributed_nodes            {reason}
  ome_quota_backend_applied_total
  ome_quota_backend_swept_total     {trigger=materialize|finalize}
Capacity gauges are a snapshot of the last pass (Reset before
repopulate) and are recorded from the raw observation before the
high-water-mark merge, since only the merged figure reaches status.
Unattributed nodes are counted once per node, not per (node,
resource). Empty applies and sweeps are not counted, so a counter
that never moves is distinguishable from a sweep that never ran.

Placement (multi-cluster control plane):
  ome_isvc_placement_phase        {namespace, isvc, phase}
  ome_isvc_placement_winner       {namespace, isvc, cluster}
  ome_isvc_placement_candidate    {namespace, isvc, cluster, phase}
  ome_isvc_placement_candidate_admitted_replicas / _ready_replicas
  ome_isvc_placement_policy_info  {namespace, isvc, mode,
                                   requirements, cluster_selector,
                                   spread}
  ome_isvc_placement_split_replicas /
  _split_max_replicas_per_cluster / _split_min_replicas_per_cluster
Info-style gauges are always 1 with exactly one series per ISVC;
transitions delete the previous series before publishing, and the
ISVC finalizer drops everything for the object.

Workload clusters:
  ome_workload_cluster_ready   {cluster}         1/0 per cluster
  ome_workload_cluster_status  {cluster, status, reason}
Reason churn replaces the single series rather than accumulating;
deleting the WorkloadCluster removes its series.

Tests pin: every collector is registered on the controller-runtime
registry; schedulable vs unavailable capacity split; unattributed
nodes counted once across resources and separated by reason;
resolved capacity series cleared on the next pass; empty applies and
sweeps ignored and sweep triggers kept separate; budgets publish
every figure, separate planes, drop unlabelled samples, publish the
tree path, leave exactly one series after a reparent, republish in
place, and are removed by both the finalizer and the tree sweep;
placement phase/winner/candidate publication with no stale series
across transitions, policy fields on mode change, nothing emitted
without a placement, and full removal on delete; workload cluster
ready/not-ready values, reason churn, unassessed clusters, and
removal on delete.

## Verification

`go build`, `go vet` and `go test` on the affected packages; codespell clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Prometheus metrics for accelerator quota capacity, budgets, materialization, cleanup, and resource attribution.
  - Added placement metrics for InferenceServices, including phase, winner, candidates, replicas, and placement policies.
  - Added WorkloadCluster metrics for readiness, status, and reasons.

- **Bug Fixes**
  - Metrics now reflect successfully persisted status updates.
  - Removed stale metrics when quotas, placements, or workload clusters are deleted or change state.
  - Added operating-mode labels to accelerator quota metrics for clearer workload and management reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->