### PR TITLE
[Bugfix] Preserve runtime resolution paths

### DIFF
--- a/pkg/cli/runtimegraph/context_projection_test.go
+++ b/pkg/cli/runtimegraph/context_projection_test.go
@@ -1,0 +1,579 @@
+package runtimegraph
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestProjectKeepsNamespaceFirstResolutionAfterClusterFallback(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("bridge", "base"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "base", ""),
+			namespacedRuntime("team-a", "leaf", "bridge"),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, Projection{
+		Target: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+		Contexts: []ContextProjection{{
+			Context: namespacedContext("team-a"),
+			Paths: []ResolutionPath{{
+				Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+				Runtimes: []Runtime{
+					{Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "base"}},
+					{
+						Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+						ParentName: "base",
+						ResolvedParent: identityPointer(Identity{
+							Kind: KindServingRuntime, Namespace: "team-a", Name: "base",
+						}),
+					},
+					{
+						Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+						ParentName: "bridge",
+						ResolvedParent: identityPointer(Identity{
+							Kind: KindClusterServingRuntime, Name: "bridge",
+						}),
+					},
+				},
+			}},
+		}},
+	}, projection)
+}
+
+func TestProjectKeepsDirectClusterResolutionSeparateFromNamespacedUses(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("bridge", "base"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "base", ""),
+			namespacedRuntime("team-a", "leaf", "bridge"),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "bridge"})
+
+	require.NoError(t, err)
+	require.Len(t, projection.Contexts, 2)
+	assert.Equal(t, []ResolutionContext{
+		clusterContext(), namespacedContext("team-a"),
+	}, projectionContexts(projection))
+	assert.Equal(t, ResolutionPath{
+		Subject: Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+		Runtimes: []Runtime{{
+			Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "base",
+		}},
+		Issue: &Issue{
+			Code:       IssueParentMissing,
+			Subject:    Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "base",
+			Path:       []Identity{{Kind: KindClusterServingRuntime, Name: "bridge"}},
+		},
+	}, projection.Contexts[0].Paths[0])
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "base"}},
+		{
+			Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "base",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "base",
+			}),
+		},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+			ParentName: "bridge",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "bridge",
+			}),
+		},
+	}, projection.Contexts[1].Paths[0].Runtimes)
+}
+
+func TestProjectGivesOneClusterRuntimeDifferentParentsByResolutionContext(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("cluster-root", ""),
+			clusterRuntime("base", ""),
+			clusterRuntime("bridge", "base"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-b", "leaf", "bridge"),
+			namespacedRuntime("team-a", "leaf", "bridge"),
+			namespacedRuntime("team-b", "base", "cluster-root"),
+			namespacedRuntime("team-a", "base", ""),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "bridge"})
+
+	require.NoError(t, err)
+	require.Len(t, projection.Contexts, 3)
+	assert.Equal(t, []ResolutionContext{
+		clusterContext(), namespacedContext("team-a"), namespacedContext("team-b"),
+	}, projectionContexts(projection))
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "base"}},
+		{
+			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName:     "base",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "base"}),
+		},
+	}, projection.Contexts[0].Paths[0].Runtimes)
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "base"}},
+		{
+			Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "base",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "base",
+			}),
+		},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+			ParentName: "bridge",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "bridge",
+			}),
+		},
+	}, projection.Contexts[1].Paths[0].Runtimes)
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "cluster-root"}},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-b", Name: "base"},
+			ParentName: "cluster-root",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "cluster-root",
+			}),
+		},
+		{
+			Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "base",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-b", Name: "base",
+			}),
+		},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-b", Name: "leaf"},
+			ParentName: "bridge",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "bridge",
+			}),
+		},
+	}, projection.Contexts[2].Paths[0].Runtimes)
+}
+
+func TestProjectDoesNotCreateFalseDescendantsAcrossResolutionContexts(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("base", ""),
+			clusterRuntime("bridge", "base"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "base", ""),
+			namespacedRuntime("team-a", "leaf", "bridge"),
+		},
+	})
+	require.NoError(t, err)
+
+	clusterBase, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "base"})
+	require.NoError(t, err)
+	localBase, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "base",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []ContextProjection{{
+		Context: clusterContext(),
+		Paths: []ResolutionPath{
+			{
+				Subject:  Identity{Kind: KindClusterServingRuntime, Name: "base"},
+				Runtimes: []Runtime{{Identity: Identity{Kind: KindClusterServingRuntime, Name: "base"}}},
+			},
+			{
+				Subject: Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+				Runtimes: []Runtime{
+					{Identity: Identity{Kind: KindClusterServingRuntime, Name: "base"}},
+					{
+						Identity:       Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+						ParentName:     "base",
+						ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "base"}),
+					},
+				},
+			},
+		},
+	}}, clusterBase.Contexts, "the team-a leaf is shadowed away from the cluster base")
+	assert.Equal(t, []ContextProjection{{
+		Context: namespacedContext("team-a"),
+		Paths: []ResolutionPath{
+			{
+				Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "base"},
+				Runtimes: []Runtime{{Identity: Identity{
+					Kind: KindServingRuntime, Namespace: "team-a", Name: "base",
+				}}},
+			},
+			{
+				Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+				Runtimes: []Runtime{
+					{Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "base"}},
+					{
+						Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+						ParentName: "base",
+						ResolvedParent: identityPointer(Identity{
+							Kind: KindServingRuntime, Namespace: "team-a", Name: "base",
+						}),
+					},
+					{
+						Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+						ParentName: "bridge",
+						ResolvedParent: identityPointer(Identity{
+							Kind: KindClusterServingRuntime, Name: "bridge",
+						}),
+					},
+				},
+			},
+		},
+	}}, localBase.Contexts)
+}
+
+func TestProjectDetectsRepeatedNamesBeforeCrossScopeLookup(t *testing.T) {
+	graph, err := Build(Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("bridge", "same-name"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "same-name", "bridge"),
+		},
+	})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, projection.Contexts, 1)
+	require.Len(t, projection.Contexts[0].Paths, 1)
+	path := projection.Contexts[0].Paths[0]
+	assert.Equal(t, []Runtime{
+		{
+			Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "same-name",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+			}),
+		},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+			ParentName: "bridge",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "bridge",
+			}),
+		},
+	}, path.Runtimes)
+	assert.Equal(t, &Issue{
+		Code:       IssueCycleDetected,
+		Subject:    Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+		ParentName: "same-name",
+		Path: []Identity{
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+			{Kind: KindClusterServingRuntime, Name: "bridge"},
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+		},
+	}, path.Issue)
+}
+
+func TestProjectKeepsMaxDepthResultsSeparatePerHead(t *testing.T) {
+	graph, err := Build(Snapshot{ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+		clusterRuntime("level-1", ""),
+		clusterRuntime("level-2", "level-1"),
+		clusterRuntime("level-3", "level-2"),
+		clusterRuntime("level-4", "level-3"),
+		clusterRuntime("level-5", "level-4"),
+		clusterRuntime("level-6", "level-5"),
+	}})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "level-5"})
+
+	require.NoError(t, err)
+	require.Len(t, projection.Contexts, 1)
+	assert.Equal(t, []ResolutionPath{
+		{
+			Subject: Identity{Kind: KindClusterServingRuntime, Name: "level-5"},
+			Runtimes: []Runtime{
+				{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-1"}},
+				resolvedClusterRuntime("level-2", "level-1"),
+				resolvedClusterRuntime("level-3", "level-2"),
+				resolvedClusterRuntime("level-4", "level-3"),
+				resolvedClusterRuntime("level-5", "level-4"),
+			},
+		},
+		{
+			Subject: Identity{Kind: KindClusterServingRuntime, Name: "level-6"},
+			Runtimes: []Runtime{
+				{
+					Identity:   Identity{Kind: KindClusterServingRuntime, Name: "level-2"},
+					ParentName: "level-1",
+				},
+				resolvedClusterRuntime("level-3", "level-2"),
+				resolvedClusterRuntime("level-4", "level-3"),
+				resolvedClusterRuntime("level-5", "level-4"),
+				resolvedClusterRuntime("level-6", "level-5"),
+			},
+			Issue: &Issue{
+				Code:       IssueMaxDepthExceeded,
+				Subject:    Identity{Kind: KindClusterServingRuntime, Name: "level-6"},
+				ParentName: "level-1",
+				Path: []Identity{
+					{Kind: KindClusterServingRuntime, Name: "level-6"},
+					{Kind: KindClusterServingRuntime, Name: "level-5"},
+					{Kind: KindClusterServingRuntime, Name: "level-4"},
+					{Kind: KindClusterServingRuntime, Name: "level-3"},
+					{Kind: KindClusterServingRuntime, Name: "level-2"},
+				},
+			},
+		},
+	}, projection.Contexts[0].Paths)
+
+	root, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "level-1"})
+	require.NoError(t, err)
+	assert.NotContains(t, pathSubjects(root), Identity{
+		Kind: KindClusterServingRuntime, Name: "level-6",
+	}, "the sixth head stopped before it visited level-1")
+}
+
+func TestProjectChecksMaxDepthBeforeCycleAtTheBoundary(t *testing.T) {
+	graph, err := Build(Snapshot{ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+		clusterRuntime("level-1", "level-5"),
+		clusterRuntime("level-2", "level-1"),
+		clusterRuntime("level-3", "level-2"),
+		clusterRuntime("level-4", "level-3"),
+		clusterRuntime("level-5", "level-4"),
+	}})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "level-5"})
+
+	require.NoError(t, err)
+	path := pathForSubject(t, projection, Identity{
+		Kind: KindClusterServingRuntime, Name: "level-5",
+	})
+	require.NotNil(t, path.Issue)
+	assert.Equal(t, IssueMaxDepthExceeded, path.Issue.Code)
+	assert.Equal(t, "level-5", path.Issue.ParentName)
+	assert.Equal(t, []Identity{
+		{Kind: KindClusterServingRuntime, Name: "level-5"},
+		{Kind: KindClusterServingRuntime, Name: "level-4"},
+		{Kind: KindClusterServingRuntime, Name: "level-3"},
+		{Kind: KindClusterServingRuntime, Name: "level-2"},
+		{Kind: KindClusterServingRuntime, Name: "level-1"},
+	}, path.Issue.Path)
+	assert.Nil(t, path.Runtimes[0].ResolvedParent)
+}
+
+func TestProjectPreservesMissingParentIssueForEveryPathThatReachedTarget(t *testing.T) {
+	graph, err := Build(Snapshot{ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+		clusterRuntime("target", "missing"),
+		clusterRuntime("child", "target"),
+	}})
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "target"})
+
+	require.NoError(t, err)
+	require.Len(t, projection.Contexts, 1)
+	assert.Equal(t, []ResolutionPath{
+		{
+			Subject: Identity{Kind: KindClusterServingRuntime, Name: "target"},
+			Runtimes: []Runtime{{
+				Identity:   Identity{Kind: KindClusterServingRuntime, Name: "target"},
+				ParentName: "missing",
+			}},
+			Issue: &Issue{
+				Code:       IssueParentMissing,
+				Subject:    Identity{Kind: KindClusterServingRuntime, Name: "target"},
+				ParentName: "missing",
+				Path:       []Identity{{Kind: KindClusterServingRuntime, Name: "target"}},
+			},
+		},
+		{
+			Subject: Identity{Kind: KindClusterServingRuntime, Name: "child"},
+			Runtimes: []Runtime{
+				{
+					Identity:   Identity{Kind: KindClusterServingRuntime, Name: "target"},
+					ParentName: "missing",
+				},
+				resolvedClusterRuntime("child", "target"),
+			},
+			Issue: &Issue{
+				Code:       IssueParentMissing,
+				Subject:    Identity{Kind: KindClusterServingRuntime, Name: "child"},
+				ParentName: "missing",
+				Path: []Identity{
+					{Kind: KindClusterServingRuntime, Name: "child"},
+					{Kind: KindClusterServingRuntime, Name: "target"},
+				},
+			},
+		},
+	}, projection.Contexts[0].Paths)
+}
+
+func TestProjectOrdersContextsAndPathsDeterministically(t *testing.T) {
+	snapshot := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("target", ""),
+			clusterRuntime("a-child", "target"),
+			clusterRuntime("z-child", "target"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("z-team", "leaf", "target"),
+			namespacedRuntime("a-team", "z-leaf", "target"),
+			namespacedRuntime("a-team", "a-leaf", "target"),
+		},
+	}
+	shuffled := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			*snapshot.ClusterServingRuntimes[2].DeepCopy(),
+			*snapshot.ClusterServingRuntimes[0].DeepCopy(),
+			*snapshot.ClusterServingRuntimes[1].DeepCopy(),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			*snapshot.ServingRuntimes[1].DeepCopy(),
+			*snapshot.ServingRuntimes[2].DeepCopy(),
+			*snapshot.ServingRuntimes[0].DeepCopy(),
+		},
+	}
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+	shuffledGraph, err := Build(shuffled)
+	require.NoError(t, err)
+
+	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "target"})
+	require.NoError(t, err)
+	shuffledProjection, err := shuffledGraph.Project(Target{Kind: KindClusterServingRuntime, Name: "target"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []ResolutionContext{
+		clusterContext(), namespacedContext("a-team"), namespacedContext("z-team"),
+	}, projectionContexts(projection))
+	assert.Equal(t, []Identity{
+		{Kind: KindClusterServingRuntime, Name: "target"},
+		{Kind: KindClusterServingRuntime, Name: "a-child"},
+		{Kind: KindClusterServingRuntime, Name: "z-child"},
+	}, contextPathSubjects(projection.Contexts[0]))
+	assert.Equal(t, []Identity{
+		{Kind: KindServingRuntime, Namespace: "a-team", Name: "a-leaf"},
+		{Kind: KindServingRuntime, Namespace: "a-team", Name: "z-leaf"},
+	}, contextPathSubjects(projection.Contexts[1]))
+	assert.Equal(t, projection, shuffledProjection)
+	encoded, err := json.Marshal(projection)
+	require.NoError(t, err)
+	shuffledEncoded, err := json.Marshal(shuffledProjection)
+	require.NoError(t, err)
+	assert.Equal(t, string(encoded), string(shuffledEncoded))
+}
+
+func TestProjectReturnsDefensiveCopies(t *testing.T) {
+	graph, err := Build(Snapshot{ServingRuntimes: []omev1beta1.ServingRuntime{
+		namespacedRuntime("team-a", "parent", ""),
+		namespacedRuntime("team-a", "child", "parent"),
+	}})
+	require.NoError(t, err)
+
+	first, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "child",
+	})
+	require.NoError(t, err)
+	first.Contexts[0].Context.Namespace = "mutated"
+	first.Contexts[0].Paths[0].Subject.Name = "mutated"
+	first.Contexts[0].Paths[0].Runtimes[0].Identity.Name = "mutated"
+	first.Contexts[0].Paths[0].Runtimes[1].ResolvedParent.Name = "mutated"
+
+	again, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "child",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, namespacedContext("team-a"), again.Contexts[0].Context)
+	assert.Equal(t, Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"}, again.Contexts[0].Paths[0].Subject)
+	assert.Equal(t, "parent", again.Contexts[0].Paths[0].Runtimes[0].Identity.Name)
+	assert.Equal(t, "parent", again.Contexts[0].Paths[0].Runtimes[1].ResolvedParent.Name)
+}
+
+func clusterContext() ResolutionContext {
+	return ResolutionContext{Mode: ResolutionModeCluster}
+}
+
+func namespacedContext(namespace string) ResolutionContext {
+	return ResolutionContext{Mode: ResolutionModeNamespaced, Namespace: namespace}
+}
+
+func resolvedClusterRuntime(name, parent string) Runtime {
+	return Runtime{
+		Identity:       Identity{Kind: KindClusterServingRuntime, Name: name},
+		ParentName:     parent,
+		ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: parent}),
+	}
+}
+
+func projectionContexts(projection Projection) []ResolutionContext {
+	result := make([]ResolutionContext, len(projection.Contexts))
+	for i := range projection.Contexts {
+		result[i] = projection.Contexts[i].Context
+	}
+	return result
+}
+
+func contextPathSubjects(context ContextProjection) []Identity {
+	result := make([]Identity, len(context.Paths))
+	for i := range context.Paths {
+		result[i] = context.Paths[i].Subject
+	}
+	return result
+}
+
+func pathSubjects(projection Projection) []Identity {
+	var result []Identity
+	for _, context := range projection.Contexts {
+		result = append(result, contextPathSubjects(context)...)
+	}
+	return result
+}
+
+func onlyPath(t *testing.T, projection Projection) ResolutionPath {
+	t.Helper()
+	require.Len(t, projection.Contexts, 1)
+	require.Len(t, projection.Contexts[0].Paths, 1)
+	return projection.Contexts[0].Paths[0]
+}
+
+func pathForSubject(t *testing.T, projection Projection, subject Identity) ResolutionPath {
+	t.Helper()
+	for _, context := range projection.Contexts {
+		for _, path := range context.Paths {
+			if path.Subject == subject {
+				return path
+			}
+		}
+	}
+	require.Failf(t, "path not found", "subject: %#v", subject)
+	return ResolutionPath{}
+}

