### PR TITLE
[Bugfix] Project the pinned rollout plan

### DIFF
--- a/pkg/cli/rolloutprojection/project.go
+++ b/pkg/cli/rolloutprojection/project.go
@@ -56,14 +56,19 @@ func Project(
 		return reportv1alpha1.RolloutStatusReport{}, ErrSubjectUIDRequired
 	}
 
+	// Validate and project one rollout view: the active run's pinned plan when
+	// present, including an intentionally empty plan, and the live spec otherwise.
+	effectiveSpec := isvc.Spec
+	effectiveSpec.Rollout = omev1beta1.EffectiveRollout(isvc)
 	b := projector{
-		isvc:         isvc,
-		groupFor:     make(map[omev1beta1.ComponentType]int),
-		declared:     make(map[omev1beta1.ComponentType]struct{}),
-		issueKeys:    make(map[string]struct{}),
-		warningCodes: make(map[reportv1alpha1.WarningCode]struct{}),
+		isvc:          isvc,
+		effectiveSpec: &effectiveSpec,
+		groupFor:      make(map[omev1beta1.ComponentType]int),
+		declared:      make(map[omev1beta1.ComponentType]struct{}),
+		issueKeys:     make(map[string]struct{}),
+		warningCodes:  make(map[reportv1alpha1.WarningCode]struct{}),
 	}
