### PR TITLE
[Core] Index runtime inference users

### DIFF
--- a/pkg/cli/runtimeusage/index.go
+++ b/pkg/cli/runtimeusage/index.go
@@ -1,0 +1,287 @@
+// Package runtimeusage indexes explicit runtime references from an
+// already-collected InferenceService snapshot. It performs no cluster reads
+// and keeps references that cannot be attributed as bounded evidence.
+package runtimeusage
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/runtimegraph"
+)
+
+// InferenceServiceIdentity uniquely identifies an InferenceService in a
+// cluster snapshot.
+type InferenceServiceIdentity struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// ReferenceState classifies whether one InferenceService can be attributed to
+// exactly one explicitly referenced runtime.
+type ReferenceState string
+
+const (
+	// ReferenceResolved means the declared reference has one complete runtime
+	// identity.
+	ReferenceResolved ReferenceState = "Resolved"
+	// ReferenceUnresolved means the service cannot be attributed to one runtime,
+	// either because it requests automatic selection or because its declared
+	// runtime was not present in the supplied snapshot.
+	ReferenceUnresolved ReferenceState = "Unresolved"
+	// ReferenceInvalid means the object or declared reference is malformed.
+	ReferenceInvalid ReferenceState = "Invalid"
+	// ReferenceAmbiguous means a snapshot repeats an InferenceService identity,
+	// so none of the competing observations can be treated as current.
+	ReferenceAmbiguous ReferenceState = "Ambiguous"
+)
+
+// ReferenceReason is a bounded explanation for a non-resolved reference.
+type ReferenceReason string
+
+const (
+	ReasonAutomaticSelection        ReferenceReason = "AutomaticSelection"
+	ReasonInvalidRuntimeName        ReferenceReason = "InvalidRuntimeName"
+	ReasonInvalidKind               ReferenceReason = "InvalidKind"
+	ReasonInvalidAPIGroup           ReferenceReason = "InvalidAPIGroup"
+	ReasonInvalidInferenceService   ReferenceReason = "InvalidInferenceService"
+	ReasonDuplicateInferenceService ReferenceReason = "DuplicateInferenceService"
+	ReasonRuntimeNotFound           ReferenceReason = "RuntimeNotFound"
+)
+
+// ReferenceEvidence is a safe, immutable-by-value observation of one service
+// reference. Runtime is present only when State is Resolved. Occurrences is
+// greater than one only for an ambiguous duplicate identity.
+type ReferenceEvidence struct {
+	InferenceService InferenceServiceIdentity `json:"inferenceService"`
+	State            ReferenceState           `json:"state"`
+	RuntimeName      string                   `json:"runtimeName,omitempty"`
+	Runtime          *runtimegraph.Identity   `json:"runtime,omitempty"`
+	Reason           ReferenceReason          `json:"reason,omitempty"`
+	Occurrences      int                      `json:"occurrences"`
+}
+
+// Projection contains the explicit InferenceService users of one runtime.
+type Projection struct {
+	Runtime           runtimegraph.Identity      `json:"runtime"`
+	InferenceServices []InferenceServiceIdentity `json:"inferenceServices"`
+}
+
+// ErrInvalidRuntimeIdentity indicates that a query is not one complete
+// ServingRuntime or ClusterServingRuntime identity.
+var ErrInvalidRuntimeIdentity = errors.New("runtime identity is invalid")
+
+// Index is an immutable index over an InferenceService snapshot.
+type Index struct {
+	users      map[runtimegraph.Identity][]InferenceServiceIdentity
+	references []ReferenceEvidence
+}
+
+// Build indexes explicit references against an already-collected runtime
+// snapshot without mutating or retaining either input. Duplicate and malformed
+// services remain visible through References but are never silently attributed
+// to a runtime. Nil and ClusterServingRuntime kinds resolve cluster-first with
+// a same-namespace ServingRuntime fallback, matching the API's defaulted
+// reference semantics. ServingRuntime kinds resolve only in the service's
+// namespace.
+func Build(services []omev1beta1.InferenceService, snapshot runtimegraph.Snapshot) *Index {
+	runtimes := runtimeIdentitySet(snapshot)
+	counts := make(map[InferenceServiceIdentity]int, len(services))
+	for i := range services {
+		identity := serviceIdentity(&services[i])
+		if validServiceIdentity(identity) {
+			counts[identity]++
+		}
+	}
+
+	index := &Index{
+		users:      make(map[runtimegraph.Identity][]InferenceServiceIdentity),
+		references: make([]ReferenceEvidence, 0, len(services)),
+	}
+	ambiguous := make(map[InferenceServiceIdentity]struct{})
+	for i := range services {
+		service := &services[i]
+		identity := serviceIdentity(service)
+		if !validServiceIdentity(identity) {
+			index.references = append(index.references, ReferenceEvidence{
+				InferenceService: identity,
+				State:            ReferenceInvalid,
+				Reason:           ReasonInvalidInferenceService,
+				Occurrences:      1,
+			})
+			continue
+		}
+		if counts[identity] > 1 {
+			if _, emitted := ambiguous[identity]; emitted {
+				continue
+			}
+			ambiguous[identity] = struct{}{}
+			index.references = append(index.references, ReferenceEvidence{
+				InferenceService: identity,
+				State:            ReferenceAmbiguous,
+				Reason:           ReasonDuplicateInferenceService,
+				Occurrences:      counts[identity],
+			})
+			continue
+		}
+
+		evidence := classifyReference(identity, service.Spec.Runtime, runtimes)
+		index.references = append(index.references, evidence)
+		if evidence.State == ReferenceResolved {
+			index.users[*evidence.Runtime] = append(index.users[*evidence.Runtime], identity)
+		}
+	}
+
+	for runtime := range index.users {
+		sort.Slice(index.users[runtime], func(i, j int) bool {
+			return serviceIdentityLess(index.users[runtime][i], index.users[runtime][j])
+		})
+	}
+	sort.Slice(index.references, func(i, j int) bool {
+		return serviceIdentityLess(
+			index.references[i].InferenceService,
+			index.references[j].InferenceService,
+		)
+	})
+	return index
+}
+
+// ForRuntime returns a defensive copy of every service that explicitly
+// references runtime. A valid runtime with no users returns an empty slice.
+func (i *Index) ForRuntime(runtime runtimegraph.Identity) (Projection, error) {
+	if err := validateRuntimeIdentity(runtime); err != nil {
+		return Projection{}, err
+	}
+	services := make([]InferenceServiceIdentity, len(i.users[runtime]))
+	copy(services, i.users[runtime])
+	return Projection{Runtime: runtime, InferenceServices: services}, nil
+}
+
+// References returns a defensive copy of every normalized reference
+// observation, including unresolved, invalid, and ambiguous evidence.
+func (i *Index) References() []ReferenceEvidence {
+	result := make([]ReferenceEvidence, len(i.references))
+	for index, evidence := range i.references {
+		result[index] = evidence
+		if evidence.Runtime != nil {
+			runtime := *evidence.Runtime
+			result[index].Runtime = &runtime
+		}
+	}
+	return result
+}
+
+func classifyReference(
+	identity InferenceServiceIdentity,
+	reference *omev1beta1.ServingRuntimeRef,
+	runtimes map[runtimegraph.Identity]struct{},
+) ReferenceEvidence {
+	evidence := ReferenceEvidence{InferenceService: identity, Occurrences: 1}
+	if reference == nil {
+		evidence.State = ReferenceUnresolved
+		evidence.Reason = ReasonAutomaticSelection
+		return evidence
+	}
+	if reference.Name == "" {
+		evidence.State = ReferenceInvalid
+		evidence.Reason = ReasonInvalidRuntimeName
+		return evidence
+	}
+	evidence.RuntimeName = reference.Name
+
+	kind := runtimegraph.KindClusterServingRuntime
+	if reference.Kind != nil {
+		kind = runtimegraph.Kind(*reference.Kind)
+		if kind != runtimegraph.KindClusterServingRuntime && kind != runtimegraph.KindServingRuntime {
+			evidence.State = ReferenceInvalid
+			evidence.Reason = ReasonInvalidKind
+			return evidence
+		}
+	}
+	apiGroup := omev1beta1.SchemeGroupVersion.Group
+	if reference.APIGroup != nil {
+		apiGroup = *reference.APIGroup
+	}
+	if apiGroup != omev1beta1.SchemeGroupVersion.Group {
+		evidence.State = ReferenceInvalid
+		evidence.Reason = ReasonInvalidAPIGroup
+		return evidence
+	}
+
+	cluster := runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Name: reference.Name}
+	local := runtimegraph.Identity{
+		Kind: runtimegraph.KindServingRuntime, Namespace: identity.Namespace, Name: reference.Name,
+	}
+	var runtime runtimegraph.Identity
+	if kind == runtimegraph.KindServingRuntime {
+		if _, exists := runtimes[local]; exists {
+			runtime = local
+		}
+	} else if _, exists := runtimes[cluster]; exists {
+		runtime = cluster
+	} else if _, exists := runtimes[local]; exists {
+		runtime = local
+	}
+	if runtime.Name == "" {
+		evidence.State = ReferenceUnresolved
+		evidence.Reason = ReasonRuntimeNotFound
+		return evidence
+	}
+	evidence.State = ReferenceResolved
+	evidence.Runtime = &runtime
+	return evidence
+}
+
+func runtimeIdentitySet(snapshot runtimegraph.Snapshot) map[runtimegraph.Identity]struct{} {
+	runtimes := make(map[runtimegraph.Identity]struct{},
+		len(snapshot.ClusterServingRuntimes)+len(snapshot.ServingRuntimes))
+	for i := range snapshot.ClusterServingRuntimes {
+		runtimes[runtimegraph.Identity{
+			Kind: runtimegraph.KindClusterServingRuntime,
+			Name: snapshot.ClusterServingRuntimes[i].Name,
+		}] = struct{}{}
+	}
+	for i := range snapshot.ServingRuntimes {
+		runtime := &snapshot.ServingRuntimes[i]
+		runtimes[runtimegraph.Identity{
+			Kind: runtimegraph.KindServingRuntime, Namespace: runtime.Namespace, Name: runtime.Name,
+		}] = struct{}{}
+	}
+	return runtimes
+}
+
+func serviceIdentity(service *omev1beta1.InferenceService) InferenceServiceIdentity {
+	return InferenceServiceIdentity{Namespace: service.Namespace, Name: service.Name}
+}
+
+func validServiceIdentity(identity InferenceServiceIdentity) bool {
+	return identity.Namespace != "" && identity.Name != ""
+}
+
+func validateRuntimeIdentity(identity runtimegraph.Identity) error {
+	if identity.Name == "" {
+		return fmt.Errorf("%w: name is required", ErrInvalidRuntimeIdentity)
+	}
+	switch identity.Kind {
+	case runtimegraph.KindServingRuntime:
+		if identity.Namespace == "" {
+			return fmt.Errorf("%w: namespace is required for ServingRuntime", ErrInvalidRuntimeIdentity)
+		}
+	case runtimegraph.KindClusterServingRuntime:
+		if identity.Namespace != "" {
+			return fmt.Errorf("%w: namespace is forbidden for ClusterServingRuntime", ErrInvalidRuntimeIdentity)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported kind %q", ErrInvalidRuntimeIdentity, identity.Kind)
+	}
+	return nil
+}
+
+func serviceIdentityLess(left, right InferenceServiceIdentity) bool {
+	if left.Namespace != right.Namespace {
+		return left.Namespace < right.Namespace
+	}
+	return left.Name < right.Name
+}

--- a/pkg/cli/runtimeusage/index_test.go
+++ b/pkg/cli/runtimeusage/index_test.go
@@ -1,0 +1,453 @@
+package runtimeusage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/runtimegraph"
+)
+
+func TestBuildDefaultsNilAndClusterKindsToClusterFirstOnCollision(t *testing.T) {
+	clusterKind := string(runtimegraph.KindClusterServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "default-kind", runtimeReference("shared", nil, nil)),
+		inferenceService("team-a", "explicit-cluster-kind", runtimeReference("shared", &clusterKind, nil)),
+	}, runtimegraph.Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{{
+			ObjectMeta: metav1.ObjectMeta{Name: "shared"},
+		}},
+		ServingRuntimes: []omev1beta1.ServingRuntime{{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "shared"},
+		}},
+	})
+
+	cluster, err := index.ForRuntime(runtimegraph.Identity{
+		Kind: runtimegraph.KindClusterServingRuntime,
+		Name: "shared",
+	})
+	require.NoError(t, err)
+	local, err := index.ForRuntime(runtimegraph.Identity{
+		Kind:      runtimegraph.KindServingRuntime,
+		Namespace: "team-a",
+		Name:      "shared",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []InferenceServiceIdentity{
+		{Namespace: "team-a", Name: "default-kind"},
+		{Namespace: "team-a", Name: "explicit-cluster-kind"},
+	}, cluster.InferenceServices)
+	assert.Empty(t, local.InferenceServices)
+}
+
+func TestBuildFallsBackFromNilAndClusterKindsToNamespacedRuntime(t *testing.T) {
+	clusterKind := string(runtimegraph.KindClusterServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "default-kind", runtimeReference("local-only", nil, nil)),
+		inferenceService("team-a", "explicit-cluster-kind", runtimeReference("local-only", &clusterKind, nil)),
+	}, runtimegraph.Snapshot{
+		ServingRuntimes: []omev1beta1.ServingRuntime{{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "local-only"},
+		}},
+	})
+
+	local, err := index.ForRuntime(runtimegraph.Identity{
+		Kind:      runtimegraph.KindServingRuntime,
+		Namespace: "team-a",
+		Name:      "local-only",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []InferenceServiceIdentity{
+		{Namespace: "team-a", Name: "default-kind"},
+		{Namespace: "team-a", Name: "explicit-cluster-kind"},
+	}, local.InferenceServices)
+}
+
+func TestBuildDoesNotFallbackNamespacedKindToClusterRuntime(t *testing.T) {
+	namespacedKind := string(runtimegraph.KindServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "local-reference", runtimeReference("cluster-only", &namespacedKind, nil)),
+	}, runtimegraph.Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-only"},
+		}},
+	})
+
+	cluster, err := index.ForRuntime(runtimegraph.Identity{
+		Kind: runtimegraph.KindClusterServingRuntime,
+		Name: "cluster-only",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, cluster.InferenceServices)
+	assert.Equal(t, []ReferenceEvidence{{
+		InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "local-reference"},
+		State:            ReferenceUnresolved,
+		RuntimeName:      "cluster-only",
+		Reason:           ReasonRuntimeNotFound,
+		Occurrences:      1,
+	}}, index.References())
+}
+
+func TestBuildPreservesMissingRuntimeEvidence(t *testing.T) {
+	clusterKind := string(runtimegraph.KindClusterServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "default-kind", runtimeReference("missing", nil, nil)),
+		inferenceService("team-a", "explicit-cluster-kind", runtimeReference("missing", &clusterKind, nil)),
+	}, runtimegraph.Snapshot{})
+
+	assert.Equal(t, []ReferenceEvidence{
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "default-kind"},
+			State:            ReferenceUnresolved,
+			RuntimeName:      "missing",
+			Reason:           ReasonRuntimeNotFound,
+			Occurrences:      1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "explicit-cluster-kind"},
+			State:            ReferenceUnresolved,
+			RuntimeName:      "missing",
+			Reason:           ReasonRuntimeNotFound,
+			Occurrences:      1,
+		},
+	}, index.References())
+}
+
+func TestBuildIndexesClusterReferencesAcrossNamespaces(t *testing.T) {
+	services := []omev1beta1.InferenceService{
+		inferenceService("team-z", "z-service", runtimeReference("shared", nil, nil)),
+		inferenceService("team-a", "a-service", runtimeReference(
+			"shared",
+			ptr.To(string(runtimegraph.KindClusterServingRuntime)),
+			ptr.To(omev1beta1.SchemeGroupVersion.Group),
+		)),
+	}
+	index := Build(services, runtimeSnapshot(
+		runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Name: "shared"},
+	))
+
+	projection, err := index.ForRuntime(runtimegraph.Identity{
+		Kind: runtimegraph.KindClusterServingRuntime,
+		Name: "shared",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, Projection{
+		Runtime: runtimegraph.Identity{
+			Kind: runtimegraph.KindClusterServingRuntime,
+			Name: "shared",
+		},
+		InferenceServices: []InferenceServiceIdentity{
+			{Namespace: "team-a", Name: "a-service"},
+			{Namespace: "team-z", Name: "z-service"},
+		},
+	}, projection)
+	assert.Equal(t, []ReferenceEvidence{
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "a-service"},
+			State:            ReferenceResolved,
+			RuntimeName:      "shared",
+			Runtime: identityPointer(runtimegraph.Identity{
+				Kind: runtimegraph.KindClusterServingRuntime,
+				Name: "shared",
+			}),
+			Occurrences: 1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-z", Name: "z-service"},
+			State:            ReferenceResolved,
+			RuntimeName:      "shared",
+			Runtime: identityPointer(runtimegraph.Identity{
+				Kind: runtimegraph.KindClusterServingRuntime,
+				Name: "shared",
+			}),
+			Occurrences: 1,
+		},
+	}, index.References())
+}
+
+func TestBuildUsesFullScopeForNamespacedReferencesAndNameCollisions(t *testing.T) {
+	clusterKind := string(runtimegraph.KindClusterServingRuntime)
+	namespacedKind := string(runtimegraph.KindServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "cluster-user", runtimeReference("shared", &clusterKind, nil)),
+		inferenceService("team-b", "local-user", runtimeReference("shared", &namespacedKind, nil)),
+		inferenceService("team-a", "local-user", runtimeReference("shared", &namespacedKind, nil)),
+	}, runtimeSnapshot(
+		runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Name: "shared"},
+		runtimegraph.Identity{Kind: runtimegraph.KindServingRuntime, Namespace: "team-a", Name: "shared"},
+		runtimegraph.Identity{Kind: runtimegraph.KindServingRuntime, Namespace: "team-b", Name: "shared"},
+	))
+
+	cluster, err := index.ForRuntime(runtimegraph.Identity{
+		Kind: runtimegraph.KindClusterServingRuntime,
+		Name: "shared",
+	})
+	require.NoError(t, err)
+	teamA, err := index.ForRuntime(runtimegraph.Identity{
+		Kind:      runtimegraph.KindServingRuntime,
+		Namespace: "team-a",
+		Name:      "shared",
+	})
+	require.NoError(t, err)
+	teamB, err := index.ForRuntime(runtimegraph.Identity{
+		Kind:      runtimegraph.KindServingRuntime,
+		Namespace: "team-b",
+		Name:      "shared",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []InferenceServiceIdentity{{Namespace: "team-a", Name: "cluster-user"}}, cluster.InferenceServices)
+	assert.Equal(t, []InferenceServiceIdentity{{Namespace: "team-a", Name: "local-user"}}, teamA.InferenceServices)
+	assert.Equal(t, []InferenceServiceIdentity{{Namespace: "team-b", Name: "local-user"}}, teamB.InferenceServices)
+}
+
+func TestBuildDistinguishesAutomaticSelectionFromEmptyRuntimeName(t *testing.T) {
+	unsupportedKind := "OtherRuntime"
+	unexpectedGroup := "other.example"
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "nil-reference", nil),
+		inferenceService("team-a", "empty-reference", runtimeReference("", &unsupportedKind, &unexpectedGroup)),
+	}, runtimegraph.Snapshot{})
+
+	projection, err := index.ForRuntime(runtimegraph.Identity{
+		Kind: runtimegraph.KindClusterServingRuntime,
+		Name: "unused",
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, projection.InferenceServices)
+	assert.Equal(t, []ReferenceEvidence{
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "empty-reference"},
+			State:            ReferenceInvalid,
+			Reason:           ReasonInvalidRuntimeName,
+			Occurrences:      1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "nil-reference"},
+			State:            ReferenceUnresolved,
+			Reason:           ReasonAutomaticSelection,
+			Occurrences:      1,
+		},
+	}, index.References())
+}
+
+func TestBuildPreservesInvalidRuntimeReferenceEvidence(t *testing.T) {
+	empty := ""
+	unsupportedKind := "OtherRuntime"
+	unexpectedGroup := "other.example"
+	namespacedKind := string(runtimegraph.KindServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "empty-kind", runtimeReference("runtime-a", &empty, nil)),
+		inferenceService("team-a", "unsupported-kind", runtimeReference("runtime-b", &unsupportedKind, nil)),
+		inferenceService("team-a", "empty-group", runtimeReference("runtime-c", &namespacedKind, &empty)),
+		inferenceService("team-a", "unexpected-group", runtimeReference("runtime-d", &namespacedKind, &unexpectedGroup)),
+	}, runtimegraph.Snapshot{})
+
+	assert.Equal(t, []ReferenceEvidence{
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "empty-group"},
+			State:            ReferenceInvalid,
+			RuntimeName:      "runtime-c",
+			Reason:           ReasonInvalidAPIGroup,
+			Occurrences:      1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "empty-kind"},
+			State:            ReferenceInvalid,
+			RuntimeName:      "runtime-a",
+			Reason:           ReasonInvalidKind,
+			Occurrences:      1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "unexpected-group"},
+			State:            ReferenceInvalid,
+			RuntimeName:      "runtime-d",
+			Reason:           ReasonInvalidAPIGroup,
+			Occurrences:      1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "unsupported-kind"},
+			State:            ReferenceInvalid,
+			RuntimeName:      "runtime-b",
+			Reason:           ReasonInvalidKind,
+			Occurrences:      1,
+		},
+	}, index.References())
+}
+
+func TestBuildPreservesDuplicateObjectsAsAmbiguousEvidence(t *testing.T) {
+	clusterKind := string(runtimegraph.KindClusterServingRuntime)
+	namespacedKind := string(runtimegraph.KindServingRuntime)
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("team-a", "duplicate", runtimeReference("cluster-runtime", &clusterKind, nil)),
+		inferenceService("team-a", "healthy", runtimeReference("cluster-runtime", &clusterKind, nil)),
+		inferenceService("team-a", "duplicate", runtimeReference("local-runtime", &namespacedKind, nil)),
+	}, runtimeSnapshot(
+		runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Name: "cluster-runtime"},
+		runtimegraph.Identity{Kind: runtimegraph.KindServingRuntime, Namespace: "team-a", Name: "local-runtime"},
+	))
+
+	cluster, err := index.ForRuntime(runtimegraph.Identity{
+		Kind: runtimegraph.KindClusterServingRuntime,
+		Name: "cluster-runtime",
+	})
+	require.NoError(t, err)
+	local, err := index.ForRuntime(runtimegraph.Identity{
+		Kind:      runtimegraph.KindServingRuntime,
+		Namespace: "team-a",
+		Name:      "local-runtime",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []InferenceServiceIdentity{{Namespace: "team-a", Name: "healthy"}}, cluster.InferenceServices)
+	assert.Empty(t, local.InferenceServices)
+	assert.Equal(t, []ReferenceEvidence{
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "duplicate"},
+			State:            ReferenceAmbiguous,
+			Reason:           ReasonDuplicateInferenceService,
+			Occurrences:      2,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a", Name: "healthy"},
+			State:            ReferenceResolved,
+			RuntimeName:      "cluster-runtime",
+			Runtime: identityPointer(runtimegraph.Identity{
+				Kind: runtimegraph.KindClusterServingRuntime,
+				Name: "cluster-runtime",
+			}),
+			Occurrences: 1,
+		},
+	}, index.References())
+}
+
+func TestBuildPreservesInvalidObjectIdentityEvidence(t *testing.T) {
+	index := Build([]omev1beta1.InferenceService{
+		inferenceService("", "missing-namespace", runtimeReference("runtime", nil, nil)),
+		inferenceService("team-a", "", runtimeReference("runtime", nil, nil)),
+	}, runtimegraph.Snapshot{})
+
+	assert.Equal(t, []ReferenceEvidence{
+		{
+			InferenceService: InferenceServiceIdentity{Name: "missing-namespace"},
+			State:            ReferenceInvalid,
+			Reason:           ReasonInvalidInferenceService,
+			Occurrences:      1,
+		},
+		{
+			InferenceService: InferenceServiceIdentity{Namespace: "team-a"},
+			State:            ReferenceInvalid,
+			Reason:           ReasonInvalidInferenceService,
+			Occurrences:      1,
+		},
+	}, index.References())
+}
+
+func TestIndexIsDeterministicAndImmutable(t *testing.T) {
+	clusterKind := string(runtimegraph.KindClusterServingRuntime)
+	group := omev1beta1.SchemeGroupVersion.Group
+	services := []omev1beta1.InferenceService{
+		inferenceService("team-z", "service-z", runtimeReference("runtime", &clusterKind, &group)),
+		inferenceService("team-a", "service-a", runtimeReference("runtime", nil, nil)),
+	}
+	original := deepCopyInferenceServices(services)
+	reversed := []omev1beta1.InferenceService{*services[1].DeepCopy(), *services[0].DeepCopy()}
+
+	snapshot := runtimeSnapshot(
+		runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Name: "runtime"},
+	)
+	index := Build(services, snapshot)
+	reversedIndex := Build(reversed, snapshot)
+	assert.Equal(t, original, services)
+	services[0].Name = "changed"
+	services[0].Spec.Runtime.Name = "changed"
+	*services[0].Spec.Runtime.Kind = string(runtimegraph.KindServingRuntime)
+	*services[0].Spec.Runtime.APIGroup = "changed.example"
+
+	target := runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Name: "runtime"}
+	first, err := index.ForRuntime(target)
+	require.NoError(t, err)
+	fromReversed, err := reversedIndex.ForRuntime(target)
+	require.NoError(t, err)
+	firstReferences := index.References()
+	assert.Equal(t, first, fromReversed)
+	assert.Equal(t, firstReferences, reversedIndex.References())
+
+	first.InferenceServices[0].Name = "mutated"
+	firstReferences[0].InferenceService.Name = "mutated"
+	firstReferences[0].Runtime.Name = "mutated"
+	again, err := index.ForRuntime(target)
+	require.NoError(t, err)
+
+	assert.Equal(t, []InferenceServiceIdentity{
+		{Namespace: "team-a", Name: "service-a"},
+		{Namespace: "team-z", Name: "service-z"},
+	}, again.InferenceServices)
+	assert.Equal(t, "runtime", index.References()[0].Runtime.Name)
+}
+
+func TestForRuntimeRejectsIncompleteOrUnsupportedIdentity(t *testing.T) {
+	index := Build(nil, runtimegraph.Snapshot{})
+	tests := []struct {
+		name     string
+		identity runtimegraph.Identity
+	}{
+		{name: "name required", identity: runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime}},
+		{name: "kind required", identity: runtimegraph.Identity{Name: "runtime"}},
+		{name: "kind supported", identity: runtimegraph.Identity{Kind: runtimegraph.Kind("Other"), Name: "runtime"}},
+		{name: "namespaced namespace required", identity: runtimegraph.Identity{Kind: runtimegraph.KindServingRuntime, Name: "runtime"}},
+		{name: "cluster namespace forbidden", identity: runtimegraph.Identity{Kind: runtimegraph.KindClusterServingRuntime, Namespace: "team-a", Name: "runtime"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := index.ForRuntime(test.identity)
+			assert.ErrorIs(t, err, ErrInvalidRuntimeIdentity)
+		})
+	}
+}
+
+func inferenceService(namespace, name string, runtime *omev1beta1.ServingRuntimeRef) omev1beta1.InferenceService {
+	return omev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       omev1beta1.InferenceServiceSpec{Runtime: runtime},
+	}
+}
+
+func runtimeReference(name string, kind, apiGroup *string) *omev1beta1.ServingRuntimeRef {
+	return &omev1beta1.ServingRuntimeRef{Name: name, Kind: kind, APIGroup: apiGroup}
+}
+
+func runtimeSnapshot(identities ...runtimegraph.Identity) runtimegraph.Snapshot {
+	var snapshot runtimegraph.Snapshot
+	for _, identity := range identities {
+		switch identity.Kind {
+		case runtimegraph.KindClusterServingRuntime:
+			snapshot.ClusterServingRuntimes = append(snapshot.ClusterServingRuntimes, omev1beta1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: identity.Name},
+			})
+		case runtimegraph.KindServingRuntime:
+			snapshot.ServingRuntimes = append(snapshot.ServingRuntimes, omev1beta1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Namespace: identity.Namespace, Name: identity.Name},
+			})
+		}
+	}
+	return snapshot
+}
+
+func identityPointer(identity runtimegraph.Identity) *runtimegraph.Identity { return &identity }
+
+func deepCopyInferenceServices(services []omev1beta1.InferenceService) []omev1beta1.InferenceService {
+	result := make([]omev1beta1.InferenceService, len(services))
+	for i := range services {
+		result[i] = *services[i].DeepCopy()
+	}
+	return result
+}


