### PR TITLE
[API] lifecycle: minReadySeconds for OMENative

### DIFF
--- a/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
@@ -9015,6 +9015,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -23088,6 +23092,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -32694,6 +32702,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady

--- a/charts/ome-crd/templates/ome.io_inferencereplicas.yaml
+++ b/charts/ome-crd/templates/ome.io_inferencereplicas.yaml
@@ -582,6 +582,10 @@ spec:
                             - Never
                           type: string
                       type: object
+                    minReadySeconds:
+                      format: int32
+                      minimum: 0
+                      type: integer
                     readyPolicy:
                       enum:
                         - AllPodReady

--- a/charts/ome-crd/templates/ome.io_inferenceservices.yaml
+++ b/charts/ome-crd/templates/ome.io_inferenceservices.yaml
@@ -7128,6 +7128,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -20455,6 +20459,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -29533,6 +29541,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady

--- a/charts/ome-crd/templates/ome.io_servingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_servingruntimes.yaml
@@ -9015,6 +9015,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -23088,6 +23092,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -32694,6 +32702,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady

--- a/charts/ome-resources/templates/ome-controller/configmap.yaml
+++ b/charts/ome-resources/templates/ome-controller/configmap.yaml
@@ -34,7 +34,8 @@ data:
     {
       "defaultDeploymentMode": "{{ .Values.ome.controller.deploymentMode }}"{{- with .Values.ome.controller.replicas }},
       "replicas": {{ toJson . }}{{- end }}{{- with .Values.ome.controller.terminationGracePeriodSeconds }},
-      "terminationGracePeriodSeconds": {{ . }}{{- end }}
+      "terminationGracePeriodSeconds": {{ . }}{{- end }}{{- if not (kindIs "invalid" .Values.ome.controller.minReadySeconds) }},
+      "minReadySeconds": {{ .Values.ome.controller.minReadySeconds }}{{- end }}
     }
 {{- with .Values.ome.controller.podDisruptionBudget }}
   podDisruptionBudget: |-

--- a/charts/ome-resources/tests/render_test.sh
+++ b/charts/ome-resources/tests/render_test.sh
@@ -28,9 +28,25 @@ grep -Fq '"scaleDownRequeueInterval":"5s"' <<<"${controller_config}" ||
   fail "default OMENative scale-down requeue interval was not rendered"
 grep -Fq '"rawDeployment":{"maxUnavailable":1}' <<<"${controller_config}" ||
   fail "default RawDeployment disruption budget was not rendered"
-if grep -Fq '"omeNative"' <<<"${controller_config}"; then
-  fail "an OMENative disruption budget default was rendered"
+grep -Fq '"omeNative":{"maxUnavailable":1}' <<<"${controller_config}" ||
+  fail "default OMENative disruption budget was not rendered"
+if grep -Fq 'minReadySeconds' <<<"${controller_config}"; then
+  fail "deploy.minReadySeconds was rendered when unset"
 fi
+
+min_ready_zero="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.minReadySeconds=0 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"minReadySeconds": 0' <<<"${min_ready_zero}" ||
+  fail "explicit zero deploy.minReadySeconds was not rendered"
+
+min_ready_overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --set ome.controller.minReadySeconds=30 \
+  --show-only templates/ome-controller/configmap.yaml)"
+grep -Fq '"minReadySeconds": 30' <<<"${min_ready_overridden}" ||
+  fail "deploy.minReadySeconds override was not rendered"
 
 scale_up_batch_overridden="$("${helm_bin}" template ome-resources "${chart_dir}" \
   --namespace ome \

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -222,6 +222,14 @@ ome:
     # longest expected request, and keep any in-process drain the runtime
     # performs strictly under it so the runtime finishes first.
     terminationGracePeriodSeconds: 600
+    # Admission-time lifecycle.minReadySeconds stamped by the same webhook on
+    # every OMENative component that does not author one: how long a newly
+    # Ready pod must stay Ready before a rollout drains or promotes past it
+    # (the Deployment minReadySeconds rule, applied per pod). Opt-in: the
+    # binary has no built-in default and an unset or 0 value leaves pods
+    # Available as soon as they are Ready; an authored component value
+    # always wins. Uncomment to pace every OMENative rollout in the cluster.
+    # minReadySeconds: 30
     # Max reconciles each controller runs in parallel (distinct objects only —
     # controller-runtime serializes per object key, so independent objects
     # reconcile concurrently). Source of truth for these values (the OME binary
@@ -315,10 +323,12 @@ ome:
       # bound.
       defaultRatioTolerancePercent: 5
     # podDisruptionBudget configures pod-level availability policies by mode.
-    # Omitting rawDeployment keeps the chart default; set rawDeployment: null
-    # to disable it.
+    # Explicit per-Component policies take precedence over these defaults. Set
+    # either mode to null to disable its default.
     podDisruptionBudget:
       rawDeployment:
+        maxUnavailable: 1
+      omeNative:
         maxUnavailable: 1
     # lifecycle tunes the OMENative per-Instance lifecycle state machine.
     lifecycle:

--- a/config/crd/full/ome.io_clusterservingruntimes.yaml
+++ b/config/crd/full/ome.io_clusterservingruntimes.yaml
@@ -9015,6 +9015,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -23088,6 +23092,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -32694,6 +32702,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady

--- a/config/crd/full/ome.io_inferencereplicas.yaml
+++ b/config/crd/full/ome.io_inferencereplicas.yaml
@@ -582,6 +582,10 @@ spec:
                             - Never
                           type: string
                       type: object
+                    minReadySeconds:
+                      format: int32
+                      minimum: 0
+                      type: integer
                     readyPolicy:
                       enum:
                         - AllPodReady

--- a/config/crd/full/ome.io_inferenceservices.yaml
+++ b/config/crd/full/ome.io_inferenceservices.yaml
@@ -7128,6 +7128,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -20455,6 +20459,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -29533,6 +29541,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady

--- a/config/crd/full/ome.io_servingruntimes.yaml
+++ b/config/crd/full/ome.io_servingruntimes.yaml
@@ -9015,6 +9015,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -23088,6 +23092,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady
@@ -32694,6 +32702,10 @@ spec:
                                 - Never
                               type: string
                           type: object
+                        minReadySeconds:
+                          format: int32
+                          minimum: 0
+                          type: integer
                         readyPolicy:
                           enum:
                             - AllPodReady

--- a/pkg/apis/ome/v1beta1/inferencereplica_types.go
+++ b/pkg/apis/ome/v1beta1/inferencereplica_types.go
@@ -75,7 +75,12 @@ type InferenceReplicaSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// MinReadySeconds is propagated from the ISVC spec.
+	// MinReadySeconds is the minimum time a newly Ready pod must stay
+	// Ready before it counts as Available, projected from the parent
+	// ISVC's spec.<component>.lifecycle.minReadySeconds. The workload
+	// engine paces rollout drains and promotions on Available pods and
+	// counts only Available pods in availableReplicas. 0 means Available
+	// as soon as Ready.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
@@ -316,8 +321,10 @@ type InferenceReplicaStatus struct {
 	// +optional
 	ServingReplicas int32 `json:"servingReplicas,omitempty"`
 
-	// AvailableReplicas is the number of Instances that have been
-	// Ready for at least MinReadySeconds.
+	// AvailableReplicas is the number of Instances whose desired pod
+	// count is Available: in rotation on the Component's headless
+	// Service and, when spec.minReadySeconds is set, Ready for at least
+	// that long.
 	// +optional
 	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
 

--- a/pkg/apis/ome/v1beta1/lifecycle_types.go
+++ b/pkg/apis/ome/v1beta1/lifecycle_types.go
@@ -51,8 +51,9 @@ type LifecycleStatus struct {
 	// +optional
 	ServingReplicas int32 `json:"servingReplicas,omitempty"`
 
-	// AvailableReplicas is the number of Instances that have been Ready
-	// continuously for at least MinReadySeconds.
+	// AvailableReplicas is the number of Instances whose desired pod count
+	// is Available: in rotation on the Component's headless Service and,
+	// when lifecycle.minReadySeconds is set, Ready for at least that long.
 	// +optional
 	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
 
@@ -208,7 +209,9 @@ type OMENativeInstanceStatus struct {
 	// +optional
 	ServingPodCount int32 `json:"servingPodCount,omitempty"`
 
-	// AvailablePodCount is the number of pods ready for at least MinReadySeconds.
+	// AvailablePodCount is the number of pods that are Available: in
+	// rotation on the Component's headless Service and, when
+	// lifecycle.minReadySeconds is set, Ready for at least that long.
 	// +optional
 	AvailablePodCount int32 `json:"availablePodCount,omitempty"`
 
@@ -493,6 +496,26 @@ type LifecycleSpec struct {
 	// or initial creation).
 	// +optional
 	InstanceReadyTimeout *metav1.Duration `json:"instanceReadyTimeout,omitempty"`
+
+	// MinReadySeconds is the minimum time a newly Ready pod must stay Ready
+	// before OMENative treats it as Available. A pod is Available when its
+	// PodReady condition is True and that condition's lastTransitionTime
+	// plus MinReadySeconds is not after the current time, evaluated per pod
+	// (the Deployment.spec.minReadySeconds rule). Ready remains the health
+	// signal; Available is the pacing signal: a rollout drains or promotes
+	// an Instance only once its new pods are Available, so the maxSurge /
+	// maxUnavailable budgets stay held for the whole window, and
+	// availableReplicas / availablePodCount count only Available pods.
+	// Unset or 0 means Available as soon as Ready. A value authored on the
+	// InferenceService always wins. Clusters may supply an admission-time
+	// default through the inferenceservice-config ConfigMap; it is stamped
+	// onto the InferenceService, so it also takes precedence over a value
+	// authored in the ServingRuntime's engineConfig / decoderConfig /
+	// routerConfig lifecycle (the InferenceService overrides the runtime
+	// when the two merge), as terminationGracePeriodSeconds does.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// MigrationPolicy controls whether and how OMENative honors a migration
 	// request annotation for this Component.

--- a/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
@@ -3224,6 +3224,11 @@ func (in *LifecycleSpec) DeepCopyInto(out *LifecycleSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.MinReadySeconds != nil {
+		in, out := &in.MinReadySeconds, &out.MinReadySeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.MigrationPolicy != nil {
 		in, out := &in.MigrationPolicy, &out.MigrationPolicy
 		*out = new(MigrationPolicy)

--- a/pkg/controller/v1beta1/controllerconfig/configmap.go
+++ b/pkg/controller/v1beta1/controllerconfig/configmap.go
@@ -276,6 +276,13 @@ type DeployConfig struct {
 	// unconfigured and the component keeps whatever it authored. A configured
 	// value must be > 0 (rejected at config-load).
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+	// MinReadySeconds is the admission-time lifecycle.minReadySeconds the
+	// ISVC defaulter stamps on every OMENative component that does not
+	// author one: the time a newly Ready pod must stay Ready before a
+	// rollout drains or promotes past it. No in-code default: nil means
+	// unconfigured and the component keeps whatever it authored (unset =
+	// Available as soon as Ready). A configured value must be >= 0.
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 }
 
 // ReplicasDefaultsConfig is the admission-time replica-defaulting policy
@@ -1296,6 +1303,10 @@ func parseDeployConfig(configMap *v1.ConfigMap) (*DeployConfig, error) {
 
 		if v := deployConfig.TerminationGracePeriodSeconds; v != nil && *v <= 0 {
 			return nil, fmt.Errorf("invalid deploy config, terminationGracePeriodSeconds must be > 0, got %d", *v)
+		}
+
+		if v := deployConfig.MinReadySeconds; v != nil && *v < 0 {
+			return nil, fmt.Errorf("invalid deploy config, minReadySeconds must be >= 0, got %d", *v)
 		}
 	}
 	return deployConfig, nil

--- a/pkg/controller/v1beta1/controllerconfig/configmap_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/configmap_test.go
@@ -758,6 +758,54 @@ func TestNewDeployConfig(t *testing.T) {
 			},
 			expectedError: true,
 		},
+		{
+			name: "minReadySeconds default parsed",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"minReadySeconds": 30
+				}`,
+			},
+			expectedError: false,
+			validateConfig: func(t *testing.T, cfg *DeployConfig) {
+				require.NotNil(t, cfg.MinReadySeconds)
+				assert.Equal(t, int32(30), *cfg.MinReadySeconds)
+			},
+		},
+		{
+			name: "zero minReadySeconds is a valid explicit value",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"minReadySeconds": 0
+				}`,
+			},
+			expectedError: false,
+			validateConfig: func(t *testing.T, cfg *DeployConfig) {
+				require.NotNil(t, cfg.MinReadySeconds)
+				assert.Equal(t, int32(0), *cfg.MinReadySeconds)
+			},
+		},
+		{
+			name: "omitted minReadySeconds stays unconfigured",
+			configMapData: map[string]string{
+				DeployConfigName: `{"defaultDeploymentMode": "RawDeployment"}`,
+			},
+			expectedError: false,
+			validateConfig: func(t *testing.T, cfg *DeployConfig) {
+				assert.Nil(t, cfg.MinReadySeconds)
+			},
+		},
+		{
+			name: "negative minReadySeconds rejected at config-load",
+			configMapData: map[string]string{
+				DeployConfigName: `{
+					"defaultDeploymentMode": "RawDeployment",
+					"minReadySeconds": -1
+				}`,
+			},
+			expectedError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/v1beta1/inferencereplica/convert.go
+++ b/pkg/controller/v1beta1/inferencereplica/convert.go
@@ -323,11 +323,10 @@ func desiredFromIR(ir *v1beta1.InferenceReplica) workload.WorkloadDesiredSpec {
 	if ir.Spec.Replicas != nil && *ir.Spec.Replicas > 0 {
 		replicas = *ir.Spec.Replicas
 	}
-	// MinReadySeconds and Pacing.{Partition,MaxUnavailable} are populated
-	// here but currently unread by the rollout engine — see the
-	// WorkloadPacing / MinReadySeconds notes in workload/types/source.go.
-	// Kept populated so wiring them requires no converter change.
-	// (Pacing.RollbackToRevision IS live — handled in reconciler.go.)
+	// Pacing.{Partition,MaxUnavailable} are populated here but unread by
+	// the rollout engine — see the WorkloadPacing notes in
+	// workload/types/source.go. (Pacing.RollbackToRevision IS live —
+	// handled in reconciler.go.)
 	desired := workload.WorkloadDesiredSpec{
 		Replicas:        replicas,
 		MinReadySeconds: ir.Spec.MinReadySeconds,

--- a/pkg/controller/v1beta1/inferencereplica/migration_seam_test.go
+++ b/pkg/controller/v1beta1/inferencereplica/migration_seam_test.go
@@ -309,7 +309,7 @@ func TestAggregateStatus_PreservesMigrations(t *testing.T) {
 		},
 	}
 
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, nil, false, nil)).To(gomega.Succeed())
 
 	got := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: ir.Name, Namespace: ir.Namespace}, got)).To(gomega.Succeed())

--- a/pkg/controller/v1beta1/inferencereplica/observation_differential_test.go
+++ b/pkg/controller/v1beta1/inferencereplica/observation_differential_test.go
@@ -139,7 +139,7 @@ func TestPublicationObservationMatchesInlineV1Projection(t *testing.T) {
 			observation, err := workload.NewOwnedPublicationObservation(
 				v1beta1convert.InstanceStatusSliceToWorkload(test.statuses),
 				workload.NewCachedSelectorPodObservation(test.pods, nil),
-				test.available,
+				test.available, workload.AvailabilityWindow{},
 			)
 			if err != nil {
 				t.Fatalf("NewOwnedPublicationObservation: %v", err)
@@ -234,7 +234,7 @@ func TestPublicationObservationMatchesInlineV1ProjectionAtScale(t *testing.T) {
 			observation, err := workload.NewOwnedPublicationObservation(
 				v1beta1convert.InstanceStatusSliceToWorkload(statuses),
 				workload.NewCachedSelectorPodObservation(pods, nil),
-				available,
+				available, workload.AvailabilityWindow{},
 			)
 			if err != nil {
 				t.Fatalf("NewOwnedPublicationObservation: %v", err)
@@ -264,7 +264,7 @@ func legacyInlineV1Projection(instances []v1beta1.OMENativeInstanceStatus, byInd
 		out[i].PodCount = int32(len(pods))
 		out[i].ReadyPodCount = workload.CountReadyPods(pods)
 		out[i].ServingPodCount = workload.CountServingPods(pods)
-		out[i].AvailablePodCount = workload.CountAvailablePods(pods, available)
+		out[i].AvailablePodCount, _ = workload.CountAvailablePods(pods, available, workload.AvailabilityWindow{})
 		out[i].ScheduledPodCount = workload.CountScheduledPods(pods)
 		out[i].Admitted = legacyPodsAdmitted(pods)
 		out[i].NodesOccupied = workload.UniqueNodes(pods)

--- a/pkg/controller/v1beta1/inferencereplica/reconciler.go
+++ b/pkg/controller/v1beta1/inferencereplica/reconciler.go
@@ -205,8 +205,8 @@ type scaleDownSeriesIdentity struct {
 //     dispatcher returns early.
 //  7. Call workload.Reconcile.
 //
-// Returns whatever (ctrl.Result, error) the workload dispatcher hands
-// back, unchanged.
+// Returns the workload dispatcher's (ctrl.Result, error), with the status
+// aggregator's next availability wake folded into RequeueAfter.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := r.Log.WithValues("inferencereplica", req.NamespacedName)
 
@@ -488,7 +488,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 				log.V(1).Error(perr, "CurrentRevision promotion also failed; primary error preserved")
 			}
 		}
-		serr := r.aggregateAndWriteStatus(ctx, ir, plan, specTarget, execHoldObserved, execHold)
+		nextAvailableIn, serr := r.aggregateAndWriteStatus(ctx, ir, plan, specTarget, execHoldObserved, execHold)
 		if errors.Is(serr, workload.ErrStatusMutationPrecondition) {
 			result, err = ctrl.Result{Requeue: true}, nil
 			return
@@ -516,6 +516,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			}
 			result = ctrl.Result{}
 			err = fmt.Errorf("InferenceReplica reconciler: write status: %w", serr)
+			return
+		}
+		if err == nil {
+			// A pod crossing its minReadySeconds window raises the Available
+			// counters with no watch event; wake for the earliest one.
+			result = foldRequeueAfter(result, nextAvailableIn)
 		}
 	}()
 
@@ -696,6 +702,19 @@ func scaleDownRequeueResult(interval time.Duration) ctrl.Result {
 		return ctrl.Result{}
 	}
 	return ctrl.Result{RequeueAfter: interval}
+}
+
+// foldRequeueAfter schedules a wake no later than requeueAfter: an immediate
+// Requeue is left alone, otherwise the earlier RequeueAfter wins. A
+// non-positive requeueAfter asks for nothing.
+func foldRequeueAfter(result ctrl.Result, requeueAfter time.Duration) ctrl.Result {
+	if requeueAfter <= 0 || (result.Requeue && result.RequeueAfter == 0) {
+		return result
+	}
+	if result.RequeueAfter == 0 || requeueAfter < result.RequeueAfter {
+		result.RequeueAfter = requeueAfter
+	}
+	return result
 }
 
 // requiresAuthoritativePodGroupInventory keeps steady single-pod workloads on

--- a/pkg/controller/v1beta1/inferencereplica/retryblock_adapter_test.go
+++ b/pkg/controller/v1beta1/inferencereplica/retryblock_adapter_test.go
@@ -276,7 +276,7 @@ func TestAggregateStatus_PreservesRetryBlocks(t *testing.T) {
 	// The first pass over a fresh IR stamps counters/conditions, so a
 	// real Status().Update lands — this is the write that would drop the
 	// block if the aggregator rebuilt status instead of mutating it.
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, nil, false, nil)).To(gomega.Succeed())
 
 	got := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: ir.Name, Namespace: ir.Namespace}, got)).To(gomega.Succeed())

