### PR TITLE
[Core] Collect runtime usage inputs

### DIFF
--- a/pkg/cli/inferenceservicecollection/collect.go
+++ b/pkg/cli/inferenceservicecollection/collect.go
@@ -1,0 +1,82 @@
+// Package inferenceservicecollection reads the bounded InferenceService
+// snapshot used to attribute services to serving runtimes.
+package inferenceservicecollection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	omeclient "sigs.k8s.io/ome/pkg/client/clientset/versioned/typed/ome/v1beta1"
+)
+
+// Completeness describes the bounded observations in an InferenceService
+// collection.
+type Completeness struct {
+	ObservedPages int
+	ObservedItems int
+	Truncated     bool
+}
+
+// Result contains a defensive snapshot and its collection completeness.
+type Result struct {
+	InferenceServices []omev1beta1.InferenceService
+	Completeness      Completeness
+}
+
+// Collect reads InferenceServices across all namespaces through bounded
+// Kubernetes pagination.
+func Collect(
+	ctx context.Context,
+	client omeclient.OmeV1beta1Interface,
+	limits paging.Limits,
+) (Result, error) {
+	result := Result{InferenceServices: []omev1beta1.InferenceService{}}
+	observedPages := 0
+	services, err := paging.ListBounded(
+		ctx,
+		metav1.ListOptions{},
+		limits,
+		func(
+			requestCtx context.Context,
+			options metav1.ListOptions,
+		) (paging.Page[omev1beta1.InferenceService], error) {
+			list, listErr := client.InferenceServices(metav1.NamespaceAll).List(requestCtx, options)
+			if requestErr := requestCtx.Err(); requestErr != nil {
+				return paging.Page[omev1beta1.InferenceService]{}, requestErr
+			}
+			if listErr != nil {
+				return paging.Page[omev1beta1.InferenceService]{}, listErr
+			}
+			if list == nil {
+				return paging.Page[omev1beta1.InferenceService]{}, errors.New("empty response")
+			}
+			observedPages++
+			return paging.Page[omev1beta1.InferenceService]{
+				Items: list.Items, Continue: list.Continue,
+			}, nil
+		},
+	)
+	result.InferenceServices = copyInferenceServices(services.Items)
+	result.Completeness = Completeness{
+		ObservedPages: observedPages,
+		ObservedItems: len(services.Items),
+		Truncated:     services.Truncated,
+	}
+	if err != nil {
+		return result, fmt.Errorf("list InferenceServices: %w", err)
+	}
+	return result, nil
+}
+
+func copyInferenceServices(items []omev1beta1.InferenceService) []omev1beta1.InferenceService {
+	result := make([]omev1beta1.InferenceService, len(items))
+	for i := range items {
+		result[i] = *items[i].DeepCopy()
+	}
+	return result
+}

