### PR TITLE
[Core] Add runtime history command

### DIFF
--- a/pkg/cli/cmd/runtime/history.go
+++ b/pkg/cli/cmd/runtime/history.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/effective"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/namespace"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	"sigs.k8s.io/ome/pkg/cli/report"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	"sigs.k8s.io/ome/pkg/cli/runtimeprojection"
+)
+
+type historyProjector func(
+	*v1beta1.InferenceService,
+	*effective.RuntimeState,
+	reportv1alpha1.Clock,
+) (reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent], error)
+
+type historyCommandDependencies struct {
+	clock     reportv1alpha1.Clock
+	limits    paging.Limits
+	projector historyProjector
+}
+
+type historyOptions struct {
+	genericiooptions.IOStreams
+	namespaceOptions *namespace.Options
+	dependencies     historyCommandDependencies
+	output           string
+	name             string
+	format           report.Format
+}
+
+func newHistoryCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	return newHistoryCmdWithDependencies(f, streams, historyCommandDependencies{
+		clock: reportv1alpha1.SystemClock{},
+		limits: paging.Limits{
+			PageSize:       paging.ChunkSize,
+			MaxItems:       1000,
+			MaxPages:       2,
+			RequestTimeout: 10 * time.Second,
+		},
+		projector: runtimeprojection.ProjectHistory,
+	})
+}
+
+func newHistoryCmdWithDependencies(
+	f factory.Factory,
+	streams genericiooptions.IOStreams,
+	dependencies historyCommandDependencies,
+) *cobra.Command {
+	o := &historyOptions{
+		IOStreams: streams, namespaceOptions: namespace.NewOptions(), dependencies: dependencies,
+	}
+	cmd := &cobra.Command{
+		Use:   "history INFERENCESERVICE",
+		Short: "Show bounded runtime revision history for an InferenceService",
+		Long: `Shows allowlisted, retention-bounded ControllerRevision history for an
+InferenceService's resolved runtime.
+
+The command reads at most two pages and 1,000 revisions, and reports whether
+the observed window is complete or truncated. Raw runtime specs,
+ControllerRevision data, status messages, resource versions, and
+synchronization tokens are never printed.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.name = args[0]
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run(cmd.Context(), f)
+		},
+	}
+	cmd.Flags().StringVarP(&o.output, "output", "o", "table", "Output format: table, json or yaml")
+	o.namespaceOptions.AddOMEFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *historyOptions) validate() error {
+	format, err := report.ParseFormat(o.output)
+	if err != nil {
+		return err
+	}
+	o.format = format
+	if problems := validation.IsDNS1123Subdomain(o.name); len(problems) > 0 {
+		return fmt.Errorf("InferenceService name %q is invalid: %s", o.name, strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func (o *historyOptions) run(ctx context.Context, f factory.Factory) error {
+	evidence, err := collectRuntimeEvidence(
+		ctx, f, o.namespaceOptions, o.name, o.dependencies.limits,
+		runtimeEvidenceOptions{IncludeHistory: true},
+	)
+	if err != nil {
+		return err
+	}
+	projected, err := o.dependencies.projector(
+		evidence.inferenceService, evidence.state, o.dependencies.clock,
+	)
+	if err != nil {
+		return fmt.Errorf("project runtime history evidence: %w", err)
+	}
+	if err := report.Write(o.Out, o.format, projected); err != nil {
+		return fmt.Errorf("write runtime history report: %w", err)
+	}
+	return nil
+}

--- a/pkg/cli/cmd/runtime/history_execution_test.go
+++ b/pkg/cli/cmd/runtime/history_execution_test.go
@@ -1,0 +1,366 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	appstypedv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	k8stesting "k8s.io/client-go/testing"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	reportv1alpha1 "sigs.k8s.io/ome/pkg/cli/report/v1alpha1"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+type recordingHistoryKubeClient struct {
+	kubernetes.Interface
+	listNamespaces []string
+	listOptions    []metav1.ListOptions
+	listResponses  []*appsv1.ControllerRevisionList
+}
+
+func (c *recordingHistoryKubeClient) AppsV1() appstypedv1.AppsV1Interface {
+	return &recordingHistoryAppsClient{AppsV1Interface: c.Interface.AppsV1(), parent: c}
+}
+
+type recordingHistoryAppsClient struct {
+	appstypedv1.AppsV1Interface
+	parent *recordingHistoryKubeClient
+}
+
+func (c *recordingHistoryAppsClient) ControllerRevisions(namespace string) appstypedv1.ControllerRevisionInterface {
+	return &recordingHistoryRevisions{
+		ControllerRevisionInterface: c.AppsV1Interface.ControllerRevisions(namespace),
+		parent:                      c.parent,
+		namespace:                   namespace,
+	}
+}
+
+type recordingHistoryRevisions struct {
+	appstypedv1.ControllerRevisionInterface
+	parent    *recordingHistoryKubeClient
+	namespace string
+}
+
+func (c *recordingHistoryRevisions) List(
+	ctx context.Context,
+	options metav1.ListOptions,
+) (*appsv1.ControllerRevisionList, error) {
+	c.parent.listNamespaces = append(c.parent.listNamespaces, c.namespace)
+	c.parent.listOptions = append(c.parent.listOptions, options)
+	index := len(c.parent.listOptions) - 1
+	if index < len(c.parent.listResponses) {
+		return c.parent.listResponses[index].DeepCopy(), nil
+	}
+	return c.ControllerRevisionInterface.List(ctx, options)
+}
+
+func executeHistory(
+	t *testing.T,
+	f factory.Factory,
+	out io.Writer,
+	args ...string,
+) (string, error) {
+	t.Helper()
+	var errOut bytes.Buffer
+	cmd := newHistoryCmd(f, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: out, ErrOut: &errOut,
+	})
+	cmd.SetArgs(args)
+	return errOut.String(), cmd.Execute()
+}
+
+func TestHistoryReadsExactlyOneTargetAndBoundedHistory(t *testing.T) {
+	f, _ := healthyPinnedFactory(t)
+	omeClient := f.ome.(*omefake.Clientset)
+	recordingKube := &recordingHistoryKubeClient{Interface: f.kube}
+	f.kube = recordingKube
+	var out bytes.Buffer
+
+	errOut, err := executeHistory(t, f, &out, "service", "--ome-namespace", "control-plane")
+
+	require.NoError(t, err)
+	require.Len(t, omeClient.Actions(), 1)
+	get, ok := omeClient.Actions()[0].(k8stesting.GetAction)
+	require.True(t, ok)
+	assert.Equal(t, "inferenceservices", get.GetResource().Resource)
+	assert.Equal(t, "team-a", get.GetNamespace())
+	assert.Equal(t, "service", get.GetName())
+	assert.Equal(t, 1, f.namespaceGet)
+	assert.Equal(t, 1, f.omeGet)
+	assert.Equal(t, 1, f.kubeGet)
+	assert.Equal(t, 1, f.runtimeGet)
+	require.Len(t, recordingKube.listOptions, 1)
+	assert.Equal(t, []string{"control-plane"}, recordingKube.listNamespaces)
+	assert.Equal(t, int64(500), recordingKube.listOptions[0].Limit)
+	assert.Empty(t, recordingKube.listOptions[0].Continue)
+	assert.Equal(t, constants.RuntimeRevisionOfLabelKey+"=cluster-runtime", recordingKube.listOptions[0].LabelSelector)
+	assert.Contains(t, out.String(), "RetentionBounded")
+	assert.Empty(t, errOut)
+}
+
+func TestHistoryStopsAfterTwoPages(t *testing.T) {
+	f, _ := healthyPinnedFactory(t)
+	recordingKube := &recordingHistoryKubeClient{
+		Interface: f.kube,
+		listResponses: []*appsv1.ControllerRevisionList{
+			{ListMeta: metav1.ListMeta{Continue: "second-page"}},
+			{ListMeta: metav1.ListMeta{Continue: "must-not-be-read"}},
+		},
+	}
+	f.kube = recordingKube
+	var out bytes.Buffer
+
+	errOut, err := executeHistory(t, f, &out, "service", "--ome-namespace", "control-plane")
+
+	require.NoError(t, err)
+	require.Len(t, recordingKube.listOptions, 2)
+	assert.Equal(t, int64(500), recordingKube.listOptions[0].Limit)
+	assert.Equal(t, int64(500), recordingKube.listOptions[1].Limit)
+	assert.Empty(t, recordingKube.listOptions[0].Continue)
+	assert.Equal(t, "second-page", recordingKube.listOptions[1].Continue)
+	assert.Contains(t, out.String(), "Partial")
+	assert.Contains(t, out.String(), "Incomplete")
+	assert.Contains(t, out.String(), "2/2")
+	assert.Contains(t, out.String(), "HistoryTruncated")
+	assert.Empty(t, errOut)
+}
+
+func TestHistoryHealthyPinnedFormats(t *testing.T) {
+	for _, format := range []string{"table", "json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			f, _ := healthyPinnedFactory(t)
+			var out bytes.Buffer
+			errOut, err := executeHistory(
+				t, f, &out, "service", "--ome-namespace", "control-plane", "--output", format,
+			)
+			require.NoError(t, err)
+			assert.Empty(t, errOut)
+
+			if format == "table" {
+				assert.Equal(t, []string{
+					"OBSERVATION", "COMPLETENESS", "PAGES", "REVISION", "CREATED", "HASH", "ROLES", "SOURCE",
+					"CONSISTENCY", "RELATION", "REVISION-ISSUES", "REPORT-ISSUES",
+					"Complete", "RetentionBounded", "1/1", "cr-cluster-runtime-e0e2b0d6", "2026-08-30T01:02:03Z",
+					"e0e2b0d6", "Active,Requested,Reported,History", "ClusterServingRuntime/cluster-runtime",
+					"Consistent", "MatchesLive", "-", "-",
+				}, strings.Fields(out.String()))
+				return
+			}
+
+			var got reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent]
+			if format == "json" {
+				require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+			} else {
+				require.NoError(t, yaml.Unmarshal(out.Bytes(), &got))
+			}
+			assertHealthyHistoryReport(t, got)
+		})
+	}
+}
+
+func assertHealthyHistoryReport(
+	t *testing.T,
+	got reportv1alpha1.RuntimeEnvelope[reportv1alpha1.RuntimeHistoryContent],
+) {
+	t.Helper()
+	assert.Equal(t, "cli.ome.io/v1alpha1", got.APIVersion)
+	assert.Equal(t, "RuntimeHistoryReport", got.Kind)
+	assert.Equal(t, reportv1alpha1.Metadata{Namespace: "team-a", Name: "service"}, got.Metadata)
+	assert.False(t, got.CollectedAt.IsZero())
+	assert.Equal(t, time.UTC, got.CollectedAt.Location())
+	require.NotNil(t, got.Content.Runtime)
+	assert.Equal(t, reportv1alpha1.RuntimeKindClusterServingRuntime, got.Content.Runtime.Kind)
+	assert.Equal(t, "cluster-runtime", got.Content.Runtime.Name)
+	assert.Equal(t, "runtime-uid", got.Content.Runtime.UID)
+	assert.Equal(t, int64(2), got.Content.Runtime.Generation)
+	assert.Equal(t, reportv1alpha1.HistoryObservationStateComplete, got.Content.Observation)
+	assert.Equal(t, reportv1alpha1.HistoryCompletenessRetentionBounded, got.Content.Completeness)
+	assert.Equal(t, 1, got.Content.RequestedPages)
+	assert.Equal(t, 1, got.Content.ObservedPages)
+	require.Len(t, got.Content.Revisions, 1)
+	revision := got.Content.Revisions[0]
+	assert.Equal(t, "control-plane", revision.Revision.Namespace)
+	assert.Equal(t, "cr-cluster-runtime-e0e2b0d6", revision.Revision.Name)
+	assert.Equal(t, "revision-uid", revision.Revision.UID)
+	require.NotNil(t, revision.Revision.CreatedAt)
+	assert.Equal(t, time.Date(2026, 8, 30, 1, 2, 3, 0, time.UTC), *revision.Revision.CreatedAt)
+	assert.Equal(t, "e0e2b0d6", revision.Hash)
+	assert.Equal(t, []reportv1alpha1.RuntimeRevisionRole{
+		reportv1alpha1.RuntimeRevisionRoleActive,
+		reportv1alpha1.RuntimeRevisionRoleRequested,
+		reportv1alpha1.RuntimeRevisionRoleReported,
+		reportv1alpha1.RuntimeRevisionRoleHistory,
+	}, revision.Roles)
+	assert.Equal(t, reportv1alpha1.RevisionConsistencyConsistent, revision.Consistency)
+	assert.Equal(t, reportv1alpha1.RevisionRelationMatchesLive, revision.RelationToLive)
+	assert.Empty(t, revision.Issues)
+	assert.Empty(t, got.Content.Issues)
+	assert.Empty(t, got.Warnings)
+}
+
+func TestHistoryValidationPrecedesAcquisition(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		workloadNamespace  string
+		wantError          string
+		wantNamespaceCalls int
+	}{
+		{name: "zero arguments", wantError: "accepts 1 arg(s)"},
+		{name: "two arguments", args: []string{"one", "two"}, wantError: "accepts 1 arg(s)"},
+		{name: "invalid service name", args: []string{"Bad_Name"}, wantError: "InferenceService name"},
+		{name: "invalid output", args: []string{"service", "--output", "xml"}, wantError: "unsupported output format"},
+		{name: "invalid output before invalid service name", args: []string{"Bad_Name", "--output", "xml"}, wantError: "unsupported output format"},
+		{name: "invalid workload namespace", args: []string{"service"}, workloadNamespace: "Bad_NS", wantError: "workload namespace", wantNamespaceCalls: 1},
+		{name: "invalid OME namespace", args: []string{"service", "--ome-namespace", "Bad_NS"}, workloadNamespace: "team-a", wantError: "OME namespace", wantNamespaceCalls: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := &validationFactory{namespace: test.workloadNamespace}
+			var out bytes.Buffer
+			errOut, err := executeHistory(t, f, &out, test.args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantError)
+			assert.Equal(t, test.wantNamespaceCalls, f.namespaceCalls)
+			assert.Empty(t, out.String())
+			assert.Empty(t, errOut)
+		})
+	}
+}
+
+func TestHistoryRejectsUnboundPrimarySnapshots(t *testing.T) {
+	valid := func() *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+			Name: "service", Namespace: "team-a", UID: types.UID("isvc-uid"), ResourceVersion: "17",
+		}}
+	}
+	tests := []struct {
+		name string
+		got  func() *v1beta1.InferenceService
+		want error
+	}{
+		{name: "nil response", got: func() *v1beta1.InferenceService { return nil }, want: errNilInferenceService},
+		{name: "wrong name", got: func() *v1beta1.InferenceService { value := valid(); value.Name = "hostile-returned-name"; return value }, want: errInferenceServiceNameMismatch},
+		{name: "wrong namespace", got: func() *v1beta1.InferenceService {
+			value := valid()
+			value.Namespace = "hostile-returned-namespace"
+			return value
+		}, want: errInferenceServiceNamespaceMismatch},
+		{name: "empty UID", got: func() *v1beta1.InferenceService { value := valid(); value.UID = ""; return value }, want: errInferenceServiceUIDEmpty},
+		{name: "empty resource version", got: func() *v1beta1.InferenceService { value := valid(); value.ResourceVersion = ""; return value }, want: errInferenceServiceVersionEmpty},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ome := omefake.NewSimpleClientset()
+			ome.PrependReactor("get", "inferenceservices", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+				return true, test.got(), nil
+			})
+			f := &acquisitionFactory{
+				ome: ome, kube: k8sfake.NewSimpleClientset(),
+				runtime: ctrlfake.NewClientBuilder().WithScheme(scheme(t)).Build(), namespace: "team-a",
+			}
+			var out bytes.Buffer
+			errOut, err := executeHistory(t, f, &out, "service")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+			assert.NotContains(t, err.Error(), "hostile-returned")
+			assert.Zero(t, f.kubeGet)
+			assert.Zero(t, f.runtimeGet)
+			assert.Empty(t, out.String())
+			assert.Empty(t, errOut)
+		})
+	}
+}
+
+func TestHistoryPreservesRequiredFailureCauses(t *testing.T) {
+	namespaceFailure := errors.New("namespace sentinel")
+	omeFailure := errors.New("OME client sentinel")
+	kubeFailure := errors.New("Kubernetes client sentinel")
+	runtimeFailure := errors.New("runtime client sentinel")
+	tests := []struct {
+		name      string
+		want      error
+		configure func(*failingFactory)
+	}{
+		{name: "namespace", want: namespaceFailure, configure: func(f *failingFactory) { f.nsErr = namespaceFailure }},
+		{name: "OME client", want: omeFailure, configure: func(f *failingFactory) { f.omeErr = omeFailure }},
+		{name: "Kubernetes client", want: kubeFailure, configure: func(f *failingFactory) { f.kubeErr = kubeFailure }},
+		{name: "runtime client", want: runtimeFailure, configure: func(f *failingFactory) { f.runtimeErr = runtimeFailure }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := completeFactory(t)
+			test.configure(f)
+			var out bytes.Buffer
+			errOut, err := executeHistory(t, f, &out, "service")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+			assert.Empty(t, out.String())
+			assert.Empty(t, errOut)
+		})
+	}
+}
+
+func TestHistoryOptionalListFailureIsBoundedDiagnostic(t *testing.T) {
+	const canary = "secret-history-list-failure"
+	f, _ := healthyPinnedFactory(t)
+	client := f.kube.(*k8sfake.Clientset)
+	client.PrependReactor("list", "controllerrevisions", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, errors.New(canary)
+	})
+	var out bytes.Buffer
+
+	errOut, err := executeHistory(t, f, &out, "service", "--ome-namespace", "control-plane")
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "HistoryUnavailable")
+	assert.NotContains(t, out.String(), canary)
+	assert.NotContains(t, errOut, canary)
+	assert.Empty(t, errOut)
+}
+
+func TestHistoryPreservesWriterFailures(t *testing.T) {
+	writerFailure := errors.New("writer sentinel")
+	tests := []struct {
+		name   string
+		writer io.Writer
+		want   error
+	}{
+		{name: "failure", writer: failingWriter{err: writerFailure}, want: writerFailure},
+		{name: "short write", writer: failingWriter{short: true}, want: io.ErrShortWrite},
+	}
+	for _, test := range tests {
+		for _, format := range []string{"table", "json", "yaml"} {
+			t.Run(test.name+"/"+format, func(t *testing.T) {
+				f, _ := healthyPinnedFactory(t)
+				errOut, err := executeHistory(
+					t, f, test.writer, "service", "--ome-namespace", "control-plane", "--output", format,
+				)
+				require.Error(t, err)
+				assert.ErrorIs(t, err, test.want)
+				assert.Contains(t, err.Error(), "write runtime history report")
+				assert.Empty(t, errOut)
+			})
+		}
+	}
+}

--- a/pkg/cli/cmd/runtime/history_test.go
+++ b/pkg/cli/cmd/runtime/history_test.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+)
+
+func TestHistoryCommandContract(t *testing.T) {
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	parent := NewCmd(factory.Static{}, streams)
+
+	cmd, _, err := parent.Find([]string{"history"})
+	require.NoError(t, err)
+	require.NotSame(t, parent, cmd)
+	assert.Equal(t, "history INFERENCESERVICE", cmd.Use)
+	assert.Equal(t, "Show bounded runtime revision history for an InferenceService", cmd.Short)
+	assert.Equal(t, `Shows allowlisted, retention-bounded ControllerRevision history for an
+InferenceService's resolved runtime.
+
+The command reads at most two pages and 1,000 revisions, and reports whether
+the observed window is complete or truncated. Raw runtime specs,
+ControllerRevision data, status messages, resource versions, and
+synchronization tokens are never printed.`, cmd.Long)
+
+	output := cmd.Flags().Lookup("output")
+	require.NotNil(t, output)
+	assert.Equal(t, "o", output.Shorthand)
+	assert.Equal(t, "table", output.DefValue)
+	assert.Equal(t, "Output format: table, json or yaml", output.Usage)
+	omeNamespace := cmd.Flags().Lookup("ome-namespace")
+	require.NotNil(t, omeNamespace)
+	assert.Equal(t, "ome", omeNamespace.DefValue)
+	assert.Equal(t, "Namespace where the OME control plane is installed", omeNamespace.Usage)
+	assert.Nil(t, cmd.Flags().Lookup("namespace"), "namespace must remain inherited from the root")
+
+	wantLocalFlags := map[string]bool{"ome-namespace": true, "output": true}
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		assert.Truef(t, wantLocalFlags[flag.Name], "unexpected local flag %q", flag.Name)
+		delete(wantLocalFlags, flag.Name)
+	})
+	assert.Empty(t, wantLocalFlags)
+}
+
+func TestHistoryHelpOutput(t *testing.T) {
+	var out bytes.Buffer
+	parent := NewCmd(factory.Static{}, genericiooptions.IOStreams{
+		In: &bytes.Buffer{}, Out: &out, ErrOut: &out,
+	})
+	parent.SetOut(&out)
+	parent.SetErr(&out)
+	parent.SetArgs([]string{"history", "--help"})
+	require.NoError(t, parent.Execute())
+	assert.Equal(t, `Shows allowlisted, retention-bounded ControllerRevision history for an
+InferenceService's resolved runtime.
+
+The command reads at most two pages and 1,000 revisions, and reports whether
+the observed window is complete or truncated. Raw runtime specs,
+ControllerRevision data, status messages, resource versions, and
+synchronization tokens are never printed.
+
+Usage:
+  runtime history INFERENCESERVICE [flags]
+
+Flags:
+  -h, --help                   help for history
+      --ome-namespace string   Namespace where the OME control plane is installed (default "ome")
+  -o, --output string          Output format: table, json or yaml (default "table")
+`, out.String())
+}

--- a/pkg/cli/cmd/runtime/runtime.go
+++ b/pkg/cli/cmd/runtime/runtime.go
@@ -15,5 +15,6 @@ func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Comman
 	}
 	cmd.AddCommand(newExplainCmd(f, streams))
 	cmd.AddCommand(newEffectiveCmd(f, streams))
+	cmd.AddCommand(newHistoryCmd(f, streams))
 	return cmd
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -34,6 +34,7 @@ func TestRootCommandTree(t *testing.T) {
 		"ome runtime",
 		"ome runtime effective",
 		"ome runtime explain",
+		"ome runtime history",
 		"ome status",
 		"ome version",
 	}


### PR DESCRIPTION
## What this PR does

Adds `kubectl ome runtime history INFERENCESERVICE`, exposing the existing
typed runtime-revision history report through the CLI in table, JSON, and YAML
formats.

The command resolves the InferenceService and its effective runtime using the
workload namespace, reads ControllerRevisions from `--ome-namespace`, and
limits history collection to two 500-item pages / 1,000 revisions with a
10-second timeout on each request. Truncation and unavailable optional history
are explicit diagnostics; raw runtime specs, ControllerRevision data, status
messages, resource versions, and synchronization tokens are never printed.

### CLI output from Moirai

This exact output was captured from the isolated
`ome-cli-tree-b4d9098` fixture after deploying today's controller image:

```console
$ kubectl ome runtime history kome-tree-b4d9098-isvc-leaf-a \
    -n ome-cli-tree-b4d9098 --ome-namespace ome
OBSERVATION   COMPLETENESS       PAGES   REVISION   CREATED   HASH   ROLES   SOURCE   CONSISTENCY   RELATION   REVISION-ISSUES   REPORT-ISSUES
Complete      RetentionBounded   1/1     -          -         -      -       -        -             -          -                 -
```

The compact machine-readable view from the same live request is:

```json
{
  "runtime": {
    "apiVersion": "ome.io/v1beta1",
    "kind": "ServingRuntime",
    "namespace": "ome-cli-tree-b4d9098",
    "name": "kome-tree-b4d9098-leaf-a",
    "uid": "eb091f29-e092-4cac-a1b6-6dc2c26d282e",
    "generation": 1
  },
  "observation": "Complete",
  "completeness": "RetentionBounded",
  "pages": "1/1",
  "revisions": [],
  "issues": [],
  "warnings": []
}
```

An empty `revisions` list is expected for this model-free RawDeployment
fixture; the report still proves which inherited runtime was resolved and
that the bounded history window was read completely.

## Why we need it

The CLI already collected and projected runtime revision evidence internally,
but operators had no command to access it. Diagnosing a pinned, drifted, or
auto-synchronized runtime therefore required manual CR and ControllerRevision
inspection. This command makes that evidence available without exposing raw
configuration or secrets.

Fixes # (no linked issue)

## How to test

```bash
go test -race ./pkg/cli/cmd/runtime ./pkg/cli/runtimeprojection \
  ./pkg/cli/effective ./pkg/cli/report/v1alpha1 -count=1
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
go build -mod=readonly ./cmd/kubectl-ome
```

Command tests cover registration/help, all output formats, namespace routing,
pagination and truncation, validation-before-acquisition, response identity
binding, required/optional API failures, redaction, and writer failures.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable; help and live CLI output are included)
- [ ] `make test` passes locally (the complete CLI suite and focused race/vet
  checks pass locally; repository CI remains required before merge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `runtime history` CLI command for viewing bounded runtime history.
  * Supports table, JSON, and YAML output formats.
  * Includes output and namespace options with validation and helpful error reporting.
  * Displays runtime evidence and history for a specified inference service.

* **Tests**
  * Added coverage for command discovery, help output, pagination limits, validation, output formats, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->