### PR TITLE
[Core] Add runtime inheritance graph index

### DIFF
--- a/pkg/cli/runtimegraph/graph.go
+++ b/pkg/cli/runtimegraph/graph.go
@@ -1,0 +1,365 @@
+// Package runtimegraph indexes an already-collected snapshot of OME serving
+// runtimes. It performs no cluster reads.
+package runtimegraph
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// Kind identifies a runtime's Kubernetes kind.
+type Kind string
+
+const (
+	KindServingRuntime        Kind = "ServingRuntime"
+	KindClusterServingRuntime Kind = "ClusterServingRuntime"
+)
+
+// Identity uniquely identifies one runtime in a snapshot.
+type Identity struct {
+	Kind      Kind   `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+// Target selects the runtime to project. An empty Kind requests discovery.
+type Target struct {
+	Kind      Kind
+	Namespace string
+	Name      string
+}
+
+// Snapshot contains runtime objects collected by a caller.
+type Snapshot struct {
+	ClusterServingRuntimes []omev1beta1.ClusterServingRuntime
+	ServingRuntimes        []omev1beta1.ServingRuntime
+}
+
+// Runtime contains the bounded graph data retained for one runtime.
+type Runtime struct {
+	Identity       Identity  `json:"identity"`
+	ParentName     string    `json:"parentName,omitempty"`
+	ResolvedParent *Identity `json:"resolvedParent,omitempty"`
+}
+
+// IssueCode classifies an inheritance topology problem.
+type IssueCode string
+
+const (
+	IssueParentMissing    IssueCode = "ParentMissing"
+	IssueCycleDetected    IssueCode = "CycleDetected"
+	IssueMaxDepthExceeded IssueCode = "MaxDepthExceeded"
+)
+
+// Issue describes why Subject's inheritance chain could not be resolved.
+// Path is ordered from Subject toward its ancestors.
+type Issue struct {
+	Code       IssueCode  `json:"code"`
+	Subject    Identity   `json:"subject"`
+	ParentName string     `json:"parentName,omitempty"`
+	Path       []Identity `json:"path"`
+}
+
+// Projection is the graph view rooted at a target runtime. Ancestors are
+// ordered root first and exclude Target.
+type Projection struct {
+	Target      Runtime   `json:"target"`
+	Ancestors   []Runtime `json:"ancestors"`
+	Descendants []Subtree `json:"descendants"`
+	Issues      []Issue   `json:"issues"`
+}
+
+// Subtree is one node in the target's descendant tree.
+type Subtree struct {
+	Runtime  Runtime   `json:"runtime"`
+	Children []Subtree `json:"children"`
+}
+
+var (
+	// ErrInvalidTarget indicates that a target lacks required identity data or
+	// names an unsupported kind.
+	ErrInvalidTarget = errors.New("runtime target is invalid")
+	// ErrTargetNotFound indicates that no runtime matched a target.
+	ErrTargetNotFound = errors.New("runtime target was not found")
+	// ErrTargetAmbiguous indicates that an implicit target matched multiple
+	// runtime identities.
+	ErrTargetAmbiguous = errors.New("runtime target is ambiguous")
+	// ErrDuplicateRuntime indicates that a snapshot repeats an identity.
+	ErrDuplicateRuntime = errors.New("runtime snapshot contains a duplicate identity")
+	// ErrInvalidRuntime indicates that a snapshot runtime lacks a complete
+	// Kubernetes identity.
+	ErrInvalidRuntime = errors.New("runtime snapshot contains an invalid identity")
+)
+
+// InvalidRuntimeError identifies an incomplete snapshot identity.
+type InvalidRuntimeError struct {
+	Identity Identity
+}
+
+func (e *InvalidRuntimeError) Error() string {
+	return fmt.Sprintf("%v: %s", ErrInvalidRuntime, formatIdentity(e.Identity))
+}
+
+func (e *InvalidRuntimeError) Unwrap() error { return ErrInvalidRuntime }
+
+// DuplicateRuntimeError identifies the repeated snapshot identity.
+type DuplicateRuntimeError struct {
+	Identity Identity
+}
+
+func (e *DuplicateRuntimeError) Error() string {
+	return fmt.Sprintf("%v: %s", ErrDuplicateRuntime, formatIdentity(e.Identity))
+}
+
+func (e *DuplicateRuntimeError) Unwrap() error { return ErrDuplicateRuntime }
+
+// TargetNotFoundError retains the unresolved target for callers that need to
+// construct a diagnostic.
+type TargetNotFoundError struct {
+	Target Target
+}
+
+func (e *TargetNotFoundError) Error() string {
+	return fmt.Sprintf("%v: %q", ErrTargetNotFound, e.Target.Name)
+}
+
+func (e *TargetNotFoundError) Unwrap() error { return ErrTargetNotFound }
+
+// AmbiguousTargetError reports every candidate for an ambiguous target.
+type AmbiguousTargetError struct {
+	Target     Target
+	Candidates []Identity
+}
+
+func (e *AmbiguousTargetError) Error() string {
+	return fmt.Sprintf("%v: %q matched %d runtimes", ErrTargetAmbiguous, e.Target.Name, len(e.Candidates))
+}
+
+func (e *AmbiguousTargetError) Unwrap() error { return ErrTargetAmbiguous }
+
+// Graph is an immutable runtime index built from a snapshot.
+type Graph struct {
+	runtimes map[Identity]runtimeNode
+	children map[Identity][]Identity
+}
+
+type runtimeNode struct {
+	identity   Identity
+	parentName string
+	parent     Identity
+	hasParent  bool
+}
+
+// Build indexes a runtime snapshot.
+func Build(snapshot Snapshot) (*Graph, error) {
+	runtimes := make(map[Identity]runtimeNode, len(snapshot.ClusterServingRuntimes)+len(snapshot.ServingRuntimes))
+	for i := range snapshot.ClusterServingRuntimes {
+		object := &snapshot.ClusterServingRuntimes[i]
+		identity := Identity{Kind: KindClusterServingRuntime, Name: object.Name}
+		if identity.Name == "" {
+			return nil, &InvalidRuntimeError{Identity: identity}
+		}
+		if _, duplicate := runtimes[identity]; duplicate {
+			return nil, &DuplicateRuntimeError{Identity: identity}
+		}
+		runtimes[identity] = runtimeNode{
+			identity: identity, parentName: object.Annotations[constants.RuntimeInheritFromAnnotationKey],
+		}
+	}
+	for i := range snapshot.ServingRuntimes {
+		object := &snapshot.ServingRuntimes[i]
+		identity := Identity{Kind: KindServingRuntime, Namespace: object.Namespace, Name: object.Name}
+		if identity.Namespace == "" || identity.Name == "" {
+			return nil, &InvalidRuntimeError{Identity: identity}
+		}
+		if _, duplicate := runtimes[identity]; duplicate {
+			return nil, &DuplicateRuntimeError{Identity: identity}
+		}
+		runtimes[identity] = runtimeNode{
+			identity: identity, parentName: object.Annotations[constants.RuntimeInheritFromAnnotationKey],
+		}
+	}
+	graph := &Graph{runtimes: runtimes, children: make(map[Identity][]Identity)}
+	graph.resolveParents()
+	graph.indexChildren()
+	return graph, nil
+}
+
+// Project resolves target and returns its graph view.
+func (g *Graph) Project(target Target) (Projection, error) {
+	if target.Name == "" {
+		return Projection{}, fmt.Errorf("%w: name is required", ErrInvalidTarget)
+	}
+	if target.Kind == KindServingRuntime && target.Namespace == "" {
+		return Projection{}, fmt.Errorf("%w: namespace is required for ServingRuntime", ErrInvalidTarget)
+	}
+	if target.Kind != "" && target.Kind != KindServingRuntime && target.Kind != KindClusterServingRuntime {
+		return Projection{}, fmt.Errorf("%w: unsupported kind %q", ErrInvalidTarget, target.Kind)
+	}
+	identity, err := g.resolveTarget(target)
+	if err != nil {
+		return Projection{}, err
+	}
+	node, ok := g.runtimes[identity]
+	if !ok {
+		return Projection{}, &TargetNotFoundError{Target: target}
+	}
+	ancestors, issue := g.ancestorSpine(identity)
+	issues := make([]Issue, 0, 1)
+	if issue != nil {
+		issues = append(issues, *issue)
+	}
+	return Projection{
+		Target: node.runtime(), Ancestors: ancestors,
+		Descendants: g.descendantSubtrees(identity, map[Identity]struct{}{identity: {}}),
+		Issues:      issues,
+	}, nil
+}
+
+func (g *Graph) ancestorSpine(subject Identity) ([]Runtime, *Issue) {
+	path := []Identity{subject}
+	visited := map[Identity]struct{}{subject: {}}
+	current := g.runtimes[subject]
+	for current.parentName != "" {
+		if len(path) >= constants.RuntimeInheritMaxDepth {
+			return reverseRuntimePath(g, path[1:]), &Issue{
+				Code: IssueMaxDepthExceeded, Subject: subject, ParentName: current.parentName,
+				Path: append([]Identity{}, path...),
+			}
+		}
+		if !current.hasParent {
+			return reverseRuntimePath(g, path[1:]), &Issue{
+				Code: IssueParentMissing, Subject: subject, ParentName: current.parentName,
+				Path: append([]Identity{}, path...),
+			}
+		}
+		if _, seen := visited[current.parent]; seen {
+			cyclePath := append(append([]Identity{}, path...), current.parent)
+			return reverseRuntimePath(g, path[1:]), &Issue{
+				Code: IssueCycleDetected, Subject: subject, ParentName: current.parentName, Path: cyclePath,
+			}
+		}
+		visited[current.parent] = struct{}{}
+		path = append(path, current.parent)
+		current = g.runtimes[current.parent]
+	}
+	return reverseRuntimePath(g, path[1:]), nil
+}
+
+func reverseRuntimePath(g *Graph, childFirst []Identity) []Runtime {
+	runtimes := make([]Runtime, len(childFirst))
+	for i := range childFirst {
+		runtimes[len(childFirst)-1-i] = g.runtimes[childFirst[i]].runtime()
+	}
+	return runtimes
+}
+
+func (g *Graph) resolveTarget(target Target) (Identity, error) {
+	if target.Kind == KindClusterServingRuntime {
+		return Identity{Kind: target.Kind, Name: target.Name}, nil
+	}
+	if target.Kind == KindServingRuntime {
+		return Identity(target), nil
+	}
+	candidates := make([]Identity, 0, 2)
+	cluster := Identity{Kind: KindClusterServingRuntime, Name: target.Name}
+	if _, ok := g.runtimes[cluster]; ok {
+		candidates = append(candidates, cluster)
+	}
+	namespaced := Identity{Kind: KindServingRuntime, Namespace: target.Namespace, Name: target.Name}
+	if _, ok := g.runtimes[namespaced]; ok {
+		candidates = append(candidates, namespaced)
+	}
+	if len(candidates) > 1 {
+		return Identity{}, &AmbiguousTargetError{Target: target, Candidates: candidates}
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	return Identity{}, &TargetNotFoundError{Target: target}
+}
+
+func (g *Graph) resolveParents() {
+	for identity, node := range g.runtimes {
+		if node.parentName == "" {
+			continue
+		}
+		var parent Identity
+		if identity.Kind == KindClusterServingRuntime {
+			parent = Identity{Kind: KindClusterServingRuntime, Name: node.parentName}
+		} else {
+			parent = Identity{Kind: KindServingRuntime, Namespace: identity.Namespace, Name: node.parentName}
+			if _, ok := g.runtimes[parent]; !ok {
+				parent = Identity{Kind: KindClusterServingRuntime, Name: node.parentName}
+			}
+		}
+		if _, ok := g.runtimes[parent]; !ok {
+			continue
+		}
+		node.parent = parent
+		node.hasParent = true
+		g.runtimes[identity] = node
+	}
+}
+
+func (g *Graph) indexChildren() {
+	for identity, node := range g.runtimes {
+		if node.hasParent {
+			g.children[node.parent] = append(g.children[node.parent], identity)
+		}
+	}
+	for parent := range g.children {
+		sort.Slice(g.children[parent], func(i, j int) bool {
+			return identityLess(g.children[parent][i], g.children[parent][j])
+		})
+	}
+}
+
+func (g *Graph) descendantSubtrees(parent Identity, path map[Identity]struct{}) []Subtree {
+	result := make([]Subtree, 0, len(g.children[parent]))
+	for _, child := range g.children[parent] {
+		if _, seen := path[child]; seen {
+			continue
+		}
+		childPath := make(map[Identity]struct{}, len(path)+1)
+		for identity := range path {
+			childPath[identity] = struct{}{}
+		}
+		childPath[child] = struct{}{}
+		result = append(result, Subtree{
+			Runtime:  g.runtimes[child].runtime(),
+			Children: g.descendantSubtrees(child, childPath),
+		})
+	}
+	return result
+}
+
+func identityLess(left, right Identity) bool {
+	if left.Kind != right.Kind {
+		return left.Kind < right.Kind
+	}
+	if left.Namespace != right.Namespace {
+		return left.Namespace < right.Namespace
+	}
+	return left.Name < right.Name
+}
+
+func formatIdentity(identity Identity) string {
+	if identity.Namespace == "" {
+		return fmt.Sprintf("%s/%s", identity.Kind, identity.Name)
+	}
+	return fmt.Sprintf("%s/%s/%s", identity.Kind, identity.Namespace, identity.Name)
+}
+
+func (n runtimeNode) runtime() Runtime {
+	result := Runtime{Identity: n.identity, ParentName: n.parentName}
+	if n.hasParent {
+		parent := n.parent
+		result.ResolvedParent = &parent
+	}
+	return result
+}

--- a/pkg/cli/runtimegraph/graph_test.go
+++ b/pkg/cli/runtimegraph/graph_test.go
@@ -1,0 +1,464 @@
+package runtimegraph
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestProjectRejectsAmbiguousImplicitTarget(t *testing.T) {
+	snapshot := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{clusterRuntime("shared", "")},
+		ServingRuntimes:        []omev1beta1.ServingRuntime{namespacedRuntime("team-a", "shared", "")},
+	}
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+
+	_, err = graph.Project(Target{Namespace: "team-a", Name: "shared"})
+
+	assert.ErrorIs(t, err, ErrTargetAmbiguous)
+	var ambiguous *AmbiguousTargetError
+	require.True(t, errors.As(err, &ambiguous))
+	assert.Equal(t, []Identity{
+		{Kind: KindClusterServingRuntime, Name: "shared"},
+		{Kind: KindServingRuntime, Namespace: "team-a", Name: "shared"},
+	}, ambiguous.Candidates)
+}
+
+func TestProjectResolvesNamespacedParentsBeforeClusterParents(t *testing.T) {
+	snapshot := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{clusterRuntime("shared", "")},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "shared", ""),
+			namespacedRuntime("team-a", "child", "shared"),
+			namespacedRuntime("team-b", "child", "shared"),
+		},
+	}
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+
+	local, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"})
+	require.NoError(t, err)
+	clusterFallback, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-b", Name: "child"})
+	require.NoError(t, err)
+
+	assert.Equal(t, Runtime{
+		Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"},
+		ParentName:     "shared",
+		ResolvedParent: identityPointer(Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "shared"}),
+	}, local.Target)
+	assert.Equal(t, []Runtime{{
+		Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "shared"},
+	}}, local.Ancestors)
+	assert.Equal(t, []Runtime{{
+		Identity: Identity{Kind: KindClusterServingRuntime, Name: "shared"},
+	}}, clusterFallback.Ancestors)
+}
+
+func TestProjectAcceptsFiveRuntimeChainAndRejectsSixthLevel(t *testing.T) {
+	snapshot := Snapshot{ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+		clusterRuntime("level-1", ""),
+		clusterRuntime("level-2", "level-1"),
+		clusterRuntime("level-3", "level-2"),
+		clusterRuntime("level-4", "level-3"),
+		clusterRuntime("level-5", "level-4"),
+		clusterRuntime("level-6", "level-5"),
+	}}
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+
+	five, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "level-5"})
+	require.NoError(t, err)
+	six, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "level-6"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-1"}},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-2"}, ParentName: "level-1", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-1"})},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-3"}, ParentName: "level-2", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-2"})},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-4"}, ParentName: "level-3", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-3"})},
+	}, five.Ancestors)
+	assert.Empty(t, five.Issues)
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-2"}, ParentName: "level-1", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-1"})},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-3"}, ParentName: "level-2", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-2"})},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-4"}, ParentName: "level-3", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-3"})},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-5"}, ParentName: "level-4", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-4"})},
+	}, six.Ancestors)
+	assert.Equal(t, []Issue{{
+		Code: IssueMaxDepthExceeded, Subject: Identity{Kind: KindClusterServingRuntime, Name: "level-6"},
+		ParentName: "level-1",
+		Path: []Identity{
+			{Kind: KindClusterServingRuntime, Name: "level-6"},
+			{Kind: KindClusterServingRuntime, Name: "level-5"},
+			{Kind: KindClusterServingRuntime, Name: "level-4"},
+			{Kind: KindClusterServingRuntime, Name: "level-3"},
+			{Kind: KindClusterServingRuntime, Name: "level-2"},
+		},
+	}}, six.Issues)
+}
+
+func TestProjectReportsMissingParentWithoutCrossNamespaceLookup(t *testing.T) {
+	snapshot := Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{
+		namespacedRuntime("team-a", "child", "shared"),
+		namespacedRuntime("team-b", "shared", ""),
+	}}
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"})
+	require.NoError(t, err)
+
+	assert.Nil(t, projection.Target.ResolvedParent)
+	assert.Empty(t, projection.Ancestors)
+	assert.Equal(t, []Issue{{
+		Code: IssueParentMissing, Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"},
+		ParentName: "shared",
+		Path:       []Identity{{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"}},
+	}}, projection.Issues)
+}
+
+func TestProjectReportsSameScopeCycleByFullIdentity(t *testing.T) {
+	graph, err := Build(Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{
+		namespacedRuntime("team-a", "runtime-a", "runtime-b"),
+		namespacedRuntime("team-a", "runtime-b", "runtime-a"),
+	}})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Runtime{{
+		Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-b"},
+		ParentName: "runtime-a",
+		ResolvedParent: identityPointer(Identity{
+			Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a",
+		}),
+	}}, projection.Ancestors)
+	assert.Equal(t, []Issue{{
+		Code: IssueCycleDetected, Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"},
+		ParentName: "runtime-a",
+		Path: []Identity{
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"},
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-b"},
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"},
+		},
+	}}, projection.Issues)
+}
+
+func TestProjectReportsCycleAfterCrossingFromNamespaceToCluster(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("cluster-a", "cluster-b"),
+			clusterRuntime("cluster-b", "cluster-a"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "entry", "cluster-a"),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "entry"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Runtime{
+		{
+			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "cluster-b"},
+			ParentName:     "cluster-a",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "cluster-a"}),
+		},
+		{
+			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "cluster-a"},
+			ParentName:     "cluster-b",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "cluster-b"}),
+		},
+	}, projection.Ancestors)
+	assert.Equal(t, []Issue{{
+		Code: IssueCycleDetected, Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "entry"},
+		ParentName: "cluster-a",
+		Path: []Identity{
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "entry"},
+			{Kind: KindClusterServingRuntime, Name: "cluster-a"},
+			{Kind: KindClusterServingRuntime, Name: "cluster-b"},
+			{Kind: KindClusterServingRuntime, Name: "cluster-a"},
+		},
+	}}, projection.Issues)
+}
+
+func TestProjectUsesFullIdentityForRepeatedNameAcrossScopes(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("same-name", ""),
+			clusterRuntime("bridge", "same-name"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "same-name", "bridge"),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "same-name"}},
+		{
+			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName:     "same-name",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "same-name"}),
+		},
+	}, projection.Ancestors)
+	assert.Empty(t, projection.Issues)
+}
+
+func TestProjectBuildsDeterministicDescendantSubtree(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("root", ""),
+			clusterRuntime("z-branch", "root"),
+			clusterRuntime("a-branch", "root"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-b", "leaf", "root"),
+			namespacedRuntime("team-a", "leaf", "a-branch"),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "root"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Subtree{
+		{
+			Runtime: Runtime{
+				Identity:       Identity{Kind: KindClusterServingRuntime, Name: "a-branch"},
+				ParentName:     "root",
+				ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
+			},
+			Children: []Subtree{{
+				Runtime: Runtime{
+					Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+					ParentName:     "a-branch",
+					ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "a-branch"}),
+				},
+				Children: []Subtree{},
+			}},
+		},
+		{
+			Runtime: Runtime{
+				Identity:       Identity{Kind: KindClusterServingRuntime, Name: "z-branch"},
+				ParentName:     "root",
+				ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
+			},
+			Children: []Subtree{},
+		},
+		{
+			Runtime: Runtime{
+				Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-b", Name: "leaf"},
+				ParentName:     "root",
+				ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
+			},
+			Children: []Subtree{},
+		},
+	}, projection.Descendants)
+}
+
+func TestClusterRuntimeParentNeverResolvesToNamespacedRuntime(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{clusterRuntime("child", "parent")},
+		ServingRuntimes:        []omev1beta1.ServingRuntime{namespacedRuntime("team-a", "parent", "")},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "child"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []Issue{{
+		Code: IssueParentMissing, Subject: Identity{Kind: KindClusterServingRuntime, Name: "child"},
+		ParentName: "parent",
+		Path:       []Identity{{Kind: KindClusterServingRuntime, Name: "child"}},
+	}}, projection.Issues)
+}
+
+func TestBuildRejectsDuplicateRuntimeIdentity(t *testing.T) {
+	duplicate := namespacedRuntime("team-a", "runtime", "")
+
+	_, err := Build(Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{duplicate, duplicate}})
+
+	assert.ErrorIs(t, err, ErrDuplicateRuntime)
+	var duplicateError *DuplicateRuntimeError
+	require.True(t, errors.As(err, &duplicateError))
+	assert.Equal(t, Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime"}, duplicateError.Identity)
+}
+
+func TestBuildRejectsIncompleteRuntimeIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot Snapshot
+		want     Identity
+	}{
+		{
+			name: "cluster name required",
+			snapshot: Snapshot{ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+				clusterRuntime("", ""),
+			}},
+			want: Identity{Kind: KindClusterServingRuntime},
+		},
+		{
+			name: "namespaced name required",
+			snapshot: Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{
+				namespacedRuntime("team-a", "", ""),
+			}},
+			want: Identity{Kind: KindServingRuntime, Namespace: "team-a"},
+		},
+		{
+			name: "namespace required",
+			snapshot: Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{
+				namespacedRuntime("", "runtime", ""),
+			}},
+			want: Identity{Kind: KindServingRuntime, Name: "runtime"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Build(test.snapshot)
+
+			assert.ErrorIs(t, err, ErrInvalidRuntime)
+			var invalid *InvalidRuntimeError
+			require.True(t, errors.As(err, &invalid))
+			assert.Equal(t, test.want, invalid.Identity)
+		})
+	}
+}
+
+func TestProjectReturnsTypedTargetErrors(t *testing.T) {
+	graph, err := Build(Snapshot{})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		target Target
+		want   error
+	}{
+		{name: "name required", target: Target{}, want: ErrInvalidTarget},
+		{name: "namespace required", target: Target{Kind: KindServingRuntime, Name: "runtime"}, want: ErrInvalidTarget},
+		{name: "kind rejected", target: Target{Kind: Kind("Other"), Name: "runtime"}, want: ErrInvalidTarget},
+		{name: "explicit target absent", target: Target{Kind: KindClusterServingRuntime, Name: "runtime"}, want: ErrTargetNotFound},
+		{name: "implicit target absent", target: Target{Namespace: "team-a", Name: "runtime"}, want: ErrTargetNotFound},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := graph.Project(test.target)
+			assert.ErrorIs(t, err, test.want)
+		})
+	}
+}
+
+func TestBuildIgnoresReportedInheritanceStatus(t *testing.T) {
+	stale := namespacedRuntime("team-a", "child", "parent")
+	stale.Status.InheritanceChain = []string{"wrong-root", "child"}
+	stale.Status.Conditions = []metav1.Condition{{Type: "InheritanceReady", Status: metav1.ConditionFalse}}
+	current := stale.DeepCopy()
+	current.Status = omev1beta1.ServingRuntimeStatus{}
+	parent := namespacedRuntime("team-a", "parent", "")
+
+	staleGraph, err := Build(Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{stale, parent}})
+	require.NoError(t, err)
+	currentGraph, err := Build(Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{*current, parent}})
+	require.NoError(t, err)
+	staleProjection, err := staleGraph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"})
+	require.NoError(t, err)
+	currentProjection, err := currentGraph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"})
+	require.NoError(t, err)
+
+	assert.Equal(t, currentProjection, staleProjection)
+}
+
+func TestBuildAndProjectAreDeterministicAndDoNotMutateInput(t *testing.T) {
+	snapshot := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("root", ""),
+			clusterRuntime("branch-b", "root"),
+			clusterRuntime("branch-a", "root"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-b", "leaf", "branch-b"),
+			namespacedRuntime("team-a", "leaf", "branch-a"),
+		},
+	}
+	original := copySnapshot(snapshot)
+	shuffled := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			*snapshot.ClusterServingRuntimes[2].DeepCopy(),
+			*snapshot.ClusterServingRuntimes[0].DeepCopy(),
+			*snapshot.ClusterServingRuntimes[1].DeepCopy(),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			*snapshot.ServingRuntimes[1].DeepCopy(),
+			*snapshot.ServingRuntimes[0].DeepCopy(),
+		},
+	}
+
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+	shuffledGraph, err := Build(shuffled)
+	require.NoError(t, err)
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "root"})
+	require.NoError(t, err)
+	shuffledProjection, err := shuffledGraph.Project(Target{Kind: KindClusterServingRuntime, Name: "root"})
+	require.NoError(t, err)
+	encoded, err := json.Marshal(projection)
+	require.NoError(t, err)
+	shuffledEncoded, err := json.Marshal(shuffledProjection)
+	require.NoError(t, err)
+
+	assert.Equal(t, graph, shuffledGraph)
+	assert.Equal(t, projection, shuffledProjection)
+	assert.Equal(t, string(encoded), string(shuffledEncoded))
+	assert.Equal(t, original, snapshot)
+}
+
+func copySnapshot(snapshot Snapshot) Snapshot {
+	result := Snapshot{
+		ClusterServingRuntimes: make([]omev1beta1.ClusterServingRuntime, len(snapshot.ClusterServingRuntimes)),
+		ServingRuntimes:        make([]omev1beta1.ServingRuntime, len(snapshot.ServingRuntimes)),
+	}
+	for i := range snapshot.ClusterServingRuntimes {
+		result.ClusterServingRuntimes[i] = *snapshot.ClusterServingRuntimes[i].DeepCopy()
+	}
+	for i := range snapshot.ServingRuntimes {
+		result.ServingRuntimes[i] = *snapshot.ServingRuntimes[i].DeepCopy()
+	}
+	return result
+}
+
+func identityPointer(identity Identity) *Identity { return &identity }
+
+func clusterRuntime(name, parent string) omev1beta1.ClusterServingRuntime {
+	annotations := map[string]string{}
+	if parent != "" {
+		annotations[constants.RuntimeInheritFromAnnotationKey] = parent
+	}
+	return omev1beta1.ClusterServingRuntime{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Annotations: annotations,
+	}}
+}
+
+func namespacedRuntime(namespace, name, parent string) omev1beta1.ServingRuntime {
+	annotations := map[string]string{}
+	if parent != "" {
+		annotations[constants.RuntimeInheritFromAnnotationKey] = parent
+	}
+	return omev1beta1.ServingRuntime{ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace, Name: name, Annotations: annotations,
+	}}
+}


### PR DESCRIPTION
## What this PR does

Adds the read-only graph foundation for the upcoming runtime tree command.
It indexes `ServingRuntime` and `ClusterServingRuntime` snapshots by full
Kubernetes identity and projects a selected runtime's ancestors and
descendants deterministically.

The graph follows the controller's inheritance rules:

- cluster runtimes can inherit only from cluster runtimes;
- namespaced runtimes prefer a same-namespace parent, then fall back to a
  cluster runtime;
- topology comes from the live `ome.io/inherit-from` annotation, not possibly
  stale status;
- missing parents, cycles, ambiguity, and chains beyond five runtimes are
  represented with typed errors or issues.

### CLI impact

This is an internal foundation PR, so it intentionally adds no command or
user-visible output yet. The next runtime-tree PRs will add collection,
InferenceService usage, and rendering on top of this stable graph contract.
Keeping those layers separate makes scope and failure semantics reviewable.

## Why we need it

Runtime names are not globally unique: a cluster runtime and a namespaced
runtime can share a name, and namespaced parent lookup has shadowing rules.
A name-only tree can therefore attribute inheritance or services to the wrong
runtime. This graph establishes the scope-aware semantics before exposing the
operator-facing command.

Fixes # (no linked issue)

## How to test

```bash
go test -race ./pkg/cli/runtimegraph -count=1
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/runtimegraph
```

The tests cover namespace shadowing, cluster fallback, same names in both
scopes, namespace isolation, missing parents, same- and cross-scope cycles,
the five/six-runtime depth boundary, deterministic ordering, stale status,
duplicate identities, and input non-mutation.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable; no user-visible surface in this PR)
- [ ] `make test` passes locally (the complete CLI suite and focused race/vet
  checks pass locally; repository CI remains required before merge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added runtime graph construction from provided runtime snapshots without requiring cluster reads.
  - Added support for resolving runtime inheritance, descendants, explicit targets, and inferred targets.
  - Added deterministic projections with root-first ancestors and consistently ordered descendant trees.
  - Added validation for runtime identities and duplicate entries.
  - Added diagnostics for invalid runtimes, missing or ambiguous targets, missing parents, inheritance cycles, and excessive inheritance depth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->