### PR DESCRIPTION
## What this PR does

Adds the pure runtime-usage index needed by the upcoming
`kubectl ome runtime tree` command.

- Attributes every explicit `InferenceService.spec.runtime` reference to an
  exact `ServingRuntime` or `ClusterServingRuntime` identity.
- Matches the operator's lookup rules: cluster scope wins for the defaulted
  `ClusterServingRuntime` kind, with same-namespace fallback; an explicit
  `ServingRuntime` kind remains namespace-only.
- Keeps automatic selection, missing runtimes, malformed references, and
  duplicate InferenceServices as typed evidence instead of silently dropping
  them or guessing.
- Sorts all results and returns defensive copies so later rendering is stable
  and cannot mutate the collected snapshot.

This is a foundation PR. It intentionally adds no Cobra command and changes no
user-visible terminal output. Before and after this PR, existing CLI output is
byte-for-byte unchanged.

The next report layer consumes normalized evidence shaped like this:

```text
ClusterServingRuntime/shared
`-- InferenceService/team-a/predict-a

ServingRuntime/team-b/local-runtime
`-- InferenceService/team-b/predict-b

Unresolved references
|-- InferenceService/team-c/auto: AutomaticSelection
`-- InferenceService/team-d/missing: RuntimeNotFound (missing-runtime)

Invalid references
`-- InferenceService/team-e/bad-ref: InvalidRuntimeName
```

## Why we need it

A runtime tree is operationally useful only when it shows which inference
services depend on each exact runtime. Names alone are unsafe because a
cluster runtime and namespaced runtime can share a name, and OME's defaulted
reference kind has a deliberate namespace fallback. Centralizing those rules
in a tested, I/O-free index prevents the command and machine report from
disagreeing with the controller.

Fixes # N/A

## How to test

```bash
go test -race ./pkg/cli/runtimeusage -count=20
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
go build -o /tmp/kubectl-ome ./cmd/kubectl-ome
```

The tests cover cluster/name collisions, defaulted and explicit cluster
references, same-namespace fallback, explicit namespace-only references,
missing runtimes, automatic selection, empty required names, malformed
group/kind values, duplicate InferenceServices, stable ordering, defensive
copies, and invalid query identities. The new package has 100% statement
coverage.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable) — no user-facing command exists in this PR
- [ ] `make test` passes locally — focused race tests, the full CLI suite, vet,
  and the CLI build pass locally