--- a/pkg/cli/inferenceservicecollection/collect_test.go
+++ b/pkg/cli/inferenceservicecollection/collect_test.go
@@ -1,0 +1,293 @@
+package inferenceservicecollection
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktesting "k8s.io/client-go/testing"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/paging"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+	ometyped "sigs.k8s.io/ome/pkg/client/clientset/versioned/typed/ome/v1beta1"
+)
+
+var testLimits = paging.Limits{
+	PageSize:       2,
+	MaxItems:       10,
+	MaxPages:       5,
+	RequestTimeout: time.Second,
+}
+
+func TestCollectDrainsInferenceServicesAcrossAllNamespaces(t *testing.T) {
+	t.Parallel()
+
+	client := omefake.NewSimpleClientset()
+	var requests []metav1.ListOptions
+	var namespaces []string
+	client.PrependReactor("list", "inferenceservices", func(action ktesting.Action) (bool, runtime.Object, error) {
+		options := action.(interface{ GetListOptions() metav1.ListOptions }).GetListOptions()
+		requests = append(requests, options)
+		namespaces = append(namespaces, action.GetNamespace())
+		if options.Continue == "" {
+			return true, &omev1beta1.InferenceServiceList{
+				Items:    []omev1beta1.InferenceService{inferenceService("team-b", "service-b")},
+				ListMeta: metav1.ListMeta{Continue: "next"},
+			}, nil
+		}
+		require.Equal(t, "next", options.Continue)
+		return true, &omev1beta1.InferenceServiceList{
+			Items: []omev1beta1.InferenceService{inferenceService("team-a", "service-a")},
+		}, nil
+	})
+
+	got, err := Collect(context.Background(), client.OmeV1beta1(), testLimits)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"team-b/service-b", "team-a/service-a"}, []string{
+		got.InferenceServices[0].Namespace + "/" + got.InferenceServices[0].Name,
+		got.InferenceServices[1].Namespace + "/" + got.InferenceServices[1].Name,
+	})
+	assert.Equal(t, Completeness{ObservedPages: 2, ObservedItems: 2}, got.Completeness)
+	assert.Equal(t, []metav1.ListOptions{{Limit: 2}, {Limit: 2, Continue: "next"}}, requests)
+	assert.Equal(t, []string{metav1.NamespaceAll, metav1.NamespaceAll}, namespaces)
+}
+
+func TestCollectReturnsDefensiveCopies(t *testing.T) {
+	t.Parallel()
+
+	source := inferenceService("team-a", "service")
+	client := omefake.NewSimpleClientset()
+	client.PrependReactor("list", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &omev1beta1.InferenceServiceList{
+			Items: []omev1beta1.InferenceService{source},
+		}, nil
+	})
+
+	got, err := Collect(context.Background(), client.OmeV1beta1(), testLimits)
+	require.NoError(t, err)
+
+	got.InferenceServices[0].Annotations["source"] = "output-mutated"
+	got.InferenceServices[0].Spec.Runtime.Name = "output-mutated"
+	assert.Equal(t, "fixture", source.Annotations["source"])
+	assert.Equal(t, "runtime", source.Spec.Runtime.Name)
+
+	source.Annotations["source"] = "source-mutated"
+	source.Spec.Runtime.Name = "source-mutated"
+	assert.Equal(t, "output-mutated", got.InferenceServices[0].Annotations["source"])
+	assert.Equal(t, "output-mutated", got.InferenceServices[0].Spec.Runtime.Name)
+}
+
+func TestCollectReportsItemAndPageTruncation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		limits     paging.Limits
+		response   *omev1beta1.InferenceServiceList
+		wantItems  int
+		wantPages  int
+		wantLimits []int64
+	}{
+		{
+			name: "item limit",
+			limits: paging.Limits{
+				PageSize: 2, MaxItems: 3, MaxPages: 5, RequestTimeout: time.Second,
+			},
+			response: &omev1beta1.InferenceServiceList{
+				Items: []omev1beta1.InferenceService{
+					inferenceService("team-a", "one"),
+					inferenceService("team-a", "two"),
+				},
+				ListMeta: metav1.ListMeta{Continue: "more"},
+			},
+			wantItems: 3, wantPages: 2, wantLimits: []int64{2, 1},
+		},
+		{
+			name: "page limit",
+			limits: paging.Limits{
+				PageSize: 1, MaxItems: 5, MaxPages: 2, RequestTimeout: time.Second,
+			},
+			response: &omev1beta1.InferenceServiceList{
+				Items:    []omev1beta1.InferenceService{inferenceService("team-a", "one")},
+				ListMeta: metav1.ListMeta{Continue: "more"},
+			},
+			wantItems: 2, wantPages: 2, wantLimits: []int64{1, 1},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			client := omefake.NewSimpleClientset()
+			var limits []int64
+			client.PrependReactor("list", "inferenceservices", func(action ktesting.Action) (bool, runtime.Object, error) {
+				options := action.(interface{ GetListOptions() metav1.ListOptions }).GetListOptions()
+				limits = append(limits, options.Limit)
+				response := test.response.DeepCopy()
+				if int(options.Limit) < len(response.Items) {
+					response.Items = response.Items[:options.Limit]
+				}
+				response.Continue += options.Continue + "n"
+				return true, response, nil
+			})
+
+			got, err := Collect(context.Background(), client.OmeV1beta1(), test.limits)
+
+			require.NoError(t, err)
+			assert.Len(t, got.InferenceServices, test.wantItems)
+			assert.Equal(t, Completeness{
+				ObservedPages: test.wantPages, ObservedItems: test.wantItems, Truncated: true,
+			}, got.Completeness)
+			assert.Equal(t, test.wantLimits, limits)
+		})
+	}
+}
+
+func TestCollectRejectsSuccessfulResponseAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := omefake.NewSimpleClientset()
+	client.PrependReactor("list", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+		cancel()
+		return true, &omev1beta1.InferenceServiceList{
+			Items: []omev1beta1.InferenceService{inferenceService("team-a", "too-late")},
+		}, nil
+	})
+
+	got, err := Collect(ctx, client.OmeV1beta1(), testLimits)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, got.InferenceServices)
+	assert.Equal(t, Completeness{}, got.Completeness)
+}
+
+func TestCollectRejectsSuccessfulResponseAfterRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := omefake.NewSimpleClientset()
+	client.PrependReactor("list", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+		time.Sleep(30 * time.Millisecond)
+		return true, &omev1beta1.InferenceServiceList{
+			Items: []omev1beta1.InferenceService{inferenceService("team-a", "too-late")},
+		}, nil
+	})
+	limits := testLimits
+	limits.RequestTimeout = time.Millisecond
+
+	got, err := Collect(context.Background(), client.OmeV1beta1(), limits)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Empty(t, got.InferenceServices)
+	assert.Equal(t, Completeness{}, got.Completeness)
+}
+
+func TestCollectPreservesBoundedProgressAndTypedErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-advancing continue token", func(t *testing.T) {
+		t.Parallel()
+		client := omefake.NewSimpleClientset()
+		client.PrependReactor("list", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, &omev1beta1.InferenceServiceList{
+				Items:    []omev1beta1.InferenceService{inferenceService("team-a", "service")},
+				ListMeta: metav1.ListMeta{Continue: "stuck"},
+			}, nil
+		})
+
+		got, err := Collect(context.Background(), client.OmeV1beta1(), testLimits)
+
+		require.ErrorContains(t, err, "continue token did not advance")
+		assert.Len(t, got.InferenceServices, 1)
+		assert.Equal(t, Completeness{ObservedPages: 2, ObservedItems: 1}, got.Completeness)
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		t.Parallel()
+		client := omefake.NewSimpleClientset()
+		forbidden := apierrors.NewForbidden(schema.GroupResource{
+			Group: "ome.io", Resource: "inferenceservices",
+		}, "", errors.New("denied"))
+		client.PrependReactor("list", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, forbidden
+		})
+
+		got, err := Collect(context.Background(), client.OmeV1beta1(), testLimits)
+
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+		assert.ErrorIs(t, err, forbidden)
+		assert.Empty(t, got.InferenceServices)
+		assert.Equal(t, Completeness{}, got.Completeness)
+	})
+
+	t.Run("nil response", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := Collect(context.Background(), nilListClient{}, testLimits)
+
+		require.ErrorContains(t, err, "empty response")
+		assert.Empty(t, got.InferenceServices)
+		assert.Equal(t, Completeness{}, got.Completeness)
+	})
+}
+
+type nilListClient struct {
+	ometyped.OmeV1beta1Interface
+}
+
+func (nilListClient) InferenceServices(string) ometyped.InferenceServiceInterface {
+	return nilListInferenceServices{}
+}
+
+type nilListInferenceServices struct {
+	ometyped.InferenceServiceInterface
+}
+
+func (nilListInferenceServices) List(
+	context.Context,
+	metav1.ListOptions,
+) (*omev1beta1.InferenceServiceList, error) {
+	return nil, nil
+}
+
+func TestCollectRejectsInvalidLimitsWithoutListing(t *testing.T) {
+	t.Parallel()
+
+	client := omefake.NewSimpleClientset()
+	called := false
+	client.PrependReactor("list", "inferenceservices", func(ktesting.Action) (bool, runtime.Object, error) {
+		called = true
+		return true, &omev1beta1.InferenceServiceList{}, nil
+	})
+
+	got, err := Collect(context.Background(), client.OmeV1beta1(), paging.Limits{})
+
+	require.Error(t, err)
+	assert.False(t, called)
+	assert.Empty(t, got.InferenceServices)
+	assert.Equal(t, Completeness{}, got.Completeness)
+}
+
+func inferenceService(namespace, name string) omev1beta1.InferenceService {
+	return omev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Annotations: map[string]string{
+				"source": "fixture",
+			},
+		},
+		Spec: omev1beta1.InferenceServiceSpec{
+			Runtime: &omev1beta1.ServingRuntimeRef{Name: "runtime"},
+		},
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds the bounded InferenceService collector needed to place runtime users in
the upcoming `kubectl ome runtime tree` report.

