### PR TITLE
[Helm] quota-manager: metrics collector endpoint

### DIFF
--- a/charts/ome-quota-manager/templates/_helpers.tpl
+++ b/charts/ome-quota-manager/templates/_helpers.tpl
@@ -41,6 +41,18 @@ app.kubernetes.io/part-of: ome
 {{- end -}}
 
 {{/*
+The one Service in front of this component. It fronts both the webhook and the
+metrics endpoint, so the name is referenced from five places: the Service, the
+serving cert's CN and DNS names, the ValidatingWebhookConfiguration's
+clientConfig, the --webhook-service-name flag, and the ServiceMonitor's target.
+A rename that missed any one of them would fail closed — the apiserver dialling
+a name the cert does not cover rejects every AcceleratorQuota write.
+*/}}
+{{- define "ome-quota-manager.serviceName" -}}
+{{ .Values.quotaManager.name }}-service
+{{- end -}}
+
+{{/*
 Where the webhook serving cert lives inside the container. Not a values knob —
 it is a container-local path, not an operator decision — but it is shared
 between the volume mount and the flag, and the two silently disagreeing would

--- a/charts/ome-quota-manager/templates/deployment.yaml
+++ b/charts/ome-quota-manager/templates/deployment.yaml
@@ -17,9 +17,34 @@ spec:
         {{- with .Values.quotaManager.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.quotaManager.podAnnotations }}
+      {{- $sm := (.Values.quotaManager.metrics | default dict).serviceMonitor | default dict }}
+      {{- $ann := .Values.quotaManager.podAnnotations | default dict }}
+      {{- if or (not $sm.enabled) $ann }}
       annotations:
+        {{- if not $sm.enabled }}
+        # The annotation path, for collectors that discover by pod annotation --
+        # among them the bundled Prometheus in charts/ome-resources, whose
+        # ome-control-plane job keeps a pod on exactly these plus the release
+        # namespace.
+        #
+        # Suppressed when a ServiceMonitor is enabled, because the two paths are
+        # collectors, not preferences: a cluster that runs both scrapes the pod
+        # twice and every unqualified sum() over the result is doubled. The
+        # monitor wins because it carries namespace, pod, service and endpoint,
+        # which the annotation path does not.
+        #
+        # An operator who genuinely wants both can restate these under
+        # podAnnotations below; that is deliberate rather than accidental.
+        #
+        # The port tracks metricsPort so moving the endpoint cannot leave a
+        # collector dialling the old one.
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: {{ .Values.quotaManager.metricsPort | quote }}
+        {{- end }}
+        {{- with $ann }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.quotaManager.name }}
@@ -80,7 +105,7 @@ spec:
         # could disagree with what this chart rendered.
         - "--cert-namespace={{ .Release.Namespace }}"
         - "--cert-secret-name={{ .Values.quotaManager.name }}-webhook-cert"
-        - "--webhook-service-name={{ .Values.quotaManager.name }}-webhook"
+        - "--webhook-service-name={{ include "ome-quota-manager.serviceName" . }}"
         - "--webhook-config-name={{ .Values.quotaManager.name }}.ome.io"
         - "--ca-name={{ .Values.quotaManager.name }}-ca"
         - "--ca-organization=ome"

--- a/charts/ome-quota-manager/templates/service.yaml
+++ b/charts/ome-quota-manager/templates/service.yaml
@@ -1,0 +1,39 @@
+{{/*
+The component's Service, fronting every port it serves. One object rather than
+one per purpose: the webhook and the metrics endpoint live in the same pod
+behind the same selector, so splitting them would mean two objects whose labels
+are identical and whose only difference is a port.
+
+Each port is gated by whether anything needs it, and the Service itself renders
+only when at least one does — a Service with no ports is rejected by the
+apiserver.
+*/}}
+{{- $metrics := .Values.quotaManager.metrics | default dict }}
+{{- $sm := $metrics.serviceMonitor | default dict }}
+{{- if or .Values.quotaManager.webhook.enabled $sm.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ome-quota-manager.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "ome-quota-manager.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- if .Values.quotaManager.webhook.enabled }}
+  - name: https
+    port: 443
+    targetPort: webhook
+    protocol: TCP
+  {{- end }}
+  {{- if $sm.enabled }}
+  # targetPort is the container port NAME, so moving metricsPort cannot leave
+  # the Service pointing at the old one.
+  - name: metrics
+    port: {{ .Values.quotaManager.metricsPort }}
+    targetPort: metrics
+    protocol: TCP
+  {{- end }}
+{{- end }}

--- a/charts/ome-quota-manager/templates/servicemonitor.yaml
+++ b/charts/ome-quota-manager/templates/servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{/*
+Scrape wiring for the controller-runtime metrics endpoint, for collectors that
+select monitor objects. The other path -- pod annotations, for the bundled
+Prometheus in charts/ome-resources -- is on the Deployment.
+
+Both are off by default. A monitor object no collector selects is
+indistinguishable from a broken scrape, and an annotation on a cluster with no
+annotation-driven job is inert; neither should appear uninvited.
+*/}}
+{{- $metrics := .Values.quotaManager.metrics | default dict }}
+{{- $sm := $metrics.serviceMonitor | default dict }}
+{{- if $sm.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.quotaManager.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ome-quota-manager.labels" . | nindent 4 }}
+    {{- with $sm.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ome-quota-manager.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  # Named, so the webhook port on the same Service is not scraped.
+  - port: metrics
+    path: /metrics
+    {{- with $sm.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with $sm.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- if $sm.honorLabels }}
+    honorLabels: true
+    {{- end }}
+    {{- with $sm.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $sm.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/ome-quota-manager/templates/webhook.yaml
+++ b/charts/ome-quota-manager/templates/webhook.yaml
@@ -41,31 +41,15 @@ metadata:
   labels:
     {{- include "ome-quota-manager.labels" . | nindent 4 }}
 spec:
-  commonName: {{ .Values.quotaManager.name }}-webhook.{{ .Release.Namespace }}.svc
+  commonName: {{ include "ome-quota-manager.serviceName" . }}.{{ .Release.Namespace }}.svc
   dnsNames:
-  - {{ .Values.quotaManager.name }}-webhook.{{ .Release.Namespace }}.svc
-  - {{ .Values.quotaManager.name }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ include "ome-quota-manager.serviceName" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "ome-quota-manager.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: {{ .Values.quotaManager.name }}-selfsigned
   secretName: {{ .Values.quotaManager.name }}-webhook-cert
 {{- end }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ .Values.quotaManager.name }}-webhook
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "ome-quota-manager.labels" . | nindent 4 }}
-spec:
-  ports:
-  - port: 443
-    targetPort: webhook
-    protocol: TCP
-    name: https
-  selector:
-    {{- include "ome-quota-manager.selectorLabels" . | nindent 4 }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -84,7 +68,7 @@ webhooks:
     # or cainjector via the annotation above.
     caBundle: Cg==
     service:
-      name: {{ .Values.quotaManager.name }}-webhook
+      name: {{ include "ome-quota-manager.serviceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-ome-io-v1beta1-acceleratorquota
   # Fail closed. A write that breaks the tree is exactly what this exists to

--- a/charts/ome-quota-manager/tests/render_test.sh
+++ b/charts/ome-quota-manager/tests/render_test.sh
@@ -470,4 +470,155 @@ for forbidden in \
   fi
 done
 
+# --- the metrics endpoint is served always; the monitor object is opt-in ---
+#
+# Scrape annotations are stamped unconditionally, matching ome-controller-manager:
+# inert where no annotation-driven collector runs, required where one does. A
+# ServiceMonitor is different -- an object no collector selects is
+# indistinguishable from a broken scrape -- so it may not appear uninvited.
+
+if grep -Fq 'kind: ServiceMonitor' <<<"${default}"; then
+  fail "a ServiceMonitor rendered without being asked for"
+fi
+grep -Fq 'prometheus.io/scrape: "true"' <<<"${default}" ||
+  fail "the scrape annotation is not stamped by default"
+# The port must track metricsPort. A literal would be scraped at the wrong port
+# the moment an operator moves the endpoint.
+grep -Fq 'prometheus.io/port: "8080"' <<<"${default}" ||
+  fail "the scrape annotation did not carry metricsPort"
+
+# --- one Service fronts every port, and five references must agree on its name ---
+#
+# The Service name reaches the serving cert's CN and DNS names, the
+# ValidatingWebhookConfiguration's clientConfig, the --webhook-service-name flag
+# and the ServiceMonitor's target. A rename that missed one would fail closed:
+# the apiserver dialling a name the cert does not cover rejects every
+# AcceleratorQuota write.
+
+if [ "$(grep -c '^kind: Service$' <<<"${default}")" -ne 1 ]; then
+  fail "expected exactly one Service; the component fronts all ports with one"
+fi
+# Anchored: the cert Secret is ome-quota-manager-webhook-cert and keeps its name.
+if grep -Eq 'name: ome-quota-manager-webhook$' <<<"${default}"; then
+  fail "the webhook-only Service name came back"
+fi
+grep -Fq 'name: ome-quota-manager-service' <<<"${default}" ||
+  fail "the Service is not named from the serviceName helper"
+# Under internal cert management the DNS name is not in a manifest at all: the
+# rotator derives it from this flag. cert-controller verifies the existing cert
+# against that name and reissues on a mismatch, which is what makes renaming the
+# Service safe on a live cluster.
+grep -Fq -- '--webhook-service-name=ome-quota-manager-service' <<<"${default}" ||
+  fail "the cert flag does not point at the Service"
+
+# On the cert-manager path the SANs are explicit, and must cover the same name.
+certmgr="$(render --set quotaManager.mode=workload \
+  --set quotaManager.webhook.internalCertManagement=false)"
+for san in \
+  'commonName: ome-quota-manager-service.ome.svc' \
+  '- ome-quota-manager-service.ome.svc' \
+  '- ome-quota-manager-service.ome.svc.cluster.local'; do
+  grep -Fq -- "${san}" <<<"${certmgr}" ||
+    fail "the issued cert does not cover the Service DNS name: ${san}"
+done
+
+# The rename must follow quotaManager.name through every reference. The cert
+# flags render only under internal management and the SANs only under
+# cert-manager, so each path is checked on its own render.
+svc_renamed="$(render --set quotaManager.mode=workload --set quotaManager.name=aq-mgr)"
+for ref in \
+  'name: aq-mgr-service' \
+  '--webhook-service-name=aq-mgr-service'; do
+  grep -Fq -- "${ref}" <<<"${svc_renamed}" ||
+    fail "a Service-name reference did not follow the rename: ${ref}"
+done
+if grep -Eq 'name: aq-mgr-webhook$' <<<"${svc_renamed}"; then
+  fail "the renamed chart still emits a webhook-only Service"
+fi
+
+certmgr_renamed="$(render --set quotaManager.mode=workload --set quotaManager.name=aq-mgr \
+  --set quotaManager.webhook.internalCertManagement=false)"
+grep -Fq 'commonName: aq-mgr-service.ome.svc' <<<"${certmgr_renamed}" ||
+  fail "the issued cert's DNS name did not follow the rename"
+
+# With the webhook off there is nothing to front unless metrics asked for it.
+nowebhook="$(render --set quotaManager.mode=workload --set quotaManager.webhook.enabled=false)"
+if grep -q '^kind: Service$' <<<"${nowebhook}"; then
+  fail "a Service rendered with no port to serve"
+fi
+
+annotated="$(render --set quotaManager.mode=workload \
+  --set quotaManager.podAnnotations.keep=me)"
+grep -Fq 'keep: me' <<<"${annotated}" ||
+  fail "the scrape annotations displaced operator-supplied podAnnotations"
+
+moved="$(render --set quotaManager.mode=workload --set quotaManager.metricsPort=9090)"
+grep -Fq 'prometheus.io/port: "9090"' <<<"${moved}" ||
+  fail "the scrape annotation did not follow metricsPort"
+
+monitored="$(render --set quotaManager.mode=workload \
+  --set quotaManager.metrics.serviceMonitor.enabled=true \
+  --set quotaManager.metrics.serviceMonitor.additionalLabels.release=kps)"
+grep -Fq 'kind: ServiceMonitor' <<<"${monitored}" ||
+  fail "the ServiceMonitor did not render"
+grep -Fq 'release: kps' <<<"${monitored}" ||
+  fail "additionalLabels did not reach the ServiceMonitor"
+# Still one Service: the metrics port joins the existing one rather than
+# spawning a second object whose labels would be indistinguishable from it.
+if [ "$(grep -c '^kind: Service$' <<<"${monitored}")" -ne 1 ]; then
+  fail "enabling the ServiceMonitor added a second Service"
+fi
+# targetPort is the container port NAME, so it survives a metricsPort change.
+grep -Fq 'targetPort: metrics' <<<"${monitored}" ||
+  fail "the Service did not target the named metrics container port"
+# The monitor selects the metrics port by name, so the webhook port on the same
+# Service is not scraped.
+grep -Fq 'port: metrics' <<<"${monitored}" ||
+  fail "the ServiceMonitor did not select the metrics port by name"
+
+# --- exactly one collector, never two ---
+#
+# The annotation path and the ServiceMonitor are collectors, not preferences. A
+# cluster that runs both scrapes the pod twice, every unqualified sum() over the
+# result is doubled, and a leader gauge reads 2 on a healthy deployment. The
+# monitor wins because it carries namespace, pod, service and endpoint.
+
+if grep -Fq 'prometheus.io/scrape' <<<"${monitored}"; then
+  fail "both scrape paths are on at once; the pod would be collected twice"
+fi
+# ...and with no operator annotations either, the block must not render empty.
+if grep -Eq '^      annotations:$' <<<"${monitored}"; then
+  fail "an empty annotations block rendered"
+fi
+# Operator annotations still render when the scrape ones are suppressed.
+ident="$(render --set quotaManager.mode=workload \
+  --set quotaManager.metrics.serviceMonitor.enabled=true \
+  --set 'quotaManager.podAnnotations.identity\.example\.com/inject=true')"
+grep -Fq 'identity.example.com/inject: true' <<<"${ident}" ||
+  fail "suppressing the scrape annotations dropped operator podAnnotations"
+if grep -Fq 'prometheus.io/scrape' <<<"${ident}"; then
+  fail "the scrape annotation survived alongside a ServiceMonitor"
+fi
+# The escape hatch: an operator who genuinely wants both restates it explicitly.
+both="$(render --set quotaManager.mode=workload \
+  --set quotaManager.metrics.serviceMonitor.enabled=true \
+  --set 'quotaManager.podAnnotations.prometheus\.io/scrape=true')"
+grep -Fq 'prometheus.io/scrape' <<<"${both}" ||
+  fail "an explicit podAnnotations override could not re-enable the annotation path"
+
+# Metrics without a webhook: the Service exists for the metrics port alone.
+metricsonly="$(render --set quotaManager.mode=workload \
+  --set quotaManager.webhook.enabled=false \
+  --set quotaManager.metrics.serviceMonitor.enabled=true)"
+grep -Fq 'name: ome-quota-manager-service' <<<"${metricsonly}" ||
+  fail "the Service did not render for metrics alone"
+if grep -Fq 'targetPort: webhook' <<<"${metricsonly}"; then
+  fail "the Service kept a webhook port with the webhook disabled"
+fi
+# No interval is set by default: the collector's own default applies, rather
+# than the chart inventing a scrape rate on its behalf.
+if grep -Eq '^\s+interval:' <<<"${monitored}"; then
+  fail "the ServiceMonitor invented a scrape interval"
+fi
+
 echo "ome-quota-manager chart contracts OK"

--- a/charts/ome-quota-manager/values.yaml
+++ b/charts/ome-quota-manager/values.yaml
@@ -242,6 +242,40 @@ quotaManager:
   metricsPort: 8080
   probePort: 8081
 
+  # Who collects the metrics endpoint. The binary always serves it.
+  #
+  # Two paths, and the chart keeps them mutually exclusive. By default the
+  # Deployment stamps prometheus.io/scrape, which is all the bundled Prometheus
+  # in charts/ome-resources consults. Enabling serviceMonitor below suppresses
+  # those annotations, because a cluster running both collectors scrapes the pod
+  # twice and every unqualified sum() over the result is doubled. The monitor
+  # wins because it carries namespace, pod, service and endpoint, which the
+  # annotation path does not. An operator who genuinely wants both can restate
+  # prometheus.io/scrape under podAnnotations.
+  #
+  # serviceMonitor is off by default: an object no collector selects is
+  # indistinguishable from a broken scrape. additionalLabels has no default for
+  # the same reason -- kube-prometheus-stack wants `release: <name>`, other
+  # collectors key on their own label, and guessing wrong yields an object that
+  # exists and is never scraped. Enabling it adds a metrics port to the
+  # component's Service, which the webhook already fronts.
+  #
+  # relabelings and metricRelabelings pass through verbatim, for collectors that
+  # derive labels from pod annotations or need targets renamed before ingest.
+  metrics:
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      # Left unset so the collector's own default applies. Set only to override.
+      interval: ""
+      scrapeTimeout: ""
+      # The endpoint exports no namespace or pod label of its own, so the
+      # collector's target labels win either way; honorLabels is here for
+      # symmetry with collectors that need it.
+      honorLabels: false
+      relabelings: []
+      metricRelabelings: []
+
   # Projecting the authored fleet tree onto workload clusters. Management mode
   # only; a workload-mode manager holds no transport, which is what makes a
   # projection unable to be re-projected.


### PR DESCRIPTION
## Summary

The quota-manager binary always serves controller-runtime metrics on
metricsPort, but the chart offered no way to collect them. This wires
the endpoint to a collector and keeps the wiring to exactly one path.

One Service now fronts the component. It replaces the webhook-only
Service and carries the webhook port, plus a metrics port when a
ServiceMonitor is requested. It renders only when at least one port is
needed. The name comes from a single serviceName helper, which the
serving cert's CN and DNS names, the ValidatingWebhookConfiguration
clientConfig, the --webhook-service-name flag and the ServiceMonitor
target all reference, so a rename cannot leave the apiserver dialling a
name the cert does not cover.

An optional ServiceMonitor renders under
quotaManager.metrics.serviceMonitor.enabled (default false, since the
Prometheus Operator CRD may not be installed). It selects the metrics
port by name so the webhook port is never scraped, and passes through
additionalLabels, interval, scrapeTimeout, honorLabels, relabelings and
metricRelabelings. No interval is set by default.

The Deployment stamps prometheus.io/scrape, path and port annotations
(port tracks metricsPort) for annotation-driven collectors such as the
bundled Prometheus in ome-resources. The annotations are suppressed
when the ServiceMonitor is enabled, so a cluster running both never
collects the pod twice and doubles every unqualified sum(). An operator
who wants both can restate the annotation under podAnnotations, which
still renders alongside or instead of the scrape annotations, and the
annotations block is omitted entirely when it would be empty.

The render test covers: no ServiceMonitor by default, scrape annotation
present and tracking metricsPort, exactly one Service, all five name
references agreeing under both cert paths and after a quotaManager.name
rename, no Service with the webhook off unless metrics asked for one,
operator podAnnotations preserved, ServiceMonitor rendering with
additionalLabels and a named metrics port, mutual exclusion of the two
collector paths, the explicit podAnnotations override, a metrics-only
Service, and no invented scrape interval.

## Verification

`helm lint`, the chart render test, and `helm template` with default values, with the ServiceMonitor enabled, and in management mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Prometheus metrics collection through pod annotations or an optional ServiceMonitor.
  - Added support for customizing ServiceMonitor labels, intervals, timeouts, label handling, and relabeling.
  - Added a shared quota manager Service exposing webhook and metrics endpoints.
  - Standardized Service naming across webhook certificates and configuration.
- **Bug Fixes**
  - Prevented duplicate metrics scraping when ServiceMonitor is enabled.
  - Ensured custom pod annotations are preserved while applying appropriate default metrics annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->