--- a/pkg/cli/runtimegraph/controller_conformance_test.go
+++ b/pkg/cli/runtimegraph/controller_conformance_test.go
@@ -1,0 +1,145 @@
+package runtimegraph
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omev1beta1 "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
+)
+
+func TestProjectPathMatchesRuntimeInheritanceResolverLookupTrace(t *testing.T) {
+	snapshot := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("bridge", "base"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "base", ""),
+			namespacedRuntime("team-a", "leaf", "bridge"),
+		},
+	}
+	recorder := newIdentityRecordingClient(t, snapshot)
+
+	_, chain, err := runtimeinheritance.ResolveNamespacedRuntime(
+		context.Background(), recorder, "team-a", "leaf",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"base", "bridge", "leaf"}, chain)
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+	projection, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reversedIdentities(recorder.successfulGets), runtimePathIdentities(
+		onlyPath(t, projection),
+	))
+}
+
+func TestProjectCycleMatchesResolverNameCheckBeforeLookup(t *testing.T) {
+	snapshot := Snapshot{
+		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
+			clusterRuntime("bridge", "same-name"),
+		},
+		ServingRuntimes: []omev1beta1.ServingRuntime{
+			namespacedRuntime("team-a", "same-name", "bridge"),
+		},
+	}
+	recorder := newIdentityRecordingClient(t, snapshot)
+
+	_, _, err := runtimeinheritance.ResolveNamespacedRuntime(
+		context.Background(), recorder, "team-a", "same-name",
+	)
+
+	var cycle *runtimeinheritance.CycleError
+	require.True(t, errors.As(err, &cycle))
+	assert.Equal(t, []string{"same-name", "bridge", "same-name"}, cycle.Cycle)
+	assert.Equal(t, []Identity{
+		{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+		{Kind: KindClusterServingRuntime, Name: "bridge"},
+	}, recorder.successfulGets, "the resolver detects the repeated name before fetching it again")
+
+	graph, err := Build(snapshot)
+	require.NoError(t, err)
+	projection, err := graph.Project(Target{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+	})
+	require.NoError(t, err)
+	path := onlyPath(t, projection)
+	require.NotNil(t, path.Issue)
+	assert.Equal(t, IssueCycleDetected, path.Issue.Code)
+	assert.Equal(t, []Identity{
+		{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+		{Kind: KindClusterServingRuntime, Name: "bridge"},
+		{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+	}, path.Issue.Path)
+}
+
+type identityRecordingClient struct {
+	client.Client
+	successfulGets []Identity
+}
+
+func (c *identityRecordingClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if err := c.Client.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	switch value := object.(type) {
+	case *omev1beta1.ClusterServingRuntime:
+		c.successfulGets = append(c.successfulGets, Identity{
+			Kind: KindClusterServingRuntime, Name: value.Name,
+		})
+	case *omev1beta1.ServingRuntime:
+		c.successfulGets = append(c.successfulGets, Identity{
+			Kind: KindServingRuntime, Namespace: value.Namespace, Name: value.Name,
+		})
+	}
+	return nil
+}
+
+func newIdentityRecordingClient(t *testing.T, snapshot Snapshot) *identityRecordingClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, omev1beta1.AddToScheme(scheme))
+	objects := make([]client.Object, 0,
+		len(snapshot.ClusterServingRuntimes)+len(snapshot.ServingRuntimes))
+	for i := range snapshot.ClusterServingRuntimes {
+		objects = append(objects, snapshot.ClusterServingRuntimes[i].DeepCopy())
+	}
+	for i := range snapshot.ServingRuntimes {
+		objects = append(objects, snapshot.ServingRuntimes[i].DeepCopy())
+	}
+	return &identityRecordingClient{Client: ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()}
+}
+
+func reversedIdentities(values []Identity) []Identity {
+	result := make([]Identity, len(values))
+	for i := range values {
+		result[len(values)-1-i] = values[i]
+	}
+	return result
+}
+
+func runtimePathIdentities(path ResolutionPath) []Identity {
+	result := make([]Identity, len(path.Runtimes))
+	for i := range path.Runtimes {
+		result[i] = path.Runtimes[i].Identity
+	}
+	return result
+}