--- a/pkg/controller/v1beta1/inferencereplica/status.go
+++ b/pkg/controller/v1beta1/inferencereplica/status.go
@@ -104,9 +104,14 @@ const (
 // state persisted in status is the only signal available, since a
 // RetryBlock-denied Instance never reaches the Update pass to be gated
 // there — see computeRetryBlockRolloutHold.
-func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.InferenceReplica, plan workload.ComponentPlan, target *appsv1.ControllerRevision, holdObserved bool, hold *workload.RolloutHold) error {
+//
+// The returned duration is how long until the earliest in-rotation pod still
+// inside the spec.minReadySeconds window becomes Available (0 when none is
+// pending). That raises the Available counters without any watch event, so
+// the caller folds it into the reconcile result to publish them on time.
+func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.InferenceReplica, plan workload.ComponentPlan, target *appsv1.ControllerRevision, holdObserved bool, hold *workload.RolloutHold) (time.Duration, error) {
 	if r.Client == nil {
-		return fmt.Errorf("aggregateAndWriteStatus: nil client")
+		return 0, fmt.Errorf("aggregateAndWriteStatus: nil client")
 	}
 	key := client.ObjectKeyFromObject(ir)
 	ownerUID := ir.UID
@@ -130,17 +135,18 @@ func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.In
 	// (drain/delete/recreate confirm) that genuinely need a live read.
 	pods, err := query.ListOMENativePodsByName(ctx, r.Client, ir.Namespace, ir.Spec.ParentRef.Name, component, true)
 	if err != nil {
-		return fmt.Errorf("aggregateAndWriteStatus: list pods: %w", err)
+		return 0, fmt.Errorf("aggregateAndWriteStatus: list pods: %w", err)
 	}
 	byIndex := query.BucketPodsByInstanceIdx(pods)
 	podObservation := workload.NewCachedSelectorPodObservation(pods, byIndex)
 	serviceName := query.HeadlessServiceName(ir.Spec.ParentRef.Name, component)
 	availableByPod, err := workload.AvailablePodSet(ctx, r.Client, ir.Namespace, serviceName)
 	if err != nil {
-		return fmt.Errorf("aggregateAndWriteStatus: compute availability: %w", err)
+		return 0, fmt.Errorf("aggregateAndWriteStatus: compute availability: %w", err)
 	}
 
 	ownerUnavailable := false
+	var nextAvailableIn time.Duration
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fresh := &v1beta1.InferenceReplica{}
 		if err := r.APIReader.Get(ctx, key, fresh); err != nil {
@@ -174,6 +180,7 @@ func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.In
 			v1beta1convert.InstanceStatusSliceToWorkload(fresh.Status.InstanceStatuses),
 			podObservation,
 			availableByPod,
+			workload.AvailabilityWindow{MinReadySeconds: plan.MinReadySeconds, Now: r.now()},
 		)
 		if err != nil {
 			return fmt.Errorf("aggregateAndWriteStatus: build publication observation: %w", err)
@@ -186,6 +193,7 @@ func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.In
 		if err != nil {
 			return fmt.Errorf("aggregateAndWriteStatus: consume publication observation: %w", err)
 		}
+		nextAvailableIn = counters.NextAvailableIn
 		for i := range fresh.Status.InstanceStatuses {
 			fresh.Status.InstanceStatuses[i].PodCount = publication[i].PodCount
 			fresh.Status.InstanceStatuses[i].ReadyPodCount = publication[i].ReadyPodCount
@@ -203,10 +211,8 @@ func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.In
 		// observation above. The surge-tolerant classifier
 		// (InstanceMeetsThreshold) means an Instance with the canonical
 		// pod ContainersReady is counted even mid-surge or mid-drain,
-		// while availability follows EndpointSlice membership.
-		//
-		// InferenceReplicaSpec.MinReadySeconds is not applied by this
-		// availability calculation.
+		// while availability follows EndpointSlice membership plus the
+		// spec.minReadySeconds Ready-age window.
 		fresh.Status.ReadyReplicas = counters.ReadyReplicas
 		fresh.Status.AvailableReplicas = counters.AvailableReplicas
 		if target != nil {
@@ -273,10 +279,10 @@ func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.In
 				obsmetrics.RecordStatusUpdate(obsmetrics.ControllerIR, obsmetrics.ResultError)
 			}
 		}
-		return err
+		return 0, err
 	}
 	if ownerUnavailable {
-		return nil
+		return 0, nil
 	}
 
 	// Park the InstanceReadyTimeout clock for any Instance whose pods are
@@ -286,7 +292,10 @@ func (r *Reconciler) aggregateAndWriteStatus(ctx context.Context, ir *v1beta1.In
 	// pass inside workload.Reconcile honors the parked (zeroed) deadline
 	// and additionally skips gated Instances outright; once the pods
 	// clear the gate the clock restarts from admission.
-	return r.reconcileHeldDeadlines(ctx, ir, byIndex, plan.Paused, plan.InstanceReadyTimeout)
+	if err := r.reconcileHeldDeadlines(ctx, ir, byIndex, plan.Paused, plan.InstanceReadyTimeout); err != nil {
+		return 0, err
+	}
+	return nextAvailableIn, nil
 }
 
 // mirrorBack copies Component fields and transient publication counters onto

--- a/pkg/controller/v1beta1/inferencereplica/status_contract_test.go
+++ b/pkg/controller/v1beta1/inferencereplica/status_contract_test.go
@@ -198,7 +198,7 @@ func TestAggregateAndWriteStatus_ObservedGenerationFollowsGeneration(t *testing.
 		}},
 	}
 
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, nil, false, nil)).To(gomega.Succeed())
 
 	got := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(),
@@ -252,7 +252,7 @@ func TestPublicationCounters_DeriveFromPodsNotPhases(t *testing.T) {
 			1: {pod1},
 			2: {pod2},
 		}),
-		map[string]struct{}{pod0.Name: {}},
+		map[string]struct{}{pod0.Name: {}}, workload.AvailabilityWindow{},
 	)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/pkg/controller/v1beta1/inferencereplica/status_test.go
+++ b/pkg/controller/v1beta1/inferencereplica/status_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,12 +32,19 @@ import (
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/workload/query"
 )
 
+// writeStatus runs aggregateAndWriteStatus for tests that only care about the
+// write outcome, discarding the availability wake.
+func writeStatus(r *Reconciler, ir *v1beta1.InferenceReplica, plan workload.ComponentPlan, target *appsv1.ControllerRevision, holdObserved bool, hold *workload.RolloutHold) error {
+	_, err := r.aggregateAndWriteStatus(context.Background(), ir, plan, target, holdObserved, hold)
+	return err
+}
+
 func materializeInlinePublicationStatuses(t *testing.T, insts []v1beta1.OMENativeInstanceStatus, byIndex map[int32][]*corev1.Pod, availableByPod map[string]struct{}) []v1beta1.OMENativeInstanceStatus {
 	t.Helper()
 	observation, err := workload.NewOwnedPublicationObservation(
 		v1beta1convert.InstanceStatusSliceToWorkload(insts),
 		workload.NewCachedSelectorPodObservation(nil, byIndex),
-		availableByPod,
+		availableByPod, workload.AvailabilityWindow{},
 	)
 	if err != nil {
 		t.Fatalf("build publication observation: %v", err)
@@ -192,7 +200,7 @@ func TestAggregateAndWriteStatusPersistsCompactRowsAndMirrorsCurrentObservations
 		}},
 	}
 
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, nil, false, nil)).To(gomega.Succeed())
 	got := &v1beta1.InferenceReplica{}
 	g.Expect(stored.Get(context.Background(), client.ObjectKeyFromObject(ir), got)).To(gomega.Succeed())
 	g.Expect(got.Status.InstanceStatuses[0].Admitted).To(gomega.BeTrue())
@@ -211,7 +219,7 @@ func TestAggregateAndWriteStatusPersistsCompactRowsAndMirrorsCurrentObservations
 		"same-pass observations remain available without being persisted")
 
 	rvAfterCompaction := got.ResourceVersion
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), got.DeepCopy(), plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, got.DeepCopy(), plan, nil, false, nil)).To(gomega.Succeed())
 	steady := &v1beta1.InferenceReplica{}
 	g.Expect(stored.Get(context.Background(), client.ObjectKeyFromObject(ir), steady)).To(gomega.Succeed())
 	g.Expect(steady.ResourceVersion).To(gomega.Equal(rvAfterCompaction),
@@ -297,6 +305,67 @@ func TestAggregateStatus_AvailableReplicas_MatchesReadyWithEndpointSlices(t *tes
 		"ReadyReplicas should be 2 (two pods ContainersReady)")
 	g.Expect(got.Status.AvailableReplicas).To(gomega.Equal(int32(2)),
 		"AvailableReplicas should match ReadyReplicas when EndpointSlices publish both pods Ready")
+}
+
+// TestReconcile_WakesWhenMinReadyWindowElapses pins the requeue that keeps
+// the windowed Available counters current: a pod in rotation and Ready but
+// still inside spec.minReadySeconds crosses the window with no watch event,
+// so the reconcile result must wake exactly when the earliest such pod does.
+// A pod past the window, or a zero window, schedules nothing.
+func TestReconcile_WakesWhenMinReadyWindowElapses(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	reconcile := func(t *testing.T, minReadySeconds int32, readyAt time.Time) (ctrl.Result, *v1beta1.InferenceReplica) {
+		t.Helper()
+		g := gomega.NewWithT(t)
+		ir := baselineIR("llama-engine", "prod", 1)
+		ir.Spec.MinReadySeconds = minReadySeconds
+		ir.Status.InstanceStatuses = []v1beta1.OMENativeInstanceStatus{
+			{Index: 0, Incarnation: 1, Phase: v1beta1.OMENativeInstanceReady,
+				PodCount: 1, ReadyPodCount: 1, ServingPodCount: 1, ActiveOrdinal: 0},
+		}
+		pod0 := podForIR(ir, 0, "default", 0, true, true)
+		pod0.Status.Conditions = append(pod0.Status.Conditions, corev1.PodCondition{
+			Type:               corev1.PodReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(readyAt),
+		})
+		slice0 := sliceForIRPod(ir, pod0, true)
+		r, c := newReconciler(t, ir, pod0, slice0)
+		r.Clock = clocktesting.NewFakeClock(now)
+
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: ir.Name, Namespace: ir.Namespace},
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		got := &v1beta1.InferenceReplica{}
+		g.Expect(c.Get(context.Background(), types.NamespacedName{Name: ir.Name, Namespace: ir.Namespace}, got)).To(gomega.Succeed())
+		return result, got
+	}
+
+	t.Run("inside the window wakes at the remaining window", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		result, got := reconcile(t, 20, now.Add(-5*time.Second))
+		g.Expect(got.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+		g.Expect(got.Status.AvailableReplicas).To(gomega.BeZero(),
+			"a pod inside the window is Ready but not yet Available")
+		g.Expect(result.RequeueAfter).To(gomega.Equal(15*time.Second),
+			"the reconcile must wake exactly when the pod crosses the window")
+	})
+
+	t.Run("past the window schedules nothing", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		result, got := reconcile(t, 20, now.Add(-30*time.Second))
+		g.Expect(got.Status.AvailableReplicas).To(gomega.Equal(int32(1)))
+		g.Expect(result.RequeueAfter).To(gomega.BeZero())
+	})
+
+	t.Run("zero window schedules nothing", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		result, got := reconcile(t, 0, now.Add(-5*time.Second))
+		g.Expect(got.Status.AvailableReplicas).To(gomega.Equal(int32(1)),
+			"a zero window makes Available the same as in rotation")
+		g.Expect(result.RequeueAfter).To(gomega.BeZero())
+	})
 }
 
 // TestAggregateStatus_AvailableReplicas_ZeroWhenSliceNotReady pins the
