### PR TITLE
[Bugfix] scheduler: wake gang on template completion

### DIFF
--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -68,7 +68,9 @@ pod's own resource requests. The OME chart maps that generic setting to
 gang without any producer annotation. The plugin binary bakes in neither a
 producer metadata prefix nor a fabric value. A rejected gang member re-attempts promptly via
 precise requeue hints for its siblings, PodGroup, and relevant capacity changes
-rather than the scheduler's slow periodic flush. `NodeResourcesFit` supplies
+rather than the scheduler's slow periodic flush; gang-internal transitions that
+no cluster event represents (a member set reaching `minMember`, a member
+reaching the gate) are turned into explicit activations. `NodeResourcesFit` supplies
 node-level `MostAllocated` packing. Placement
 decisions, gate outcomes, unwinds, and the count of pinned groups are exported as
 `ome_scheduler_*` metrics on the

--- a/scheduler/pkg/plugins/gangpack/activation_test.go
+++ b/scheduler/pkg/plugins/gangpack/activation_test.go
@@ -1,0 +1,387 @@
+package gangpack
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kube-scheduler/framework"
+
+	"sigs.k8s.io/ome/scheduler/pkg/placement"
+	"sigs.k8s.io/ome/scheduler/pkg/topology"
+)
+
+// roleLabel marks a member's role so a worker's required affinity term can
+// target the leader alone.
+const roleLabel = "testing.example/role"
+
+// twoMemberGang wires a plugin for a 2-member gang whose live member set is
+// served by a swappable fake lister, with two free nodes in one domain.
+func twoMemberGang(members ...*v1.Pod) (*GangPack, *fakeHandle, []framework.NodeInfo) {
+	h := &fakeHandle{}
+	g := &GangPack{
+		handle:    h,
+		pins:      placement.New(),
+		pgReader:  fakeReader{"team/pf": {min: 2, topo: testKey, to: time.Minute}},
+		podLister: fakeGangPodLister{pods: members},
+	}
+	nodes := []framework.NodeInfo{nodeInfo(gpuNode("a1", "a", "4")), nodeInfo(gpuNode("a2", "a", "4"))}
+	return g, h, nodes
+}
+
+func namedMember(name string) *v1.Pod {
+	p := gangGPUPod("team", "pf", "4")
+	p.Name = name
+	return p
+}
+
+func leaderMember(name string) *v1.Pod {
+	p := namedMember(name)
+	p.Labels[roleLabel] = "leader"
+	return p
+}
+
+// workerMember carries a REQUIRED podAffinity term that only the gang's leader
+// can satisfy.
+func workerMember(name string) *v1.Pod {
+	p := namedMember(name)
+	p.Labels[roleLabel] = "worker"
+	p.Spec.Affinity = requiredAffinityTo(map[string]string{podGroupLabel: "pf", roleLabel: "leader"})
+	return p
+}
+
+func requiredAffinityTo(matchLabels map[string]string) *v1.Affinity {
+	return &v1.Affinity{PodAffinity: &v1.PodAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{{
+			TopologyKey:   testKey,
+			LabelSelector: &metav1.LabelSelector{MatchLabels: matchLabels},
+		}},
+	}}
+}
+
+// TestTemplatesCompleteActivatesParkedMembersOnce: a member parked because the
+// live set was short of minMember is activated by the first PreFilter that sees
+// the set complete, and only by that one. The observing member is in flight and
+// is left out of the activation. Later PreFilters of the same complete gang
+// activate nobody.
+func TestTemplatesCompleteActivatesParkedMembersOnce(t *testing.T) {
+	ctx := context.Background()
+	leader, worker := namedMember("leader"), namedMember("worker")
+	g, h, nodes := twoMemberGang(leader)
+
+	// Leader alone: parked on the incomplete set; nothing to wake yet.
+	if _, st := g.PreFilter(ctx, newCycleState(), leader, nodes); st.Code() != framework.Unschedulable {
+		t.Fatalf("lone leader PreFilter = %v, want Unschedulable (templates incomplete)", st)
+	}
+	if h.activateCalls != 0 {
+		t.Fatalf("activate calls after lone leader = %d, want 0", h.activateCalls)
+	}
+
+	// Worker arrives; its PreFilter is the first to observe the full set.
+	g.podLister = fakeGangPodLister{pods: []*v1.Pod{leader, worker}}
+	before := counterValue(t, gangActivationTotal.WithLabelValues(activationTriggerTemplatesComplete))
+	if _, st := g.PreFilter(ctx, newCycleState(), worker, nodes); !st.IsSuccess() {
+		t.Fatalf("worker PreFilter = %v, want Success", st)
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after set completed = %d, want exactly 1", h.activateCalls)
+	}
+	if _, ok := h.activated["team/leader"]; !ok {
+		t.Fatalf("activated = %v, want the parked leader included", h.activated)
+	}
+	if _, ok := h.activated["team/worker"]; ok {
+		t.Fatalf("activated = %v, want the in-flight observing worker left out", h.activated)
+	}
+	if d := counterValue(t, gangActivationTotal.WithLabelValues(activationTriggerTemplatesComplete)) - before; d != 1 {
+		t.Fatalf("templates_complete activation counter delta = %v, want 1", d)
+	}
+
+	// The set stays complete: further PreFilters of either member must not
+	// re-activate (activation bypasses backoff, so repeats would spin).
+	for _, pod := range []*v1.Pod{leader, worker, leader} {
+		if _, st := g.PreFilter(ctx, newCycleState(), pod, nodes); !st.IsSuccess() {
+			t.Fatalf("PreFilter of %s on complete gang = %v, want Success", pod.Name, st)
+		}
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after repeated complete PreFilters = %d, want still 1", h.activateCalls)
+	}
+}
+
+// TestTemplatesIncompleteAgainRearmsActivation: once the set is complete the
+// wake-up is spent; a member leaving (set incomplete again) re-arms it, and the
+// next completion fires exactly one more activation.
+func TestTemplatesIncompleteAgainRearmsActivation(t *testing.T) {
+	ctx := context.Background()
+	leader, worker := namedMember("leader"), namedMember("worker")
+	g, h, nodes := twoMemberGang(leader, worker)
+
+	// Complete from the start: nobody was ever parked, so nothing fires.
+	if _, st := g.PreFilter(ctx, newCycleState(), worker, nodes); !st.IsSuccess() {
+		t.Fatalf("worker PreFilter = %v, want Success", st)
+	}
+	if h.activateCalls != 0 {
+		t.Fatalf("activate calls on a never-parked gang = %d, want 0", h.activateCalls)
+	}
+
+	// Worker gone: the leader parks again.
+	g.podLister = fakeGangPodLister{pods: []*v1.Pod{leader}}
+	if _, st := g.PreFilter(ctx, newCycleState(), leader, nodes); st.Code() != framework.Unschedulable {
+		t.Fatalf("leader PreFilter after worker left = %v, want Unschedulable", st)
+	}
+	if h.activateCalls != 0 {
+		t.Fatalf("activate calls while incomplete = %d, want 0", h.activateCalls)
+	}
+
+	// Replacement arrives: one activation for this new completion.
+	replacement := namedMember("worker-2")
+	g.podLister = fakeGangPodLister{pods: []*v1.Pod{leader, replacement}}
+	if _, st := g.PreFilter(ctx, newCycleState(), replacement, nodes); !st.IsSuccess() {
+		t.Fatalf("replacement PreFilter = %v, want Success", st)
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after re-completion = %d, want 1", h.activateCalls)
+	}
+	if _, st := g.PreFilter(ctx, newCycleState(), leader, nodes); !st.IsSuccess() {
+		t.Fatalf("leader PreFilter after re-completion = %v, want Success", st)
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after a further complete PreFilter = %d, want still 1", h.activateCalls)
+	}
+}
+
+// TestCapacityFailuresDoNotActivateSiblings: members that keep failing for lack
+// of capacity, whether in PreFilter (no domain fits) or after PreFilter (every
+// candidate rejected, unwound by PostFilter), never activate each other. The
+// wake-up is tied to the set-completion transition alone, so two failing
+// members cannot ping-pong through the backoff-bypassing Activate.
+func TestCapacityFailuresDoNotActivateSiblings(t *testing.T) {
+	ctx := context.Background()
+	leader, worker := namedMember("leader"), namedMember("worker")
+
+	t.Run("no domain fits", func(t *testing.T) {
+		g, h, nodes := twoMemberGang(leader, worker)
+		nodes = nodes[:1] // one node cannot hold a 2-member gang
+		for range 2 {
+			for _, pod := range []*v1.Pod{leader, worker} {
+				_, st := g.PreFilter(ctx, newCycleState(), pod, nodes)
+				if st.Code() != framework.Unschedulable || !strings.Contains(st.Message(), "no domain has room") {
+					t.Fatalf("PreFilter of %s = %v, want Unschedulable for lack of room", pod.Name, st)
+				}
+			}
+		}
+		if h.activateCalls != 0 {
+			t.Fatalf("activate calls across repeated no-fit failures = %d, want 0", h.activateCalls)
+		}
+		if g.clearTemplatesIncomplete(gangInfo{key: "team/pf"}) {
+			t.Fatal("a gang that was never short of members must hold no incomplete-set record")
+		}
+	})
+
+	t.Run("all candidates filtered", func(t *testing.T) {
+		g, h, nodes := twoMemberGang(leader, worker)
+		for range 2 {
+			for _, pod := range []*v1.Pod{leader, worker} {
+				state := newCycleState()
+				if _, st := g.PreFilter(ctx, state, pod, nodes); !st.IsSuccess() {
+					t.Fatalf("PreFilter of %s = %v, want Success", pod.Name, st)
+				}
+				if _, st := g.PostFilter(ctx, state, pod, nil); st.Code() != framework.Unschedulable {
+					t.Fatalf("PostFilter of %s = %v, want Unschedulable", pod.Name, st)
+				}
+			}
+		}
+		if h.activateCalls != 0 {
+			t.Fatalf("activate calls across repeated post-PreFilter failures = %d, want 0", h.activateCalls)
+		}
+	})
+}
+
+// TestTemplatesCompleteActivationIsOneShotUnderNoFit: the completion wake-up
+// fires once even when the completing member's own attempt then finds no room,
+// and the members' subsequent no-fit failures do not fire it again.
+func TestTemplatesCompleteActivationIsOneShotUnderNoFit(t *testing.T) {
+	ctx := context.Background()
+	leader, worker := namedMember("leader"), namedMember("worker")
+	g, h, nodes := twoMemberGang(leader)
+
+	if _, st := g.PreFilter(ctx, newCycleState(), leader, nodes); st.Code() != framework.Unschedulable {
+		t.Fatalf("lone leader PreFilter = %v, want Unschedulable (templates incomplete)", st)
+	}
+
+	// The cluster shrinks to one node; the arriving worker completes the set
+	// but the gang no longer fits anywhere.
+	nodes = nodes[:1]
+	g.podLister = fakeGangPodLister{pods: []*v1.Pod{leader, worker}}
+	_, st := g.PreFilter(ctx, newCycleState(), worker, nodes)
+	if st.Code() != framework.Unschedulable || !strings.Contains(st.Message(), "no domain has room") {
+		t.Fatalf("worker PreFilter = %v, want Unschedulable for lack of room", st)
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after completion under no-fit = %d, want 1", h.activateCalls)
+	}
+
+	for range 3 {
+		for _, pod := range []*v1.Pod{leader, worker} {
+			_, st := g.PreFilter(ctx, newCycleState(), pod, nodes)
+			if st.Code() != framework.Unschedulable || !strings.Contains(st.Message(), "no domain has room") {
+				t.Fatalf("PreFilter of %s = %v, want Unschedulable for lack of room", pod.Name, st)
+			}
+		}
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after repeated no-fit failures = %d, want still 1", h.activateCalls)
+	}
+	if g.clearTemplatesIncomplete(gangInfo{key: "team/pf"}) {
+		t.Fatal("incomplete-set record must be consumed by the completion wake-up")
+	}
+}
+
+// TestAffinityToUnplacedSiblingYieldsWithoutPinning: a member whose required
+// affinity can only be satisfied by a sibling that is neither bound nor assumed
+// yields in PreFilter, without planning a domain: no pin is written, no domain
+// is recorded as failed, and the completion wake-up still fires exactly once.
+// The yield does not depend on the wake-up record, and ends as soon as the
+// sibling is placed.
+func TestAffinityToUnplacedSiblingYieldsWithoutPinning(t *testing.T) {
+	ctx := context.Background()
+	leader, worker := leaderMember("leader"), workerMember("worker")
+	g, h, nodes := twoMemberGang(leader)
+	gang := gangInfo{key: "team/pf", topologyKey: testKey}
+
+	if _, st := g.PreFilter(ctx, newCycleState(), leader, nodes); st.Code() != framework.Unschedulable {
+		t.Fatalf("lone leader PreFilter = %v, want Unschedulable (templates incomplete)", st)
+	}
+
+	g.podLister = fakeGangPodLister{pods: []*v1.Pod{leader, worker}}
+	for attempt := range 2 {
+		state := newCycleState()
+		_, st := g.PreFilter(ctx, state, worker, nodes)
+		if st.Code() != framework.Unschedulable || !strings.Contains(st.Message(), "waiting for gang sibling team/leader to be placed") {
+			t.Fatalf("worker PreFilter attempt %d = %v, want Unschedulable waiting for the leader", attempt, st)
+		}
+		if readPin(state) != nil {
+			t.Fatalf("attempt %d wrote a cycle pin %+v while yielding", attempt, readPin(state))
+		}
+		if _, pinned := g.pins.Get("team/pf"); pinned {
+			t.Fatalf("attempt %d pinned the gang while yielding", attempt)
+		}
+		if _, hadFailed := g.withoutFailedDomains(gang, topology.FreeByDomain{"a": 2}); hadFailed {
+			t.Fatalf("attempt %d recorded a failed domain while yielding", attempt)
+		}
+		// One activation from the completion transition on the first attempt;
+		// the yield itself never activates, so a second yield adds nothing.
+		if h.activateCalls != 1 {
+			t.Fatalf("activate calls after yield attempt %d = %d, want 1", attempt, h.activateCalls)
+		}
+	}
+	if _, ok := h.activated["team/leader"]; !ok {
+		t.Fatalf("activated = %v, want the parked leader included", h.activated)
+	}
+	if _, ok := h.activated["team/worker"]; ok {
+		t.Fatalf("activated = %v, want the in-flight worker left out", h.activated)
+	}
+
+	// The leader is assumed in domain a: the worker's term is now satisfiable
+	// there, so it plans, adopts the leader's domain, and narrows to the free node.
+	assumed := []framework.NodeInfo{nodeInfo(gpuNode("a1", "a", "4"), leader), nodeInfo(gpuNode("a2", "a", "4"))}
+	state := newCycleState()
+	result, st := g.PreFilter(ctx, state, worker, assumed)
+	if !st.IsSuccess() {
+		t.Fatalf("worker PreFilter with leader assumed = %v, want Success", st)
+	}
+	if pin := readPin(state); pin == nil || pin.domain != "a" {
+		t.Fatalf("pin = %+v, want the leader's domain a", pin)
+	}
+	if result == nil || !result.NodeNames.Has("a2") || result.NodeNames.Has("a1") {
+		t.Fatalf("candidates = %v, want the node the leader does not occupy", result)
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls after the worker proceeded = %d, want still 1", h.activateCalls)
+	}
+}
+
+// TestAffinityYieldScope: only a required term that some unplaced sibling of the
+// same gang satisfies causes a yield. A term the member satisfies itself may pass
+// the framework's first-pod rule, and a term aimed at pods outside the gang is
+// not this plugin's concern; both plan and pin as before.
+func TestAffinityYieldScope(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name   string
+		labels map[string]string
+	}{
+		{name: "self-matching term", labels: map[string]string{podGroupLabel: "pf"}},
+		{name: "term outside the gang", labels: map[string]string{"app": "cache"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			leader, worker := leaderMember("leader"), namedMember("worker")
+			worker.Spec.Affinity = requiredAffinityTo(tc.labels)
+			g, _, nodes := twoMemberGang(leader, worker)
+			state := newCycleState()
+			if _, st := g.PreFilter(ctx, state, worker, nodes); !st.IsSuccess() {
+				t.Fatalf("worker PreFilter = %v, want Success (no sibling wait)", st)
+			}
+			if pin := readPin(state); pin == nil || pin.domain != "a" {
+				t.Fatalf("pin = %+v, want domain a", pin)
+			}
+		})
+	}
+}
+
+// TestPermitActivatesGangMembers: every member reaching Permit activates the
+// gang's live members, itself included, and counts it under the permit trigger.
+// A sibling whose Filter depends on this member being assumed has no cluster
+// event to react to otherwise.
+func TestPermitActivatesGangMembers(t *testing.T) {
+	pins := placement.New()
+	_, token, ok := pins.ChooseInTopologyOnNodes("team/pf", testKey,
+		topology.FreeByDomain{"a": 2}, map[string][]string{"a": {"a1", "a2"}}, 2)
+	if !ok {
+		t.Fatal("failed to reserve gang")
+	}
+	leader, worker := namedMember("leader"), namedMember("worker")
+	h := &fakeHandle{}
+	g := &GangPack{handle: h, pins: pins, podLister: fakeGangPodLister{pods: []*v1.Pod{leader, worker}}}
+	state := newCycleState()
+	writePin(state, "a", gangInfo{key: "team/pf", minMember: 2, topologyKey: testKey, timeout: time.Minute}, token)
+
+	before := counterValue(t, gangActivationTotal.WithLabelValues(activationTriggerPermit))
+	status, _ := g.Permit(context.Background(), state, leader, "a1")
+	if !status.IsWait() {
+		t.Fatalf("Permit = %v, want Wait for the incomplete gang", status)
+	}
+	if h.activateCalls != 1 {
+		t.Fatalf("activate calls from Permit = %d, want 1", h.activateCalls)
+	}
+	for _, key := range []string{"team/leader", "team/worker"} {
+		if _, ok := h.activated[key]; !ok {
+			t.Fatalf("activated = %v, want %s included", h.activated, key)
+		}
+	}
+	if d := counterValue(t, gangActivationTotal.WithLabelValues(activationTriggerPermit)) - before; d != 1 {
+		t.Fatalf("permit activation counter delta = %v, want 1", d)
+	}
+}
+
+// TestGCPrunesTemplatesIncomplete: the incomplete-set record of a gang whose
+// pods are all gone is dropped by the pin garbage collector; a live gang's
+// record survives.
+func TestGCPrunesTemplatesIncomplete(t *testing.T) {
+	g := &GangPack{pins: placement.New(), podLister: fakeGangPodLister{pods: []*v1.Pod{gangPod("team", "live")}}}
+	g.markTemplatesIncomplete(gangInfo{key: "team/live"})
+	g.markTemplatesIncomplete(gangInfo{key: "team/gone"})
+
+	g.gcPins()
+
+	if !g.clearTemplatesIncomplete(gangInfo{key: "team/live"}) {
+		t.Fatal("record for a gang with live pods must survive GC")
+	}
+	if g.clearTemplatesIncomplete(gangInfo{key: "team/gone"}) {
+		t.Fatal("record for a gang with no live pods must be pruned by GC")
+	}
+}