--- a/pkg/cli/runtimegraph/graph.go
+++ b/pkg/cli/runtimegraph/graph.go
@@ -33,7 +33,11 @@ type Target struct {
 	Name      string
 }
 
-// Snapshot contains runtime objects collected by a caller.
+// Snapshot contains runtime objects collected by a caller. Build treats both
+// lists as authoritative: absence means a runtime is not present. Callers with
+// truncated or unavailable lists must preserve that incompleteness alongside
+// the projection instead of presenting absence-based fallbacks or issues as
+// definitive cluster state.
 type Snapshot struct {
 	ClusterServingRuntimes []omev1beta1.ClusterServingRuntime
 	ServingRuntimes        []omev1beta1.ServingRuntime
@@ -64,19 +68,51 @@ type Issue struct {
 	Path       []Identity `json:"path"`
 }
 
-// Projection is the graph view rooted at a target runtime. Ancestors are
-// ordered root first and exclude Target.
-type Projection struct {
-	Target      Runtime   `json:"target"`
-	Ancestors   []Runtime `json:"ancestors"`
-	Descendants []Subtree `json:"descendants"`
-	Issues      []Issue   `json:"issues"`
+// ResolutionMode identifies the lookup policy the controller keeps for an
+// entire inheritance walk.
+type ResolutionMode string
+
+const (
+	// ResolutionModeCluster resolves every parent as a
+	// ClusterServingRuntime.
+	ResolutionModeCluster ResolutionMode = "Cluster"
+	// ResolutionModeNamespaced resolves every parent as a ServingRuntime in
+	// Namespace first, then falls back to a ClusterServingRuntime.
+	ResolutionModeNamespaced ResolutionMode = "Namespaced"
+)
+
+// ResolutionContext is the fixed lookup context for one controller
+// inheritance walk. Namespace is empty for cluster-only resolution.
+type ResolutionContext struct {
+	Mode      ResolutionMode `json:"mode"`
+	Namespace string         `json:"namespace,omitempty"`
 }
 
-// Subtree is one node in the target's descendant tree.
-type Subtree struct {
-	Runtime  Runtime   `json:"runtime"`
-	Children []Subtree `json:"children"`
+// ResolutionPath is the exact bounded walk for one real runtime head.
+// Runtimes are ordered from the observed root or error boundary to Subject.
+// An unsuccessful walk retains every runtime visited before it stopped.
+type ResolutionPath struct {
+	Subject  Identity  `json:"subject"`
+	Runtimes []Runtime `json:"runtimes"`
+	Issue    *Issue    `json:"issue,omitempty"`
+}
+
+// ContextProjection groups real-head paths that visited Target under one
+// fixed controller lookup context. Paths are not merged: both namespace
+// shadowing and the maximum-depth budget can give the same runtime occurrence
+// different visible ancestors in different head walks.
+type ContextProjection struct {
+	Context ResolutionContext `json:"context"`
+	Paths   []ResolutionPath  `json:"paths"`
+}
+
+// Projection contains every real-head controller walk that visited Target.
+// A ServingRuntime target has one namespaced context. A
+// ClusterServingRuntime target always has its direct cluster context and may
+// also occur in namespaced contexts reached by ServingRuntime heads.
+type Projection struct {
+	Target   Identity            `json:"target"`
+	Contexts []ContextProjection `json:"contexts"`
 }
 
 var (
@@ -144,14 +180,12 @@ func (e *AmbiguousTargetError) Unwrap() error { return ErrTargetAmbiguous }
 // Graph is an immutable runtime index built from a snapshot.
 type Graph struct {
 	runtimes map[Identity]runtimeNode
-	children map[Identity][]Identity
+	heads    []Identity
 }
 
 type runtimeNode struct {
 	identity   Identity
 	parentName string
-	parent     Identity
-	hasParent  bool
 }
 
 // Build indexes a runtime snapshot.
@@ -183,10 +217,12 @@ func Build(snapshot Snapshot) (*Graph, error) {
 			identity: identity, parentName: object.Annotations[constants.RuntimeInheritFromAnnotationKey],
 		}
 	}
-	graph := &Graph{runtimes: runtimes, children: make(map[Identity][]Identity)}
-	graph.resolveParents()
-	graph.indexChildren()
-	return graph, nil
+	heads := make([]Identity, 0, len(runtimes))
+	for identity := range runtimes {
+		heads = append(heads, identity)
+	}
+	sort.Slice(heads, func(i, j int) bool { return identityLess(heads[i], heads[j]) })
+	return &Graph{runtimes: runtimes, heads: heads}, nil
 }
 
 // Project resolves target and returns its graph view.
@@ -197,6 +233,9 @@ func (g *Graph) Project(target Target) (Projection, error) {
 	if target.Kind == KindServingRuntime && target.Namespace == "" {
 		return Projection{}, fmt.Errorf("%w: namespace is required for ServingRuntime", ErrInvalidTarget)
 	}
+	if target.Kind == KindClusterServingRuntime && target.Namespace != "" {
+		return Projection{}, fmt.Errorf("%w: namespace is forbidden for ClusterServingRuntime", ErrInvalidTarget)
+	}
 	if target.Kind != "" && target.Kind != KindServingRuntime && target.Kind != KindClusterServingRuntime {
 		return Projection{}, fmt.Errorf("%w: unsupported kind %q", ErrInvalidTarget, target.Kind)
 	}
@@ -204,58 +243,157 @@ func (g *Graph) Project(target Target) (Projection, error) {
 	if err != nil {
 		return Projection{}, err
 	}
-	node, ok := g.runtimes[identity]
-	if !ok {
+	if _, ok := g.runtimes[identity]; !ok {
 		return Projection{}, &TargetNotFoundError{Target: target}
 	}
-	ancestors, issue := g.ancestorSpine(identity)
-	issues := make([]Issue, 0, 1)
-	if issue != nil {
-		issues = append(issues, *issue)
+
+	pathsByContext := make(map[ResolutionContext][]ResolutionPath)
+	for _, head := range g.heads {
+		context := resolutionContextForHead(head)
+		walk := g.resolveHead(head, context)
+		if !walk.visits(identity) {
+			continue
+		}
+		pathsByContext[context] = append(pathsByContext[context], walk.project())
 	}
-	return Projection{
-		Target: node.runtime(), Ancestors: ancestors,
-		Descendants: g.descendantSubtrees(identity, map[Identity]struct{}{identity: {}}),
-		Issues:      issues,
-	}, nil
+
+	contexts := make([]ResolutionContext, 0, len(pathsByContext))
+	for context := range pathsByContext {
+		contexts = append(contexts, context)
+	}
+	sort.Slice(contexts, func(i, j int) bool { return resolutionContextLess(contexts[i], contexts[j]) })
+	result := Projection{Target: identity, Contexts: make([]ContextProjection, 0, len(contexts))}
+	for _, context := range contexts {
+		paths := pathsByContext[context]
+		sort.Slice(paths, func(i, j int) bool {
+			leftTarget := paths[i].Subject == identity
+			rightTarget := paths[j].Subject == identity
+			if leftTarget != rightTarget {
+				return leftTarget
+			}
+			return identityLess(paths[i].Subject, paths[j].Subject)
+		})
+		result.Contexts = append(result.Contexts, ContextProjection{Context: context, Paths: paths})
+	}
+	return result, nil
 }
 
-func (g *Graph) ancestorSpine(subject Identity) ([]Runtime, *Issue) {
-	path := []Identity{subject}
-	visited := map[Identity]struct{}{subject: {}}
-	current := g.runtimes[subject]
-	for current.parentName != "" {
-		if len(path) >= constants.RuntimeInheritMaxDepth {
-			return reverseRuntimePath(g, path[1:]), &Issue{
-				Code: IssueMaxDepthExceeded, Subject: subject, ParentName: current.parentName,
-				Path: append([]Identity{}, path...),
-			}
-		}
-		if !current.hasParent {
-			return reverseRuntimePath(g, path[1:]), &Issue{
-				Code: IssueParentMissing, Subject: subject, ParentName: current.parentName,
-				Path: append([]Identity{}, path...),
-			}
-		}
-		if _, seen := visited[current.parent]; seen {
-			cyclePath := append(append([]Identity{}, path...), current.parent)
-			return reverseRuntimePath(g, path[1:]), &Issue{
-				Code: IssueCycleDetected, Subject: subject, ParentName: current.parentName, Path: cyclePath,
-			}
-		}
-		visited[current.parent] = struct{}{}
-		path = append(path, current.parent)
-		current = g.runtimes[current.parent]
-	}
-	return reverseRuntimePath(g, path[1:]), nil
+type resolvedHead struct {
+	subject            Identity
+	runtimesChildFirst []Runtime
+	issue              *Issue
 }
 
-func reverseRuntimePath(g *Graph, childFirst []Identity) []Runtime {
-	runtimes := make([]Runtime, len(childFirst))
-	for i := range childFirst {
-		runtimes[len(childFirst)-1-i] = g.runtimes[childFirst[i]].runtime()
+func (g *Graph) resolveHead(subject Identity, context ResolutionContext) resolvedHead {
+	start := g.runtimes[subject].runtime()
+	result := resolvedHead{subject: subject, runtimesChildFirst: []Runtime{start}}
+	visited := map[string]Identity{subject.Name: subject}
+
+	for {
+		currentIndex := len(result.runtimesChildFirst) - 1
+		current := result.runtimesChildFirst[currentIndex]
+		if current.ParentName == "" {
+			return result
+		}
+		path := runtimeIdentities(result.runtimesChildFirst)
+		if len(result.runtimesChildFirst) >= constants.RuntimeInheritMaxDepth {
+			result.issue = &Issue{
+				Code: IssueMaxDepthExceeded, Subject: subject,
+				ParentName: current.ParentName, Path: path,
+			}
+			return result
+		}
+		if closing, seen := visited[current.ParentName]; seen {
+			parent := closing
+			result.runtimesChildFirst[currentIndex].ResolvedParent = &parent
+			result.issue = &Issue{
+				Code: IssueCycleDetected, Subject: subject,
+				ParentName: current.ParentName, Path: append(path, closing),
+			}
+			return result
+		}
+		parent, found := g.lookupParent(context, current.ParentName)
+		if !found {
+			result.issue = &Issue{
+				Code: IssueParentMissing, Subject: subject,
+				ParentName: current.ParentName, Path: path,
+			}
+			return result
+		}
+		resolvedParent := parent
+		result.runtimesChildFirst[currentIndex].ResolvedParent = &resolvedParent
+		visited[parent.Name] = parent
+		result.runtimesChildFirst = append(result.runtimesChildFirst, g.runtimes[parent].runtime())
 	}
-	return runtimes
+}
+
+func (g *Graph) lookupParent(context ResolutionContext, name string) (Identity, bool) {
+	if context.Mode == ResolutionModeNamespaced {
+		namespaced := Identity{Kind: KindServingRuntime, Namespace: context.Namespace, Name: name}
+		if _, ok := g.runtimes[namespaced]; ok {
+			return namespaced, true
+		}
+	}
+	cluster := Identity{Kind: KindClusterServingRuntime, Name: name}
+	_, ok := g.runtimes[cluster]
+	return cluster, ok
+}
+
+func resolutionContextForHead(head Identity) ResolutionContext {
+	if head.Kind == KindServingRuntime {
+		return ResolutionContext{Mode: ResolutionModeNamespaced, Namespace: head.Namespace}
+	}
+	return ResolutionContext{Mode: ResolutionModeCluster}
+}
+
+func resolutionContextLess(left, right ResolutionContext) bool {
+	if left.Mode != right.Mode {
+		return left.Mode == ResolutionModeCluster
+	}
+	return left.Namespace < right.Namespace
+}
+
+func runtimeIdentities(runtimes []Runtime) []Identity {
+	result := make([]Identity, len(runtimes))
+	for i := range runtimes {
+		result[i] = runtimes[i].Identity
+	}
+	return result
+}
+
+func (r resolvedHead) visits(target Identity) bool {
+	for _, runtime := range r.runtimesChildFirst {
+		if runtime.Identity == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (r resolvedHead) project() ResolutionPath {
+	runtimes := make([]Runtime, len(r.runtimesChildFirst))
+	for i := range r.runtimesChildFirst {
+		runtimes[len(r.runtimesChildFirst)-1-i] = copyRuntime(r.runtimesChildFirst[i])
+	}
+	return ResolutionPath{Subject: r.subject, Runtimes: runtimes, Issue: copyIssue(r.issue)}
+}
+
+func copyRuntime(runtime Runtime) Runtime {
+	result := runtime
+	if runtime.ResolvedParent != nil {
+		parent := *runtime.ResolvedParent
+		result.ResolvedParent = &parent
+	}
+	return result
+}
+
+func copyIssue(issue *Issue) *Issue {
+	if issue == nil {
+		return nil
+	}
+	result := *issue
+	result.Path = append([]Identity{}, issue.Path...)
+	return &result
 }
 
 func (g *Graph) resolveTarget(target Target) (Identity, error) {
@@ -283,61 +421,6 @@ func (g *Graph) resolveTarget(target Target) (Identity, error) {
 	return Identity{}, &TargetNotFoundError{Target: target}
 }
 
-func (g *Graph) resolveParents() {
-	for identity, node := range g.runtimes {
-		if node.parentName == "" {
-			continue
-		}
-		var parent Identity
-		if identity.Kind == KindClusterServingRuntime {
-			parent = Identity{Kind: KindClusterServingRuntime, Name: node.parentName}
-		} else {
-			parent = Identity{Kind: KindServingRuntime, Namespace: identity.Namespace, Name: node.parentName}
-			if _, ok := g.runtimes[parent]; !ok {
-				parent = Identity{Kind: KindClusterServingRuntime, Name: node.parentName}
-			}
-		}
-		if _, ok := g.runtimes[parent]; !ok {
-			continue
-		}
-		node.parent = parent
-		node.hasParent = true
-		g.runtimes[identity] = node
-	}
-}
-
-func (g *Graph) indexChildren() {
-	for identity, node := range g.runtimes {
-		if node.hasParent {
-			g.children[node.parent] = append(g.children[node.parent], identity)
-		}
-	}
-	for parent := range g.children {
-		sort.Slice(g.children[parent], func(i, j int) bool {
-			return identityLess(g.children[parent][i], g.children[parent][j])
-		})
-	}
-}
-
-func (g *Graph) descendantSubtrees(parent Identity, path map[Identity]struct{}) []Subtree {
-	result := make([]Subtree, 0, len(g.children[parent]))
-	for _, child := range g.children[parent] {
-		if _, seen := path[child]; seen {
-			continue
-		}
-		childPath := make(map[Identity]struct{}, len(path)+1)
-		for identity := range path {
-			childPath[identity] = struct{}{}
-		}
-		childPath[child] = struct{}{}
-		result = append(result, Subtree{
-			Runtime:  g.runtimes[child].runtime(),
-			Children: g.descendantSubtrees(child, childPath),
-		})
-	}
-	return result
-}
-
 func identityLess(left, right Identity) bool {
 	if left.Kind != right.Kind {
 		return left.Kind < right.Kind
@@ -356,10 +439,5 @@ func formatIdentity(identity Identity) string {
 }
 
 func (n runtimeNode) runtime() Runtime {
-	result := Runtime{Identity: n.identity, ParentName: n.parentName}
-	if n.hasParent {
-		parent := n.parent
-		result.ResolvedParent = &parent
-	}
-	return result
+	return Runtime{Identity: n.identity, ParentName: n.parentName}
 }

--- a/pkg/cli/runtimegraph/graph_test.go
+++ b/pkg/cli/runtimegraph/graph_test.go
@@ -49,17 +49,26 @@ func TestProjectResolvesNamespacedParentsBeforeClusterParents(t *testing.T) {
 	clusterFallback, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-b", Name: "child"})
 	require.NoError(t, err)
 
-	assert.Equal(t, Runtime{
-		Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"},
-		ParentName:     "shared",
-		ResolvedParent: identityPointer(Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "shared"}),
-	}, local.Target)
-	assert.Equal(t, []Runtime{{
-		Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "shared"},
-	}}, local.Ancestors)
-	assert.Equal(t, []Runtime{{
-		Identity: Identity{Kind: KindClusterServingRuntime, Name: "shared"},
-	}}, clusterFallback.Ancestors)
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "shared"}},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"},
+			ParentName: "shared",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "shared",
+			}),
+		},
+	}, onlyPath(t, local).Runtimes)
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "shared"}},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-b", Name: "child"},
+			ParentName: "shared",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "shared",
+			}),
+		},
+	}, onlyPath(t, clusterFallback).Runtimes)
 }
 
 func TestProjectAcceptsFiveRuntimeChainAndRejectsSixthLevel(t *testing.T) {
@@ -84,15 +93,18 @@ func TestProjectAcceptsFiveRuntimeChainAndRejectsSixthLevel(t *testing.T) {
 		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-2"}, ParentName: "level-1", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-1"})},
 		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-3"}, ParentName: "level-2", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-2"})},
 		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-4"}, ParentName: "level-3", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-3"})},