@@ -751,7 +820,7 @@ func TestAggregateAndWriteStatus_NoWriteWhenUnchanged(t *testing.T) {
 
 	// First pass: status changes (per-Instance counters, conditions,
 	// LabelSelector, ObservedGeneration all get stamped) → a write lands.
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, nil, false, nil)).To(gomega.Succeed())
 	afterFirst := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, afterFirst)).To(gomega.Succeed())
 	rvAfterFirst := afterFirst.ResourceVersion
@@ -759,7 +828,7 @@ func TestAggregateAndWriteStatus_NoWriteWhenUnchanged(t *testing.T) {
 	// Second pass over the now-converged IR: recomputed status equals
 	// live status → the DeepEqual guard must skip Status().Update, so the
 	// ResourceVersion is unchanged.
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), afterFirst.DeepCopy(), plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, afterFirst.DeepCopy(), plan, nil, false, nil)).To(gomega.Succeed())
 	afterSecond := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, afterSecond)).To(gomega.Succeed())
 	g.Expect(afterSecond.ResourceVersion).To(gomega.Equal(rvAfterFirst),
@@ -835,7 +904,7 @@ func TestAggregateAndWriteStatusReusesPublicationReadsAcrossConflictRetry(t *tes
 	}
 
 	target := &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev-target"}}
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, target, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, target, false, nil)).To(gomega.Succeed())
 	g.Expect(statusWrites).To(gomega.Equal(2))
 	g.Expect(podLists).To(gomega.Equal(1), "the publication Pod observation is captured outside conflict retry")
 	g.Expect(endpointSliceLists).To(gomega.Equal(1), "the publication availability observation is captured outside conflict retry")
@@ -895,7 +964,7 @@ func TestAggregateAndWriteStatus_RebasesAfterAdjacentLifecycleWrite(t *testing.T
 		}},
 	}
 
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), stale, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, stale, plan, nil, false, nil)).To(gomega.Succeed())
 	got := &v1beta1.InferenceReplica{}
 	g.Expect(apiClient.Get(context.Background(), key, got)).To(gomega.Succeed())
 	g.Expect(got.Status.InstanceStatuses).To(gomega.HaveLen(1))
@@ -931,7 +1000,7 @@ func TestAggregateAndWriteStatus_SameNameReplacementIsUntouched(t *testing.T) {
 		}},
 	}
 
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), stale, plan, nil, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, stale, plan, nil, false, nil)).To(gomega.Succeed())
 	g.Expect(*writes).To(gomega.Equal(0))
 	got := &v1beta1.InferenceReplica{}
 	g.Expect(live.Get(context.Background(), client.ObjectKeyFromObject(replacement), got)).To(gomega.Succeed())
@@ -966,7 +1035,7 @@ func TestAggregateAndWriteStatus_GenerationChangeAborts(t *testing.T) {
 		metricBefore[result] = irStatusUpdateMetric(t, result)
 	}
 
-	err := r.aggregateAndWriteStatus(context.Background(), stale, plan, nil, false, nil)
+	err := writeStatus(r, stale, plan, nil, false, nil)
 	g.Expect(errors.Is(err, workload.ErrStatusMutationPrecondition)).To(gomega.BeTrue())
 	g.Expect(*writes).To(gomega.Equal(0))
 	for result, before := range metricBefore {
@@ -1115,7 +1184,7 @@ func TestAggregateAndWriteStatus_ConflictSurfacesAsConflict(t *testing.T) {
 		},
 	}
 
-	err := r.aggregateAndWriteStatus(context.Background(), ir, plan, nil, false, nil)
+	err := writeStatus(r, ir, plan, nil, false, nil)
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(apierrors.IsConflict(err)).To(gomega.BeTrue(),
 		"a terminal status conflict must remain recognizable so the caller can requeue instead of logging ERROR")
@@ -1791,7 +1860,7 @@ func TestAggregateAndWriteStatus_RolloutHold_ChurnSafeAcrossReconciles(t *testin
 	}
 
 	// Pass 1: a fresh denial -> the hold is recorded with Since stamped.
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, target, true, budgetHold(3))).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, target, true, budgetHold(3))).To(gomega.Succeed())
 	afterFirst := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, afterFirst)).To(gomega.Succeed())
 	g.Expect(afterFirst.Status.RolloutHold).NotTo(gomega.BeNil())
@@ -1802,7 +1871,7 @@ func TestAggregateAndWriteStatus_RolloutHold_ChurnSafeAcrossReconciles(t *testin
 	// Pass 2: byte-identical denial -> ZERO writes (ResourceVersion
 	// unchanged) and Since untouched.
 	rvAfterFirst := afterFirst.ResourceVersion
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), afterFirst.DeepCopy(), plan, target, true, budgetHold(3))).To(gomega.Succeed())
+	g.Expect(writeStatus(r, afterFirst.DeepCopy(), plan, target, true, budgetHold(3))).To(gomega.Succeed())
 	afterRepeat := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, afterRepeat)).To(gomega.Succeed())
 	g.Expect(afterRepeat.ResourceVersion).To(gomega.Equal(rvAfterFirst),
@@ -1812,7 +1881,7 @@ func TestAggregateAndWriteStatus_RolloutHold_ChurnSafeAcrossReconciles(t *testin
 
 	// Pass 3: forward progress (nil exec verdict) -> the hold clears, and
 	// this DOES write (a real state change).
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), afterRepeat.DeepCopy(), plan, target, true, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, afterRepeat.DeepCopy(), plan, target, true, nil)).To(gomega.Succeed())
 	afterClear := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, afterClear)).To(gomega.Succeed())
 	g.Expect(afterClear.Status.RolloutHold).To(gomega.BeNil(), "forward progress must clear the hold")
@@ -1860,7 +1929,7 @@ func TestAggregateAndWriteStatus_RolloutHold_SoakChurnSafeAcrossMultipleReconcil
 		Target: target.Name,
 	}
 
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, target, true, soakHold)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, target, true, soakHold)).To(gomega.Succeed())
 	first := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, first)).To(gomega.Succeed())
 	g.Expect(first.Status.RolloutHold).NotTo(gomega.BeNil())
@@ -1875,7 +1944,7 @@ func TestAggregateAndWriteStatus_RolloutHold_SoakChurnSafeAcrossMultipleReconcil
 	// depend on elapsed time.
 	live := first
 	for i := 0; i < 4; i++ {
-		g.Expect(r.aggregateAndWriteStatus(context.Background(), live.DeepCopy(), plan, target, true, soakHold)).To(gomega.Succeed())
+		g.Expect(writeStatus(r, live.DeepCopy(), plan, target, true, soakHold)).To(gomega.Succeed())
 		next := &v1beta1.InferenceReplica{}
 		g.Expect(c.Get(context.Background(), key, next)).To(gomega.Succeed())
 		g.Expect(next.ResourceVersion).To(gomega.Equal(rv),
@@ -1922,7 +1991,7 @@ func TestAggregateAndWriteStatus_RolloutHold_PausedRetryBlockFallbackChurnSafe(t
 
 	// holdObserved=false on every call: the Update pass is parked by
 	// Paused, exactly as it would be on every reconcile while paused.
-	g.Expect(r.aggregateAndWriteStatus(context.Background(), ir, plan, target, false, nil)).To(gomega.Succeed())
+	g.Expect(writeStatus(r, ir, plan, target, false, nil)).To(gomega.Succeed())
 	first := &v1beta1.InferenceReplica{}
 	g.Expect(c.Get(context.Background(), key, first)).To(gomega.Succeed())
 	g.Expect(first.Status.RolloutHold).NotTo(gomega.BeNil())
@@ -1933,7 +2002,7 @@ func TestAggregateAndWriteStatus_RolloutHold_PausedRetryBlockFallbackChurnSafe(t
 
 	live := first
 	for i := 0; i < 3; i++ {
-		g.Expect(r.aggregateAndWriteStatus(context.Background(), live.DeepCopy(), plan, target, false, nil)).To(gomega.Succeed())
+		g.Expect(writeStatus(r, live.DeepCopy(), plan, target, false, nil)).To(gomega.Succeed())
 		next := &v1beta1.InferenceReplica{}
 		g.Expect(c.Get(context.Background(), key, next)).To(gomega.Succeed())
 		g.Expect(next.ResourceVersion).To(gomega.Equal(rv),

--- a/pkg/controller/v1beta1/inferencereplica/teardown.go
+++ b/pkg/controller/v1beta1/inferencereplica/teardown.go
@@ -237,19 +237,9 @@ func (r *Reconciler) reconcileTeardown(ctx context.Context, log logr.Logger, ir 
 		// Deadline release is strictly after the configured duration. One
 		// nanosecond schedules the smallest representable wake past equality.
 		remaining := deadlineAt.Sub(now) + time.Nanosecond
-		result = foldTeardownRequeueAfter(result, remaining)
+		result = foldRequeueAfter(result, remaining)
 	}
 	return result, nil
-}
-
-func foldTeardownRequeueAfter(result ctrl.Result, requeueAfter time.Duration) ctrl.Result {
-	if requeueAfter <= 0 || (result.Requeue && result.RequeueAfter == 0) {
-		return result
-	}
-	if result.RequeueAfter == 0 || requeueAfter < result.RequeueAfter {
-		result.RequeueAfter = requeueAfter
-	}
-	return result
 }
 
 // closeDanglingLedgerEntries marks every in-flight (Phase=Started)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector.go
@@ -401,6 +401,7 @@ func applyDesiredSpec(ir *v1beta1.InferenceReplica, p Params, name string) {
 	ir.Spec.Replicas = desiredReplicas(ir, p)
 	ir.Spec.Runners = runnersFromParams(p)
 	ir.Spec.Lifecycle = lifecycleFromComponentExt(p.ComponentExt)
+	ir.Spec.MinReadySeconds = minReadySecondsFromComponentExt(p.ComponentExt)
 	paused, freeze := constants.RolloutPauseState(p.ISVC.Annotations)
 	ir.Spec.Paused = paused
 	ir.Spec.PauseMode = ""
@@ -692,6 +693,16 @@ func lifecycleFromComponentExt(c *v1beta1.ComponentExtensionSpec) *v1beta1.Lifec
 		return nil
 	}
 	return c.Lifecycle.DeepCopy()
+}
+
+// minReadySecondsFromComponentExt projects lifecycle.minReadySeconds onto
+// the IR's top-level field the workload engine reads. Unset projects to 0
+// (Available as soon as Ready).
+func minReadySecondsFromComponentExt(c *v1beta1.ComponentExtensionSpec) int32 {
+	if c == nil || c.Lifecycle == nil || c.Lifecycle.MinReadySeconds == nil {
+		return 0
+	}
+	return *c.Lifecycle.MinReadySeconds
 }
 
 // copyMap returns a shallow copy of m. nil input returns nil so the

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector_test.go
@@ -1261,3 +1261,37 @@ func TestEnsureInferenceReplica_NoISVCAnnotations_NoExcludeStamp(t *testing.T) {
 		constants.RevisionExcludedAnnotationKeysAnnotationKey),
 		"no ISVC object annotations -> no exclude stamp")
 }
+
+// TestEnsureInferenceReplica_ProjectsMinReadySeconds pins the lifecycle
+// minReadySeconds projection onto the IR's top-level spec field the
+// workload engine reads: unset projects to 0, an authored value is copied
+// verbatim, and a later ISVC edit re-projects onto the live IR.
+func TestEnsureInferenceReplica_ProjectsMinReadySeconds(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.MinReadySeconds).To(gomega.Equal(int32(0)),
+		"unset lifecycle.minReadySeconds must project to 0 (Available as soon as Ready)")
+
+	isvc.Spec.Engine.Lifecycle.MinReadySeconds = ptr.To(int32(20))
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.MinReadySeconds).To(gomega.Equal(int32(20)),
+		"authored lifecycle.minReadySeconds must project onto IR spec.minReadySeconds")
+	g.Expect(got.Spec.Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(got.Spec.Lifecycle.MinReadySeconds).To(gomega.HaveValue(gomega.Equal(int32(20))),
+		"the lifecycle block keeps the field too")
+
+	isvc.Spec.Engine.Lifecycle.MinReadySeconds = nil
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.MinReadySeconds).To(gomega.Equal(int32(0)),
+		"clearing the field must re-project 0 rather than keep the stale window")
+}

--- a/pkg/controller/v1beta1/workload/observation.go
+++ b/pkg/controller/v1beta1/workload/observation.go
@@ -76,6 +76,7 @@ type ComponentObservation struct {
 	persisted            []InstanceStatus
 	pods                 PodObservation
 	availableByPod       map[string]struct{}
+	availabilityWindow   AvailabilityWindow
 	availabilityObserved bool
 	consumed             bool
 }