- Lists `InferenceService` objects across every namespace, because a
  `ClusterServingRuntime` can have consumers anywhere in the cluster.
- Uses finite page, item, and per-request time limits through the shared CLI
  paging contract.
- Reports accepted pages, retained items, and truncation separately from the
  objects themselves.
- Rejects responses that arrive after parent cancellation or the request
  deadline, even when a client returns a nominal success.
- Preserves typed Kubernetes/context errors and returns deep copies of every
  collected object.

This is a foundation PR. It adds no command and changes no user-visible CLI
output. Existing terminal, JSON, and YAML output remains byte-for-byte
unchanged.

The next composition layer receives this bounded result:

```text
InferenceServices
|-- team-a/chat-a
`-- team-b/chat-b

Completeness
  observedPages: 2
  observedItems: 2
  truncated:     false
```

## Why we need it

The runtime tree must show all known InferenceServices that reference each
runtime without issuing an unbounded cluster-wide list. Keeping collection
separate from reference resolution and rendering also lets the command report
partial evidence honestly when limits are reached or access fails.

Fixes # N/A

## How to test

```bash
go test -race ./pkg/cli/inferenceservicecollection -count=10
go test ./pkg/cli/... ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
go build -o /tmp/kubectl-ome ./cmd/kubectl-ome
```

The tests cover multi-page all-namespace collection, reduced final-page
limits, independent item/page truncation, non-advancing continuation tokens,
parent cancellation, late request timeout, forbidden and nil responses,
invalid limits, typed error preservation, and two-way deep-copy isolation.
The new package has 100% statement coverage.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable) — no user-facing command exists in this PR
- [ ] `make test` passes locally — focused race tests, the full CLI suite, vet,
  and the CLI build pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collection of inference services across all namespaces.
  - Supports bounded pagination with completeness information, including observed pages, items, and truncation status.
  - Returns a safe snapshot of collected inference services for reliable downstream use.
  - Handles cancellation, timeouts, invalid limits, empty responses, and collection errors with clear failure reporting.

- **Tests**
  - Added coverage for pagination, truncation, cancellation, timeout handling, error propagation, defensive copying, and invalid request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->