-	}, five.Ancestors)
-	assert.Empty(t, five.Issues)
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-5"}, ParentName: "level-4", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-4"})},
+	}, pathForSubject(t, five, Identity{Kind: KindClusterServingRuntime, Name: "level-5"}).Runtimes)
+	assert.Nil(t, pathForSubject(t, five, Identity{Kind: KindClusterServingRuntime, Name: "level-5"}).Issue)
+	sixPath := onlyPath(t, six)
 	assert.Equal(t, []Runtime{
-		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-2"}, ParentName: "level-1", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-1"})},
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-2"}, ParentName: "level-1"},
 		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-3"}, ParentName: "level-2", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-2"})},
 		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-4"}, ParentName: "level-3", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-3"})},
 		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-5"}, ParentName: "level-4", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-4"})},
-	}, six.Ancestors)
-	assert.Equal(t, []Issue{{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "level-6"}, ParentName: "level-5", ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "level-5"})},
+	}, sixPath.Runtimes)
+	assert.Equal(t, &Issue{
 		Code: IssueMaxDepthExceeded, Subject: Identity{Kind: KindClusterServingRuntime, Name: "level-6"},
 		ParentName: "level-1",
 		Path: []Identity{
@@ -102,7 +114,7 @@ func TestProjectAcceptsFiveRuntimeChainAndRejectsSixthLevel(t *testing.T) {
 			{Kind: KindClusterServingRuntime, Name: "level-3"},
 			{Kind: KindClusterServingRuntime, Name: "level-2"},
 		},
-	}}, six.Issues)
+	}, sixPath.Issue)
 }
 
 func TestProjectReportsMissingParentWithoutCrossNamespaceLookup(t *testing.T) {
@@ -116,13 +128,16 @@ func TestProjectReportsMissingParentWithoutCrossNamespaceLookup(t *testing.T) {
 	projection, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"})
 	require.NoError(t, err)
 
-	assert.Nil(t, projection.Target.ResolvedParent)
-	assert.Empty(t, projection.Ancestors)
-	assert.Equal(t, []Issue{{
+	path := onlyPath(t, projection)
+	assert.Equal(t, []Runtime{{
+		Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"},
+		ParentName: "shared",
+	}}, path.Runtimes)
+	assert.Equal(t, &Issue{
 		Code: IssueParentMissing, Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"},
 		ParentName: "shared",
 		Path:       []Identity{{Kind: KindServingRuntime, Namespace: "team-a", Name: "child"}},
-	}}, projection.Issues)
+	}, path.Issue)
 }
 
 func TestProjectReportsSameScopeCycleByFullIdentity(t *testing.T) {
@@ -135,14 +150,26 @@ func TestProjectReportsSameScopeCycleByFullIdentity(t *testing.T) {
 	projection, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"})
 	require.NoError(t, err)
 
-	assert.Equal(t, []Runtime{{
-		Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-b"},
-		ParentName: "runtime-a",
-		ResolvedParent: identityPointer(Identity{
-			Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a",
-		}),
-	}}, projection.Ancestors)
-	assert.Equal(t, []Issue{{
+	path := pathForSubject(t, projection, Identity{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a",
+	})
+	assert.Equal(t, []Runtime{
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-b"},
+			ParentName: "runtime-a",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a",
+			}),
+		},
+		{
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"},
+			ParentName: "runtime-b",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-b",
+			}),
+		},
+	}, path.Runtimes)
+	assert.Equal(t, &Issue{
 		Code: IssueCycleDetected, Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"},
 		ParentName: "runtime-a",
 		Path: []Identity{
@@ -150,7 +177,7 @@ func TestProjectReportsSameScopeCycleByFullIdentity(t *testing.T) {
 			{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-b"},
 			{Kind: KindServingRuntime, Namespace: "team-a", Name: "runtime-a"},
 		},
-	}}, projection.Issues)
+	}, path.Issue)
 }
 
 func TestProjectReportsCycleAfterCrossingFromNamespaceToCluster(t *testing.T) {
@@ -168,6 +195,7 @@ func TestProjectReportsCycleAfterCrossingFromNamespaceToCluster(t *testing.T) {
 	projection, err := graph.Project(Target{Kind: KindServingRuntime, Namespace: "team-a", Name: "entry"})
 	require.NoError(t, err)
 
+	path := onlyPath(t, projection)
 	assert.Equal(t, []Runtime{
 		{
 			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "cluster-b"},
@@ -179,8 +207,13 @@ func TestProjectReportsCycleAfterCrossingFromNamespaceToCluster(t *testing.T) {
 			ParentName:     "cluster-b",
 			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "cluster-b"}),
 		},
-	}, projection.Ancestors)
-	assert.Equal(t, []Issue{{
+		{
+			Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "entry"},
+			ParentName:     "cluster-a",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "cluster-a"}),
+		},
+	}, path.Runtimes)
+	assert.Equal(t, &Issue{
 		Code: IssueCycleDetected, Subject: Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "entry"},
 		ParentName: "cluster-a",
 		Path: []Identity{
@@ -189,10 +222,10 @@ func TestProjectReportsCycleAfterCrossingFromNamespaceToCluster(t *testing.T) {
 			{Kind: KindClusterServingRuntime, Name: "cluster-b"},
 			{Kind: KindClusterServingRuntime, Name: "cluster-a"},
 		},
-	}}, projection.Issues)
+	}, path.Issue)
 }
 