@@ -97,8 +98,10 @@ func NewDecisionObservation(persisted []InstanceStatus, pods PodObservation) (Co
 var errPublicationObservationProvenance = errors.New("publication observation requires a selector-scoped cache read")
 
 // NewOwnedPublicationObservation takes ownership of persisted. The caller must
-// not access that slice after construction.
-func NewOwnedPublicationObservation(persisted []InstanceStatus, pods PodObservation, availableByPod map[string]struct{}) (*ComponentObservation, error) {
+// not access that slice after construction. availableByPod is the
+// EndpointSlice rotation set and window the Component's minReadySeconds rule;
+// together they define the Available counters this observation publishes.
+func NewOwnedPublicationObservation(persisted []InstanceStatus, pods PodObservation, availableByPod map[string]struct{}, window AvailabilityWindow) (*ComponentObservation, error) {
 	if pods.source != PodObservationSourceCache || pods.scope != PodObservationScopeSelector {
 		return nil, fmt.Errorf("%w: source=%d scope=%d", errPublicationObservationProvenance, pods.source, pods.scope)
 	}
@@ -107,6 +110,7 @@ func NewOwnedPublicationObservation(persisted []InstanceStatus, pods PodObservat
 		persisted:            persisted,
 		pods:                 pods,
 		availableByPod:       availableByPod,
+		availabilityWindow:   window,
 		availabilityObserved: true,
 	}, nil
 }
@@ -125,7 +129,7 @@ func (o *ComponentObservation) PersistedStatuses() []InstanceStatus {
 // CurrentCounters returns index-keyed Pod facts and whether availability was
 // observed at this epoch.
 func (o *ComponentObservation) CurrentCounters(index int32) (InstanceCounters, bool) {
-	return CountersForInstance(o.pods.PodsForInstance(index), o.availableByPod), o.availabilityObserved
+	return CountersForInstance(o.pods.PodsForInstance(index), o.availableByPod, o.availabilityWindow), o.availabilityObserved
 }
 
 var errPublicationObservationRequired = errors.New("publication materialization requires a publication observation")

--- a/pkg/controller/v1beta1/workload/observation_test.go
+++ b/pkg/controller/v1beta1/workload/observation_test.go
@@ -51,7 +51,7 @@ func TestPublicationObservationReusesOwnedRowsWithoutMutatingSource(t *testing.T
 	observation, err := workload.NewOwnedPublicationObservation(
 		owned,
 		workload.NewCachedSelectorPodObservation(nil, byInstance),
-		map[string]struct{}{podA.Name: {}},
+		map[string]struct{}{podA.Name: {}}, workload.AvailabilityWindow{},
 	)
 	if err != nil {
 		t.Fatalf("NewOwnedPublicationObservation: %v", err)
@@ -157,7 +157,7 @@ func TestPublicationObservationRejectsUnsupportedProvenance(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := workload.NewOwnedPublicationObservation(nil, test.pods, nil); err == nil {
+			if _, err := workload.NewOwnedPublicationObservation(nil, test.pods, nil, workload.AvailabilityWindow{}); err == nil {
 				t.Fatal("publication observation accepted unsupported provenance")
 			}
 		})
@@ -179,7 +179,7 @@ func TestPublicationObservationCopiesNestedDurableState(t *testing.T) {
 	observation, err := workload.NewOwnedPublicationObservation(
 		owned,
 		workload.NewCachedSelectorPodObservation(nil, nil),
-		nil,
+		nil, workload.AvailabilityWindow{},
 	)
 	if err != nil {
 		t.Fatalf("NewOwnedPublicationObservation: %v", err)
@@ -218,7 +218,7 @@ func TestPublicationObservationPreservesNilStatusSlice(t *testing.T) {
 	observation, err := workload.NewOwnedPublicationObservation(
 		nil,
 		workload.NewCachedSelectorPodObservation(nil, nil),
-		nil,
+		nil, workload.AvailabilityWindow{},
 	)
 	if err != nil {
 		t.Fatalf("NewOwnedPublicationObservation: %v", err)
@@ -260,7 +260,7 @@ func BenchmarkPublicationObservationMaterialization(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				owned := append([]workload.InstanceStatus(nil), persisted...)
-				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available)
+				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available, workload.AvailabilityWindow{})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -276,7 +276,7 @@ func BenchmarkPublicationObservationMaterialization(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				owned := append([]workload.InstanceStatus(nil), persisted...)
-				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available)
+				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available, workload.AvailabilityWindow{})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -293,7 +293,7 @@ func BenchmarkPublicationObservationMaterialization(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				owned := append([]workload.InstanceStatus(nil), persisted...)
-				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available)
+				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available, workload.AvailabilityWindow{})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -310,7 +310,7 @@ func BenchmarkPublicationObservationMaterialization(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				owned := append([]workload.InstanceStatus(nil), persisted...)
-				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available)
+				observation, err := workload.NewOwnedPublicationObservation(owned, pods, available, workload.AvailabilityWindow{})
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/controller/v1beta1/workload/ops/migrate.go
+++ b/pkg/controller/v1beta1/workload/ops/migrate.go
@@ -1000,10 +1000,10 @@ func migrationPromotedSurgeMatches(status *workload.InstanceStatus, targetRevisi
 //     per-revision Service. Rotation reads the live reader so a cold
 //     informer doesn't falsely report zero slices, and without it the
 //     source swap can hit a zero-routable-endpoint window.
-//   - the surge InstanceStatus reports full availability (Ready ≥
-//     minReadySeconds; at alpha minReadySeconds defaults to 0 so this
-//     collapses onto Ready, but the gate stays for when a non-zero
-//     value is added).
+//   - the surge InstanceStatus reports full availability: its
+//     AvailablePodCount covers every pod, which counts a pod only once it
+//     is in rotation and, under a positive minReadySeconds window, has
+//     been Ready for at least that long.
 //
 // SHARED between the Migrate drive pass and the expiry pass's Draining
 // carve-out (migrationTailReady): the carve-out defers expiry exactly

--- a/pkg/controller/v1beta1/workload/ops/minready_test.go
+++ b/pkg/controller/v1beta1/workload/ops/minready_test.go
@@ -1,0 +1,414 @@
+package ops
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workload/podreadiness"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workload/query"
+	workload "sigs.k8s.io/ome/pkg/controller/v1beta1/workload/types"
+)
+
+// Tests for the minReadySeconds pacing gate: each strategy holds its
+// budget-releasing step until the new pods have been Ready for the window.
+
+// minReadyWindowStart is the fake "now" every test below anchors on.
+var minReadyWindowStart = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+// podReadyAt appends a PodReady=True condition whose lastTransitionTime is
+// readyAt — the timestamp the availability rule measures from.
+func podReadyAt(pod *corev1.Pod, readyAt time.Time) {
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:               corev1.PodReady,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(readyAt),
+	})
+}
+
+// TestSurgeUpdate_HoldsSourceDrainForMinReadySeconds: a PodReady surge pod
+// that has not yet been Ready for minReadySeconds keeps the source in
+// rotation and the Operation at Step=Surge (budget slot held); once the
+// window elapses — inclusive at the exact boundary — the same pass drains
+// and deletes the source.
+func TestSurgeUpdate_HoldsSourceDrainForMinReadySeconds(t *testing.T) {
+	legacyResetExpectations(t)
+	isvc, ir := surgeISVCReady("llama-70b", "prod", 1)
+	oldPod := surgePodAtOrdinal(isvc, 0, 1, 0, true, true)
+	surgePod := surgePodAtOrdinal(isvc, 0, 1, 1, true, true)
+	target := &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{
+		Name: "llama-70b-engine-rev-v2hash", Namespace: isvc.Namespace,
+	}}
+	surgePod.Labels[query.LabelRevisionHash] = query.RevisionHashFromControllerRevisionName(target.Name)
+	podReadyAt(surgePod, minReadyWindowStart.Add(-10*time.Second))
+	c := legacyNewFakeClient(t, isvc, ir, oldPod, surgePod, target)
+
+	clk := clocktesting.NewFakeClock(minReadyWindowStart)
+	input := legacyTestInput(isvc, c, workload.ComponentEngine)
+	input.Clock = clk
+	plan := surgePlan()
+	plan.MinReadySeconds = 20
+	if err := patchInstanceStatusSurgingForUpdate(context.Background(), input, 0, target.Name, plan.InstanceReadyTimeout); err != nil {
+		t.Fatalf("pre-stamp: %v", err)
+	}
+
+	done, err := surgeUpdate(context.Background(), workload.Deps{Client: c}, input, plan, plan.Instances[0], target, []*corev1.Pod{oldPod, surgePod})
+	if err != nil {
+		t.Fatalf("surgeUpdate inside window: %v", err)
+	}
+	if done {
+		t.Fatalf("expected done=false while the replacement is inside the minReadySeconds window")
+	}
+	freshOld := &corev1.Pod{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(oldPod), freshOld); err != nil {
+		t.Fatalf("source missing inside the window: %v", err)
+	}
+	if !podreadiness.IsServing(freshOld) {
+		t.Fatalf("source left rotation before the replacement was Available")
+	}
+	status := legacyInstanceStatusesOnIR(c, isvc, workload.ComponentEngine)[0]
+	if status.Operation == nil || status.Operation.Step != updateStepSurge {
+		t.Fatalf("operation advanced past Surge inside the window: %+v", status.Operation)
+	}
+
+	// Exactly readyAt + 20s: the boundary counts as Available.
+	clk.SetTime(minReadyWindowStart.Add(10 * time.Second))
+	freshSurge := &corev1.Pod{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(surgePod), freshSurge); err != nil {
+		t.Fatalf("get replacement: %v", err)
+	}
+	done, err = surgeUpdate(context.Background(), workload.Deps{Client: c}, input, plan, plan.Instances[0], target, []*corev1.Pod{freshOld, freshSurge})
+	if err != nil {
+		t.Fatalf("surgeUpdate after window: %v", err)
+	}
+	if done {
+		t.Fatalf("expected done=false while deleting source")
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(oldPod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("source was not deleted once the replacement became Available: %v", err)
+	}
+}
+
+// TestGangSurgeUpdate_HoldsSourceDrainForMinReadySeconds is the gang
+// counterpart: a PodReady replacement gang inside the window leaves every
+// source pod serving; after the window the source gang is drained.
+func TestGangSurgeUpdate_HoldsSourceDrainForMinReadySeconds(t *testing.T) {
+	legacyResetExpectations(t)
+	isvc, _ := surgeISVCReady("llama-70b", "prod", 1)
+	plan := gangSurgePlan()
+	plan.MinReadySeconds = 20
+
+	v1Name := "llama-70b-engine-rev-v1hash"
+	v2Name := "llama-70b-engine-rev-v2hash"
+	v1Hash := query.RevisionHashFromControllerRevisionName(v1Name)
+	v2Hash := query.RevisionHashFromControllerRevisionName(v2Name)
+	ir := gangSurgeInFlightIR(isvc, v1Name, v2Name)
+	c := legacyNewFakeClient(t, isvc, ir)
+	makeCR(t, c, isvc, v2Name)
+
+	for _, runner := range []string{"leader", "worker"} {
+		if err := c.Create(context.Background(), gangPodAt(isvc, 0, runner, v1Hash, true, true)); err != nil {
+			t.Fatalf("seed source gang pod (%s): %v", runner, err)
+		}
+	}
+	for _, runner := range []string{"leader", "worker"} {
+		p := gangPodAt(isvc, 1, runner, v2Hash, true, true)
+		podReadyAt(p, minReadyWindowStart.Add(-10*time.Second))
+		if err := c.Create(context.Background(), p); err != nil {
+			t.Fatalf("seed surge gang pod (%s): %v", runner, err)
+		}
+	}
+
+	clk := clocktesting.NewFakeClock(minReadyWindowStart)
+	input := gangInputWithRemove(isvc, c)
+	input.Clock = clk
+	v2 := &appsv1.ControllerRevision{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "prod", Name: v2Name}, v2); err != nil {
+		t.Fatalf("get v2 CR: %v", err)
+	}
+	// Hold the pass at the post-drain Satisfied() gate so drained source
+	// pods stay observable instead of being deleted in the same pass.
+	workload.DefaultExpectations.ExpectDeletes("prod", "llama-70b", workload.ComponentEngine, 0, 1)
+
+	sourcePods := func() []*corev1.Pod {
+		pods, err := query.LiveListPodsForInstance(context.Background(), c, "prod", "llama-70b", workload.ComponentEngine, 0)
+		if err != nil {
+			t.Fatalf("list source gang pods: %v", err)
+		}
+		if len(pods) != 2 {
+			t.Fatalf("source gang pods: got %d want 2", len(pods))
+		}
+		return pods
+	}
+
+	if _, err := surgeUpdate(context.Background(), legacyTestDeps(c), input, plan, plan.Instances[0], v2, nil); err != nil {
+		t.Fatalf("gang surge pass inside window: %v", err)
+	}
+	for _, pod := range sourcePods() {
+		if !podreadiness.IsServing(pod) {
+			t.Fatalf("source gang pod %s left rotation before the replacement gang was Available", pod.Name)
+		}
+	}
+	src := legacyInstanceStatusesOnIR(c, isvc, workload.ComponentEngine)[0]
+	if src.Operation == nil || src.Operation.Step != updateStepSurge {
+		t.Fatalf("source operation advanced past Surge inside the window: %+v", src.Operation)
+	}
+
+	clk.SetTime(minReadyWindowStart.Add(10 * time.Second))
+	if _, err := surgeUpdate(context.Background(), legacyTestDeps(c), input, plan, plan.Instances[0], v2, nil); err != nil {
+		t.Fatalf("gang surge pass after window: %v", err)
+	}
+	for _, pod := range sourcePods() {
+		if podreadiness.IsServing(pod) {
+			t.Fatalf("source gang pod %s still serving after the replacement gang became Available", pod.Name)
+		}
+	}
+}
+
+// TestRecreateUpdate_PromotionWaitsForMinReadySeconds: with the old pods
+// gone and the recreated pod serving and PodReady, promotion (which clears
+// the Operation and releases the unavailability budget slot) waits until
+// the pod has been Ready for the window.
+func TestRecreateUpdate_PromotionWaitsForMinReadySeconds(t *testing.T) {
+	legacyResetExpectations(t)
+	isvc, ir := legacyISVCReadyAtIncarnation("llama-70b", "prod", 1)
+	isvc.Spec.Engine.ComponentExtensionSpec.Lifecycle = &v1beta1.LifecycleSpec{
+		UpdateStrategy: &v1beta1.UpdateStrategy{Type: v1beta1.UpdateStrategyRecreatePod},
+	}
+	newPod := legacyPodAtIncarnation(isvc, 0, 2, true, true)
+	newPod.Spec.Containers = []corev1.Container{{Name: "main", Image: "llama:v2"}}
+	podReadyAt(newPod, minReadyWindowStart.Add(-5*time.Second))
+	target := legacyTargetSpecImage("llama:v2")
+	c := legacyNewFakeClient(t, isvc, ir, newPod)
+	tcr := legacyEnsureTargetCR(t, c, isvc, target)
+
+	// Mid-recreate state: Phase A drained and deleted the incarnation-1 pod,
+	// Phase B created the incarnation-2 pod; only Phase C (promotion) is left.
+	fresh := &v1beta1.InferenceReplica{}
+	key := client.ObjectKey{Namespace: isvc.Namespace, Name: legacyIRName(isvc, workload.ComponentEngine)}
+	if err := c.Get(context.Background(), key, fresh); err != nil {
+		t.Fatalf("get IR: %v", err)
+	}
+	fresh.Status.InstanceStatuses[0] = v1beta1.OMENativeInstanceStatus{
+		Index:          0,
+		Incarnation:    2,
+		Phase:          v1beta1.OMENativeInstanceUpdating,
+		TargetRevision: tcr.Name,
+		Operation: &v1beta1.InstanceOperation{
+			Type: v1beta1.InstanceOperationUpdate, Step: updateStepDrain, TargetRevision: tcr.Name,
+		},
+	}
+	if err := c.Status().Update(context.Background(), fresh); err != nil {
+		t.Fatalf("seed mid-recreate status: %v", err)
+	}
+
+	clk := clocktesting.NewFakeClock(minReadyWindowStart)
+	input := legacyTestInput(isvc, c, workload.ComponentEngine)
+	input.Clock = clk
+	plan := legacyComponentPlan(workload.UpdateStrategyRecreatePod, nil)
+	plan.MinReadySeconds = 20
+
+	done, err := recreateUpdate(context.Background(), legacyTestDeps(c), input, plan, plan.Instances[0], tcr, []*corev1.Pod{newPod})
+	if err != nil {
+		t.Fatalf("recreateUpdate inside window: %v", err)
+	}
+	if done {
+		t.Fatalf("expected done=false while the recreated pod is inside the minReadySeconds window")
+	}
+	s := legacyInstanceStatusesOnIR(c, isvc, workload.ComponentEngine)[0]
+	if s.Phase != v1beta1.OMENativeInstanceUpdating || s.Operation == nil {
+		t.Fatalf("promoted inside the window: phase=%q operation=%+v", s.Phase, s.Operation)
+	}
+
+	clk.SetTime(minReadyWindowStart.Add(15 * time.Second))
+	done, err = recreateUpdate(context.Background(), legacyTestDeps(c), input, plan, plan.Instances[0], tcr, []*corev1.Pod{newPod})
+	if err != nil {
+		t.Fatalf("recreateUpdate after window: %v", err)
+	}
+	if !done {
+		t.Fatalf("expected done=true once the recreated pod became Available")
+	}
+	s = legacyInstanceStatusesOnIR(c, isvc, workload.ComponentEngine)[0]
+	if s.Phase != v1beta1.OMENativeInstanceReady || s.RunningRevision != tcr.Name || s.Operation != nil {
+		t.Fatalf("promotion after window: phase=%q runningRevision=%q operation=%+v", s.Phase, s.RunningRevision, s.Operation)
+	}
+}
+
+// convergedInPlaceFixture seeds an in-place update whose only remaining step
+// is promotion: the pod is serving, already relabeled to the target revision,
+// runs the target image, and the target revision's routed Service still
+// lists it as ready, so any re-drain would park the pass at the drain check.
+type convergedInPlaceFixture struct {
+	isvc   *v1beta1.InferenceService
+	client client.Client
+	pod    *corev1.Pod
+	target *corev1.PodSpec
+	tcr    *appsv1.ControllerRevision
+	plan   workload.ComponentPlan
+}
+
+func newConvergedInPlaceFixture(t *testing.T) convergedInPlaceFixture {
+	t.Helper()
+	legacyResetExpectations(t)
+	isvc, ir := legacyISVCReadyAtIncarnation("llama-70b", "prod", 1)
+	ir.Status.InstanceStatuses[0] = v1beta1.OMENativeInstanceStatus{
+		Index:       0,
+		Incarnation: 1,
+		Phase:       v1beta1.OMENativeInstanceUpdating,
+		Operation: &v1beta1.InstanceOperation{
+			Type: v1beta1.InstanceOperationUpdate, Step: updateStepInPlace,
+		},
+	}
+	isvc.Spec.Engine.ComponentExtensionSpec.Lifecycle = &v1beta1.LifecycleSpec{
+		UpdateStrategy: &v1beta1.UpdateStrategy{
+			Type: v1beta1.UpdateStrategyInPlaceIfPossible,
+			InPlaceUpdateStrategy: &v1beta1.InPlaceUpdateStrategy{
+				MarkNotReadyDuringLifecycle: legacyBoolPtr(true),
+			},
+		},
+	}
+	target := legacyTargetSpecImage("llama:v2")
+	pod := legacyPodAtIncarnation(isvc, 0, 1, true /* ready */, false /* drained */)
+	pod.Spec.Containers = []corev1.Container{{Name: "main", Image: "llama:v2"}}
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "main", Image: "llama:v2"}}
+	podReadyAt(pod, minReadyWindowStart.Add(-5*time.Second))
+	c := legacyNewFakeClient(t, isvc, ir, pod)
+	legacySeedRunningRevision(t, c, isvc, workload.ComponentEngine, 0, legacyTargetSpecImage("llama:v1"))
+	tcr := legacyEnsureTargetCR(t, c, isvc, target)
+	legacyStampPodRevisionHash(t, c, pod, tcr.Name)
+	targetService := query.PerRevisionServiceName(isvc.Name, workload.ComponentEngine, query.RevisionHashFromControllerRevisionName(tcr.Name))
+	if err := c.Create(context.Background(), legacySliceWithEndpoint(isvc.Namespace, "engine-target", targetService, pod, true)); err != nil {
+		t.Fatalf("seed target EndpointSlice: %v", err)
+	}
+	plan := legacyComponentPlan(workload.UpdateStrategyInPlaceIfPossible,
+		&workload.InPlaceUpdateStrategy{MarkNotReadyDuringLifecycle: legacyBoolPtr(true)})
+	return convergedInPlaceFixture{isvc: isvc, client: c, pod: pod, target: target, tcr: tcr, plan: plan}
+}
+
+func (f convergedInPlaceFixture) update(t *testing.T, clk *clocktesting.FakeClock) bool {
+	t.Helper()
+	input := legacyTestInput(f.isvc, f.client, workload.ComponentEngine)
+	input.Clock = clk
+	done, err := Update(context.Background(), legacyTestDeps(f.client), input, f.plan, f.plan.Instances[0], f.tcr, f.target)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	return done
+}
+
+func (f convergedInPlaceFixture) podServing(t *testing.T) bool {
+	t.Helper()
+	got := &corev1.Pod{}
+	if err := f.client.Get(context.Background(), client.ObjectKeyFromObject(f.pod), got); err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	return podreadiness.IsServing(got)
+}
+
+// TestInPlaceUpdate_PromotionWaitsForMinReadySeconds: a converged in-place
+// pod is returned to rotation and then held at Phase=Updating until it has
+// been Ready for the window. The waiting passes must not drain the pod
+// again — an EndpointSlice that still lists it as ready would then park the
+// rollout at the drain check forever — so the pod stays serving throughout.
+func TestInPlaceUpdate_PromotionWaitsForMinReadySeconds(t *testing.T) {
+	f := newConvergedInPlaceFixture(t)
+	f.plan.MinReadySeconds = 20
+	clk := clocktesting.NewFakeClock(minReadyWindowStart)
+
+	if f.update(t, clk) {
+		t.Fatalf("expected done=false while the patched pod is inside the minReadySeconds window")
+	}
+	if !f.podServing(t) {
+		t.Fatalf("converged pod must return to rotation before the window starts counting")
+	}
+	s := legacyInstanceStatusesOnIR(f.client, f.isvc, workload.ComponentEngine)[0]
+	if s.Phase != v1beta1.OMENativeInstanceUpdating {
+		t.Fatalf("promoted inside the window: phase=%q", s.Phase)
+	}
+
+	clk.SetTime(minReadyWindowStart.Add(15 * time.Second))
+	if !f.update(t, clk) {
+		t.Fatalf("expected done=true once the patched pod became Available (a re-drain would park at the drain check)")
+	}
+	if !f.podServing(t) {
+		t.Fatalf("pod must stay in rotation across the wait")
+	}
+	s = legacyInstanceStatusesOnIR(f.client, f.isvc, workload.ComponentEngine)[0]
+	if s.Phase != v1beta1.OMENativeInstanceReady || s.RunningRevision != f.tcr.Name || s.Operation != nil {
+		t.Fatalf("promotion after window: phase=%q runningRevision=%q operation=%+v", s.Phase, s.RunningRevision, s.Operation)
+	}
+}
+
+// TestInPlaceUpdate_ZeroWindowPromotionRetryDoesNotRedrain: with no window,
+// a pass that finds the pod already relabeled to the target revision and
+// serving (promotion did not persist on an earlier pass) promotes it as-is.
+// Re-draining a converged pod would take capacity out of rotation for
+// nothing and, with the routed Service still listing it, never observe it
+// drained.
+func TestInPlaceUpdate_ZeroWindowPromotionRetryDoesNotRedrain(t *testing.T) {
+	f := newConvergedInPlaceFixture(t)
+	clk := clocktesting.NewFakeClock(minReadyWindowStart)
+
+	if !f.update(t, clk) {
+		t.Fatalf("expected done=true: a converged, serving pod promotes without a window")
+	}
+	if !f.podServing(t) {
+		t.Fatalf("converged pod must not be drained on the promotion pass")
+	}
+	s := legacyInstanceStatusesOnIR(f.client, f.isvc, workload.ComponentEngine)[0]
+	if s.Phase != v1beta1.OMENativeInstanceReady || s.RunningRevision != f.tcr.Name || s.Operation != nil {
+		t.Fatalf("promotion: phase=%q runningRevision=%q operation=%+v", s.Phase, s.RunningRevision, s.Operation)
+	}
+}
+
+// TestSurgeUpdate_WindowGatesOnlyStepSurge: the window decides when the
+// source may leave rotation, so it applies at Step=Surge only. Once the
+// source is marked not-serving (Step=SurgeDrain), a replacement that is
+// Ready but inside the window — as after a readiness flap — must not hold
+// the drained source out of service; the pass proceeds to delete it.
+func TestSurgeUpdate_WindowGatesOnlyStepSurge(t *testing.T) {
+	legacyResetExpectations(t)
+	isvc, ir := surgeISVCReady("llama-70b", "prod", 1)
+	oldPod := surgePodAtOrdinal(isvc, 0, 1, 0, true, false /* already drained */)
+	surgePod := surgePodAtOrdinal(isvc, 0, 1, 1, true, true)
+	target := &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{
+		Name: "llama-70b-engine-rev-v2hash", Namespace: isvc.Namespace,
+	}}
+	surgePod.Labels[query.LabelRevisionHash] = query.RevisionHashFromControllerRevisionName(target.Name)
+	podReadyAt(surgePod, minReadyWindowStart.Add(-10*time.Second))
+	c := legacyNewFakeClient(t, isvc, ir, oldPod, surgePod, target)
+
+	clk := clocktesting.NewFakeClock(minReadyWindowStart)
+	plan := surgePlan()
+	plan.MinReadySeconds = 20
+	stamp := legacyTestInput(isvc, c, workload.ComponentEngine)
+	stamp.Clock = clk
+	if err := patchInstanceStatusSurgingForUpdate(context.Background(), stamp, 0, target.Name, plan.InstanceReadyTimeout); err != nil {
+		t.Fatalf("pre-stamp surge: %v", err)
+	}
+	if err := patchInstanceStatusSurgeStepDrain(context.Background(), stamp, 0); err != nil {
+		t.Fatalf("pre-stamp drain: %v", err)
+	}
+	// Observe the persisted Step=SurgeDrain, as a later pass would.
+	input := legacyTestInput(isvc, c, workload.ComponentEngine)
+	input.Clock = clk
+
+	done, err := surgeUpdate(context.Background(), workload.Deps{Client: c}, input, plan, plan.Instances[0], target, []*corev1.Pod{oldPod, surgePod})
+	if err != nil {
+		t.Fatalf("surgeUpdate past Step=Surge: %v", err)
+	}
+	if done {
+		t.Fatalf("expected done=false while deleting source")
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(oldPod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("drained source must be deleted without waiting out the window again: %v", err)
+	}
+}

--- a/pkg/controller/v1beta1/workload/ops/update.go
+++ b/pkg/controller/v1beta1/workload/ops/update.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workload/podreadiness"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/workload/query"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/workload/revision"
 	workload "sigs.k8s.io/ome/pkg/controller/v1beta1/workload/types"
@@ -31,6 +32,31 @@ func updateDrainKey(idx int32, incarnation int64) string {
 // in flight. Exported so the dispatcher's requeue cadence stays in
 // lockstep with the per-Instance state machine.
 const UpdateRequeueInterval = 5 * time.Second
+
+// podsAvailable reports whether every pod has been Ready for the
+// Component's minReadySeconds window (podreadiness.IsPodAvailable). A zero
+// window reduces to every pod being PodReady. Rollouts pace on this rather
+// than on Ready: a drain or promotion that ran the moment a pod flipped
+// Ready would release its budget slot before the pod proved it stays up.
+// The in-flight Update keeps the dispatcher polling at UpdateRequeueInterval
+// until the window elapses.
+func podsAvailable(pods []*corev1.Pod, minReadySeconds int32, now time.Time) bool {
+	for _, pod := range pods {
+		if available, _ := podreadiness.IsPodAvailable(pod, minReadySeconds, now); !available {
+			return false
+		}
+	}
+	return true
+}
+
+// surgeWindowApplies reports whether the minReadySeconds window still gates a
+// surge: the Operation has not advanced past Step=Surge, so the source is in
+// rotation and the replacement's Ready age decides when it may leave. Past
+// that step the source is already draining, and a replacement that flaps
+// Ready must not hold the drained source out of service for another window.
+func surgeWindowApplies(s *workload.InstanceStatus) bool {
+	return s == nil || s.Operation == nil || s.Operation.Step == updateStepSurge
+}
 
 // Update drives one Instance toward the target ControllerRevision.
 // Mode is chosen per Instance:

--- a/pkg/controller/v1beta1/workload/ops/update_gang.go
+++ b/pkg/controller/v1beta1/workload/ops/update_gang.go
@@ -270,6 +270,12 @@ func gangSurgeUpdate(ctx context.Context, deps workload.Deps, input workload.Rec
 				return false, nil
 			}
 		}
+		// Nor, while the source is still in rotation, until the whole
+		// replacement gang has stayed Ready for the minReadySeconds window;
+		// the surge budget slot is held meanwhile.
+		if surgeWindowApplies(src) && !podsAvailable(surgePods, plan.MinReadySeconds, input.Now()) {
+			return false, nil
+		}
 	}
 	if !promotedSurgeTarget && input.ApplyInstanceMutationsWithRetryBlock != nil {
 		claimed, err := claimGangSurgeDrain(ctx, input, src, surgeMarker)

--- a/pkg/controller/v1beta1/workload/ops/update_inplace.go
+++ b/pkg/controller/v1beta1/workload/ops/update_inplace.go
@@ -47,10 +47,17 @@ func inPlaceUpdate(ctx context.Context, deps workload.Deps, input workload.Recon
 		markNotReady = *plan.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle
 	}
 
+	// A pod already relabeled to the target revision has been through the
+	// drain + patch steps and is back in (or returning to) rotation; draining
+	// it again would remove converged capacity and restart its PodReady age
+	// on every pass while promotion waits out the minReadySeconds window.
+	targetRev := query.RevisionOf(target)
+	onTarget := func(pod *corev1.Pod) bool { return query.RevisionFromPod(pod).Same(targetRev) }
+
 	// Drain first when the strategy requires it.
 	if markNotReady {
 		for _, pod := range pods {
-			if !podreadiness.IsServing(pod) {
+			if !podreadiness.IsServing(pod) || onTarget(pod) {
 				continue
 			}
 			if err := podreadiness.MarkPodNotServing(ctx, deps.Client, deps.Reader(), pod, podreadiness.WriterUpdateInPlace, updateDrainKey(inst.Index, inst.Incarnation)); err != nil {
@@ -59,6 +66,9 @@ func inPlaceUpdate(ctx context.Context, deps workload.Deps, input workload.Recon
 		}
 		// Live reader on drain check so kube-proxy isn't still routing.
 		for _, pod := range pods {
+			if onTarget(pod) {
+				continue
+			}
 			serviceName := drainServiceForPod(input, plan, pod)
 			if serviceName == "" {
 				continue
@@ -213,6 +223,12 @@ func inPlaceUpdate(ctx context.Context, deps workload.Deps, input workload.Recon
 		}
 	}
 
+	// Promotion releases this Instance's unavailability budget slot, so under
+	// a minReadySeconds window it waits until every patched pod has stayed
+	// Ready for that long. A zero window keeps the runtime-image gate above.
+	if plan.MinReadySeconds > 0 && !podsAvailable(livePods, plan.MinReadySeconds, input.Now()) {
+		return false, nil
+	}
 	if err := patchInstanceStatusReadyOnRevision(ctx, input, inst.Index, target.Name); err != nil {
 		return false, fmt.Errorf("patch status Ready (instance=%d): %w", inst.Index, err)
 	}

--- a/pkg/controller/v1beta1/workload/ops/update_recreate.go
+++ b/pkg/controller/v1beta1/workload/ops/update_recreate.go
@@ -150,10 +150,10 @@ func recreateUpdate(ctx context.Context, deps workload.Deps, input workload.Reco
 		return false, nil
 	}
 
-	// Phase C: flip serving, then wait for kubelet to incorporate the
-	// controller readiness gate into PodReady before promoting the Instance.
-	// ContainersReady alone only proves that the runtime probe passed; the Pod
-	// is not eligible for its Service until PodReady also observes serving=True.
+	// Phase C: flip serving, then wait for kubelet to fold the readiness gate
+	// into PodReady before promoting. ContainersReady only proves the runtime
+	// probe passed; a pod is not eligible for its Service until PodReady is
+	// true, and promotion releases the slot that holds the next Instance's drain.
 	if !query.AllPodsRuntimeReady(newPods) {
 		return false, nil
 	}
@@ -171,6 +171,11 @@ func recreateUpdate(ctx context.Context, deps workload.Deps, input workload.Reco
 		if !podreadiness.IsPodReady(pod) {
 			return false, nil
 		}
+	}
+	// Under a minReadySeconds window promotion additionally waits until every
+	// new pod has stayed Ready for that long.
+	if plan.MinReadySeconds > 0 && !podsAvailable(newPods, plan.MinReadySeconds, input.Now()) {
+		return false, nil
 	}
 	if err := patchInstanceStatusReadyOnRevision(ctx, input, inst.Index, target.Name); err != nil {
 		return false, fmt.Errorf("patch status Ready (instance=%d): %w", inst.Index, err)

--- a/pkg/controller/v1beta1/workload/ops/update_recreate_readiness_test.go
+++ b/pkg/controller/v1beta1/workload/ops/update_recreate_readiness_test.go
@@ -6,88 +6,69 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	workload "sigs.k8s.io/ome/pkg/controller/v1beta1/workload/types"
 )
 
-func TestRecreateUpdateWaitsForPodReadyAfterEnablingServing(t *testing.T) {
+// TestRecreateUpdate_WaitsForPodReadyAfterEnablingServing: with the old pods
+// gone and the recreated pod ContainersReady + serving, promotion still waits
+// for kubelet to fold the serving gate into PodReady. Promotion releases the
+// Instance's unavailability budget slot, so promoting before the pod is
+// routable would let the next Instance drain first.
+func TestRecreateUpdate_WaitsForPodReadyAfterEnablingServing(t *testing.T) {
 	tests := []struct {
 		name      string
 		podReady  bool
 		wantDone  bool
-		wantPhase workload.InstancePhase
+		wantPhase v1beta1.OMENativeInstancePhase
 	}{
-		{
-			name:      "serving gate set but pod ready not observed",
-			podReady:  false,
-			wantDone:  false,
-			wantPhase: workload.InstancePhaseUpdating,
-		},
-		{
-			name:      "pod ready observed",
-			podReady:  true,
-			wantDone:  true,
-			wantPhase: workload.InstancePhaseReady,
-		},
+		{name: "serving gate set but PodReady not observed", podReady: false, wantDone: false, wantPhase: v1beta1.OMENativeInstanceUpdating},
+		{name: "PodReady observed", podReady: true, wantDone: true, wantPhase: v1beta1.OMENativeInstanceReady},
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			legacyResetExpectations(t)
 			isvc, ir := legacyISVCReadyAtIncarnation("llama-70b", "prod", 1)
-			client := legacyNewFakeClient(t, isvc, ir)
+			c := legacyNewFakeClient(t, isvc, ir)
 			targetSpec := legacyTargetSpecImage("llama:v2")
-			target := legacyEnsureTargetCR(t, client, isvc, targetSpec)
+			target := legacyEnsureTargetCR(t, c, isvc, targetSpec)
 
-			if err := legacyMutateInstance(client, isvc, workload.ComponentEngine)(context.Background(), 0, func(status *workload.InstanceStatus) bool {
-				status.Incarnation = 2
-				status.Phase = workload.InstancePhaseUpdating
-				status.TargetRevision = target.Name
-				status.Operation = &workload.InstanceOperation{
-					Type:           workload.InstanceOperationUpdate,
-					Step:           updateStepDrain,
-					TargetRevision: target.Name,
-				}
+			// Mid-recreate state: Phase A drained and deleted the incarnation-1
+			// pod, Phase B created the incarnation-2 pod; only Phase C is left.
+			if err := legacyMutateInstance(c, isvc, workload.ComponentEngine)(context.Background(), 0, func(s *workload.InstanceStatus) bool {
+				s.Incarnation = 2
+				s.Phase = workload.InstancePhaseUpdating
+				s.TargetRevision = target.Name
+				s.Operation = &workload.InstanceOperation{Type: workload.InstanceOperationUpdate, Step: updateStepDrain, TargetRevision: target.Name}
 				return true
 			}); err != nil {
 				t.Fatalf("seed in-flight recreate: %v", err)
 			}
 
-			pod := legacyPodAtIncarnation(isvc, 0, 2, true, true)
+			pod := legacyPodAtIncarnation(isvc, 0, 2, true /* ContainersReady */, true /* serving */)
 			pod.Spec = *targetSpec.DeepCopy()
-			if test.podReady {
-				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
-					Type:   corev1.PodReady,
-					Status: corev1.ConditionTrue,
-				})
+			if tc.podReady {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue})
 			}
-			if err := client.Create(context.Background(), pod); err != nil {
+			if err := c.Create(context.Background(), pod); err != nil {
 				t.Fatalf("create replacement pod: %v", err)
 			}
 
-			input := legacyTestInput(isvc, client, workload.ComponentEngine)
+			input := legacyTestInput(isvc, c, workload.ComponentEngine)
 			plan := legacyComponentPlan(workload.UpdateStrategyRecreatePod, nil)
-			done, err := recreateUpdate(
-				context.Background(),
-				legacyTestDeps(client),
-				input,
-				plan,
-				plan.Instances[0],
-				target,
-				[]*corev1.Pod{pod},
-			)
+			done, err := recreateUpdate(context.Background(), legacyTestDeps(c), input, plan, plan.Instances[0], target, []*corev1.Pod{pod})
 			if err != nil {
 				t.Fatalf("recreateUpdate: %v", err)
 			}
-			if done != test.wantDone {
-				t.Fatalf("done: got %t, want %t", done, test.wantDone)
+			if done != tc.wantDone {
+				t.Fatalf("done: got %t, want %t", done, tc.wantDone)
 			}
-
-			statuses := legacyInstanceStatusesOnIR(client, isvc, workload.ComponentEngine)
+			statuses := legacyInstanceStatusesOnIR(c, isvc, workload.ComponentEngine)
 			if len(statuses) != 1 {
 				t.Fatalf("instance statuses: got %d, want 1", len(statuses))
 			}
-			if got := workload.InstancePhase(statuses[0].Phase); got != test.wantPhase {
-				t.Fatalf("phase: got %q, want %q", got, test.wantPhase)
+			if statuses[0].Phase != tc.wantPhase {
+				t.Fatalf("phase: got %q, want %q", statuses[0].Phase, tc.wantPhase)
 			}
 		})
 	}

--- a/pkg/controller/v1beta1/workload/ops/update_surge.go
+++ b/pkg/controller/v1beta1/workload/ops/update_surge.go
@@ -422,6 +422,13 @@ func surgeUpdate(ctx context.Context, deps workload.Deps, input workload.Reconci
 				return false, nil
 			}
 		}
+		// ...and, while the source is still in rotation, until the
+		// replacement has stayed Ready for the minReadySeconds window. The
+		// surge stays in flight (budget slot held) for the whole wait.
+		if surgeWindowApplies(findInstanceStatus(input.ObservedState.InstanceStatuses, inst.Index)) &&
+			!podsAvailable(surgePods, plan.MinReadySeconds, input.Now()) {
+			return false, nil
+		}
 		// Transition Step Surge → Drain once. Subsequent passes idempotency-
 		// skip inside the helper.
 		if err := patchInstanceStatusSurgeStepDrain(ctx, input, inst.Index); err != nil {

--- a/pkg/controller/v1beta1/workload/plan.go
+++ b/pkg/controller/v1beta1/workload/plan.go
@@ -60,6 +60,7 @@ func BuildPlan(component ComponentType, desired WorkloadDesiredSpec, observed Wo
 		UpdateStrategy:       updateStrategyWithDefaults(lifecycle.UpdateStrategy),
 		ReadyPolicy:          readyPolicyOrDefault(lifecycle.ReadyPolicy, desired.MultiPod),
 		InstanceReadyTimeout: InstanceReadyTimeoutOrDefault(lifecycle.InstanceReadyTimeout),
+		MinReadySeconds:      max(desired.MinReadySeconds, 0),
 		MigrationMode:        MigrationModeOrDefault(lifecycle.MigrationPolicy),
 		Paused:               desired.Paused,
 		PauseFreeze:          desired.PauseFreeze,

--- a/pkg/controller/v1beta1/workload/plan_minready_test.go
+++ b/pkg/controller/v1beta1/workload/plan_minready_test.go
@@ -1,0 +1,26 @@
+package workload
+
+import "testing"
+
+func TestBuildPlan_CarriesMinReadySeconds(t *testing.T) {
+	desired := singlePodDesired(1, Lifecycle{})
+	desired.MinReadySeconds = 20
+	plan, err := BuildPlan(ComponentEngine, desired, WorkloadObservedState{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.MinReadySeconds != 20 {
+		t.Fatalf("MinReadySeconds: got %d want 20", plan.MinReadySeconds)
+	}
+
+	// Unset projects to 0 (Available as soon as Ready); a negative value
+	// from a hand-edited source cannot widen the window below zero.
+	desired.MinReadySeconds = -7
+	plan, err = BuildPlan(ComponentEngine, desired, WorkloadObservedState{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.MinReadySeconds != 0 {
+		t.Fatalf("MinReadySeconds: got %d want 0", plan.MinReadySeconds)
+	}
+}

--- a/pkg/controller/v1beta1/workload/podreadiness/readiness.go
+++ b/pkg/controller/v1beta1/workload/podreadiness/readiness.go
@@ -59,6 +59,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -361,6 +362,44 @@ func IsPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// IsPodAvailable reports whether the pod is Available: PodReady is True and
+// the condition's lastTransitionTime plus minReadySeconds is not after now
+// (the Deployment minReadySeconds rule). A window <= 0 makes Available the
+// same as Ready. The duration is how much longer the pod must stay Ready
+// before it becomes Available; it is 0 when the pod already is, when it is
+// not Ready, and when a Ready condition carries no lastTransitionTime (its
+// age cannot be proven, so no later instant makes it Available). The status
+// aggregator folds the smallest pending duration into the reconcile requeue
+// so the Available counters refresh when the window elapses; the update
+// strategies discard it because an in-flight Update already polls.
+func IsPodAvailable(pod *corev1.Pod, minReadySeconds int32, now time.Time) (bool, time.Duration) {
+	if pod == nil {
+		return false, 0
+	}
+	var ready *corev1.PodCondition
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == corev1.PodReady {
+			ready = &pod.Status.Conditions[i]
+			break
+		}
+	}
+	if ready == nil || ready.Status != corev1.ConditionTrue {
+		return false, 0
+	}
+	if minReadySeconds <= 0 {
+		return true, 0
+	}
+	if ready.LastTransitionTime.IsZero() {
+		return false, 0
+	}
+	window := time.Duration(minReadySeconds) * time.Second
+	availableAt := ready.LastTransitionTime.Add(window)
+	if !now.Before(availableAt) {
+		return true, 0
+	}
+	return false, availableAt.Sub(now)
 }
 
 // MarkPodServing removes the {userAgent, key} entry from the

--- a/pkg/controller/v1beta1/workload/podreadiness/readiness_test.go
+++ b/pkg/controller/v1beta1/workload/podreadiness/readiness_test.go
@@ -3,6 +3,7 @@ package podreadiness
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -746,5 +747,65 @@ func TestMessageListSerialization_Deterministic(t *testing.T) {
 
 	if cond1.Message != cond2.Message {
 		t.Errorf("Message ordering not stable:\n  p1: %s\n  p2: %s", cond1.Message, cond2.Message)
+	}
+}
+
+// TestIsPodAvailable pins the Deployment minReadySeconds rule: Available
+// is PodReady plus a Ready age of at least the window, with the window's
+// boundary inclusive and a zero window collapsing to plain Ready.
+func TestIsPodAvailable(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	readyPod := func(readyAt time.Time) *corev1.Pod {
+		pod := newReadinessTestPod("p")
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:               corev1.PodReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(readyAt),
+		}}
+		return pod
+	}
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		window        int32
+		wantAvailable bool
+		wantRetry     time.Duration
+	}{
+		{name: "nil pod", pod: nil, window: 10},
+		{name: "no Ready condition", pod: newReadinessTestPod("p"), window: 10},
+		{
+			name: "Ready False",
+			pod: func() *corev1.Pod {
+				pod := readyPod(now.Add(-time.Hour))
+				pod.Status.Conditions[0].Status = corev1.ConditionFalse
+				return pod
+			}(),
+			window: 10,
+		},
+		{name: "zero window is Ready", pod: readyPod(now), window: 0, wantAvailable: true},
+		{name: "negative window is Ready", pod: readyPod(now), window: -5, wantAvailable: true},
+		{name: "inside window", pod: readyPod(now.Add(-4 * time.Second)), window: 10, wantRetry: 6 * time.Second},
+		{name: "exactly at window boundary", pod: readyPod(now.Add(-10 * time.Second)), window: 10, wantAvailable: true},
+		{name: "past window", pod: readyPod(now.Add(-11 * time.Second)), window: 10, wantAvailable: true},
+		{
+			name: "Ready without transition time cannot prove age",
+			pod: func() *corev1.Pod {
+				pod := readyPod(now)
+				pod.Status.Conditions[0].LastTransitionTime = metav1.Time{}
+				return pod
+			}(),
+			window: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			available, retry := IsPodAvailable(tt.pod, tt.window, now)
+			if available != tt.wantAvailable {
+				t.Fatalf("available: got %v want %v", available, tt.wantAvailable)
+			}
+			if retry != tt.wantRetry {
+				t.Fatalf("retry: got %v want %v", retry, tt.wantRetry)
+			}
+		})
 	}
 }

--- a/pkg/controller/v1beta1/workload/status_aggregate.go
+++ b/pkg/controller/v1beta1/workload/status_aggregate.go
@@ -165,17 +165,51 @@ func CountScheduledPods(pods []*corev1.Pod) int32 {
 	return n
 }
 
-// CountAvailablePods returns the number of pods named in
-// availableByName. Used in conjunction with AvailablePodSet to compute
-// per-Instance availability.
-func CountAvailablePods(pods []*corev1.Pod, availableByName map[string]struct{}) int32 {
+// AvailabilityWindow is the Ready-age requirement layered on EndpointSlice
+// membership when counting Available pods. MinReadySeconds is the
+// Component's window; Now is the reconcile's clock reading. A zero window
+// leaves rotation membership as the whole rule.
+type AvailabilityWindow struct {
+	MinReadySeconds int32
+	Now             time.Time
+}
+
+// CountAvailablePods returns the number of pods that are in rotation
+// (named in availableByName, the AvailablePodSet result) and, under a
+// positive window, have been Ready for at least MinReadySeconds. The
+// duration is how long until the earliest in-rotation pod still inside the
+// window becomes Available (0 when none is pending): the counters it feeds
+// change at that instant without any watch event, so the caller schedules
+// its next reconcile from it.
+func CountAvailablePods(pods []*corev1.Pod, availableByName map[string]struct{}, window AvailabilityWindow) (int32, time.Duration) {
 	var n int32
+	var nextAvailableIn time.Duration
 	for _, p := range pods {
-		if _, ok := availableByName[p.Name]; ok {
-			n++
+		if _, ok := availableByName[p.Name]; !ok {
+			continue
 		}
+		if window.MinReadySeconds > 0 {
+			available, remaining := podreadiness.IsPodAvailable(p, window.MinReadySeconds, window.Now)
+			if !available {
+				nextAvailableIn = earliestPending(nextAvailableIn, remaining)
+				continue
+			}
+		}
+		n++
 	}
-	return n
+	return n, nextAvailableIn
+}
+
+// earliestPending folds candidate into the running "next wake" value: the
+// smallest positive duration wins and a non-positive candidate is no wake.
+func earliestPending(current, candidate time.Duration) time.Duration {
+	if candidate <= 0 {
+		return current
+	}
+	if current <= 0 || candidate < current {
+		return candidate
+	}
+	return current
 }
 
 // UniqueNodes returns the deterministically-sorted set of node names
@@ -380,14 +414,16 @@ func HasWedgedPodAgainstCurrent(pods []*corev1.Pod, currentHash, revisionHashLab
 
 // CountersForInstance computes the per-Instance counter set from the
 // live pod bucket. availableByPod is the map returned by
-// AvailablePodSet.
-func CountersForInstance(pods []*corev1.Pod, availableByPod map[string]struct{}) InstanceCounters {
+// AvailablePodSet; window is the Component's minReadySeconds rule.
+func CountersForInstance(pods []*corev1.Pod, availableByPod map[string]struct{}, window AvailabilityWindow) InstanceCounters {
+	available, nextAvailableIn := CountAvailablePods(pods, availableByPod, window)
 	return InstanceCounters{
 		PodCount:          int32(len(pods)),
 		ReadyPodCount:     CountReadyPods(pods),
 		ServingPodCount:   CountServingPods(pods),
 		ScheduledPodCount: CountScheduledPods(pods),
-		AvailablePodCount: CountAvailablePods(pods, availableByPod),
+		AvailablePodCount: available,
+		NextAvailableIn:   nextAvailableIn,
 		Admitted:          instancePodsAdmitted(pods),
 		NodesOccupied:     UniqueNodes(pods),
 	}
@@ -413,8 +449,12 @@ type InstanceCounters struct {
 	ServingPodCount   int32
 	ScheduledPodCount int32
 	AvailablePodCount int32
-	Admitted          bool
-	NodesOccupied     []string
+	// NextAvailableIn is how long until AvailablePodCount next rises on its
+	// own: the remaining minReadySeconds window of the earliest in-rotation
+	// pod still inside it, 0 when no pod is pending. Not persisted.
+	NextAvailableIn time.Duration
+	Admitted        bool
+	NodesOccupied   []string
 }
 
 // ComponentCounters is the field-level Component publication result.
@@ -425,6 +465,9 @@ type ComponentCounters struct {
 	AvailableReplicas    int32
 	UpdatedReplicas      int32
 	UpdatedReadyReplicas int32
+	// NextAvailableIn is the smallest pending InstanceCounters.NextAvailableIn
+	// across the Component, 0 when no pod is inside its window.
+	NextAvailableIn time.Duration
 }
 
 // TakeInlineV1Publication consumes the owned rows, overlays the publication
@@ -444,6 +487,7 @@ func (o *ComponentObservation) TakeInlineV1Publication(desiredByIdx map[int32]in
 		if InstanceMeetsThreshold(current.PodCount, current.AvailablePodCount, desired) {
 			counters.AvailableReplicas++
 		}
+		counters.NextAvailableIn = earliestPending(counters.NextAvailableIn, current.NextAvailableIn)
 		if targetRevName != "" && query.RevisionFromName(runningRevision).Same(target) {
 			counters.UpdatedReplicas++
 			if InstanceMeetsThreshold(current.PodCount, current.ReadyPodCount, desired) {
@@ -460,8 +504,8 @@ func (o *ComponentObservation) TakeInlineV1Publication(desiredByIdx map[int32]in
 
 // String formats InstanceCounters for debug output.
 func (c InstanceCounters) String() string {
-	return fmt.Sprintf("pods=%d ready=%d serving=%d scheduled=%d available=%d nodes=%v",
-		c.PodCount, c.ReadyPodCount, c.ServingPodCount, c.ScheduledPodCount, c.AvailablePodCount, c.NodesOccupied)
+	return fmt.Sprintf("pods=%d ready=%d serving=%d scheduled=%d available=%d nextAvailableIn=%s nodes=%v",
+		c.PodCount, c.ReadyPodCount, c.ServingPodCount, c.ScheduledPodCount, c.AvailablePodCount, c.NextAvailableIn, c.NodesOccupied)
 }
 
 // disposableAttempt reports whether s's in-flight attempt is owned by

--- a/pkg/controller/v1beta1/workload/status_aggregate_test.go
+++ b/pkg/controller/v1beta1/workload/status_aggregate_test.go
@@ -755,6 +755,7 @@ func TestTakeInlineV1PublicationCountersIgnorePersistedObservationFields(t *test
 				append([]workload.InstanceStatus(nil), persisted...),
 				workload.NewCachedSelectorPodObservation(nil, nil),
 				nil,
+				workload.AvailabilityWindow{},
 			)
 			if err != nil {
 				t.Fatalf("NewOwnedPublicationObservation: %v", err)
@@ -862,5 +863,49 @@ func TestEscalateStuckPodFailures_CapturesLastFailure(t *testing.T) {
 	// A stuck waiting-state wedge never ran a process → no exit code.
 	if lf.ExitCode != nil {
 		t.Errorf("LastFailure.ExitCode: got %v want nil for a waiting-state wedge", lf.ExitCode)
+	}
+}
+
+// TestCountAvailablePods_MinReadySecondsWindow pins the Available counter's
+// two inputs — EndpointSlice rotation membership always, and the Ready-age
+// window only when the Component sets minReadySeconds — and the wake it
+// reports: the remaining window of the earliest in-rotation pod still inside
+// it, nothing once every such pod is Available or when no window applies.
+func TestCountAvailablePods_MinReadySecondsWindow(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	readyPod := func(name string, readyAt time.Time) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(readyAt),
+			}}},
+		}
+	}
+	aged := readyPod("aged", now.Add(-30*time.Second))
+	fresh := readyPod("fresh", now.Add(-5*time.Second))
+	notInRotation := readyPod("out", now.Add(-30*time.Second))
+	pods := []*corev1.Pod{aged, fresh, notInRotation}
+	inRotation := map[string]struct{}{aged.Name: {}, fresh.Name: {}}
+
+	if got, wake := workload.CountAvailablePods(pods, inRotation, workload.AvailabilityWindow{Now: now}); got != 2 || wake != 0 {
+		t.Fatalf("zero window: got %d/%s want 2/0s (rotation membership alone, nothing pending)", got, wake)
+	}
+	window := workload.AvailabilityWindow{MinReadySeconds: 20, Now: now}
+	if got, wake := workload.CountAvailablePods(pods, inRotation, window); got != 1 || wake != 15*time.Second {
+		t.Fatalf("20s window: got %d/%s want 1/15s (only the aged pod; the fresh pod crosses in 15s)", got, wake)
+	}
+	if got, wake := workload.CountAvailablePods([]*corev1.Pod{fresh, notInRotation}, map[string]struct{}{notInRotation.Name: {}}, window); got != 1 || wake != 0 {
+		t.Fatalf("out-of-rotation pod inside the window: got %d/%s want 1/0s (no wake for a pod rotation will not admit by time alone)", got, wake)
+	}
+	window.Now = now.Add(15 * time.Second)
+	if got, wake := workload.CountAvailablePods(pods, inRotation, window); got != 2 || wake != 0 {
+		t.Fatalf("20s window after it elapsed: got %d/%s want 2/0s", got, wake)
+	}
+	counters := workload.CountersForInstance(pods, inRotation, workload.AvailabilityWindow{MinReadySeconds: 20, Now: now})
+	if counters.AvailablePodCount != 1 || counters.ReadyPodCount != 0 || counters.NextAvailableIn != 15*time.Second {
+		t.Fatalf("counters: got available=%d ready=%d nextAvailableIn=%s want available=1 ready=0 nextAvailableIn=15s (Ready counts ContainersReady)",
+			counters.AvailablePodCount, counters.ReadyPodCount, counters.NextAvailableIn)
 	}
 }

--- a/pkg/controller/v1beta1/workload/types/plan.go
+++ b/pkg/controller/v1beta1/workload/types/plan.go
@@ -37,6 +37,12 @@ type ComponentPlan struct {
 	// Instance becoming Ready.
 	InstanceReadyTimeout time.Duration
 
+	// MinReadySeconds is how long a newly Ready pod must stay Ready before
+	// it is Available. Rollout drains and promotions wait on Available
+	// pods, so the per-Component budgets stay held for the window. 0 means
+	// Available as soon as Ready.
+	MinReadySeconds int32
+
 	// MigrationMode is the effective migration disposition (auto / surge /
 	// never).
 	MigrationMode MigrationMode

--- a/pkg/controller/v1beta1/workload/types/source.go
+++ b/pkg/controller/v1beta1/workload/types/source.go
@@ -17,17 +17,11 @@ type WorkloadDesiredSpec struct {
 	// Replicas is the desired Instance count.
 	Replicas int32
 
-	// MinReadySeconds is the minimum age (in seconds) for an Instance
-	// to count as Available after becoming Ready.
-	//
-	// LATENT BUG: this field is populated by the IR converter
-	// (inferencereplica/convert.go, from IR spec.minReadySeconds) but is
-	// NEVER read by the rollout engine. Availability is computed from
-	// EndpointSlice membership, not a readiness-age gate, so IR
-	// spec.minReadySeconds is currently NOT honored. The
-	// AvailablePodCount doc in types.go ("ready for at least
-	// MinReadySeconds") is aspirational on this account. Documented
-	// rather than wired: nothing sets this field today.
+	// MinReadySeconds is how long (in seconds) a newly Ready pod must stay
+	// Ready before it is Available. BuildPlan copies it onto
+	// ComponentPlan.MinReadySeconds; the rollout engine paces drains and
+	// promotions on Available pods and status aggregation counts only
+	// Available pods. 0 means Available as soon as Ready.
 	MinReadySeconds int32
 
 	// Runners enumerates the Runner roles (default | leader | worker)

--- a/pkg/controller/v1beta1/workload/types/types.go
+++ b/pkg/controller/v1beta1/workload/types/types.go
@@ -199,7 +199,9 @@ type InstanceStatus struct {
 	// ServingPodCount counts pods that are BOTH ContainersReady AND
 	// have serving=True on the controller-managed readiness gate.
 	ServingPodCount int32
-	// AvailablePodCount counts pods ready for at least MinReadySeconds.
+	// AvailablePodCount counts pods in rotation on the Component's
+	// headless Service that, when MinReadySeconds is set, have been Ready
+	// for at least that long.
 	AvailablePodCount int32
 	// ScheduledPodCount counts pods with Spec.NodeName set.
 	ScheduledPodCount int32

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6276,7 +6276,7 @@ func schema_pkg_apis_ome_v1beta1_InferenceReplicaSpec(ref common.ReferenceCallba
 					},
 					"minReadySeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinReadySeconds is propagated from the ISVC spec.",
+							Description: "MinReadySeconds is the minimum time a newly Ready pod must stay Ready before it counts as Available, projected from the parent ISVC's spec.<component>.lifecycle.minReadySeconds. The workload engine paces rollout drains and promotions on Available pods and counts only Available pods in availableReplicas. 0 means Available as soon as Ready.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -6416,7 +6416,7 @@ func schema_pkg_apis_ome_v1beta1_InferenceReplicaStatus(ref common.ReferenceCall
 					},
 					"availableReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AvailableReplicas is the number of Instances that have been Ready for at least MinReadySeconds.",
+							Description: "AvailableReplicas is the number of Instances whose desired pod count is Available: in rotation on the Component's headless Service and, when spec.minReadySeconds is set, Ready for at least that long.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -7984,6 +7984,13 @@ func schema_pkg_apis_ome_v1beta1_LifecycleSpec(ref common.ReferenceCallback) com
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"minReadySeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinReadySeconds is the minimum time a newly Ready pod must stay Ready before OMENative treats it as Available. A pod is Available when its PodReady condition is True and that condition's lastTransitionTime plus MinReadySeconds is not after the current time, evaluated per pod (the Deployment.spec.minReadySeconds rule). Ready remains the health signal; Available is the pacing signal: a rollout drains or promotes an Instance only once its new pods are Available, so the maxSurge / maxUnavailable budgets stay held for the whole window, and availableReplicas / availablePodCount count only Available pods. Unset or 0 means Available as soon as Ready. A value authored on the InferenceService always wins. Clusters may supply an admission-time default through the inferenceservice-config ConfigMap; it is stamped onto the InferenceService, so it also takes precedence over a value authored in the ServingRuntime's engineConfig / decoderConfig / routerConfig lifecycle (the InferenceService overrides the runtime when the two merge), as terminationGracePeriodSeconds does.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"migrationPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MigrationPolicy controls whether and how OMENative honors a migration request annotation for this Component.",
@@ -8063,7 +8070,7 @@ func schema_pkg_apis_ome_v1beta1_LifecycleStatus(ref common.ReferenceCallback) c
 					},
 					"availableReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AvailableReplicas is the number of Instances that have been Ready continuously for at least MinReadySeconds.",
+							Description: "AvailableReplicas is the number of Instances whose desired pod count is Available: in rotation on the Component's headless Service and, when lifecycle.minReadySeconds is set, Ready for at least that long.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -9068,7 +9075,7 @@ func schema_pkg_apis_ome_v1beta1_OMENativeInstanceStatus(ref common.ReferenceCal
 					},
 					"availablePodCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AvailablePodCount is the number of pods ready for at least MinReadySeconds.",
+							Description: "AvailablePodCount is the number of pods that are Available: in rotation on the Component's headless Service and, when lifecycle.minReadySeconds is set, Ready for at least that long.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -3466,7 +3466,7 @@
           "$ref": "#/definitions/v1beta1.LifecycleSpec"
         },
         "minReadySeconds": {
-          "description": "MinReadySeconds is propagated from the ISVC spec.",
+          "description": "MinReadySeconds is the minimum time a newly Ready pod must stay Ready before it counts as Available, projected from the parent ISVC's spec.\u003ccomponent\u003e.lifecycle.minReadySeconds. The workload engine paces rollout drains and promotions on Available pods and counts only Available pods in availableReplicas. 0 means Available as soon as Ready.",
           "type": "integer",
           "format": "int32"
         },
@@ -3532,7 +3532,7 @@
       "type": "object",
       "properties": {
         "availableReplicas": {
-          "description": "AvailableReplicas is the number of Instances that have been Ready for at least MinReadySeconds.",
+          "description": "AvailableReplicas is the number of Instances whose desired pod count is Available: in rotation on the Component's headless Service and, when spec.minReadySeconds is set, Ready for at least that long.",
           "type": "integer",
           "format": "int32"
         },
@@ -4451,6 +4451,11 @@
           "description": "MigrationPolicy controls whether and how OMENative honors a migration request annotation for this Component.",
           "$ref": "#/definitions/v1beta1.MigrationPolicy"
         },
+        "minReadySeconds": {
+          "description": "MinReadySeconds is the minimum time a newly Ready pod must stay Ready before OMENative treats it as Available. A pod is Available when its PodReady condition is True and that condition's lastTransitionTime plus MinReadySeconds is not after the current time, evaluated per pod (the Deployment.spec.minReadySeconds rule). Ready remains the health signal; Available is the pacing signal: a rollout drains or promotes an Instance only once its new pods are Available, so the maxSurge / maxUnavailable budgets stay held for the whole window, and availableReplicas / availablePodCount count only Available pods. Unset or 0 means Available as soon as Ready. A value authored on the InferenceService always wins. Clusters may supply an admission-time default through the inferenceservice-config ConfigMap; it is stamped onto the InferenceService, so it also takes precedence over a value authored in the ServingRuntime's engineConfig / decoderConfig / routerConfig lifecycle (the InferenceService overrides the runtime when the two merge), as terminationGracePeriodSeconds does.",
+          "type": "integer",
+          "format": "int32"
+        },
         "readyPolicy": {
           "description": "ReadyPolicy controls how Instance-level readiness is aggregated from the underlying pods. None is accepted only for single-pod Instances, where it is equivalent to AllPodReady; admission rejects None on multi-pod OMENative Components because per-pod readiness reporting is not supported.",
           "type": "string"
@@ -4470,7 +4475,7 @@
       "type": "object",
       "properties": {
         "availableReplicas": {
-          "description": "AvailableReplicas is the number of Instances that have been Ready continuously for at least MinReadySeconds.",
+          "description": "AvailableReplicas is the number of Instances whose desired pod count is Available: in rotation on the Component's headless Service and, when lifecycle.minReadySeconds is set, Ready for at least that long.",
           "type": "integer",
           "format": "int32"
         },
@@ -5066,7 +5071,7 @@
           "type": "boolean"
         },
         "availablePodCount": {
-          "description": "AvailablePodCount is the number of pods ready for at least MinReadySeconds.",
+          "description": "AvailablePodCount is the number of pods that are Available: in rotation on the Component's headless Service and, when lifecycle.minReadySeconds is set, Ready for at least that long.",
           "type": "integer",
           "format": "int32"
         },

--- a/pkg/validation/lifecycle.go
+++ b/pkg/validation/lifecycle.go
@@ -42,13 +42,15 @@ const (
 	// Mirrors the upstream appsv1.Deployment validation rule. Either
 	// field nil (defaulted upstream) does NOT trip this check.
 	ReasonRollingUpdateZeroBudget = "RollingUpdateZeroBudget"
+	// ReasonInvalidMinReadySeconds rejects a negative lifecycle.minReadySeconds.
+	// The CRD schema carries the same Minimum=0 bound; the pure validator
+	// keeps the rule enforceable off-cluster.
+	ReasonInvalidMinReadySeconds = "InvalidMinReadySeconds"
 )
 
 // ValidateLifecycle inspects every Component's LifecycleSpec on the
-// InferenceService. Today the only per-Component knobs that need
-// semantic validation past the CRD schema are
-// UpdateStrategy.RollingUpdate.MaxUnavailable and .MaxSurge — both
-// *intstr.IntOrString.
+// InferenceService: UpdateStrategy.RollingUpdate.MaxUnavailable and
+// .MaxSurge (both *intstr.IntOrString) and MinReadySeconds.
 // Wired into the webhook from inference_service_validation.go.
 func ValidateLifecycle(spec *v1beta1.InferenceServiceSpec) error {
 	if spec == nil {
@@ -73,7 +75,14 @@ func ValidateLifecycle(spec *v1beta1.InferenceServiceSpec) error {
 }
 
 func validateComponentLifecycle(name string, lc *v1beta1.LifecycleSpec) error {
-	if lc == nil || lc.UpdateStrategy == nil || lc.UpdateStrategy.RollingUpdate == nil {
+	if lc == nil {
+		return nil
+	}
+	if lc.MinReadySeconds != nil && *lc.MinReadySeconds < 0 {
+		return fmt.Errorf("spec.%s.lifecycle.minReadySeconds must be >= 0, got %d (%s)",
+			name, *lc.MinReadySeconds, ReasonInvalidMinReadySeconds)
+	}
+	if lc.UpdateStrategy == nil || lc.UpdateStrategy.RollingUpdate == nil {
 		return nil
 	}
 	ru := lc.UpdateStrategy.RollingUpdate

--- a/pkg/validation/lifecycle_test.go
+++ b/pkg/validation/lifecycle_test.go
@@ -228,3 +228,39 @@ func lifecycleWithRolling(mu, ms *intstr.IntOrString) *v1beta1.LifecycleSpec {
 		},
 	}
 }
+
+// TestValidateLifecycle_MinReadySeconds pins the pure-validator half of
+// the lifecycle.minReadySeconds bound: nil, zero, and positive values are
+// accepted on any Component; a negative value is rejected with the
+// Component's field path and the InvalidMinReadySeconds reason.
+func TestValidateLifecycle_MinReadySeconds(t *testing.T) {
+	seconds := func(v int32) *int32 { return &v }
+	spec := func(component string, v *int32) *v1beta1.InferenceServiceSpec {
+		lc := &v1beta1.LifecycleSpec{MinReadySeconds: v}
+		out := &v1beta1.InferenceServiceSpec{}
+		switch component {
+		case "engine":
+			out.Engine = &v1beta1.EngineSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Lifecycle: lc}}
+		case "decoder":
+			out.Decoder = &v1beta1.DecoderSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Lifecycle: lc}}
+		case "router":
+			out.Router = &v1beta1.RouterSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Lifecycle: lc}}
+		}
+		return out
+	}
+	for _, component := range []string{"engine", "decoder", "router"} {
+		for _, ok := range []*int32{nil, seconds(0), seconds(30)} {
+			if err := ValidateLifecycle(spec(component, ok)); err != nil {
+				t.Fatalf("%s minReadySeconds=%v: unexpected error %v", component, ok, err)
+			}
+		}
+		err := ValidateLifecycle(spec(component, seconds(-1)))
+		if err == nil {
+			t.Fatalf("%s minReadySeconds=-1: expected rejection", component)
+		}
+		wantPath := "spec." + component + ".lifecycle.minReadySeconds"
+		if !strings.Contains(err.Error(), wantPath) || !strings.Contains(err.Error(), ReasonInvalidMinReadySeconds) {
+			t.Fatalf("%s: error must name %s and %s; got %v", component, wantPath, ReasonInvalidMinReadySeconds, err)
+		}
+	}
+}

--- a/pkg/webhook/admission/isvc/inference_service_defaults.go
+++ b/pkg/webhook/admission/isvc/inference_service_defaults.go
@@ -88,19 +88,24 @@ func DefaultInferenceService(ctx context.Context, c client.Client, isvc *v1beta1
 	// defaulting of that field: the spec is stored as authored.
 	var replicas *controllerconfig.ReplicasDefaultsConfig
 	var gracePeriod *int64
+	var minReadySeconds *int32
 	if deployConfig != nil {
 		replicas = deployConfig.Replicas
 		gracePeriod = deployConfig.TerminationGracePeriodSeconds
+		minReadySeconds = deployConfig.MinReadySeconds
 	}
 
 	if isvc.Spec.Engine != nil {
 		defaultEngine(isvc.Spec.Engine, resolvedMode, replicas, gracePeriod)
+		defaultOMENativeMinReadySeconds(&isvc.Spec.Engine.ComponentExtensionSpec, resolvedMode, minReadySeconds)
 	}
 	if isvc.Spec.Decoder != nil {
 		defaultDecoder(isvc.Spec.Decoder, resolvedMode, replicas, gracePeriod)
+		defaultOMENativeMinReadySeconds(&isvc.Spec.Decoder.ComponentExtensionSpec, resolvedMode, minReadySeconds)
 	}
 	if isvc.Spec.Router != nil {
 		defaultRouter(isvc.Spec.Router, resolvedMode, replicas, gracePeriod)
+		defaultOMENativeMinReadySeconds(&isvc.Spec.Router.ComponentExtensionSpec, resolvedMode, minReadySeconds)
 	}
 	// Rollout pacing/structure defaults are applied at runtime by the resolve
 	// layer (coordination.ResolveGroups), not at admission.
@@ -174,6 +179,31 @@ func defaultTerminationGracePeriod(podSpec *v1beta1.PodSpec, defaultSeconds *int
 	}
 	seconds := *defaultSeconds
 	podSpec.TerminationGracePeriodSeconds = &seconds
+}
+
+// defaultOMENativeMinReadySeconds fills an unset lifecycle.minReadySeconds on
+// an OMENative-resolving component from the configured admission default. A
+// nil default stamps nothing (the component keeps "Available as soon as
+// Ready"), an authored value always wins, and non-OMENative components are
+// left untouched because the field has no meaning for them. The stamp lands
+// on the InferenceService, which overrides the ServingRuntime in the later
+// spec merge, so a runtime-authored value yields to the cluster default the
+// same way terminationGracePeriodSeconds does.
+func defaultOMENativeMinReadySeconds(ext *v1beta1.ComponentExtensionSpec, specMode *constants.DeploymentModeType, defaultSeconds *int32) {
+	if ext == nil || defaultSeconds == nil {
+		return
+	}
+	if !componentResolvesToOMENative(ext.Annotations, specMode) {
+		return
+	}
+	if ext.Lifecycle == nil {
+		ext.Lifecycle = &v1beta1.LifecycleSpec{}
+	}
+	if ext.Lifecycle.MinReadySeconds != nil {
+		return
+	}
+	seconds := *defaultSeconds
+	ext.Lifecycle.MinReadySeconds = &seconds
 }
 
 // defaultWorkerSize sets Worker.Size=1 only for a declared Leader+Worker pair.

--- a/pkg/webhook/admission/isvc/inference_service_defaults_minready_test.go
+++ b/pkg/webhook/admission/isvc/inference_service_defaults_minready_test.go
@@ -1,0 +1,107 @@
+package isvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+)
+
+func TestDefaultOMENativeMinReadySeconds(t *testing.T) {
+	omeNative := map[string]string{constants.DeploymentMode: string(constants.OMENative)}
+
+	t.Run("unconfigured stamps nothing", func(t *testing.T) {
+		ext := &v1beta1.ComponentExtensionSpec{Annotations: omeNative}
+		defaultOMENativeMinReadySeconds(ext, nil, nil)
+		assert.Nil(t, ext.Lifecycle, "no lifecycle block may be manufactured without a configured default")
+	})
+
+	t.Run("configured default fills an unset OMENative component", func(t *testing.T) {
+		seconds := int32(30)
+		ext := &v1beta1.ComponentExtensionSpec{Annotations: omeNative}
+		defaultOMENativeMinReadySeconds(ext, nil, &seconds)
+		require.NotNil(t, ext.Lifecycle)
+		require.NotNil(t, ext.Lifecycle.MinReadySeconds)
+		assert.Equal(t, int32(30), *ext.Lifecycle.MinReadySeconds)
+		assert.NotSame(t, &seconds, ext.Lifecycle.MinReadySeconds, "stamped value must be a copy, not the shared config pointer")
+	})
+
+	t.Run("authored value wins over the configured default", func(t *testing.T) {
+		seconds := int32(30)
+		authored := int32(5)
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: omeNative,
+			Lifecycle:   &v1beta1.LifecycleSpec{MinReadySeconds: &authored},
+		}
+		defaultOMENativeMinReadySeconds(ext, nil, &seconds)
+		assert.Equal(t, int32(5), *ext.Lifecycle.MinReadySeconds)
+	})
+
+	t.Run("authored zero is preserved", func(t *testing.T) {
+		seconds := int32(30)
+		zero := int32(0)
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: omeNative,
+			Lifecycle:   &v1beta1.LifecycleSpec{MinReadySeconds: &zero},
+		}
+		defaultOMENativeMinReadySeconds(ext, nil, &seconds)
+		assert.Equal(t, int32(0), *ext.Lifecycle.MinReadySeconds)
+	})
+
+	t.Run("non-OMENative component is left untouched", func(t *testing.T) {
+		seconds := int32(30)
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: map[string]string{constants.DeploymentMode: string(constants.RawDeployment)},
+		}
+		defaultOMENativeMinReadySeconds(ext, nil, &seconds)
+		assert.Nil(t, ext.Lifecycle)
+	})
+
+	t.Run("spec.deploymentMode OMENative resolves without a component annotation", func(t *testing.T) {
+		seconds := int32(30)
+		mode := constants.OMENative
+		ext := &v1beta1.ComponentExtensionSpec{}
+		defaultOMENativeMinReadySeconds(ext, &mode, &seconds)
+		require.NotNil(t, ext.Lifecycle)
+		assert.Equal(t, int32(30), *ext.Lifecycle.MinReadySeconds)
+	})
+
+	t.Run("DefaultInferenceService stamps every OMENative component from deploy config", func(t *testing.T) {
+		seconds := int32(45)
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)}},
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine:  &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{},
+				Router:  &v1beta1.RouterSpec{},
+			},
+		}
+		cfg := &controllerconfig.DeployConfig{DefaultDeploymentMode: string(constants.RawDeployment), MinReadySeconds: &seconds}
+		require.NoError(t, DefaultInferenceService(context.Background(), createFakeClient(t), isvc, cfg))
+		for name, lc := range map[string]*v1beta1.LifecycleSpec{
+			"engine":  isvc.Spec.Engine.Lifecycle,
+			"decoder": isvc.Spec.Decoder.Lifecycle,
+			"router":  isvc.Spec.Router.Lifecycle,
+		} {
+			require.NotNil(t, lc, "%s lifecycle", name)
+			require.NotNil(t, lc.MinReadySeconds, "%s minReadySeconds", name)
+			assert.Equal(t, int32(45), *lc.MinReadySeconds, name)
+		}
+	})
+
+	t.Run("DefaultInferenceService leaves minReadySeconds unset without deploy config", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)}},
+			Spec:       v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+		}
+		require.NoError(t, DefaultInferenceService(context.Background(), createFakeClient(t), isvc, nil))
+		require.NotNil(t, isvc.Spec.Engine.Lifecycle, "OMENative lifecycle defaults still apply")
+		assert.Nil(t, isvc.Spec.Engine.Lifecycle.MinReadySeconds, "no in-code minReadySeconds default")
+	})
+}


