### PR TITLE
[Bugfix] isvc: tolerate a missing external service

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -896,9 +896,21 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err := r.ensureIngressDisableAnnotation(isvc); err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "fails to add ingress disable annotation")
 		}
+		// A missing external service is not a failure. The reconciler above
+		// creates one only for a non-cluster-local InferenceService that has
+		// something to route to, and where it does create one, the read below
+		// goes through the informer cache, which has not observed that write
+		// yet. The Service is owned by this InferenceService and watched, so
+		// its create event brings the reconcile back to set the URL. Returning
+		// an error would add a backoff, a warning event and a stack trace to a
+		// state that either resolves itself or is correct as it stands.
 		if err := r.setExternalServiceURL(ctx, isvc, resolvedIngressConfig); err != nil {
-			r.Recorder.Event(isvc, v1.EventTypeWarning, "InternalError", err.Error())
-			return reconcile.Result{}, errors.Wrapf(err, "fails to set external service URL")
+			if !apierrors.IsNotFound(err) {
+				r.Recorder.Event(isvc, v1.EventTypeWarning, "InternalError", err.Error())
+				return reconcile.Result{}, errors.Wrapf(err, "fails to set external service URL")
+			}
+			log.V(1).Info("external service absent; leaving the URL unset for this pass",
+				"service", isvc.Name)
 		}
 	}
 
@@ -1695,6 +1707,13 @@ func (r *InferenceServiceReconciler) isvcsWithAcceleratorPreference(ctx context.
 	return reqs
 }
 
+// setExternalServiceURL points the InferenceService's URL and Address at the
+// Service that fronts it when ingress creation is disabled.
+//
+// The caller separates a missing Service from a real failure by asking
+// apierrors.IsNotFound, so the lookup's error has to reach it as an API status
+// error. Adding context around it is safe; replacing it with a plain error is
+// not, and would make every absent Service fatal again.
 func (r *InferenceServiceReconciler) setExternalServiceURL(ctx context.Context, isvc *v1beta1.InferenceService, ingressConfig *controllerconfig.IngressConfig) error {
 	// Get the external service
 	externalService := &v1.Service{}

--- a/pkg/controller/v1beta1/inferenceservice/external_service_url_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/external_service_url_test.go
@@ -1,0 +1,89 @@
+package inferenceservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+)
+
+func externalServiceScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, v1beta1.AddToScheme(s))
+	return s
+}
+
+func isvcForURL() *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "default"},
+	}
+}
+
+// The caller separates "the Service is not there" from a real failure by asking
+// apierrors.IsNotFound, so the API status error has to survive the trip. Adding
+// context around it keeps that (errors.Wrapf preserves the match); swapping it
+// for a plain error would not, and would make every InferenceService's first
+// reconcile a failed one again.
+func TestSetExternalServiceURLSurfacesNotFoundToTheCaller(t *testing.T) {
+	r := &InferenceServiceReconciler{
+		Client: fakeclient.NewClientBuilder().WithScheme(externalServiceScheme(t)).Build(),
+	}
+
+	err := r.setExternalServiceURL(context.Background(), isvcForURL(),
+		&controllerconfig.IngressConfig{UrlScheme: "https"})
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err),
+		"caller keys off apierrors.IsNotFound; got %#v", err)
+}
+
+func TestSetExternalServiceURLUsesTheServicePortAndScheme(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 30080}}},
+	}
+	r := &InferenceServiceReconciler{
+		Client: fakeclient.NewClientBuilder().
+			WithScheme(externalServiceScheme(t)).WithObjects(svc).Build(),
+	}
+
+	isvc := isvcForURL()
+	require.NoError(t, r.setExternalServiceURL(context.Background(), isvc,
+		&controllerconfig.IngressConfig{UrlScheme: "https"}))
+
+	require.NotNil(t, isvc.Status.URL)
+	assert.Equal(t, "https", isvc.Status.URL.Scheme)
+	assert.Equal(t, "sample.default.svc.cluster.local:30080", isvc.Status.URL.Host)
+	require.NotNil(t, isvc.Status.Address)
+	assert.Equal(t, isvc.Status.URL.Host, isvc.Status.Address.URL.Host)
+}
+
+// A Service with no ports is not an error; the InferenceService port stands in,
+// so the URL is still addressable rather than being left unset.
+func TestSetExternalServiceURLFallsBackToTheDefaultPort(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "default"},
+	}
+	r := &InferenceServiceReconciler{
+		Client: fakeclient.NewClientBuilder().
+			WithScheme(externalServiceScheme(t)).WithObjects(svc).Build(),
+	}
+
+	isvc := isvcForURL()
+	require.NoError(t, r.setExternalServiceURL(context.Background(), isvc,
+		&controllerconfig.IngressConfig{UrlScheme: "http"}))
+
+	require.NotNil(t, isvc.Status.URL)
+	assert.Equal(t, "sample.default.svc.cluster.local:8080", isvc.Status.URL.Host)
+}


### PR DESCRIPTION
## Summary

When the InferenceService's external Service did not exist yet, the reconcile returned an error, emitted an `InternalError` event, and went into backoff on every first pass. A NotFound now leaves `status.url` unset and logs at V(1); the Service is owned and watched, so its create event re-triggers the reconcile. Other errors are still surfaced as before.

## Tests

`external_service_url_test.go` pins the NotFound contract, the scheme and port derivation, and the default-port fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - InferenceServices now continue reconciliation when an external Service is unavailable, leaving the URL unset until the Service becomes available.
  - Other external Service errors continue to report an event and fail reconciliation.
  - External URLs now use the Service’s configured port and scheme, with port 8080 as a fallback when no port is defined.

- **Tests**
  - Added coverage for missing Services, configured ports and schemes, and the default port fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->