-func TestProjectUsesFullIdentityForRepeatedNameAcrossScopes(t *testing.T) {
+func TestProjectUsesControllerNameCyclesForRepeatedNameAcrossScopes(t *testing.T) {
 	graph, err := Build(Snapshot{
 		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
 			clusterRuntime("same-name", ""),
@@ -209,18 +242,40 @@ func TestProjectUsesFullIdentityForRepeatedNameAcrossScopes(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	path := pathForSubject(t, projection, Identity{
+		Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+	})
 	assert.Equal(t, []Runtime{
-		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "same-name"}},
 		{
-			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
-			ParentName:     "same-name",
-			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "same-name"}),
+			Identity:   Identity{Kind: KindClusterServingRuntime, Name: "bridge"},
+			ParentName: "same-name",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+			}),
 		},
-	}, projection.Ancestors)
-	assert.Empty(t, projection.Issues)
+		{
+			Identity: Identity{
+				Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+			},
+			ParentName:     "bridge",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "bridge"}),
+		},
+	}, path.Runtimes)
+	assert.Equal(t, &Issue{
+		Code: IssueCycleDetected,
+		Subject: Identity{
+			Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name",
+		},
+		ParentName: "same-name",
+		Path: []Identity{
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+			{Kind: KindClusterServingRuntime, Name: "bridge"},
+			{Kind: KindServingRuntime, Namespace: "team-a", Name: "same-name"},
+		},
+	}, path.Issue)
 }
 
