### PR TITLE
[Core] Model Alfred node health states

### DIFF
--- a/oeps/0008-alfred-gpu-cluster-caretaker/README.md
+++ b/oeps/0008-alfred-gpu-cluster-caretaker/README.md
@@ -236,7 +236,7 @@ At the 2026-09-07 baseline, the source tree has the following status:
 | Observation and configuration | Implemented | Every replica builds snapshots and publishes gauges; configuration hot-reloads with last-known-good fallback. |
 | Defragmentation Policy #1 | Partially implemented | Scoring, candidate generation, arbitration, and reporting run; placement feasibility is not yet scheduler-complete. |
 | Arbiter and Reporter | Partially implemented | Core admission gates and outputs exist; positive-benefit/regression admission and dispatch/outcome-fed ledger state are not connected. |
-| Node-Health Policy #2 | Not implemented | Node conditions only exclude unhealthy nodes as defrag targets and enqueue a coalesced early decision request. That request now forces a serialized snapshot refresh before policy evaluation without moving the regular decision deadline; no evacuation candidates or remediation signals are produced. |
+| Node-Health Policy #2 | Foundation implemented | Snapshots retain configured failure-condition status and transition time as `Clear`, `Suspect`, `Unknown`, or `Unhealthy`; every non-clear state is excluded from defrag targets and surge headroom. Condition-change requests force a serialized fresh snapshot without moving the regular decision deadline. No evacuation candidates or remediation signals are produced. |
 | Dispatcher | Not implemented | Alfred does not patch migration-request annotations and its current ClusterRole grants no InferenceService write. Both modes report Arbiter-admitted candidates as `withheld`: `RecommendOnly` in recommend-only mode and `DispatcherUnavailable` in execute mode. |
 | OMENative state | Implemented | Alfred validates dense `InferenceReplica.Status.InstanceStatuses` directly for stable Instance identity and lifecycle state, reads `Status.Migrations`, and joins live Pods by Instance index and incarnation for physical placement and readiness. Compatibility-only ready, scheduled, and nodes fields are not source-of-truth inputs. |
 | OMENative executor readiness | Not implemented | No capability producer or Alfred reader ships in the current implementation. The target design requires a fresh OMENative capability Lease; its producer, reader, and just-in-time pre-dispatch check are deferred with the Dispatcher. |
@@ -734,9 +734,11 @@ which has a broken NVLink; NCCL fails.
 unhealthy nodes are excluded from placement hints during Candidate generation.
 This is also exactly why **Node-Health Evacuation is a first-class policy** rather
 than an afterthought — the same health signal that excludes a node as a *target*
-also makes it a *source* to evacuate. Post-migration, if a migrated workload fails
-within a window, Alfred marks the node suspect and backs off from it. Mitigation,
-not full fix: a fault that is invisible to the node condition can still bite.
+also makes it a *source* to evacuate. If a configured failure condition later
+trips or becomes unknown, a refreshed snapshot quarantines the node. Workload
+failure alone does not mark a node suspect; correlating migration outcomes needs
+the later durable outcome/evacuation record. Mitigation, not full fix: a fault
+that is invisible to the node condition can still bite.
 
 **Risk: conflict with HPA / scheduler / other controllers.**
 *Mitigation:* the snapshot records active HPA scaling and the Arbiter defers
@@ -1082,7 +1084,7 @@ Each Candidate carries `HintTargetNodes`: a ranked, *advisory* list of nodes the
      evaluated soundly, the Candidate becomes advisory instead of receiving a
      speculative target hint.
    - **Model not available** — storage-aware, switching on `ModelAvailability.Backend`. *Per-node models*: the target must have the model ready, per `BaseModel.Status.NodesReady` or the node label `models.ome.io/{ns}.basemodel.{name}=Ready` (OEP-0007 Q-017) — migrating to a node that must first pull a multi-hundred-GB model defeats the purpose, and the pod's own readiness `nodeSelector` would block the placement anyway. *PVC-backed models*: `NodesReady` is intentionally empty and must **not** be used as a filter; the target set is the nodes that can mount the volume — for RWX/ROX storage, any node satisfying the PVC's CSI topology, with no model pull ever needed. *RWO (and RWOP) PVCs pin the workload*: the volume attaches to one node at a time and the source pod still holds it while a surge replacement starts, so no surge-shaped mechanism can run — the candidate is downgraded to advisory with reason `VolumePinned`.
-   - **Unhealthy or cordoned**: excluded. Excluding unhealthy nodes from placement is existing defragmentation behavior — and it is the seam Policy #2 builds on: a node Policy #1 already refuses as a *target* is exactly the kind of node Policy #2 will reason about as a *source* to drain. Nodes inside their post-evacuation **suspicion window** are excluded too, even after the condition clears (see Policy #2's "stay suspicious" rule). (Mechanism for Policy #2 in its own section.)
+   - **Health-quarantined or cordoned**: excluded. `Unhealthy`, `Unknown`, and recovery-window `Suspect` states all make capacity unusable for target hints. An `Unhealthy` node that Policy #1 refuses as a target is the source Policy #2 will consider draining; `Unknown` and `Suspect` alone do not authorize evacuation. (Mechanism for Policy #2 in its own section.)
    - **CA scale-down in progress**: a node with `scale-down-disabled` being processed is excluded, so Alfred and the cluster-autoscaler do not fight over it.
    - **Spot / preemptible**: excluded from targets by default (see the spot/preemptible section) — moving a workload onto a node that can vanish is a poor trade.
 3. **Rank** by a bin-packing heuristic whose direction depends on the goal: prefer partially-filled nodes when the goal is to consolidate, or prefer empty nodes when the goal is to free contiguous capacity elsewhere.
@@ -1210,12 +1212,16 @@ cloud provider, or the cluster autoscaler — see the anticipated objection belo
    nodes") literally true while still making the bad node *actionable*.
 4. Node health is a small state machine, not a boolean. A configured condition
    at `True` makes the node unhealthy and evacuation-eligible. `Unknown`