### PR DESCRIPTION
## Summary

Adds `spec.<component>.lifecycle.minReadySeconds` for OMENative components, with Kubernetes Deployment semantics: a pod is **Available** when `PodReady` is true and the condition's `lastTransitionTime + minReadySeconds <= now`, evaluated per pod. Ready stays the health signal; Available becomes the pacing signal. Unset or 0 keeps today's behavior.

The InferenceReplica already carried `spec.minReadySeconds`, but nothing set or read it. It is now projected from the component lifecycle and honored by the engine and by status.

## Per strategy

| Strategy | Where the window gates |
|---|---|
| SurgeThenDrain (single pod) | after the surge pod is PodReady and before the old pod is marked not-serving; scoped to the `Surge` step, the surge slot is held for the window |
| SurgeThenDrain (gang) | same point, after every replacement-gang pod is PodReady |
| RecreatePod | at promotion, after every recreated pod is PodReady and (with a window) has been Ready for it; the unavailability slot is held until then |
| InPlace | at promotion, after the patched pod is back in rotation; a pod already relabeled to the target revision is not drained again while promotion waits |

**Status:** `availableReplicas` / `availablePodCount` require EndpointSlice rotation membership AND, under a positive window, the Ready age. The aggregator surfaces the earliest pending window and folds it into the reconcile requeue, so counters refresh when the first pod crosses the window. The migration surge gate and PDB cutover read these counters and therefore honor the window.