-	if !validStoredRolloutSpec(&isvc.Spec) {
+	if !validStoredRolloutSpec(b.effectiveSpec) {
 		b.markMalformed(reportv1alpha1.RolloutIssueSpecMalformed, nil, "")
 	}
 	b.projectGroups()
@@ -151,17 +156,18 @@ func validStoredRolloutSpec(spec *omev1beta1.InferenceServiceSpec) bool {
 }
 
 type projector struct {
-	isvc         *omev1beta1.InferenceService
-	content      reportv1alpha1.RolloutStatusContent
-	groupFor     map[omev1beta1.ComponentType]int
-	declared     map[omev1beta1.ComponentType]struct{}
-	issueKeys    map[string]struct{}
-	warningCodes map[reportv1alpha1.WarningCode]struct{}
-	malformed    bool
+	isvc          *omev1beta1.InferenceService
+	effectiveSpec *omev1beta1.InferenceServiceSpec
+	content       reportv1alpha1.RolloutStatusContent
+	groupFor      map[omev1beta1.ComponentType]int
+	declared      map[omev1beta1.ComponentType]struct{}
+	issueKeys     map[string]struct{}
+	warningCodes  map[reportv1alpha1.WarningCode]struct{}
+	malformed     bool
 }
 
 func (b *projector) projectGroups() {
-	groups := b.isvc.Spec.GetRolloutGroups()
+	groups := b.effectiveSpec.GetRolloutGroups()
 	if len(groups) == 0 {
 		b.rejectUnexpectedComponentPhaseResidue()
 		if b.isvc.Status.Canary != nil {
@@ -882,7 +888,7 @@ func (b *projector) reportedState() reportv1alpha1.RolloutState {
 	if b.malformed {
 		return reportv1alpha1.RolloutStateUnknown
 	}
-	if len(b.isvc.Spec.GetRolloutGroups()) == 0 && !hasIndependentComponent(b.content.Components) {
+	if len(b.effectiveSpec.GetRolloutGroups()) == 0 && !hasIndependentComponent(b.content.Components) {
 		if b.provesNotConfigured() {
 			return reportv1alpha1.RolloutStateNotConfigured
 		}
@@ -918,12 +924,12 @@ func (b *projector) reportedState() reportv1alpha1.RolloutState {
 }
 
 func (b *projector) summaryDependsOnParentStatus() bool {
-	if len(b.isvc.Spec.GetRolloutGroups()) == 0 &&
+	if len(b.effectiveSpec.GetRolloutGroups()) == 0 &&
 		!hasIndependentComponent(b.content.Components) &&
 		!b.provesNotConfigured() {
 		return true
 	}
-	if len(b.isvc.Spec.GetRolloutGroups()) > 0 {
+	if len(b.effectiveSpec.GetRolloutGroups()) > 0 {
 		return true
 	}
 	return b.hasRolloutStatusResidue()
@@ -1008,7 +1014,7 @@ func (b *projector) normalEmptyCanarySecondary(component omev1beta1.ComponentTyp
 	if groupIndex == nil || component == "" {
 		return false
 	}
-	groups := b.isvc.Spec.GetRolloutGroups()
+	groups := b.effectiveSpec.GetRolloutGroups()
 	if *groupIndex < 0 || *groupIndex >= len(groups) || groups[*groupIndex].Canary == nil {
 		return false
 	}

--- a/pkg/cli/rolloutprojection/project_test.go
+++ b/pkg/cli/rolloutprojection/project_test.go
@@ -109,6 +109,97 @@ func TestProjectCanaryProducesSafeFaithfulReport(t *testing.T) {
 	}
 }
 
+func TestProjectUsesPinnedCanaryPlanForPolicyOnlyLiveGroup(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	pinnedGroup := isvc.Spec.Rollout.Groups[0]
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		PolicyRef: &omev1beta1.RolloutPolicyRef{
+			Name:        "guarded-canary",
+			Progression: omev1beta1.RolloutProgressionCanary,
+		},
+	}}}
+	isvc.Status.Rollout = &omev1beta1.RolloutStatus{ActiveRun: &omev1beta1.RolloutRun{
+		Plan: omev1beta1.RolloutRunPlan{Groups: []omev1beta1.RolloutRunGroup{{
+			Source: omev1beta1.RolloutPlanSourcePolicy,
+			PolicyRef: &omev1beta1.RolloutPolicyRef{
+				Name:        "guarded-canary",
+				Progression: omev1beta1.RolloutProgressionCanary,
+			},
+			Group: pinnedGroup,
+		}}},
+	}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Groups, 1)
+	assert.Equal(t, reportv1alpha1.RolloutStrategyCanary, got.Content.Groups[0].Strategy)
+	require.NotNil(t, got.Content.Groups[0].Step)
+	assert.Equal(t, int32(2), got.Content.Groups[0].Step.Total)
+	assert.Equal(t, "50%", got.Content.Groups[0].Step.Capacity)
+	assert.Equal(t, int32(50), got.Content.Groups[0].Step.TargetTraffic)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+}
+
+func TestProjectKeepsPinnedPlanWhenLiveSpecDriftsMidRun(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	pinnedGroup := isvc.Spec.Rollout.Groups[0]
+	isvc.Status.Rollout = &omev1beta1.RolloutStatus{ActiveRun: &omev1beta1.RolloutRun{
+		Plan: omev1beta1.RolloutRunPlan{Groups: []omev1beta1.RolloutRunGroup{{
+			Source: omev1beta1.RolloutPlanSourceInline,
+			Group:  pinnedGroup,
+		}}},
+	}}
+	isvc.Spec.Rollout = &omev1beta1.RolloutSpec{Groups: []omev1beta1.RolloutGroup{{
+		Components: []omev1beta1.ComponentType{omev1beta1.EngineComponent},
+		Canary: &omev1beta1.GroupCanary{Steps: []omev1beta1.RolloutGroupStep{
+			{Capacity: intstr.FromString("25%"), Traffic: 10},
+			{Capacity: intstr.FromString("100%"), Traffic: 100},
+		}},
+	}}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	require.Len(t, got.Content.Groups, 1)
+	require.NotNil(t, got.Content.Groups[0].Step)
+	assert.Equal(t, "50%", got.Content.Groups[0].Step.Capacity)
+	assert.Equal(t, int32(50), got.Content.Groups[0].Step.TargetTraffic)
+	assertOnlyEpochBoundary(t, got, reportv1alpha1.RolloutStateInProgress)
+}
+
+func TestProjectTreatsEmptyPinnedPlanAsAuthoritative(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	isvc.Status.Rollout = &omev1beta1.RolloutStatus{ActiveRun: &omev1beta1.RolloutRun{
+		Plan: omev1beta1.RolloutRunPlan{},
+	}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Empty(t, got.Content.Groups)
+}
+
+func TestProjectValidatesPinnedPlanInsteadOfLiveSpec(t *testing.T) {
+	isvc := activeCanaryInferenceService()
+	pinnedGroup := isvc.Spec.Rollout.Groups[0]
+	pinnedGroup.Canary = &omev1beta1.GroupCanary{}
+	isvc.Status.Rollout = &omev1beta1.RolloutStatus{ActiveRun: &omev1beta1.RolloutRun{
+		Plan: omev1beta1.RolloutRunPlan{Groups: []omev1beta1.RolloutRunGroup{{
+			Source: omev1beta1.RolloutPlanSourceInline,
+			Group:  pinnedGroup,
+		}}},
+	}}
+
+	got, err := rolloutprojection.Project(isvc, fixedClock())
+	require.NoError(t, err)
+
+	assert.Contains(t, got.Content.Issues, reportv1alpha1.RolloutIssue{
+		Code: reportv1alpha1.RolloutIssueSpecMalformed,
+	})
+}
+
 func TestProjectMarksStatusDerivedSummaryEpochUnverifiable(t *testing.T) {
 	isvc := activeCanaryInferenceService()
 


### PR DESCRIPTION
## What this PR does

Makes `kubectl ome rollout status` validate and render the active run's frozen
`status.rollout.activeRun.plan`. The live `spec.rollout` is still used when no
run is open, and pairing protocol remains live as required by the API helper.

This prevents a mid-run spec or RolloutPolicy edit from rewriting the CLI's
description of the rollout that the controller is actually executing. An
explicitly empty pinned plan is also authoritative instead of falling back to
the live spec.

### CLI output

The example has an active run pinned at 50% capacity/traffic, while the live
spec has since changed to 25% capacity and 10% traffic. These are the exact
selected fields from `kubectl ome rollout status chat -n prod -o json`:

```bash
jq '{reportedState: .content.summary.reportedState,
  group: (.content.groups[0] | {strategy, step}),
  issues: .content.issues}'
```

Before, the CLI mixed the new live plan with the old run status:

```json
{
  "reportedState": "Unknown",
  "group": {
    "strategy": "Canary",
    "step": {
      "index": 0,
      "total": 2,
      "capacity": "25%",
      "targetTraffic": 10,
      "observedTraffic": 50,
      "gate": "Immediate"
    }
  },
  "issues": [
    {
      "code": "EpochUnverifiable"
    },
    {
      "code": "StatusMalformed",
      "group": 0
    }
  ]
}
```

After, it reports the frozen plan and the matching run evidence:

```json
{
  "reportedState": "InProgress",
  "group": {
    "strategy": "Canary",
    "step": {
      "index": 0,
      "total": 2,
      "capacity": "50%",
      "targetTraffic": 50,
      "observedTraffic": 50,
      "gate": "Immediate"
    }
  },
  "issues": [
    {
      "code": "EpochUnverifiable"
    }
  ]
}
```

`EpochUnverifiable` is pre-existing evidence from this minimal fixture; the
incorrect `StatusMalformed` diagnosis is removed.

## Why we need it

Recent rollout work made the active plan immutable for a run so operators can
edit the next plan safely. The CLI was still reading the mutable live spec,
which could display the wrong step, traffic target, strategy, or validation
result during a rollout—the exact moment accurate diagnostics matter most.

Fixes # (no linked issue)

## How to test

```bash
go test -race ./pkg/cli/rolloutprojection ./pkg/cli/cmd/rollout -count=1
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/rolloutprojection ./pkg/cli/cmd/rollout
go build -mod=readonly ./cmd/kubectl-ome
```

Regressions cover policy-resolved pins, live-spec drift during an active run,
an empty pinned plan, malformed pinned data, and existing no-active-run
behavior.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable; exact CLI output is documented above)
- [ ] `make test` passes locally (the complete CLI suite and focused race/vet
  checks pass locally; repository CI remains required before merge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rollout projections now consistently reflect the plan pinned to an active run, even when the live rollout configuration changes.
  * Intentionally empty pinned plans are honored and produce no rollout groups.
  * Invalid pinned plans are reported with the appropriate specification error.
  * Canary and secondary rollout handling now use the active run’s effective configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->