-   quarantines the node as a target and emits a remediation signal, but does not
-   authorize migration. A transition to `False` after an incident enters the
-   suspicion window; only an expired suspicion window is clear. Condition
-   transition time is retained so this state is reconstructible after restart.
-   *Rationale:* treating `Unknown` as healthy is unsafe, while treating it as
-   sufficient evidence for disruption is also unsafe.
+   quarantines the node as a target and will make Policy #2 emit a remediation
+   signal, but does not authorize migration. A current `False` condition with a
+   recent `LastTransitionTime` enters a recovery suspicion window; only an
+   expired window is clear. A missing transition time is `Unknown`. This
+   reconstruction conservatively includes a newly initialized `False`
+   condition and cannot prove that a prior incident or Alfred evacuation
+   occurred. *Rationale:* treating inconclusive evidence as healthy is unsafe,
+   while treating it as sufficient evidence for disruption is also unsafe.
+   `policies.nodeHealth.enabled` controls candidate and signal production, not
+   this global target-safety quarantine.
 5. A condition-change early tick refreshes the snapshot before policy
    evaluation. Refresh, publication, and evaluation are serialized; a failed
    refresh skips the early decision. An early pass does not postpone the regular
@@ -1258,14 +1264,15 @@ b) **Signal.** Return, alongside the evacuation Candidates, one advisory
    result as the complete desired signal set, so cleared nodes remove stale
    records and repeated observations do not spam Events.
 