--- a/scheduler/pkg/plugins/gangpack/affinity.go
+++ b/scheduler/pkg/plugins/gangpack/affinity.go
@@ -1,0 +1,41 @@
+package gangpack
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kube-scheduler/framework"
+)
+
+// siblingAffinityBlocked returns the unplaced gang sibling that one of pod's
+// required podAffinity terms can only be satisfied by. Until that sibling is
+// assumed on a node the term rejects every node, so the member should wait
+// rather than plan a domain. A term that matches pod itself is left to the
+// framework (a first pod may satisfy its own term), a term already matched by
+// a placed member of the gang imposes no wait, and terms that target pods
+// outside the gang are not considered.
+func siblingAffinityBlocked(pod *v1.Pod, unplaced []*v1.Pod, placed map[string]*v1.Pod) (*v1.Pod, bool) {
+	terms, err := framework.GetAffinityTerms(pod, framework.GetPodAffinityTerms(pod.Spec.Affinity))
+	if err != nil || len(terms) == 0 {
+		return nil, false
+	}
+	for i := range terms {
+		term := &terms[i]
+		if term.Matches(pod, nil) || anyMemberMatches(term, placed) {
+			continue
+		}
+		for _, sibling := range unplaced {
+			if sibling != nil && sibling != pod && !samePodIdentity(sibling, pod) && term.Matches(sibling, nil) {
+				return sibling, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func anyMemberMatches(term *framework.AffinityTerm, members map[string]*v1.Pod) bool {
+	for _, member := range members {
+		if member != nil && term.Matches(member, nil) {
+			return true
+		}
+	}
+	return false
+}

--- a/scheduler/pkg/plugins/gangpack/enqueue.go
+++ b/scheduler/pkg/plugins/gangpack/enqueue.go
@@ -23,7 +23,9 @@ import (
 //
 // Registering these is what makes a gang recover promptly instead of on the
 // periodic flush. Queueing hints keep unrelated pod/node/PodGroup churn from
-// waking every blocked gang at once.
+// waking every blocked gang at once. The queue only routes an Add for an
+// already-assigned pod; an unscheduled sibling's creation reaches parked members
+// through the plugin's own activation (see activateGangMembers).
 func (g *GangPack) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
 	// Custom-resource events are named "<resource>.<version>.<group>".
 	pgGVK := fmt.Sprintf("podgroups.v1alpha1.%v", scheduling.GroupName)

--- a/scheduler/pkg/plugins/gangpack/fakes_test.go
+++ b/scheduler/pkg/plugins/gangpack/fakes_test.go
@@ -28,12 +28,14 @@ func (w *fakeWaitingPod) Reject(string, string) { w.rejected = true }
 // scan. The embedded nil Handle satisfies the rest.
 type fakeHandle struct {
 	framework.Handle
-	waiting   []framework.WaitingPod
-	snapshot  []framework.NodeInfo // nodes (with their pods) the bound scan sees
-	activated map[string]*v1.Pod
+	waiting       []framework.WaitingPod
+	snapshot      []framework.NodeInfo // nodes (with their pods) the bound scan sees
+	activated     map[string]*v1.Pod
+	activateCalls int
 }
 
 func (h *fakeHandle) Activate(_ klog.Logger, pods map[string]*v1.Pod) {
+	h.activateCalls++
 	if h.activated == nil {
 		h.activated = make(map[string]*v1.Pod)
 	}

--- a/scheduler/pkg/plugins/gangpack/gc.go
+++ b/scheduler/pkg/plugins/gangpack/gc.go
@@ -52,6 +52,7 @@ func (g *GangPack) gcPins() {
 	if err != nil {
 		return
 	}
+	g.pruneTemplatesIncomplete()
 	for group, owner := range g.pins.Owners() {
 		stale := !live[group]
 		// A live pod label only identifies namespace/name. Compare the immutable

--- a/scheduler/pkg/plugins/gangpack/metrics.go
+++ b/scheduler/pkg/plugins/gangpack/metrics.go
@@ -39,6 +39,19 @@ var (
 		[]string{"result"},
 	)
 
+	// gangActivationTotal counts explicit sibling activations by trigger:
+	// "permit" (a member reached the gate) or "templates_complete" (the live
+	// member set reached minMember after a member had parked short of it).
+	gangActivationTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      metricsSubsystem,
+			Name:           "gang_activation_total",
+			Help:           "Explicit gang member activations by trigger (permit, templates_complete).",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"trigger"},
+	)
+
 	// gangUnwindTotal counts gangs torn down by Unreserve after a member failed to
 	// schedule (gate timeout or bind failure).
 	gangUnwindTotal = metrics.NewCounter(
@@ -68,7 +81,7 @@ var registerMetricsOnce sync.Once
 // registry exactly once.
 func registerMetrics() {
 	registerMetricsOnce.Do(func() {
-		legacyregistry.MustRegister(gangPinTotal, gangGateTotal, gangUnwindTotal, pinnedGroups)
+		legacyregistry.MustRegister(gangPinTotal, gangGateTotal, gangActivationTotal, gangUnwindTotal, pinnedGroups)
 	})
 }
 

--- a/scheduler/pkg/plugins/gangpack/nodes.go
+++ b/scheduler/pkg/plugins/gangpack/nodes.go
@@ -75,7 +75,8 @@ type boundGangPlacement struct {
 	domain string
 	count  int
 	split  bool
-	names  map[string]bool
+	// placed holds the gang members found in the snapshot, by name.
+	placed map[string]*v1.Pod
 }
 
 // inspectBoundGangMembers also detects an already-split gang. Silently adopting
@@ -86,7 +87,7 @@ func inspectBoundGangMembers(nodeInfos []framework.NodeInfo, pod *v1.Pod, topolo
 	if !ok {
 		return boundGangPlacement{}
 	}
-	result := boundGangPlacement{names: make(map[string]bool)}
+	result := boundGangPlacement{placed: make(map[string]*v1.Pod)}
 	for _, info := range nodeInfos {
 		n := info.Node()
 		if n == nil {
@@ -96,7 +97,7 @@ func inspectBoundGangMembers(nodeInfos []framework.NodeInfo, pod *v1.Pod, topolo
 		for _, pi := range info.GetPods() {
 			mp := pi.GetPod()
 			if mp != nil && mp.Namespace == ns && mp.Labels[podGroupLabel] == pgName {
-				result.names[mp.Name] = true
+				result.placed[mp.Name] = mp
 				if dom == "" {
 					result.split = true
 					result.count++

--- a/scheduler/pkg/plugins/gangpack/permit.go
+++ b/scheduler/pkg/plugins/gangpack/permit.go
@@ -36,7 +36,7 @@ func (g *GangPack) Permit(_ context.Context, state framework.CycleState, pod *v1
 			"gang permit timeout is not configured"), 0
 	}
 	g.rememberAttempt(pod, pin.commitment)
-	g.activateGangMembers(gang)
+	g.activateGangMembers(gang, activationTriggerPermit, nil)
 
 	// Reserve has already converted this member's claim into assumed occupancy.
 	// The commitment reaches zero exactly when minMember slots, including any
@@ -58,37 +58,106 @@ func (g *GangPack) Permit(_ context.Context, state framework.CycleState, pod *v1
 	return framework.NewStatus(framework.Success), 0
 }
 
-// activateGangMembers closes the queueing-hint race where a sibling Add event
-// occurs while an earlier member is still in flight and that earlier member
-// subsequently becomes Unschedulable waiting for the full template set. Once any
-// member reaches Permit, the informer has the gang; force-activating its siblings
-// makes the earlier member retry immediately instead of waiting for the periodic
-// unschedulable flush.
-//
-// Unconditional and per-member: whenever any gang member reaches Permit, every
-// live member is activated, regardless of whether the gate then admits or
-// waits. This is also what lets an affinity-ordered gang (a worker whose
-// Filter depends on its leader already being assumed) converge promptly on an
-// otherwise quiet cluster, since an assumed-but-unbound pod produces no
-// cluster event of its own for that worker to react to.
-func (g *GangPack) activateGangMembers(gang gangInfo) {
+// Activation triggers, recorded as the gang_activation_total label value.
+const (
+	// activationTriggerPermit: a member reached Permit. An assumed-but-unbound
+	// member produces no cluster event, yet siblings whose Filter depends on it
+	// (a worker with required affinity to its leader) must retry now.
+	activationTriggerPermit = "permit"
+	// activationTriggerTemplatesComplete: the live member set reached
+	// minMember. An unscheduled pod's creation is not a queue move event, so a
+	// member parked on the incomplete set would otherwise wait for the
+	// periodic unschedulable flush.
+	activationTriggerTemplatesComplete = "templates_complete"
+)
+
+// activateGangMembers force-activates every live member of the gang. Gang
+// progress is plugin-internal state with no cluster event behind it, so each
+// transition that can unblock a parked sibling must be turned into queue
+// activity explicitly; the triggers above are the two such transitions.
+// Activation bypasses backoff, so callers must fire it on a real transition,
+// not on every failed attempt. except, when non-nil, is the in-flight member
+// observing the transition; it is already being scheduled and needs no wake-up.
+// The result reports whether the activation ran (lister and handle available),
+// so a caller can consume a one-shot record only after the wake-up happened.
+func (g *GangPack) activateGangMembers(gang gangInfo, trigger string, except *v1.Pod) bool {
 	lister, ok := g.podLister.(gangMemberLister)
 	if !ok || g.handle == nil {
-		return
+		return false
 	}
 	ns, name, ok := splitGangKey(gang.key)
 	if !ok {
-		return
+		return false
 	}
 	pods, err := lister.gangPods(ns, name)
 	if err != nil {
-		return
+		return false
 	}
 	activate := make(map[string]*v1.Pod, len(pods))
 	for _, pod := range pods {
-		if pod != nil {
-			activate[pod.Namespace+"/"+pod.Name] = pod
+		if pod == nil || samePodIdentity(pod, except) {
+			continue
+		}
+		activate[pod.Namespace+"/"+pod.Name] = pod
+	}
+	if len(activate) == 0 {
+		return true
+	}
+	gangActivationTotal.WithLabelValues(trigger).Inc()
+	g.handle.Activate(klog.Background(), activate)
+	return true
+}
+
+// markTemplatesIncomplete records that a member of the gang was parked because
+// the live member set is short of minMember.
+func (g *GangPack) markTemplatesIncomplete(gang gangInfo) {
+	g.templatesMu.Lock()
+	if g.templatesIncomplete == nil {
+		g.templatesIncomplete = make(map[string]bool)
+	}
+	g.templatesIncomplete[gang.key] = true
+	g.templatesMu.Unlock()
+}
+
+// hasTemplatesIncomplete reports whether the gang has an incomplete-set record.
+func (g *GangPack) hasTemplatesIncomplete(gang gangInfo) bool {
+	g.templatesMu.Lock()
+	defer g.templatesMu.Unlock()
+	return g.templatesIncomplete[gang.key]
+}
+
+// clearTemplatesIncomplete consumes the gang's incomplete-set record. It reports
+// true exactly once per incomplete-to-complete transition, so the caller's
+// activation cannot repeat while the set stays complete.
+func (g *GangPack) clearTemplatesIncomplete(gang gangInfo) bool {
+	g.templatesMu.Lock()
+	defer g.templatesMu.Unlock()
+	if !g.templatesIncomplete[gang.key] {
+		return false
+	}
+	delete(g.templatesIncomplete, gang.key)
+	return true
+}
+
+// pruneTemplatesIncomplete drops records for gangs with no live pods, so a gang
+// deleted while still incomplete does not retain its entry. Liveness is checked
+// per record under the lock: a member marking its gang concurrently waits for
+// the lock, so a record for a gang that has just gained a pod is never dropped.
+func (g *GangPack) pruneTemplatesIncomplete() {
+	lister, ok := g.podLister.(gangMemberLister)
+	if !ok {
+		return
+	}
+	g.templatesMu.Lock()
+	defer g.templatesMu.Unlock()
+	for key := range g.templatesIncomplete {
+		ns, name, ok := splitGangKey(key)
+		if !ok {
+			delete(g.templatesIncomplete, key)
+			continue
+		}
+		if pods, err := lister.gangPods(ns, name); err == nil && len(pods) == 0 {
+			delete(g.templatesIncomplete, key)
 		}
 	}
-	g.handle.Activate(klog.Background(), activate)
 }

--- a/scheduler/pkg/plugins/gangpack/plugin.go
+++ b/scheduler/pkg/plugins/gangpack/plugin.go
@@ -61,6 +61,12 @@ type GangPack struct {
 	// in-memory reservation drains; no Kubernetes object event represents it.
 	blockedMu          sync.Mutex
 	reservationBlocked map[string]*v1.Pod
+	// templatesIncomplete records gangs that parked a member because the live
+	// member set was still short of minMember. An unscheduled sibling's creation
+	// is not a queue event, so the first PreFilter that sees the set complete
+	// activates the gang once and clears the record.
+	templatesMu         sync.Mutex
+	templatesIncomplete map[string]bool
 	// failedDomains remembers domains whose candidates all failed another Filter.
 	// The next attempt excludes them until every feasible domain has been tried.
 	failedMu      sync.Mutex
@@ -236,6 +242,15 @@ func (g *GangPack) pinGang(state framework.CycleState, nodes []framework.NodeInf
 	templates, need, status := g.gangTemplates(gang, pod, placement)
 	if status != nil {
 		return nil, status
+	}
+	// A required affinity to a sibling that is neither bound nor assumed fails on
+	// every node, so planning now would only fail Filter and record the chosen
+	// domain as failed. Yield without a pin; the sibling's own Permit activation
+	// retries this member once it is placed.
+	if sibling, blocked := siblingAffinityBlocked(pod, templates[1:], placement.placed); blocked {
+		klog.V(4).InfoS("gangpack.pinGang.sibling_wait", "gang", gang.key, "sibling", klog.KObj(sibling))
+		return nil, framework.NewStatus(framework.Unschedulable,
+			"waiting for gang sibling "+sibling.Namespace+"/"+sibling.Name+" to be placed")
 	}
 
 	// Existing commitments only need matching inside their pinned domain. An
@@ -503,15 +518,22 @@ func (g *GangPack) gangTemplates(gang gangInfo, current *v1.Pod, placement bound
 	sort.Slice(members, func(i, j int) bool { return members[i].Name < members[j].Name })
 	out := []*v1.Pod{current}
 	for _, member := range members {
-		if member == nil || member.Name == current.Name || member.Spec.NodeName != "" || placement.names[member.Name] ||
+		if member == nil || member.Name == current.Name || member.Spec.NodeName != "" || placement.placed[member.Name] != nil ||
 			member.DeletionTimestamp != nil || member.Status.Phase == v1.PodSucceeded || member.Status.Phase == v1.PodFailed {
 			continue
 		}
 		out = append(out, member)
 	}
 	if len(out) < need {
+		g.markTemplatesIncomplete(gang)
 		return nil, 0, framework.NewStatus(framework.Unschedulable,
 			"waiting for all PodGroup member templates for "+gang.key)
+	}
+	// Members parked on the incomplete set are woken here, once per completion.
+	// The record is consumed only after the activation has actually run.
+	if g.hasTemplatesIncomplete(gang) && g.activateGangMembers(gang, activationTriggerTemplatesComplete, current) {
+		g.clearTemplatesIncomplete(gang)
+		klog.V(4).InfoS("gangpack.templates.complete", "gang", gang.key, "members", len(out), "need", need)
 	}
 	return out, need, nil
 }

--- a/scheduler/test/integration/harness_test.go
+++ b/scheduler/test/integration/harness_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -232,6 +233,31 @@ func ensureNotBound(t *testing.T, tc *testContext, ns, name string, window time.
 			t.Fatalf("pod %s/%s bound to %s while its gang was incomplete (gate should hold)", ns, name, p.Spec.NodeName)
 		}
 		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// waitForPodRejected polls until the scheduler has recorded a failed attempt for
+// the pod (PodScheduled=False, reason Unschedulable) whose message contains
+// reason. It orders a test step after the pod has been popped and parked for a
+// specific cause, without relying on wall-clock sleeps.
+func waitForPodRejected(t *testing.T, tc *testContext, ns, name, reason string, timeout time.Duration) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(tc.Ctx, 100*time.Millisecond, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			p, err := tc.ClientSet.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodScheduled && c.Status == v1.ConditionFalse &&
+					c.Reason == v1.PodReasonUnschedulable && strings.Contains(c.Message, reason) {
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+	if err != nil {
+		t.Fatalf("pod %s/%s was never rejected by the scheduler for %q: %v", ns, name, reason, err)
 	}
 }
 

--- a/scheduler/test/integration/permit_activation_test.go
+++ b/scheduler/test/integration/permit_activation_test.go
@@ -16,24 +16,35 @@ import (
 // "runner" convention).
 const leaderMarkerLabel = "runner"
 
-// TestPermitActivationRescuesAffinityBlockedWorker pins the production shape
-// for a multi-pod gang: the worker carries a REQUIRED podAffinity term to its
-// leader (worker-follows-leader, never mutual — a mutual requirement would
-// deadlock the very first pod scheduled), gated together by the same
-// PodGroup. That affinity is enforced by a different plugin than this one's
-// gate, so a worker whose own scheduling attempt outraces its leader fails
-// Filter with no gang-aware cluster event left to retry it on: the leader
-// that eventually pins the gang is only ASSUMED while it waits at Permit for
-// its sibling, and an assumed pod produces no Pod Update for anything to
-// react to. activateGangMembers is what rescues it: the instant the leader
-// reaches Permit, every live gang member is activated, so the worker retries
-// immediately and finds the leader already assumed.
+// affinityToLeader is the worker side of the worker-follows-leader shape: a
+// REQUIRED podAffinity term that matches only the gang's leader, within the
+// same topology domain.
+func affinityToLeader(pgName string) *v1.Affinity {
+	return &v1.Affinity{PodAffinity: &v1.PodAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{{
+			TopologyKey: domainLabelKey,
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				podGroupLabel:     pgName,
+				leaderMarkerLabel: "leader",
+			}},
+		}},
+	}}
+}
+
+// TestPermitActivationRescuesAffinityBlockedWorker pins prompt convergence of
+// the worker-first ordering of a multi-pod gang: the worker carries a REQUIRED
+// podAffinity term to its leader (worker-follows-leader, never mutual — a
+// mutual requirement would deadlock the very first pod scheduled), gated
+// together by the same PodGroup. Created first, the worker's earliest attempt
+// can only park: its leader does not exist yet, and until the leader is
+// assumed on a node no node can satisfy the term. Nothing in the cluster
+// reports the leader's later arrival or assumption to the parked worker, so
+// the plugin's own activations (on the member set completing, and on a member
+// reaching Permit) are what bring it back.
 //
-// Creating the worker before the leader forces exactly this ordering. Both
-// members must bind well inside the gate's permit timeout — a pass here is a
-// regression guard on activateGangMembers's unconditional per-member
-// activation, which otherwise has no test at this exact affinity-ordered
-// shape.
+// Both members must bind well inside the gate's permit timeout: a pass proves
+// the worker was woken and retried promptly, not that a timeout unwound and
+// re-formed the gang.
 func TestPermitActivationRescuesAffinityBlockedWorker(t *testing.T) {
 	tc := startScheduler(t, globalKubeConfig, gangPackOptions(t)...)
 	defer tc.teardown(t)
@@ -63,15 +74,7 @@ func TestPermitActivationRescuesAffinityBlockedWorker(t *testing.T) {
 
 	worker := makeGangPod("sw-worker", ns, "gang")
 	worker.Labels[leaderMarkerLabel] = "worker"
-	worker.Spec.Affinity = &v1.Affinity{PodAffinity: &v1.PodAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{{
-			TopologyKey: domainLabelKey,
-			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-				podGroupLabel:     "gang",
-				leaderMarkerLabel: "leader",
-			}},
-		}},
-	}}
+	worker.Spec.Affinity = affinityToLeader("gang")
 
 	// Worker first: its earliest attempt(s) can only fail — the leader either
 	// does not exist yet, or exists but has not been assumed anywhere the
@@ -88,6 +91,129 @@ func TestPermitActivationRescuesAffinityBlockedWorker(t *testing.T) {
 		node := waitForPodBound(t, tc, ns, name, tight)
 		if node != "sw1" && node != "sw2" {
 			t.Errorf("pod %s bound to %s, want sw1/sw2", name, node)
+		}
+	}
+}
+
+// TestTemplateCompletionRescuesLeaderFirstGang pins the opposite creation order
+// of the same worker-follows-leader shape, which is how a multi-node controller
+// typically creates a gang: leader first, then the worker. The leader is popped
+// before the worker exists and parks waiting for the full member template set.
+// An unscheduled pod's creation is not a scheduling-queue move event, so the
+// worker's arrival on its own wakes nobody; and the worker's own attempt cannot
+// succeed, because its required affinity needs the leader assumed on a node
+// first. Neither member reaches Permit, so Permit's sibling activation never
+// runs either. The plugin must therefore treat "the member set became complete"
+// as an explicit wake-up: the worker's PreFilter, the first to observe the full
+// set, activates the parked leader; the leader then pins the domain, waits at
+// Permit, and its activation pulls the worker through.
+//
+// The tight bind window is the assertion: without that wake-up both pods sit in
+// the unschedulable pool until the scheduler's periodic flush, minutes later.
+func TestTemplateCompletionRescuesLeaderFirstGang(t *testing.T) {
+	tc := startScheduler(t, globalKubeConfig, gangPackOptions(t)...)
+	defer tc.teardown(t)
+
+	const ns = "gang-leader-first"
+	createNamespace(t, tc, ns)
+
+	for _, n := range []string{"lf1", "lf2"} {
+		if _, err := tc.ClientSet.CoreV1().Nodes().Create(tc.Ctx, makeGPUNode(n, "a", 1), metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create node %s: %v", n, err)
+		}
+	}
+
+	pg := schedutil.MakePG("gang", ns, 2, nil, nil)
+	pg.Annotations = map[string]string{topologyKeyAnnotation: domainLabelKey}
+	// Generous on purpose, as in the worker-first test: convergence must come
+	// from the wake-up, never from a permit timeout unwinding and retrying.
+	longTimeout := int32(120)
+	pg.Spec.ScheduleTimeoutSeconds = &longTimeout
+	if _, err := tc.SchedClient.SchedulingV1alpha1().PodGroups(ns).Create(tc.Ctx, pg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create podgroup: %v", err)
+	}
+
+	leader := makeGangPod("lf-leader", ns, "gang")
+	leader.Labels[leaderMarkerLabel] = "leader"
+	if _, err := tc.ClientSet.CoreV1().Pods(ns).Create(tc.Ctx, leader, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create leader: %v", err)
+	}
+	// The leader must have been popped and parked on the incomplete member set
+	// before the worker exists; creating the worker any earlier could let the
+	// leader's first attempt see the full set and hide the ordering under test.
+	waitForPodRejected(t, tc, ns, "lf-leader", "waiting for all PodGroup member templates", 10*time.Second)
+
+	worker := makeGangPod("lf-worker", ns, "gang")
+	worker.Labels[leaderMarkerLabel] = "worker"
+	worker.Spec.Affinity = affinityToLeader("gang")
+	if _, err := tc.ClientSet.CoreV1().Pods(ns).Create(tc.Ctx, worker, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker: %v", err)
+	}
+
+	const tight = 10 * time.Second
+	for _, name := range []string{"lf-leader", "lf-worker"} {
+		node := waitForPodBound(t, tc, ns, name, tight)
+		if node != "lf1" && node != "lf2" {
+			t.Errorf("pod %s bound to %s, want lf1/lf2", name, node)
+		}
+	}
+}
+
+// TestLeaderFirstGangKeepsBestFitDomain is the leader-first ordering on a
+// cluster with two feasible domains: "a" (2 free nodes, the best fit for a
+// 2-member gang) and "b" (8 free nodes). A worker whose required affinity
+// targets a leader that is not yet assumed cannot pass Filter on any node, so
+// if it planned and pinned a domain anyway, the failure would be recorded
+// against that domain and the leader's own attempt would plan around it,
+// landing the gang in the looser domain. The worker must instead yield without
+// planning, leaving the leader to make the placement decision.
+//
+// Both members must bind promptly AND in domain "a".
+func TestLeaderFirstGangKeepsBestFitDomain(t *testing.T) {
+	tc := startScheduler(t, globalKubeConfig, gangPackOptions(t)...)
+	defer tc.teardown(t)
+
+	const ns = "gang-leader-first-bestfit"
+	createNamespace(t, tc, ns)
+
+	for _, n := range []string{"bf-a1", "bf-a2"} {
+		if _, err := tc.ClientSet.CoreV1().Nodes().Create(tc.Ctx, makeGPUNode(n, "a", 1), metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create node %s: %v", n, err)
+		}
+	}
+	for _, n := range []string{"bf-b1", "bf-b2", "bf-b3", "bf-b4", "bf-b5", "bf-b6", "bf-b7", "bf-b8"} {
+		if _, err := tc.ClientSet.CoreV1().Nodes().Create(tc.Ctx, makeGPUNode(n, "b", 1), metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create node %s: %v", n, err)
+		}
+	}
+
+	pg := schedutil.MakePG("gang", ns, 2, nil, nil)
+	pg.Annotations = map[string]string{topologyKeyAnnotation: domainLabelKey}
+	longTimeout := int32(120)
+	pg.Spec.ScheduleTimeoutSeconds = &longTimeout
+	if _, err := tc.SchedClient.SchedulingV1alpha1().PodGroups(ns).Create(tc.Ctx, pg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create podgroup: %v", err)
+	}
+
+	leader := makeGangPod("bf-leader", ns, "gang")
+	leader.Labels[leaderMarkerLabel] = "leader"
+	if _, err := tc.ClientSet.CoreV1().Pods(ns).Create(tc.Ctx, leader, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create leader: %v", err)
+	}
+	waitForPodRejected(t, tc, ns, "bf-leader", "waiting for all PodGroup member templates", 10*time.Second)
+
+	worker := makeGangPod("bf-worker", ns, "gang")
+	worker.Labels[leaderMarkerLabel] = "worker"
+	worker.Spec.Affinity = affinityToLeader("gang")
+	if _, err := tc.ClientSet.CoreV1().Pods(ns).Create(tc.Ctx, worker, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create worker: %v", err)
+	}
+
+	const tight = 10 * time.Second
+	for _, name := range []string{"bf-leader", "bf-worker"} {
+		node := waitForPodBound(t, tc, ns, name, tight)
+		if d := domainOfNode(t, tc, node); d != "a" {
+			t.Errorf("pod %s bound to %s in domain %q, want the best-fit domain a", name, node, d)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a stall in ome-scheduler for multi-node gangs whose leader is created before the workers and whose workers carry a required podAffinity to the leader (rendered whenever the Instance has a topologyKey), and the placement-quality defect behind it.

**Stall.** On a quiet cluster the leader is popped before its worker exists and parked with "waiting for all PodGroup member templates". In this kube-scheduler version the creation of an unscheduled pod is not a queue-move event, so the plugin's registered `Pod/Add` hint never fires for the new worker. The worker is popped, pins a domain, InterPodAffinity rejects every node because the leader is neither bound nor assumed, and PostFilter parks it. Nobody reaches Permit, which was the only caller of `activateGangMembers`, so both pods wait for the periodic unschedulable flush (up to 5 minutes plus the 30 s sweep).

**Fix 1: one-shot wake-up on template completion.** The gang records when it parks a member short of `minMember`; the first PreFilter that observes the set complete activates every live member once, before Filter, and clears the record only after the activation ran. The record re-arms only when the set is observed incomplete again, so repeated capacity failures of a complete gang activate nobody. Permit's unconditional activation is unchanged and now unit-guarded. GC prunes records for gangs with no live pods, re-checking the lister under the lock.

**Fix 2: yield instead of pinning when a required affinity targets an unplaced sibling.** Without it, the completing worker pins the best-fit domain, fails affinity on every node, and PostFilter marks that domain failed, so the woken leader lands the gang in the second-best domain whenever two are feasible. The yield is narrow: required terms matched by a live, unplaced member of the same gang; self-matching terms and terms aimed outside the gang keep today's behavior.

Observability: `ome_scheduler_gang_activation_total{trigger=permit|templates_complete}` and V(4) log lines. No thresholds or defaults added.

## Tests

- Unit (through the real PreFilter/PostFilter/Permit entry points): exactly-once activation; no re-activation while complete; re-arm after a member leaves; no activation under repeated no-fit failures; Permit activates all members once; the sibling yield leaves no pin and no failed-domain mark; yield scope; GC pruning.
- Integration (envtest, real kube-scheduler with InterPodAffinity): leader-first single-domain converges in under a second (fails without the fix: leader never bound within the timeout); leader-first two-domain gang lands in the tightest domain (fails with the wake-up alone: gang lands in the second domain); worker-first ordering unchanged.

## Verification

Inside `scheduler/`: `go build ./...`, `go vet ./...`, `CGO_ENABLED=1 go test -race ./... -count=1` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gang scheduling now promptly activates waiting members when all required templates appear or permit conditions are met.
  * Required sibling affinity is respected by waiting for the sibling to become schedulable before selecting a placement.
  * Added scheduler metrics for gang activation triggers.

* **Bug Fixes**
  * Prevented repeated activations, incorrect domain pinning, and stale incomplete-gang records.
  * Improved placement behavior while preserving best-fit domain selection.

* **Documentation**
  * Updated scheduler documentation to describe immediate gang activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->