-func TestProjectBuildsDeterministicDescendantSubtree(t *testing.T) {
+func TestProjectBuildsDeterministicDependentPaths(t *testing.T) {
 	graph, err := Build(Snapshot{
 		ClusterServingRuntimes: []omev1beta1.ClusterServingRuntime{
 			clusterRuntime("root", ""),
@@ -237,39 +292,29 @@ func TestProjectBuildsDeterministicDescendantSubtree(t *testing.T) {
 	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "root"})
 	require.NoError(t, err)
 
-	assert.Equal(t, []Subtree{
+	assert.Equal(t, []ResolutionContext{
+		clusterContext(), namespacedContext("team-a"), namespacedContext("team-b"),
+	}, projectionContexts(projection))
+	assert.Equal(t, []Identity{
+		{Kind: KindClusterServingRuntime, Name: "root"},
+		{Kind: KindClusterServingRuntime, Name: "a-branch"},
+		{Kind: KindClusterServingRuntime, Name: "z-branch"},
+	}, contextPathSubjects(projection.Contexts[0]))
+	assert.Equal(t, []Runtime{
+		{Identity: Identity{Kind: KindClusterServingRuntime, Name: "root"}},
 		{
-			Runtime: Runtime{
-				Identity:       Identity{Kind: KindClusterServingRuntime, Name: "a-branch"},
-				ParentName:     "root",
-				ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
-			},
-			Children: []Subtree{{
-				Runtime: Runtime{
-					Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
-					ParentName:     "a-branch",
-					ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "a-branch"}),
-				},
-				Children: []Subtree{},
-			}},
+			Identity:       Identity{Kind: KindClusterServingRuntime, Name: "a-branch"},
+			ParentName:     "root",
+			ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
 		},
 		{
-			Runtime: Runtime{
-				Identity:       Identity{Kind: KindClusterServingRuntime, Name: "z-branch"},
-				ParentName:     "root",
-				ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
-			},
-			Children: []Subtree{},
+			Identity:   Identity{Kind: KindServingRuntime, Namespace: "team-a", Name: "leaf"},
+			ParentName: "a-branch",
+			ResolvedParent: identityPointer(Identity{
+				Kind: KindClusterServingRuntime, Name: "a-branch",
+			}),
 		},
-		{
-			Runtime: Runtime{
-				Identity:       Identity{Kind: KindServingRuntime, Namespace: "team-b", Name: "leaf"},
-				ParentName:     "root",
-				ResolvedParent: identityPointer(Identity{Kind: KindClusterServingRuntime, Name: "root"}),
-			},
-			Children: []Subtree{},
-		},
-	}, projection.Descendants)
+	}, projection.Contexts[1].Paths[0].Runtimes)
 }
 
 func TestClusterRuntimeParentNeverResolvesToNamespacedRuntime(t *testing.T) {
@@ -282,11 +327,17 @@ func TestClusterRuntimeParentNeverResolvesToNamespacedRuntime(t *testing.T) {
 	projection, err := graph.Project(Target{Kind: KindClusterServingRuntime, Name: "child"})
 	require.NoError(t, err)
 
-	assert.Equal(t, []Issue{{
+	path := onlyPath(t, projection)
+	assert.Equal(t, clusterContext(), projection.Contexts[0].Context)
+	assert.Equal(t, []Runtime{{
+		Identity:   Identity{Kind: KindClusterServingRuntime, Name: "child"},
+		ParentName: "parent",
+	}}, path.Runtimes)
+	assert.Equal(t, &Issue{
 		Code: IssueParentMissing, Subject: Identity{Kind: KindClusterServingRuntime, Name: "child"},
 		ParentName: "parent",
 		Path:       []Identity{{Kind: KindClusterServingRuntime, Name: "child"}},
-	}}, projection.Issues)
+	}, path.Issue)
 }
 
 func TestBuildRejectsDuplicateRuntimeIdentity(t *testing.T) {
@@ -350,7 +401,8 @@ func TestProjectReturnsTypedTargetErrors(t *testing.T) {
 		want   error
 	}{
 		{name: "name required", target: Target{}, want: ErrInvalidTarget},
-		{name: "namespace required", target: Target{Kind: KindServingRuntime, Name: "runtime"}, want: ErrInvalidTarget},
+		{name: "namespaced namespace required", target: Target{Kind: KindServingRuntime, Name: "runtime"}, want: ErrInvalidTarget},
+		{name: "cluster namespace forbidden", target: Target{Kind: KindClusterServingRuntime, Namespace: "team-a", Name: "runtime"}, want: ErrInvalidTarget},
 		{name: "kind rejected", target: Target{Kind: Kind("Other"), Name: "runtime"}, want: ErrInvalidTarget},
 		{name: "explicit target absent", target: Target{Kind: KindClusterServingRuntime, Name: "runtime"}, want: ErrTargetNotFound},
 		{name: "implicit target absent", target: Target{Namespace: "team-a", Name: "runtime"}, want: ErrTargetNotFound},


### PR DESCRIPTION
## What this PR does

Fixes the runtime-inheritance graph so it models the resolver that the OME
controller actually runs.

The graph now:

- keeps cluster-only and namespace-first resolution contexts separate;
- retains namespace-first lookup for the whole namespaced inheritance walk,
  including after a fallback to a `ClusterServingRuntime`;
- represents each real runtime head as its own bounded path instead of merging
  incompatible paths into one global tree;
- detects cycles by runtime name and applies the inheritance depth limit in the
  same order as the controller; and
- keeps missing-parent, cycle, and depth-limit evidence on the path that
  observed it.

There is no new end-user command in this PR. This corrects the projection layer
used by the upcoming `kubectl ome runtime tree` command.

## Why we need it

The previous graph assigned one parent to each runtime identity. That is not
valid for OME inheritance: a cluster runtime can resolve a different parent in
each namespace because the controller keeps namespace-first lookup active for
the complete walk.

For this snapshot:

```text
ClusterServingRuntime/bridge inherits base
ServingRuntime/team-a/base has no parent
ServingRuntime/team-a/leaf inherits bridge
```

the real namespaced path is:

```text
Context: Namespaced/team-a
ServingRuntime/team-a/base
`-- ClusterServingRuntime/bridge
    `-- ServingRuntime/team-a/leaf
```

The old graph instead resolved `bridge` with cluster-only lookup and reported
`base` missing. At the same time, a direct lookup of `bridge` must remain a
separate cluster-only path:

```text
Context: Cluster
ClusterServingRuntime/bridge
Issue: ParentMissing (ClusterServingRuntime/base)
```

Keeping exact paths also prevents false descendants when namespace shadowing
changes ancestry and prevents depth-limited paths from being presented as if
they reached an ancestor that the controller never visited.

Follow-up to #854; no separate tracking issue.

## How to test

```bash
go test -race ./pkg/cli/runtimegraph -count=1
go test ./pkg/cli/... -count=1
go test ./cmd/kubectl-ome/... -count=1
go vet ./pkg/cli/... ./cmd/kubectl-ome/...
```

The focused package includes conformance tests that compare projected paths
with the actual `pkg/runtimeinheritance` resolver lookup trace. It also covers
namespace shadowing, cluster/name collisions, per-head maximum depth, cycle
ordering, missing parents, deterministic ordering, and input immutability.

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (not applicable; no user-facing surface in this PR)
- [ ] `make test` passes locally (focused CLI suites and CI-equivalent build
      checks pass locally; the full repository suite runs in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime inheritance graph accuracy across namespaced and cluster-level contexts.
  - Correctly handles namespace shadowing, cross-scope parent resolution, cycles, missing parents, and maximum-depth limits.
  - Preserves separate inheritance paths when the same runtime is resolved in different contexts.
  - Provides deterministic ordering and retains incomplete paths with relevant resolution issues.

- **Tests**
  - Expanded coverage for inheritance resolution, cycle detection, path consistency, serialization, and defensive data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->