-c) **Stay suspicious.** An evacuated node stays excluded from every policy's
-   *target* hints for `nodeSuspicionWindowMinutes` (default 30) — even after
-   the condition clears. *Failure mode this guards:* a flapping node becomes a
-   pump — condition clears, defrag consolidates workloads onto the newly
-   "empty" node, condition trips, Alfred evacuates again. The per-workload
-   cooldown never prevented this (it only stops the *evacuated* workloads from
-   returning; other workloads could still be packed onto the flapper); the
-   suspicion window does.
+c) **Stay suspicious during condition recovery.** A configured failure
+   condition that is currently `False` keeps the node excluded from every
+   policy's *target* hints until `LastTransitionTime +
+   nodeSuspicionWindowMinutes` (default 30). This reconstructible guard prevents
+   a freshly cleared node from immediately becoming a placement target. It
+   depends on the condition producer retaining the `False` row and transition
+   time; deleting the condition removes that evidence. It neither proves that
+   Alfred evacuated the node nor replaces the durable per-node evacuation
+   record that prevents repeated waves across condition flaps.
 
 The only genuinely new behavior versus Policy #1 is the **trigger** (a node
 condition, not a fragmentation score), the **remediation Event**, and the
@@ -1519,7 +1526,7 @@ config.yaml: |
       triggerConditions: [GpuUnhealthy]
       signalOnly: false            # true = signal only, never dispatch
       healthCooldownFloorMinutes: 5   # per-workload cooldown floor for NodeUnhealthy candidates
-      nodeSuspicionWindowMinutes: 30  # evacuated nodes stay out of target hints, even after the condition clears
+      nodeSuspicionWindowMinutes: 30  # recently cleared failure conditions quarantine targets during recovery
 
   # Per-workload defaults
   defaultMovable: true
@@ -2439,8 +2446,9 @@ following behavior end to end:
 10. **Rate limiting**: 10 candidates; only 3 migrations in-flight.
 11. **Policy hot reload**: update ConfigMap; Alfred reloads without restart.
 12. **Leader election**: 3 replicas; kill leader; new leader elected within 20s.
-13. **Post-migration health monitoring**: migration succeeds but target GPU
-    fails within window; Alfred marks node suspect, backs off.
+13. **Post-migration health monitoring**: migration succeeds and the target's
+    configured failure condition trips; Alfred quarantines the node, while the
+    future durable per-node evacuation record prevents repeated migration waves.
 14. **HPA coexistence**: HPA scaling the target ISVC; Alfred defers.
 15. **CA coexistence**: node marked `scale-down-disabled`; excluded from hints.
 16. **OMENative-unavailable degraded mode**: stop the controller while leaving
@@ -2655,8 +2663,8 @@ engine must not preclude them.
 - 2026-08-16: Cooldown made class-aware: health-evacuation candidates use a
   5-minute floor instead of the 30-minute per-workload cooldown (audited via
   `CooldownOverriddenForEvacuation`); flap protection restated on the per-node
-  evacuation record; a post-evacuation node-suspicion window keeps drained
-  nodes out of target hints even after the condition clears; per-node mutual
+  evacuation record; a condition-recovery suspicion window keeps recently
+  cleared nodes out of target hints; per-node mutual
   exclusion and the per-node cooldown scoped to *targets*, so a failing node
   can drain multiple workloads per cycle; within-class ordering of evacuation
   candidates defined (feasible first, higher priority first, smaller footprint
@@ -2684,6 +2692,12 @@ engine must not preclude them.
   a serialized snapshot refresh before policy evaluation without moving the
   regular decision cadence. Current implementation gaps (Node-Health
   evacuation, Dispatcher, and executor readiness) are recorded explicitly.
+- 2026-09-07: Node-health snapshots now retain configured failure-condition
+  status and transition time and reconstruct `Clear`, `Suspect`, `Unknown`, or
+  `Unhealthy` from one snapshot timestamp. Every non-clear state is excluded
+  from defrag targets and surge headroom. `Suspect` is a condition-recovery
+  quarantine, not proof of evacuation; evacuation candidates, remediation
+  signals, and the durable one-wave record remain deferred.
 - TBD: Complete Alpha implementation (capability Lease, Policy #2, Dispatcher,
   and outcome-fed safety ledger).
 - TBD: First Beta user.

--- a/pkg/alfred/config/config.go
+++ b/pkg/alfred/config/config.go
@@ -114,18 +114,20 @@ type Scoring struct {
 
 // NodeHealth is Policy #2's block.
 type NodeHealth struct {
+	// Enabled controls Policy #2 candidate and signal production. Structured
+	// observation and target quarantine remain global placement safety.
 	Enabled        *bool  `json:"enabled"`
 	Aggressiveness string `json:"aggressiveness"`
-	// TriggerConditions are the node conditions that trigger evacuation;
-	// consumed from existing signals, never detected by Alfred.
+	// TriggerConditions are failure-condition types whose True status triggers
+	// evacuation; consumed from existing signals, never detected by Alfred.
 	TriggerConditions []string `json:"triggerConditions"`
 	// SignalOnly emits the remediation signal but never evacuates.
 	SignalOnly bool `json:"signalOnly"`
 	// HealthCooldownFloorMinutes is the per-workload cooldown floor for
 	// NodeUnhealthy candidates (instead of the standard cooldown).
 	HealthCooldownFloorMinutes int `json:"healthCooldownFloorMinutes"`
-	// NodeSuspicionWindowMinutes keeps evacuated nodes out of target
-	// hints even after the condition clears.
+	// NodeSuspicionWindowMinutes keeps nodes with a recently cleared failure
+	// condition out of target hints during recovery.
 	NodeSuspicionWindowMinutes int `json:"nodeSuspicionWindowMinutes"`
 }
 

--- a/pkg/alfred/observer/loop.go
+++ b/pkg/alfred/observer/loop.go
@@ -95,10 +95,11 @@ func (l *Loop) Refresh(ctx context.Context) error {
 	cfg := l.Store.Get()
 
 	opts := snapshot.Options{
-		TriggerConditions: cfg.Policies.NodeHealth.TriggerConditions,
-		PreemptibleLabels: cfg.SpotPolicy.PreemptibleLabels,
-		DefaultMovable:    cfg.DefaultMovable,
-		Now:               l.Now,
+		TriggerConditions:   cfg.Policies.NodeHealth.TriggerConditions,
+		NodeSuspicionWindow: cfg.NodeSuspicionWindow(),
+		PreemptibleLabels:   cfg.SpotPolicy.PreemptibleLabels,
+		DefaultMovable:      cfg.DefaultMovable,
+		Now:                 l.Now,
 	}
 	if l.OMENativeExecutor != nil {
 		opts.OMENativeExecutor = l.OMENativeExecutor(ctx)
@@ -151,7 +152,7 @@ func (l *Loop) publish(snap *snapshot.ClusterSnapshot, cfg *config.Config) {
 	for _, pool := range snap.GPUPools() {
 		var headroom int64
 		for _, node := range snap.PoolNodes(pool) {
-			if node.Cordoned || node.Unhealthy || node.ScaleDownMarked || node.Suspect {
+			if node.Cordoned || node.Health.Quarantined() || node.ScaleDownMarked {
 				continue
 			}
 			if node.FreeGPUs > headroom {

--- a/pkg/alfred/observer/loop_test.go
+++ b/pkg/alfred/observer/loop_test.go
@@ -142,6 +142,111 @@ func TestRunOncePublishesSnapshotGauges(t *testing.T) {
 	}
 }
 
+func TestRefreshWiresNodeSuspicionWindow(t *testing.T) {
+	if got := config.Default().NodeSuspicionWindow(); got != snapshot.DefaultNodeSuspicionWindow {
+		t.Fatalf("config default window = %v, snapshot default = %v", got, snapshot.DefaultNodeSuspicionWindow)
+	}
+	loop, _ := newTestLoop(t)
+	base, ok := loop.Reader.(client.WithWatch)
+	if !ok {
+		t.Fatalf("test reader type = %T, want client.WithWatch", loop.Reader)
+	}
+	transitioned := loopNow.Add(-10 * time.Minute)
+	loop.Reader = interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if err := c.List(ctx, list, opts...); err != nil {
+				return err
+			}
+			nodes, ok := list.(*corev1.NodeList)
+			if !ok {
+				return nil
+			}
+			for i := range nodes.Items {
+				nodes.Items[i].Status.Conditions = []corev1.NodeCondition{
+					{
+						Type:               "GpuUnhealthy",
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(transitioned),
+					},
+					{
+						Type:               "AcceleratorDegraded",
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(transitioned),
+					},
+				}
+			}
+			return nil
+		},
+	})
+
+	if outcome, err := loop.Store.Update([]byte(`
+schemaVersion: 1
+policies:
+  nodeHealth:
+    enabled: false
+    triggerConditions: [AcceleratorDegraded]
+    nodeSuspicionWindowMinutes: 5
+`)); err != nil || outcome != config.OutcomeSuccess {
+		t.Fatalf("configure five-minute window: outcome=%q error=%v", outcome, err)
+	}
+	if err := loop.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if got := loop.Latest().Nodes["node1"].Health; got.State != snapshot.NodeHealthClear ||
+		len(got.Conditions) != 1 || got.Conditions[0].Type != "AcceleratorDegraded" ||
+		got.Conditions[0].Status != corev1.ConditionFalse {
+		t.Fatalf("five-minute window health = %+v, want Clear", got)
+	}
+
+	if outcome, err := loop.Store.Update([]byte(`
+schemaVersion: 1
+policies:
+  nodeHealth:
+    enabled: false
+    triggerConditions: [AcceleratorDegraded]
+    nodeSuspicionWindowMinutes: 15
+`)); err != nil || outcome != config.OutcomeSuccess {
+		t.Fatalf("configure fifteen-minute window: outcome=%q error=%v", outcome, err)
+	}
+	if err := loop.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	wantUntil := transitioned.Add(15 * time.Minute)
+	if got := loop.Latest().Nodes["node1"].Health; got.State != snapshot.NodeHealthSuspect ||
+		got.SuspectUntil == nil || !got.SuspectUntil.Equal(wantUntil) ||
+		len(got.Conditions) != 1 || got.Conditions[0].Type != "AcceleratorDegraded" ||
+		got.Conditions[0].Status != corev1.ConditionFalse {
+		t.Fatalf("fifteen-minute window health = %+v, want Suspect until %v", got, wantUntil)
+	}
+}
+
+func TestPublishSurgeHeadroomExcludesQuarantinedHealth(t *testing.T) {
+	loop, m := newTestLoop(t)
+	snap := &snapshot.ClusterSnapshot{Nodes: map[string]*snapshot.Node{
+		"clear": {
+			Name: "clear", GPUPool: "h100", TotalGPUs: 8, FreeGPUs: 2,
+			Health: snapshot.NodeHealthObservation{State: snapshot.NodeHealthClear},
+		},
+		"suspect": {
+			Name: "suspect", GPUPool: "h100", TotalGPUs: 8, FreeGPUs: 6,
+			Health: snapshot.NodeHealthObservation{State: snapshot.NodeHealthSuspect},
+		},
+		"unknown": {
+			Name: "unknown", GPUPool: "h100", TotalGPUs: 8, FreeGPUs: 7,
+			Health: snapshot.NodeHealthObservation{State: snapshot.NodeHealthUnknown},
+		},
+		"unhealthy": {
+			Name: "unhealthy", GPUPool: "h100", TotalGPUs: 8, FreeGPUs: 8,
+			Health: snapshot.NodeHealthObservation{State: snapshot.NodeHealthUnhealthy},
+		},
+	}}
+
+	loop.publish(snap, config.Default())
+	if got := promtestutil.ToFloat64(m.SurgeHeadroomGPUs.WithLabelValues("h100")); got != 2 {
+		t.Fatalf("surge headroom = %v, want 2 from the only clear node", got)
+	}
+}
+
 func TestRunOnceInvokesScorerHook(t *testing.T) {
 	loop, _ := newTestLoop(t)
 

--- a/pkg/alfred/policy/defrag/scoring.go
+++ b/pkg/alfred/policy/defrag/scoring.go
@@ -190,7 +190,7 @@ func schedulableBins(snap *snapshot.ClusterSnapshot, cfg *config.Config, pool st
 }
 
 func nodeSchedulable(node *snapshot.Node, avoidSpot bool) bool {
-	if node.Unhealthy || node.Cordoned || node.ScaleDownMarked || node.Suspect {
+	if node.Health.Quarantined() || node.Cordoned || node.ScaleDownMarked {
 		return false
 	}
 	if avoidSpot && node.Preemptible {

--- a/pkg/alfred/policy/defrag/scoring_test.go
+++ b/pkg/alfred/policy/defrag/scoring_test.go
@@ -168,6 +168,29 @@ func TestUnschedulableFreeCapacityIsAMirage(t *testing.T) {
 	almost(t, "Frag(8)", fragOf(t, cs, 8), 1.0)
 }
 
+func TestNodeSchedulableByHealthState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state snapshot.NodeHealthState
+		want  bool
+	}{
+		{name: "zero value", want: true},
+		{name: "clear", state: snapshot.NodeHealthClear, want: true},
+		{name: "suspect", state: snapshot.NodeHealthSuspect, want: false},
+		{name: "unknown", state: snapshot.NodeHealthUnknown, want: false},
+		{name: "unhealthy", state: snapshot.NodeHealthUnhealthy, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node := &snapshot.Node{Health: snapshot.NodeHealthObservation{State: test.state}}
+			if got := nodeSchedulable(node, false); got != test.want {
+				t.Errorf("nodeSchedulable() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 // pinScenario: node1 holds a movable-looking 1-GPU workload (7 free); node2
 // holds a 7-GPU immovable occupant (1 free). Consolidating the small pod
 // into node2's hole frees a full 8-GPU node — exactly what the repack must

--- a/pkg/alfred/snapshot/builder.go
+++ b/pkg/alfred/snapshot/builder.go
@@ -40,9 +40,12 @@ var DefaultTriggerConditions = []string{"GpuUnhealthy"}
 // Options configures a snapshot build. The zero value is usable: default
 // trigger conditions, no preemptible labels, workloads movable by default.
 type Options struct {
-	// TriggerConditions are the node condition types that mark a node
-	// Unhealthy (policies.nodeHealth.triggerConditions).
+	// TriggerConditions are failure-condition types whose True status marks a
+	// node unhealthy (policies.nodeHealth.triggerConditions).
 	TriggerConditions []string
+	// NodeSuspicionWindow keeps a recently cleared failure condition
+	// quarantined. Values <= 0 use DefaultNodeSuspicionWindow.
+	NodeSuspicionWindow time.Duration
 	// PreemptibleLabels are node-label keys whose presence (with any
 	// value but "false") marks a node spot/preemptible.
 	PreemptibleLabels []string
@@ -76,14 +79,22 @@ func (o *Options) now() time.Time {
 	return o.Now()
 }
 
+func (o *Options) nodeSuspicionWindow() time.Duration {
+	if o.NodeSuspicionWindow <= 0 {
+		return DefaultNodeSuspicionWindow
+	}
+	return o.NodeSuspicionWindow
+}
+
 // Build assembles a ClusterSnapshot from the cluster through a read-only
 // client. It never writes, and it degrades per-object rather than failing
 // wholesale wherever one broken object should not blind the caretaker (model
 // resolution); only the core lists (nodes, pods, InferenceServices) are
 // load-bearing enough to fail the build.
 func Build(ctx context.Context, r client.Reader, opts Options) (*ClusterSnapshot, error) {
+	timestamp := opts.now()
 	s := &ClusterSnapshot{
-		Timestamp:         opts.now(),
+		Timestamp:         timestamp,
 		Nodes:             map[string]*Node{},
 		Workloads:         map[types.NamespacedName]*Workload{},
 		Models:            map[ModelKey]*ModelAvailability{},
@@ -96,7 +107,7 @@ func Build(ctx context.Context, r client.Reader, opts Options) (*ClusterSnapshot
 	}
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
-		s.Nodes[node.Name] = buildNode(node, &opts)
+		s.Nodes[node.Name] = buildNode(node, &opts, timestamp)
 	}
 
 	var podList corev1.PodList
@@ -144,7 +155,7 @@ func Build(ctx context.Context, r client.Reader, opts Options) (*ClusterSnapshot
 	return s, nil
 }
 
-func buildNode(node *corev1.Node, opts *Options) *Node {
+func buildNode(node *corev1.Node, opts *Options, timestamp time.Time) *Node {
 	resource, total := NodeGPUAllocatable(node)
 	n := &Node{
 		Name:              node.Name,
@@ -167,20 +178,12 @@ func buildNode(node *corev1.Node, opts *Options) *Node {
 			break
 		}
 	}
-	triggers := opts.triggerConditions()
-	for _, cond := range node.Status.Conditions {
-		if cond.Status != corev1.ConditionTrue {
-			continue
-		}
-		for _, trigger := range triggers {
-			if string(cond.Type) == trigger {
-				n.Unhealthy = true
-				n.UnhealthyConditions = append(n.UnhealthyConditions, trigger)
-				break
-			}
-		}
-	}
-	sort.Strings(n.UnhealthyConditions)
+	n.Health = observeNodeHealth(
+		node.Status.Conditions,
+		opts.triggerConditions(),
+		timestamp,
+		opts.nodeSuspicionWindow(),
+	)
 	return n
 }
 

--- a/pkg/alfred/snapshot/builder_test.go
+++ b/pkg/alfred/snapshot/builder_test.go
@@ -308,7 +308,7 @@ func TestBuildNodeAccounting(t *testing.T) {
 	if node1.TotalGPUs != 8 || node1.AllocatedGPUs != 5 || node1.FreeGPUs != 3 {
 		t.Fatalf("node1 accounting: total=%d allocated=%d free=%d, want 8/5/3", node1.TotalGPUs, node1.AllocatedGPUs, node1.FreeGPUs)
 	}
-	if !node1.ScaleDownDisabled || node1.Cordoned || node1.Unhealthy {
+	if !node1.ScaleDownDisabled || node1.Cordoned || node1.Health.Quarantined() {
 		t.Fatalf("node1 flags: %+v", node1)
 	}
 	if len(node1.OMEPods) != 1 || len(node1.OtherOccupants) != 1 {
@@ -322,13 +322,96 @@ func TestBuildNodeAccounting(t *testing.T) {
 	if node2.AllocatedGPUs != 3 || node2.FreeGPUs != 5 || node2.TerminatingGPUs != 2 {
 		t.Fatalf("node2 accounting: allocated=%d free=%d terminating=%d, want 3/5/2", node2.AllocatedGPUs, node2.FreeGPUs, node2.TerminatingGPUs)
 	}
-	if !node2.Unhealthy || len(node2.UnhealthyConditions) != 1 || node2.UnhealthyConditions[0] != "GpuUnhealthy" {
+	if node2.Health.State != NodeHealthUnhealthy || len(node2.Health.Conditions) != 1 ||
+		node2.Health.Conditions[0].Type != "GpuUnhealthy" ||
+		node2.Health.Conditions[0].Status != corev1.ConditionTrue {
 		t.Fatalf("node2 health: %+v", node2)
 	}
 
 	node3 := snap.Nodes["node3"]
 	if !node3.Cordoned || !node3.ScaleDownMarked || !node3.Preemptible {
 		t.Fatalf("node3 flags: %+v", node3)
+	}
+}
+
+func TestBuildReconstructsNodeHealthWithDefaultWindow(t *testing.T) {
+	recent := buildNow.Add(-10 * time.Minute)
+	expired := buildNow.Add(-DefaultNodeSuspicionWindow)
+	recentNode := gpuNode("recent", "8", func(node *corev1.Node) {
+		node.Status.Conditions = []corev1.NodeCondition{{
+			Type:               "GpuUnhealthy",
+			Status:             corev1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(recent),
+		}}
+	})
+	expiredNode := gpuNode("expired", "8", func(node *corev1.Node) {
+		node.Status.Conditions = []corev1.NodeCondition{{
+			Type:               "GpuUnhealthy",
+			Status:             corev1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(expired),
+		}}
+	})
+	unknownNode := gpuNode("unknown", "8", func(node *corev1.Node) {
+		node.Status.Conditions = []corev1.NodeCondition{{
+			Type:               "GpuUnhealthy",
+			Status:             corev1.ConditionUnknown,
+			LastTransitionTime: metav1.NewTime(recent),
+		}}
+	})
+	reader := fake.NewClientBuilder().WithScheme(testScheme(t)).
+		WithObjects(recentNode, expiredNode, unknownNode).Build()
+
+	snap, err := Build(context.Background(), reader, Options{Now: func() time.Time { return buildNow }})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	wantUntil := recent.Add(DefaultNodeSuspicionWindow)
+	if got := snap.Nodes["recent"].Health; got.State != NodeHealthSuspect ||
+		got.SuspectUntil == nil || !got.SuspectUntil.Equal(wantUntil) {
+		t.Fatalf("recent health = %+v, want Suspect until %v", got, wantUntil)
+	}
+	if got := snap.Nodes["expired"].Health; got.State != NodeHealthClear || got.SuspectUntil != nil {
+		t.Fatalf("expired health = %+v, want Clear", got)
+	}
+	if got := snap.Nodes["unknown"].Health; got.State != NodeHealthUnknown || !got.Quarantined() {
+		t.Fatalf("unknown health = %+v, want quarantined Unknown", got)
+	}
+}
+
+func TestBuildUsesOneTimestampForNodeHealth(t *testing.T) {
+	transitioned := buildNow.Add(-4 * time.Minute)
+	node1 := gpuNode("node1", "8", func(node *corev1.Node) {
+		node.Status.Conditions = []corev1.NodeCondition{{
+			Type:               "GpuUnhealthy",
+			Status:             corev1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(transitioned),
+		}}
+	})
+	node2 := node1.DeepCopy()
+	node2.Name = "node2"
+	reader := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(node1, node2).Build()
+
+	clockReads := 0
+	snap, err := Build(context.Background(), reader, Options{
+		NodeSuspicionWindow: 5 * time.Minute,
+		Now: func() time.Time {
+			clockReads++
+			return buildNow.Add(time.Duration(clockReads-1) * 10 * time.Minute)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if clockReads != 1 {
+		t.Fatalf("Now calls = %d, want 1", clockReads)
+	}
+	if !snap.Timestamp.Equal(buildNow) {
+		t.Fatalf("Timestamp = %v, want %v", snap.Timestamp, buildNow)
+	}
+	for _, name := range []string{"node1", "node2"} {
+		if got := snap.Nodes[name].Health.State; got != NodeHealthSuspect {
+			t.Errorf("%s health = %q, want %q", name, got, NodeHealthSuspect)
+		}
 	}
 }
 

--- a/pkg/alfred/snapshot/node_health.go
+++ b/pkg/alfred/snapshot/node_health.go
@@ -1,0 +1,88 @@
+package snapshot
+
+import (
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DefaultNodeSuspicionWindow is the recovery-quarantine window used by a
+// zero-valued snapshot Options. Alfred's production config has the same safe
+// default and passes its validated value explicitly.
+const DefaultNodeSuspicionWindow = 30 * time.Minute
+
+// Quarantined reports whether a node must be excluded from placement targets.
+// The zero value is clear for synthetic-snapshot compatibility; unrecognized
+// future states fail closed.
+func (h NodeHealthObservation) Quarantined() bool {
+	return h.State != "" && h.State != NodeHealthClear
+}
+
+func observeNodeHealth(
+	conditions []corev1.NodeCondition,
+	triggerConditions []string,
+	now time.Time,
+	suspicionWindow time.Duration,
+) NodeHealthObservation {
+	result := NodeHealthObservation{State: NodeHealthClear}
+	configured := make(map[corev1.NodeConditionType]struct{}, len(triggerConditions))
+	for _, conditionType := range triggerConditions {
+		configured[corev1.NodeConditionType(conditionType)] = struct{}{}
+	}
+
+	var unhealthy bool
+	var unknown bool
+	var suspectUntil *time.Time
+	for _, condition := range conditions {
+		if _, ok := configured[condition.Type]; !ok {
+			continue
+		}
+		transitioned := condition.LastTransitionTime.Time
+		result.Conditions = append(result.Conditions, NodeConditionObservation{
+			Type:               condition.Type,
+			Status:             condition.Status,
+			LastTransitionTime: transitioned,
+		})
+
+		switch condition.Status {
+		case corev1.ConditionTrue:
+			unhealthy = true
+		case corev1.ConditionUnknown:
+			unknown = true
+		case corev1.ConditionFalse:
+			if transitioned.IsZero() {
+				unknown = true
+				continue
+			}
+			deadline := transitioned.Add(suspicionWindow)
+			if now.Before(deadline) && (suspectUntil == nil || deadline.After(*suspectUntil)) {
+				suspectUntil = &deadline
+			}
+		default:
+			unknown = true
+		}
+	}
+
+	sort.Slice(result.Conditions, func(i, j int) bool {
+		left, right := result.Conditions[i], result.Conditions[j]
+		if left.Type != right.Type {
+			return left.Type < right.Type
+		}
+		if left.Status != right.Status {
+			return left.Status < right.Status
+		}
+		return left.LastTransitionTime.Before(right.LastTransitionTime)
+	})
+
+	switch {
+	case unhealthy:
+		result.State = NodeHealthUnhealthy
+	case unknown:
+		result.State = NodeHealthUnknown
+	case suspectUntil != nil:
+		result.State = NodeHealthSuspect
+		result.SuspectUntil = suspectUntil
+	}
+	return result
+}

--- a/pkg/alfred/snapshot/node_health_test.go
+++ b/pkg/alfred/snapshot/node_health_test.go
@@ -1,0 +1,227 @@
+package snapshot
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestObserveNodeHealth(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	window := 30 * time.Minute
+	recent := now.Add(-10 * time.Minute)
+	older := now.Add(-20 * time.Minute)
+	expired := now.Add(-window)
+	longExpired := expired.Add(-time.Nanosecond)
+	future := now.Add(5 * time.Minute)
+	zero := time.Time{}
+
+	condition := func(conditionType string, status corev1.ConditionStatus, transitioned time.Time) corev1.NodeCondition {
+		return corev1.NodeCondition{
+			Type:               corev1.NodeConditionType(conditionType),
+			Status:             status,
+			LastTransitionTime: metav1.NewTime(transitioned),
+		}
+	}
+	observation := func(conditionType string, status corev1.ConditionStatus, transitioned time.Time) NodeConditionObservation {
+		return NodeConditionObservation{
+			Type:               corev1.NodeConditionType(conditionType),
+			Status:             status,
+			LastTransitionTime: transitioned,
+		}
+	}
+	timePtr := func(value time.Time) *time.Time { return &value }
+
+	tests := []struct {
+		name       string
+		conditions []corev1.NodeCondition
+		triggers   []string
+		wantState  NodeHealthState
+		wantUntil  *time.Time
+		wantRows   []NodeConditionObservation
+	}{
+		{
+			name: "no configured condition is clear",
+			conditions: []corev1.NodeCondition{
+				condition("Unrelated", corev1.ConditionTrue, recent),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthClear,
+		},
+		{
+			name: "true is unhealthy",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionTrue, recent),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthUnhealthy,
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionTrue, recent),
+			},
+		},
+		{
+			name: "unknown is quarantined without becoming unhealthy",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionUnknown, recent),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthUnknown,
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionUnknown, recent),
+			},
+		},
+		{
+			name: "unrecognized status fails closed as unknown",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionStatus("Invalid"), recent),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthUnknown,
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionStatus("Invalid"), recent),
+			},
+		},
+		{
+			name: "recent false is suspect",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionFalse, recent),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthSuspect,
+			wantUntil: timePtr(recent.Add(window)),
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionFalse, recent),
+			},
+		},
+		{
+			name: "exact expiry is clear",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionFalse, expired),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthClear,
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionFalse, expired),
+			},
+		},
+		{
+			name: "older false is clear",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionFalse, longExpired),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthClear,
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionFalse, longExpired),
+			},
+		},
+		{
+			name: "zero transition fails closed as unknown",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionFalse, zero),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthUnknown,
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionFalse, zero),
+			},
+		},
+		{
+			name: "future false remains quarantined",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionFalse, future),
+			},
+			triggers:  []string{"GpuUnhealthy"},
+			wantState: NodeHealthSuspect,
+			wantUntil: timePtr(future.Add(window)),
+			wantRows: []NodeConditionObservation{
+				observation("GpuUnhealthy", corev1.ConditionFalse, future),
+			},
+		},
+		{
+			name: "true wins and observations are sorted",
+			conditions: []corev1.NodeCondition{
+				condition("ZFailure", corev1.ConditionFalse, recent),
+				condition("BFailure", corev1.ConditionTrue, older),
+				condition("AFailure", corev1.ConditionUnknown, recent),
+			},
+			triggers:  []string{"ZFailure", "BFailure", "AFailure"},
+			wantState: NodeHealthUnhealthy,
+			wantRows: []NodeConditionObservation{
+				observation("AFailure", corev1.ConditionUnknown, recent),
+				observation("BFailure", corev1.ConditionTrue, older),
+				observation("ZFailure", corev1.ConditionFalse, recent),
+			},
+		},
+		{
+			name: "unknown wins over recent false",
+			conditions: []corev1.NodeCondition{
+				condition("GpuUnhealthy", corev1.ConditionFalse, recent),
+				condition("GpuReady", corev1.ConditionUnknown, older),
+			},
+			triggers:  []string{"GpuUnhealthy", "GpuReady"},
+			wantState: NodeHealthUnknown,
+			wantRows: []NodeConditionObservation{
+				observation("GpuReady", corev1.ConditionUnknown, older),
+				observation("GpuUnhealthy", corev1.ConditionFalse, recent),
+			},
+		},
+		{
+			name: "latest false deadline wins",
+			conditions: []corev1.NodeCondition{
+				condition("ZFailure", corev1.ConditionFalse, recent),
+				condition("AFailure", corev1.ConditionFalse, older),
+			},
+			triggers:  []string{"ZFailure", "AFailure"},
+			wantState: NodeHealthSuspect,
+			wantUntil: timePtr(recent.Add(window)),
+			wantRows: []NodeConditionObservation{
+				observation("AFailure", corev1.ConditionFalse, older),
+				observation("ZFailure", corev1.ConditionFalse, recent),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := observeNodeHealth(test.conditions, test.triggers, now, window)
+			if got.State != test.wantState {
+				t.Errorf("State = %q, want %q", got.State, test.wantState)
+			}
+			if !reflect.DeepEqual(got.Conditions, test.wantRows) {
+				t.Errorf("Conditions = %+v, want %+v", got.Conditions, test.wantRows)
+			}
+			if !reflect.DeepEqual(got.SuspectUntil, test.wantUntil) {
+				t.Errorf("SuspectUntil = %v, want %v", got.SuspectUntil, test.wantUntil)
+			}
+		})
+	}
+}
+
+func TestNodeHealthObservationQuarantined(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state NodeHealthState
+		want  bool
+	}{
+		{state: "", want: false},
+		{state: NodeHealthClear, want: false},
+		{state: NodeHealthSuspect, want: true},
+		{state: NodeHealthUnknown, want: true},
+		{state: NodeHealthUnhealthy, want: true},
+		{state: NodeHealthState("FutureState"), want: true},
+	}
+
+	for _, test := range tests {
+		if got := (NodeHealthObservation{State: test.state}).Quarantined(); got != test.want {
+			t.Errorf("state %q Quarantined() = %t, want %t", test.state, got, test.want)
+		}
+	}
+}

--- a/pkg/alfred/snapshot/types.go
+++ b/pkg/alfred/snapshot/types.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -51,6 +52,43 @@ type OMENativeExecutorState struct {
 	Reason      string
 }
 
+// NodeHealthState is Alfred's placement-safety view of configured node
+// failure conditions.
+type NodeHealthState string
+
+const (
+	// NodeHealthClear means no configured condition currently quarantines the
+	// node.
+	NodeHealthClear NodeHealthState = "Clear"
+	// NodeHealthSuspect means a configured failure condition recently cleared,
+	// but its recovery-quarantine window has not elapsed.
+	NodeHealthSuspect NodeHealthState = "Suspect"
+	// NodeHealthUnknown means configured health evidence is inconclusive or
+	// malformed. The node is quarantined as a target but is not known unhealthy.
+	NodeHealthUnknown NodeHealthState = "Unknown"
+	// NodeHealthUnhealthy means at least one configured failure condition is
+	// currently True.
+	NodeHealthUnhealthy NodeHealthState = "Unhealthy"
+)
+
+// NodeHealthObservation is the reconstructible health state for one snapshot.
+// Conditions contains only configured failure conditions from the current Node
+// object; Alfred retains no cross-snapshot health history here.
+type NodeHealthObservation struct {
+	State      NodeHealthState
+	Conditions []NodeConditionObservation
+	// SuspectUntil is non-nil only while State is NodeHealthSuspect.
+	SuspectUntil *time.Time
+}
+
+// NodeConditionObservation retains the current status and transition time of
+// one configured failure condition.
+type NodeConditionObservation struct {
+	Type               corev1.NodeConditionType
+	Status             corev1.ConditionStatus
+	LastTransitionTime time.Time
+}
+
 // Node is one node's physical GPU state plus the placement-relevant flags
 // policies filter on.
 type Node struct {
@@ -84,11 +122,9 @@ type Node struct {
 	// treated as free yet.
 	TerminatingGPUs int64
 
-	// Unhealthy is set when any configured trigger condition (default
-	// GpuUnhealthy) is True on the node.
-	Unhealthy bool
-	// UnhealthyConditions lists which trigger conditions were True.
-	UnhealthyConditions []string
+	// Health is derived from configured failure conditions and their transition
+	// times. Quarantined states must not be used as placement targets.
+	Health NodeHealthObservation
 	// Cordoned mirrors spec.unschedulable.
 	Cordoned bool
 	// ScaleDownDisabled mirrors the cluster-autoscaler
@@ -100,12 +136,6 @@ type Node struct {
 	// Preemptible is set when the node matches a configured
 	// spot/preemptible label.
 	Preemptible bool
-	// Suspect is set by the engine for nodes inside their post-evacuation
-	// suspicion window; such nodes are excluded from every policy's
-	// target hints even after the health condition clears. The builder
-	// always leaves it false.
-	Suspect bool
-
 	// OMEPods are the OME-managed GPU pods bound to this node.
 	OMEPods []PodInfo
 	// OtherOccupants are non-OME GPU pods (notebooks, batch jobs, ...):

--- a/pkg/alfred/testutil/builder.go
+++ b/pkg/alfred/testutil/builder.go
@@ -54,7 +54,7 @@ func NodeUnhealthy(conditions ...string) NodeOption {
 	}
 	sort.Strings(conditionTypes)
 	return func(n *snapshot.Node) {
-		n.Health.State = snapshot.NodeHealthUnhealthy
+		n.Health = snapshot.NodeHealthObservation{State: snapshot.NodeHealthUnhealthy}
 		for _, conditionType := range conditionTypes {
 			n.Health.Conditions = append(n.Health.Conditions, snapshot.NodeConditionObservation{
 				Type:               corev1.NodeConditionType(conditionType),

--- a/pkg/alfred/testutil/builder.go
+++ b/pkg/alfred/testutil/builder.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -47,12 +48,34 @@ type NodeOption func(*snapshot.Node)
 // NodeUnhealthy marks the node unhealthy with the given trigger conditions
 // (GpuUnhealthy when none given).
 func NodeUnhealthy(conditions ...string) NodeOption {
+	conditionTypes := append([]string(nil), conditions...)
+	if len(conditionTypes) == 0 {
+		conditionTypes = []string{"GpuUnhealthy"}
+	}
+	sort.Strings(conditionTypes)
 	return func(n *snapshot.Node) {
-		n.Unhealthy = true
-		if len(conditions) == 0 {
-			conditions = []string{"GpuUnhealthy"}
+		n.Health.State = snapshot.NodeHealthUnhealthy
+		for _, conditionType := range conditionTypes {
+			n.Health.Conditions = append(n.Health.Conditions, snapshot.NodeConditionObservation{
+				Type:               corev1.NodeConditionType(conditionType),
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: ReferenceTime,
+			})
 		}
-		n.UnhealthyConditions = append(n.UnhealthyConditions, conditions...)
+	}
+}
+
+// NodeUnknown marks the node's configured health evidence inconclusive.
+func NodeUnknown() NodeOption {
+	return func(n *snapshot.Node) {
+		n.Health = snapshot.NodeHealthObservation{
+			State: snapshot.NodeHealthUnknown,
+			Conditions: []snapshot.NodeConditionObservation{{
+				Type:               "GpuUnhealthy",
+				Status:             corev1.ConditionUnknown,
+				LastTransitionTime: ReferenceTime,
+			}},
+		}
 	}
 }
 
@@ -68,8 +91,21 @@ func NodeScaleDownDisabled() NodeOption { return func(n *snapshot.Node) { n.Scal
 // NodeScaleDownMarked sets the CA to-be-deleted flag.
 func NodeScaleDownMarked() NodeOption { return func(n *snapshot.Node) { n.ScaleDownMarked = true } }
 
-// NodeSuspect puts the node inside a suspicion window.
-func NodeSuspect() NodeOption { return func(n *snapshot.Node) { n.Suspect = true } }
+// NodeSuspect puts the node inside a recovery-quarantine window.
+func NodeSuspect() NodeOption {
+	return func(n *snapshot.Node) {
+		until := ReferenceTime.Add(snapshot.DefaultNodeSuspicionWindow)
+		n.Health = snapshot.NodeHealthObservation{
+			State: snapshot.NodeHealthSuspect,
+			Conditions: []snapshot.NodeConditionObservation{{
+				Type:               "GpuUnhealthy",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: ReferenceTime,
+			}},
+			SuspectUntil: &until,
+		}
+	}
+}
 
 // NodeLabels merges labels onto the node.
 func NodeLabels(labels map[string]string) NodeOption {

--- a/pkg/alfred/testutil/builder_test.go
+++ b/pkg/alfred/testutil/builder_test.go
@@ -83,6 +83,20 @@ func TestSnapshotBuilder(t *testing.T) {
 	}
 }
 
+func TestNodeUnhealthyReplacesPriorHealthObservation(t *testing.T) {
+	snap := NewSnapshot().
+		WithNode("node1", "h100", 8, NodeSuspect(), NodeUnhealthy()).
+		Build()
+
+	got := snap.Nodes["node1"].Health
+	if got.State != snapshot.NodeHealthUnhealthy || got.SuspectUntil != nil ||
+		len(got.Conditions) != 1 || got.Conditions[0].Type != "GpuUnhealthy" ||
+		got.Conditions[0].Status != corev1.ConditionTrue ||
+		!got.Conditions[0].LastTransitionTime.Equal(ReferenceTime) {
+		t.Fatalf("composed health = %+v, want a fresh unhealthy observation", got)
+	}
+}
+
 func TestSnapshotBuilderStructuredExecutorAndInvalidObservation(t *testing.T) {
 	renewed := ReferenceTime.Add(-time.Minute)
 	snap := NewSnapshot().

--- a/pkg/alfred/testutil/builder_test.go
+++ b/pkg/alfred/testutil/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/ome/pkg/alfred/snapshot"
@@ -16,6 +17,8 @@ func TestSnapshotBuilder(t *testing.T) {
 		WithNode("node1", "h100", 8).
 		WithNode("node2", "h100", 8, NodeUnhealthy()).
 		WithNode("node3", "a100", 4, NodeCordoned(), NodePreemptible()).
+		WithNode("node4", "h100", 8, NodeUnknown()).
+		WithNode("node5", "h100", 8, NodeSuspect()).
 		WithInstance("prod/svc-a", v1beta1.EngineComponent, constants.RawDeployment, "node1", 2).
 		WithMultiPodInstance("prod/svc-b", v1beta1.EngineComponent, constants.OMENative, 8, "node1", "node2").
 		WithOtherOccupant("node2", 3).
@@ -28,11 +31,24 @@ func TestSnapshotBuilder(t *testing.T) {
 		t.Fatalf("node1: allocated=%d free=%d, want 10/0 (floored)", node1.AllocatedGPUs, node1.FreeGPUs)
 	}
 	node2 := snap.Nodes["node2"]
-	if node2.AllocatedGPUs != 11 || node2.FreeGPUs != 0 || !node2.Unhealthy {
+	if node2.AllocatedGPUs != 11 || node2.FreeGPUs != 0 || node2.Health.State != snapshot.NodeHealthUnhealthy {
 		t.Fatalf("node2: %+v", node2)
 	}
 	if !snap.Nodes["node3"].Cordoned || !snap.Nodes["node3"].Preemptible {
 		t.Fatalf("node3 flags: %+v", snap.Nodes["node3"])
+	}
+	if got := snap.Nodes["node4"].Health; got.State != snapshot.NodeHealthUnknown || !got.Quarantined() ||
+		len(got.Conditions) != 1 || got.Conditions[0].Type != "GpuUnhealthy" ||
+		got.Conditions[0].Status != corev1.ConditionUnknown ||
+		!got.Conditions[0].LastTransitionTime.Equal(ReferenceTime) {
+		t.Fatalf("node4 health: %+v", got)
+	}
+	if got := snap.Nodes["node5"].Health; got.State != snapshot.NodeHealthSuspect ||
+		got.SuspectUntil == nil || !got.SuspectUntil.Equal(ReferenceTime.Add(snapshot.DefaultNodeSuspicionWindow)) ||
+		!got.Quarantined() || len(got.Conditions) != 1 ||
+		got.Conditions[0].Type != "GpuUnhealthy" || got.Conditions[0].Status != corev1.ConditionFalse ||
+		!got.Conditions[0].LastTransitionTime.Equal(ReferenceTime) {
+		t.Fatalf("node5 health: %+v", got)
 	}
 
 	svcA := snap.Workloads[types.NamespacedName{Namespace: "prod", Name: "svc-a"}]


### PR DESCRIPTION
## Summary

- replace Alfred's node-health booleans with one structured snapshot observation
- reconstruct `Clear`, `Suspect`, `Unknown`, and `Unhealthy` from configured Node conditions using one snapshot timestamp
- retain configured condition status and transition time with fail-closed precedence
- exclude every non-clear state from defrag targets and observed surge headroom
- wire hot-reloaded trigger conditions and recovery-suspicion windows into snapshot construction
- update OEP-0008 to distinguish recovery quarantine from future evacuation behavior

## Safety boundary

This is the observation and target-safety foundation for Node-Health Policy #2. It does not generate evacuation candidates or remediation signals, dispatch migrations, write Nodes, change the workload package, or create a migration package.

Stacked on #828 (`alfred/node-health-refresh`).

## Verification

- `go test ./pkg/alfred/... ./cmd/alfred/... -count=1`
- `go test -race ./pkg/alfred/snapshot ./pkg/alfred/observer ./pkg/alfred/policy/defrag ./pkg/alfred/testutil -count=1`
- `go vet ./pkg/alfred/... ./cmd/alfred/...`
- repository-wide pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured node-health states: clear, suspect, unknown, and unhealthy.
  * Added recovery-based suspicion windows for temporarily failed conditions.
  * Non-clear nodes are quarantined from placement and surge-headroom calculations.
  * Only unhealthy nodes qualify for evacuation.
  * Added configurable node suspicion-window support with a default value.

* **Bug Fixes**
  * Node health evaluations now use consistent timestamps and condition severity.
  * Invalid or missing transition times fail closed as unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->