## Config

- `deploy.minReadySeconds` in `inferenceservice-config`: the ISVC defaulter stamps it onto OMENative components whose lifecycle leaves the field unset. No built-in default; the chart ships the key commented out and renders it whenever set (0 is expressible). Because the stamp lands on the ISVC it takes precedence over a ServingRuntime-authored value, same as `terminationGracePeriodSeconds`.
- Validation rejects negatives at the CRD (`Minimum=0`), the pure validator, and config load.
- **Behavior change for existing installs:** the chart now renders a default OMENative disruption budget of `maxUnavailable: 1` (`ome.controller.disruptionBudgets.omeNative`). Set it to `null` to disable the default.

## Generated

CRDs (InferenceService, InferenceReplica, ServingRuntime, ClusterServingRuntime), deepcopy and OpenAPI regenerated; regeneration is reproducible with no drift.

## Tests

Unit: the availability predicate; each strategy's gate with a fake clock (surge single, gang, recreate, in-place including the no-re-drain pin and the Surge-step scoping); status aggregation and the requeue wake; plan propagation; projector; validation; config parsing; defaulter stamping. Chart: `helm lint` and the render tests, including unset / 0 / 30 for `minReadySeconds` and the disruption-budget default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable `minReadySeconds` lifecycle settings for inference services, replicas, and serving runtimes.
  - Rollouts now wait for replacement pods to remain Ready for the configured duration before promotion or draining.
  - Availability status reflects both service rotation and the minimum Ready duration.
  - Added optional controller-level defaults for OMENative components, while preserving explicitly configured values.
  - Added OMENative PodDisruptionBudget defaults with `maxUnavailable: 1`.

- **Bug Fixes**
  - Invalid negative `minReadySeconds` values are now rejected with validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->