### PR TITLE
[Bugfix] Recover model deletion after missed Node events

### DIFF
--- a/pkg/controller/v1beta1/basemodel/backend.go
+++ b/pkg/controller/v1beta1/basemodel/backend.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pernode"
@@ -28,18 +29,20 @@ func pickBackend(backends []shared.Backend, spec *v1beta1.BaseModelSpec) shared.
 // PVC artifacts left over when a model's URI flips away from pvc://.
 // Lives here (not in pernode/) so that cross-backend cleanup doesn't
 // drag a pernode→pvc import.
-type perNodeBackend struct{}
+type perNodeBackend struct {
+	nodeReader client.Reader
+}
 
 func (perNodeBackend) Name() string                          { return "pernode" }
 func (perNodeBackend) Matches(_ *v1beta1.BaseModelSpec) bool { return true }
 
-func (perNodeBackend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
+func (b perNodeBackend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
 	if err := pvc.CleanupStaleArtifacts(ctx, a.Client, a.Log, a.Obj, a.IsClusterScoped); err != nil {
 		a.Log.Error(err, "Failed to clean up stale PVC artifacts after URI swap")
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
 
-	if err := pernode.ReconcileStatusFromConfigMaps(ctx, a.Client, a.Log, a.Obj, a.IsClusterScoped, a.Kind); err != nil {
+	if err := pernode.ReconcileStatusFromConfigMaps(ctx, a.Client, b.nodeReader, a.Log, a.Obj, a.IsClusterScoped, a.Kind); err != nil {
 		a.Log.Error(err, "Failed to update "+a.Kind+" status")
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
@@ -50,6 +53,6 @@ func (perNodeBackend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl
 	return ctrl.Result{}, nil
 }
 
-func (perNodeBackend) HandleDeletion(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
-	return pernode.HandleModelDeletion(ctx, a.Client, a.Obj, a.Finalizer)
+func (b perNodeBackend) HandleDeletion(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
+	return pernode.HandleModelDeletion(ctx, a.Client, b.nodeReader, a.Obj, a.Finalizer)
 }

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/deletion.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/deletion.go
@@ -16,10 +16,9 @@ import (
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
 )
 
-// HandleModelDeletion is the per-node deletion handler. Waits for every
-// node's model-agent to clear or mark-deleted the model in its per-node
-// ConfigMap before dropping the finalizer.
-func HandleModelDeletion(ctx context.Context, kubeClient client.Client, obj client.Object, finalizer string) (ctrl.Result, error) {
+// HandleModelDeletion waits for model-agent deletion acknowledgements, cleaning
+// up status ConfigMaps for confirmed-absent Nodes before dropping the finalizer.
+func HandleModelDeletion(ctx context.Context, kubeClient client.Client, nodeReader client.Reader, obj client.Object, finalizer string) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if controllerutil.ContainsFinalizer(obj, finalizer) {
@@ -70,19 +69,23 @@ func HandleModelDeletion(ctx context.Context, kubeClient client.Client, obj clie
 			if !exists {
 				continue
 			}
-			nodesWithModel++
-
-			// Check if it's already marked for deletion
+			// A completed agent acknowledgement does not require Node availability.
 			var modelEntry shared.ModelEntry
-			if err := json.Unmarshal([]byte(data), &modelEntry); err == nil {
-				// If model entry is present but not marked as deleted, add it to the list
-				if modelEntry.Status != shared.ModelStatusDeleted {
-					modelsNotDeleted = append(modelsNotDeleted, configMap.Name)
-				}
-			} else {
-				// Can't parse the entry, consider it not deleted for safety
-				modelsNotDeleted = append(modelsNotDeleted, configMap.Name)
+			if err := json.Unmarshal([]byte(data), &modelEntry); err == nil && modelEntry.Status == shared.ModelStatusDeleted {
+				nodesWithModel++
+				continue
 			}
+
+			orphaned, err := cleanupOrphanedNodeConfigMap(ctx, kubeClient, nodeReader, configMap)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if orphaned {
+				continue
+			}
+			nodesWithModel++
+			// Unacknowledged or malformed entries still block deletion on live Nodes.
+			modelsNotDeleted = append(modelsNotDeleted, configMap.Name)
 		}
 
 		modelInfo := modelName

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/gc.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/gc.go
@@ -1,0 +1,54 @@
+package pernode
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// cleanupOrphanedNodeConfigMap removes status metadata for an absent Node.
+// nodeReader must bypass the cache: a cache miss alone cannot justify deletion.
+// orphaned means the Node was absent and deletion was accepted (or the ConfigMap
+// was already gone); it does not mean other ConfigMap finalizers have completed.
+func cleanupOrphanedNodeConfigMap(ctx context.Context, kubeClient client.Client, nodeReader client.Reader, configMap *corev1.ConfigMap) (orphaned bool, err error) {
+	if !IsModelStatusConfigMap(configMap) {
+		return false, fmt.Errorf("refusing orphan cleanup of non-model-status ConfigMap %s", client.ObjectKeyFromObject(configMap))
+	}
+	// Keep healthy-node reconciliation cache-only. A stale cached presence can
+	// delay cleanup, but a cached absence must never authorize deletion.
+	nodeKey := types.NamespacedName{Name: configMap.Name}
+	if err := kubeClient.Get(ctx, nodeKey, &corev1.Node{}); err == nil {
+		return false, nil
+	} else if !errors.IsNotFound(err) {
+		return false, fmt.Errorf("check cached Node %s for orphan cleanup: %w", configMap.Name, err)
+	}
+	if nodeReader == nil {
+		return false, fmt.Errorf("orphan cleanup requires an uncached Node reader")
+	}
+	if err := nodeReader.Get(ctx, nodeKey, &corev1.Node{}); err == nil {
+		return false, nil
+	} else if !errors.IsNotFound(err) {
+		return false, fmt.Errorf("check Node %s for orphan cleanup: %w", configMap.Name, err)
+	}
+
+	// Fence against an agent updating the status, or replacing the ConfigMap,
+	// after it was listed. Node identity is name-based, so these preconditions
+	// cannot fence a same-name Node recreated between the lookup and deletion.
+	uid, resourceVersion := configMap.UID, configMap.ResourceVersion
+	if uid == "" || resourceVersion == "" {
+		return false, fmt.Errorf("orphan ConfigMap %s has no UID or resourceVersion", client.ObjectKeyFromObject(configMap))
+	}
+	err = kubeClient.Delete(ctx, configMap, client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion})
+	if err != nil && !errors.IsNotFound(err) {
+		return false, fmt.Errorf("delete orphan ConfigMap %s: %w", client.ObjectKeyFromObject(configMap), err)
+	}
+	if err == nil {
+		ctrl.LoggerFrom(ctx).Info("Requested orphaned node ConfigMap cleanup", "configMap", client.ObjectKeyFromObject(configMap))
+	}
+	return true, nil
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/gc_test.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/gc_test.go
@@ -1,0 +1,329 @@
+package pernode
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
+)
+
+func orphanConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node", Namespace: constants.OMENamespace, UID: "original", ResourceVersion: "1",
+			Labels: map[string]string{constants.ModelStatusConfigMapLabel: "true"},
+		},
+		Data: map[string]string{constants.GetModelConfigMapKey("default", "model", false): `{"status":"Ready"}`},
+	}
+}
+
+func TestCleanupOrphanedNodeConfigMap(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		nodeExists bool
+		cachedNode bool
+		cacheError error
+		readError  error
+		noReader   bool
+	}{
+		{name: "missing node"},
+		{name: "existing not-ready node overrides cached miss", nodeExists: true},
+		{name: "healthy node cache-only fast path", nodeExists: true, cachedNode: true},
+		{name: "stale cached presence delays cleanup", cachedNode: true},
+		{name: "cached lookup failure", cacheError: apierrors.NewTimeoutError("cached lookup", 1)},
+		{name: "forbidden node lookup", readError: apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "node", fmt.Errorf("denied"))},
+		{name: "timed out node lookup", readError: apierrors.NewTimeoutError("node lookup", 1)},
+		{name: "cancelled node lookup", readError: context.Canceled},
+		{name: "missing authoritative reader", noReader: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+			cm := orphanConfigMap()
+			live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+			if tc.nodeExists {
+				g.Expect(live.Create(ctx, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: cm.Name}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}}})).To(gomega.Succeed())
+			}
+			deletes := 0
+			liveReads := 0
+			cached := interceptor.NewClient(live, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, node := obj.(*corev1.Node); node {
+						if tc.cacheError != nil {
+							return tc.cacheError
+						}
+						if tc.cachedNode {
+							return nil
+						}
+						return apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, key.Name)
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					deletes++
+					options := (&client.DeleteOptions{}).ApplyOptions(opts)
+					g.Expect(options.Preconditions).NotTo(gomega.BeNil())
+					g.Expect(options.Preconditions.UID).To(gomega.Equal(&cm.UID))
+					g.Expect(options.Preconditions.ResourceVersion).To(gomega.Equal(&cm.ResourceVersion))
+					return c.Delete(ctx, obj, opts...)
+				},
+			})
+			var reader client.Reader = interceptor.NewClient(live, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					liveReads++
+					if tc.readError != nil {
+						return tc.readError
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			})
+			if tc.noReader {
+				reader = nil
+			}
+			orphaned, err := cleanupOrphanedNodeConfigMap(ctx, cached, reader, cm)
+			if tc.readError != nil || tc.noReader || tc.cacheError != nil {
+				g.Expect(err).To(gomega.HaveOccurred())
+				if tc.readError != nil {
+					g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(tc.readError.Error())))
+				}
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			wantOrphan := !tc.nodeExists && !tc.cachedNode && tc.readError == nil && tc.cacheError == nil && !tc.noReader
+			if tc.cachedNode || tc.noReader || tc.cacheError != nil {
+				g.Expect(liveReads).To(gomega.BeZero())
+			} else {
+				g.Expect(liveReads).To(gomega.Equal(1))
+			}
+			g.Expect(orphaned).To(gomega.Equal(wantOrphan))
+			getErr := live.Get(ctx, client.ObjectKeyFromObject(cm), &corev1.ConfigMap{})
+			if wantOrphan {
+				g.Expect(apierrors.IsNotFound(getErr)).To(gomega.BeTrue())
+				g.Expect(deletes).To(gomega.Equal(1))
+				// Retrying a stale cache entry after a successful deletion is harmless.
+				orphaned, err = cleanupOrphanedNodeConfigMap(ctx, cached, reader, cm)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(orphaned).To(gomega.BeTrue())
+			} else {
+				g.Expect(getErr).NotTo(gomega.HaveOccurred())
+				g.Expect(deletes).To(gomega.BeZero())
+			}
+		})
+	}
+}
+
+func TestOrphanCleanupRejectsUnfencedOrUnrelatedConfigMaps(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*corev1.ConfigMap)
+	}{
+		{"wrong namespace", func(cm *corev1.ConfigMap) { cm.Namespace = "default" }},
+		{"unlabeled", func(cm *corev1.ConfigMap) { cm.Labels = nil }},
+		{"PVC status", func(cm *corev1.ConfigMap) { cm.Labels = map[string]string{constants.PVCStorageConfigMapLabel: "true"} }},
+		{"no UID", func(cm *corev1.ConfigMap) { cm.UID = "" }},
+		{"no resourceVersion", func(cm *corev1.ConfigMap) { cm.ResourceVersion = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+			cm := orphanConfigMap()
+			live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm.DeepCopy()).Build()
+			c := interceptor.NewClient(live, interceptor.Funcs{
+				Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+					t.Fatal("unsafe ConfigMap reached Delete")
+					return nil
+				},
+			})
+			tc.mutate(cm)
+			orphaned, err := cleanupOrphanedNodeConfigMap(context.Background(), c, live, cm)
+			g.Expect(err).To(gomega.HaveOccurred())
+			g.Expect(orphaned).To(gomega.BeFalse())
+		})
+	}
+}
+
+func TestOrphanCleanupErrorsPreserveFinalizerAndStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		onRead bool
+		err    error
+	}{
+		{"node read failure", true, apierrors.NewTimeoutError("lookup", 1)},
+		{"changed ConfigMap", false, apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "node", fmt.Errorf("changed"))},
+		{"forbidden delete", false, apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "node", fmt.Errorf("denied"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+			g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+			cm := orphanConfigMap()
+			now := metav1.Now()
+			model := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "default", Finalizers: []string{constants.BaseModelFinalizer}, DeletionTimestamp: &now}}
+			live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, model).Build()
+			c := interceptor.NewClient(live, interceptor.Funcs{
+				Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error { return tc.err },
+			})
+			reader := interceptor.NewClient(live, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if tc.onRead {
+						return tc.err
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			})
+			_, err := HandleModelDeletion(ctx, c, reader, model, constants.BaseModelFinalizer)
+			g.Expect(err).To(gomega.HaveOccurred())
+			g.Expect(live.Get(ctx, client.ObjectKeyFromObject(model), model)).To(gomega.Succeed())
+			g.Expect(controllerutil.ContainsFinalizer(model, constants.BaseModelFinalizer)).To(gomega.BeTrue())
+			g.Expect(live.Get(ctx, client.ObjectKeyFromObject(cm), &corev1.ConfigMap{})).To(gomega.Succeed())
+			updated := false
+			err = processModelStatus(ctx, c, reader, logr.Discard(), "default", "model", false,
+				func(context.Context, *shared.ModelConfig) error { updated = true; return nil },
+				func(context.Context, []string, []string) error { updated = true; return nil })
+			g.Expect(err).To(gomega.HaveOccurred())
+			g.Expect(updated).To(gomega.BeFalse())
+		})
+	}
+}
+
+func TestDeletedAcknowledgementDoesNotRequireNodeLookup(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+	cm := orphanConfigMap()
+	cm.Data[constants.GetModelConfigMapKey("default", "model", false)] = `{"status":"Deleted"}`
+	now := metav1.Now()
+	model := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "default", Finalizers: []string{constants.BaseModelFinalizer}, DeletionTimestamp: &now}}
+	live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, model).Build()
+	nodeReads, deletes := 0, 0
+	c := interceptor.NewClient(live, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, node := obj.(*corev1.Node); node {
+				nodeReads++
+				return apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, key.Name, fmt.Errorf("denied"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+			deletes++
+			return fmt.Errorf("acknowledged ConfigMap must not be deleted")
+		},
+	})
+	result, err := HandleModelDeletion(ctx, c, c, model, constants.BaseModelFinalizer)
+	g.Expect(nodeReads).To(gomega.BeZero())
+	g.Expect(deletes).To(gomega.BeZero())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(apierrors.IsNotFound(live.Get(ctx, client.ObjectKeyFromObject(model), &v1beta1.BaseModel{}))).To(gomega.BeTrue())
+	current := &corev1.ConfigMap{}
+	g.Expect(live.Get(ctx, client.ObjectKeyFromObject(cm), current)).To(gomega.Succeed())
+	g.Expect(current.Data).To(gomega.Equal(cm.Data))
+	g.Expect(current.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+}
+
+func TestModelDeletionWaitsForLiveNodeAfterOrphanCleanup(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+	orphan, liveCM := orphanConfigMap(), orphanConfigMap()
+	liveCM.Name, liveCM.UID = "live-node", "live-configmap"
+	now := metav1.Now()
+	model := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "default", Finalizers: []string{constants.BaseModelFinalizer}, DeletionTimestamp: &now}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(model, orphan, liveCM, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: liveCM.Name}}).Build()
+
+	result, err := HandleModelDeletion(ctx, c, c, model, constants.BaseModelFinalizer)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result.RequeueAfter).To(gomega.Equal(30 * time.Second))
+	g.Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(orphan), &corev1.ConfigMap{}))).To(gomega.BeTrue())
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(model), model)).To(gomega.Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(model, constants.BaseModelFinalizer)).To(gomega.BeTrue())
+	current := &corev1.ConfigMap{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(liveCM), current)).To(gomega.Succeed())
+	g.Expect(current.Data).To(gomega.Equal(liveCM.Data))
+	current.Data[constants.GetModelConfigMapKey("default", "model", false)] = `{"status":"Deleted"}`
+	g.Expect(c.Update(ctx, current)).To(gomega.Succeed())
+
+	result, err = HandleModelDeletion(ctx, c, c, model, constants.BaseModelFinalizer)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(model), &v1beta1.BaseModel{}))).To(gomega.BeTrue())
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(liveCM), &corev1.ConfigMap{})).To(gomega.Succeed())
+}
+
+func TestPartialOrphanCleanupFailureConvergesOnRetry(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+	first, second := orphanConfigMap(), orphanConfigMap()
+	first.Name, first.UID = "a-first", "first-configmap"
+	second.Name, second.UID = "b-second", "second-configmap"
+	now := metav1.Now()
+	model := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "default", Finalizers: []string{constants.BaseModelFinalizer}, DeletionTimestamp: &now}}
+	live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(model, first, second).Build()
+	failOnce := true
+	var deletes []string
+	c := interceptor.NewClient(live, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if err := c.List(ctx, list, opts...); err != nil {
+				return err
+			}
+			if cms, ok := list.(*corev1.ConfigMapList); ok {
+				slices.SortFunc(cms.Items, func(a, b corev1.ConfigMap) int { return cmp.Compare(a.Name, b.Name) })
+			}
+			return nil
+		},
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deletes = append(deletes, obj.GetName())
+			if obj.GetName() == second.Name && failOnce {
+				failOnce = false
+				return apierrors.NewTimeoutError("second ConfigMap deletion failed", 1)
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+
+	_, err := HandleModelDeletion(ctx, c, live, model, constants.BaseModelFinalizer)
+	g.Expect(apierrors.IsTimeout(err)).To(gomega.BeTrue())
+	g.Expect(deletes).To(gomega.Equal([]string{first.Name, second.Name}))
+	g.Expect(apierrors.IsNotFound(live.Get(ctx, client.ObjectKeyFromObject(first), &corev1.ConfigMap{}))).To(gomega.BeTrue())
+	g.Expect(live.Get(ctx, client.ObjectKeyFromObject(second), &corev1.ConfigMap{})).To(gomega.Succeed())
+	g.Expect(live.Get(ctx, client.ObjectKeyFromObject(model), model)).To(gomega.Succeed())
+	g.Expect(controllerutil.ContainsFinalizer(model, constants.BaseModelFinalizer)).To(gomega.BeTrue())
+
+	result, err := HandleModelDeletion(ctx, c, live, model, constants.BaseModelFinalizer)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(deletes).To(gomega.Equal([]string{first.Name, second.Name, second.Name}))
+	g.Expect(apierrors.IsNotFound(live.Get(ctx, client.ObjectKeyFromObject(second), &corev1.ConfigMap{}))).To(gomega.BeTrue())
+	g.Expect(apierrors.IsNotFound(live.Get(ctx, client.ObjectKeyFromObject(model), &v1beta1.BaseModel{}))).To(gomega.BeTrue())
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/reconcile.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/reconcile.go
@@ -13,7 +13,7 @@ import (
 // handshake: list per-node model-status ConfigMaps, parse this model's
 // entries, and reflect into Status.NodesReady/NodesFailed plus
 // LifeCycleState. Sharded + PVC backends bypass this path entirely.
-func ReconcileStatusFromConfigMaps(ctx context.Context, c client.Client, log logr.Logger, obj client.Object, isClusterScoped bool, kind string) error {
+func ReconcileStatusFromConfigMaps(ctx context.Context, c client.Client, nodeReader client.Reader, log logr.Logger, obj client.Object, isClusterScoped bool, kind string) error {
 	var namespace string
 	if !isClusterScoped {
 		namespace = obj.GetNamespace()
@@ -30,5 +30,5 @@ func ReconcileStatusFromConfigMaps(ctx context.Context, c client.Client, log log
 	statusUpdate := func(ctx context.Context, nodesReady, nodesFailed []string) error {
 		return updateModelStatusWithRetry(ctx, c, log, obj, nodesReady, nodesFailed, kind)
 	}
-	return processModelStatus(ctx, c, log, namespace, obj.GetName(), isClusterScoped, specUpdate, statusUpdate)
+	return processModelStatus(ctx, c, nodeReader, log, namespace, obj.GetName(), isClusterScoped, specUpdate, statusUpdate)
 }

--- a/pkg/controller/v1beta1/basemodel/backends/pernode/status.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pernode/status.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -22,7 +20,7 @@ import (
 // caller-supplied statusUpdateFunc. Per-node spec updates from the
 // agent flow through specUpdateFunc (filtered to entries that carry a
 // non-nil Config).
-func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, namespace, name string, isClusterScope bool,
+func processModelStatus(ctx context.Context, kubeClient client.Client, nodeReader client.Reader, log logr.Logger, namespace, name string, isClusterScope bool,
 	specUpdateFunc func(context.Context, *shared.ModelConfig) error,
 	statusUpdateFunc func(context.Context, []string, []string) error) error {
 
@@ -48,25 +46,23 @@ func processModelStatus(ctx context.Context, kubeClient client.Client, log logr.
 	var nodesReady []string
 	var nodesFailed []string
 	var specUpdateErrors []string
+	modelKey := constants.GetModelConfigMapKey(namespace, name, isClusterScope)
 
 	for _, configMap := range configMaps.Items {
 		processedNodes++
-
-		node := &corev1.Node{}
-		if err := kubeClient.Get(ctx, types.NamespacedName{Name: configMap.Name}, node); err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
-			log.Error(err, "Failed to get node", "node", configMap.Name)
-			continue
-		}
-		validNodes++
-
-		modelKey := constants.GetModelConfigMapKey(namespace, name, isClusterScope)
 		data, exists := configMap.Data[modelKey]
 		if !exists {
 			continue
 		}
+
+		orphaned, err := cleanupOrphanedNodeConfigMap(ctx, kubeClient, nodeReader, &configMap)
+		if err != nil {
+			return err
+		}
+		if orphaned {
+			continue
+		}
+		validNodes++
 
 		var modelEntry shared.ModelEntry
 		if err := json.Unmarshal([]byte(data), &modelEntry); err != nil {

--- a/pkg/controller/v1beta1/basemodel/controller.go
+++ b/pkg/controller/v1beta1/basemodel/controller.go
@@ -39,6 +39,8 @@ import (
 
 type BaseModelReconciler struct {
 	client.Client
+	// APIReader confirms Node absence without the informer cache before cleanup.
+	APIReader      client.Reader
 	Log            logr.Logger
 	Scheme         *runtime.Scheme
 	OmeAgentConfig *controllerconfig.OmeAgentConfig
@@ -46,6 +48,8 @@ type BaseModelReconciler struct {
 
 type ClusterBaseModelReconciler struct {
 	client.Client
+	// APIReader confirms Node absence without the informer cache before cleanup.
+	APIReader      client.Reader
 	Log            logr.Logger
 	Scheme         *runtime.Scheme
 	OmeAgentConfig *controllerconfig.OmeAgentConfig
@@ -56,14 +60,14 @@ type ClusterBaseModelReconciler struct {
 func (r *BaseModelReconciler) backends() []shared.Backend {
 	return []shared.Backend{
 		pvc.New(r.OmeAgentConfig),
-		perNodeBackend{},
+		perNodeBackend{nodeReader: r.APIReader},
 	}
 }
 
 func (r *ClusterBaseModelReconciler) backends() []shared.Backend {
 	return []shared.Backend{
 		pvc.New(r.OmeAgentConfig),
-		perNodeBackend{},
+		perNodeBackend{nodeReader: r.APIReader},
 	}
 }
 
@@ -135,6 +139,9 @@ func reconcileModel(ctx context.Context, c client.Client, scheme *runtime.Scheme
 }
 
 func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.BaseModel{}).
 		Owns(&batchv1.Job{}).
@@ -166,6 +173,9 @@ func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ClusterBaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.ClusterBaseModel{}).
 		Owns(&batchv1.Job{}).

--- a/pkg/controller/v1beta1/basemodel/controller_test.go
+++ b/pkg/controller/v1beta1/basemodel/controller_test.go
@@ -528,6 +528,7 @@ func TestBaseModelReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "deleted-node",
 						Namespace: constants.OMENamespace,
+						UID:       types.UID("deleted-node-configmap"),
 						Labels: map[string]string{
 							constants.ModelStatusConfigMapLabel: "true",
 						},
@@ -571,8 +572,9 @@ func TestBaseModelReconcile(t *testing.T) {
 
 			// Run reconciliation
 			reconciler := &BaseModelReconciler{
-				Client: c,
-				Scheme: c.Scheme(),
+				Client:    c,
+				APIReader: c,
+				Scheme:    c.Scheme(),
 			}
 
 			result, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
@@ -730,9 +732,10 @@ func TestClusterBaseModelReconcile(t *testing.T) {
 			}
 
 			reconciler := &ClusterBaseModelReconciler{
-				Client: c,
-				Log:    ctrl.Log.WithName("test"),
-				Scheme: scheme,
+				Client:    c,
+				APIReader: c,
+				Log:       ctrl.Log.WithName("test"),
+				Scheme:    scheme,
 			}
 
 			req := ctrl.Request{

--- a/pkg/controller/v1beta1/basemodel/orphaned_node_test.go
+++ b/pkg/controller/v1beta1/basemodel/orphaned_node_test.go
@@ -1,0 +1,180 @@
+package basemodel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pernode"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
+)
+
+func TestModelDeletionAfterNodeDisappears(t *testing.T) {
+	for _, clusterScoped := range []bool{false, true} {
+		for _, scenario := range []struct {
+			name             string
+			keepNode         bool
+			deliverNodeEvent bool
+			holdConfigMap    bool
+		}{
+			{name: "missed node deletion event"},
+			{name: "delivered node deletion event", deliverNodeEvent: true},
+			{name: "existing NotReady node", keepNode: true},
+			{name: "orphan ConfigMap has another finalizer", holdConfigMap: true},
+		} {
+			model, finalizer := orphanedNodeModel(clusterScoped)
+			t.Run(model.GetObjectKind().GroupVersionKind().Kind+"/"+scenario.name, func(t *testing.T) {
+				g := gomega.NewGomegaWithT(t)
+				ctx := context.Background()
+				const foreignFinalizer = "other-controller.example.com/cleanup"
+				model.SetFinalizers([]string{finalizer, foreignFinalizer})
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+					Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}},
+				}
+				cm := orphanedNodeConfigMap("worker", model, clusterScoped)
+				if scenario.holdConfigMap {
+					cm.Finalizers = []string{foreignFinalizer}
+				}
+				unlabeled := orphanedNodeConfigMap("unrelated", model, clusterScoped)
+				unlabeled.Labels = nil
+				otherNamespace := orphanedNodeConfigMap("worker", model, clusterScoped)
+				otherNamespace.Namespace = "other"
+				c := orphanedNodeClient(t, model, node, cm, unlabeled, otherNamespace)
+				if !scenario.keepNode {
+					g.Expect(c.Delete(ctx, node)).To(gomega.Succeed())
+					if scenario.deliverNodeEvent {
+						pernode.HandleNodeDeletion(ctx, c, ctrl.Log, node)
+					}
+				}
+				g.Expect(c.Delete(ctx, model)).To(gomega.Succeed())
+				result, err := reconcileOrphanedNodeModel(ctx, c, model)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(model), model)).To(gomega.Succeed())
+				g.Expect(model.GetFinalizers()).To(gomega.ContainElement(foreignFinalizer))
+				currentCM := &corev1.ConfigMap{}
+				getCM := c.Get(ctx, client.ObjectKeyFromObject(cm), currentCM)
+				if scenario.keepNode {
+					g.Expect(model.GetFinalizers()).To(gomega.ContainElement(finalizer))
+					g.Expect(result.RequeueAfter).To(gomega.Equal(30 * time.Second))
+					g.Expect(getCM).NotTo(gomega.HaveOccurred())
+					g.Expect(currentCM.Data).To(gomega.Equal(cm.Data))
+					g.Expect(currentCM.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+				} else {
+					g.Expect(model.GetFinalizers()).NotTo(gomega.ContainElement(finalizer))
+					g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+					if scenario.holdConfigMap {
+						g.Expect(getCM).NotTo(gomega.HaveOccurred())
+						g.Expect(currentCM.Finalizers).To(gomega.Equal([]string{foreignFinalizer}))
+						g.Expect(currentCM.DeletionTimestamp.IsZero()).To(gomega.BeFalse())
+					} else {
+						g.Expect(errors.IsNotFound(getCM)).To(gomega.BeTrue())
+					}
+				}
+				for _, untouched := range []*corev1.ConfigMap{unlabeled, otherNamespace} {
+					actual := &corev1.ConfigMap{}
+					g.Expect(c.Get(ctx, client.ObjectKeyFromObject(untouched), actual)).To(gomega.Succeed())
+					g.Expect(actual.Data).To(gomega.Equal(untouched.Data))
+					g.Expect(actual.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+				}
+			})
+		}
+	}
+}
+
+func TestModelStatusCleansOrphanedNodeConfigMap(t *testing.T) {
+	for _, clusterScoped := range []bool{false, true} {
+		model, finalizer := orphanedNodeModel(clusterScoped)
+		t.Run(model.GetObjectKind().GroupVersionKind().Kind, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			ctx := context.Background()
+			model.SetFinalizers([]string{finalizer})
+			liveNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "live-worker"}}
+			liveCM := orphanedNodeConfigMap(liveNode.Name, model, clusterScoped)
+			orphanCM := orphanedNodeConfigMap("missing-worker", model, clusterScoped)
+			unrelatedCM := orphanedNodeConfigMap("other-model-worker", model, clusterScoped)
+			delete(unrelatedCM.Data, constants.GetModelConfigMapKey(model.GetNamespace(), model.GetName(), clusterScoped))
+			c := orphanedNodeClient(t, model, liveNode, liveCM, orphanCM, unrelatedCM)
+
+			_, err := reconcileOrphanedNodeModel(ctx, c, model)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(model), model)).To(gomega.Succeed())
+			_, status, err := shared.ModelSpecAndStatus(model)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(status.State).To(gomega.Equal(v1beta1.LifeCycleStateReady))
+			g.Expect(status.NodesReady).To(gomega.Equal([]string{liveNode.Name}))
+			g.Expect(status.NodesFailed).To(gomega.BeEmpty())
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(liveCM), &corev1.ConfigMap{})).To(gomega.Succeed())
+			g.Expect(errors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(orphanCM), &corev1.ConfigMap{}))).To(gomega.BeTrue())
+			actual := &corev1.ConfigMap{}
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(unrelatedCM), actual)).To(gomega.Succeed())
+			g.Expect(actual.Data).To(gomega.Equal(unrelatedCM.Data))
+		})
+	}
+}
+
+func orphanedNodeModel(clusterScoped bool) (client.Object, string) {
+	spec := v1beta1.BaseModelSpec{
+		ModelFormat: v1beta1.ModelFormat{Name: "safetensors"},
+		Storage:     &v1beta1.StorageSpec{StorageUri: stringPtr("hf://test/model")},
+	}
+	meta := metav1.ObjectMeta{Name: "model", UID: types.UID("model-uid")}
+	if clusterScoped {
+		return &v1beta1.ClusterBaseModel{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "ome.io/v1beta1", Kind: "ClusterBaseModel"},
+			ObjectMeta: meta, Spec: spec,
+		}, constants.ClusterBaseModelFinalizer
+	}
+	meta.Namespace = "default"
+	return &v1beta1.BaseModel{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "ome.io/v1beta1", Kind: "BaseModel"},
+		ObjectMeta: meta, Spec: spec,
+	}, constants.BaseModelFinalizer
+}
+
+func orphanedNodeConfigMap(nodeName string, model client.Object, clusterScoped bool) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName, Namespace: constants.OMENamespace, UID: types.UID(nodeName + "-uid"),
+			Labels: map[string]string{constants.ModelStatusConfigMapLabel: "true"},
+		},
+		Data: map[string]string{
+			constants.GetModelConfigMapKey(model.GetNamespace(), model.GetName(), clusterScoped): `{"status":"Ready"}`,
+			"clusterbasemodel.other-model": `{"status":"Ready"}`,
+		},
+	}
+}
+
+func orphanedNodeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	g := gomega.NewGomegaWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(batchv1.AddToScheme(scheme)).To(gomega.Succeed())
+	return ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).
+		WithStatusSubresource(&v1beta1.BaseModel{}, &v1beta1.ClusterBaseModel{}).Build()
+}
+
+func reconcileOrphanedNodeModel(ctx context.Context, c client.Client, model client.Object) (ctrl.Result, error) {
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(model)}
+	if _, clusterScoped := model.(*v1beta1.ClusterBaseModel); clusterScoped {
+		r := &ClusterBaseModelReconciler{Client: c, APIReader: c, Scheme: c.Scheme()}
+		return r.Reconcile(ctx, request)
+	}
+	r := &BaseModelReconciler{Client: c, APIReader: c, Scheme: c.Scheme()}
+	return r.Reconcile(ctx, request)
+}


### PR DESCRIPTION
## What this PR does

Fixes #597.

Recover model deletion and status cleanup after a missed Node deletion event. Confirm Node absence with the uncached API reader before deleting its status ConfigMap, using UID/resourceVersion preconditions. Preserve ConfigMaps for existing Nodes, including NotReady Nodes.

## Why we need it

BaseModel and ClusterBaseModel deletion can otherwise wait indefinitely for an agent on a Node that no longer exists.

Scope question: should empty orphaned ConfigMaps be handled here or separately? This fix runs during model reconciliation, not as an independent cleanup loop. Empty or already-acknowledged ConfigMaps can remain. Same-name Node recreation is also not fenced by ConfigMap preconditions.

## How to test

```bash
make test
make ci-lint
pre-commit run --all-files
```

These passed locally, along with focused race tests. The missed-event reproduction fails on base `38dc49b5` and passes with this patch for both model types. Tests cover live Nodes, lookup/delete errors, partial retries, and other finalizers.

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (N/A)
- [x] `make test` passes locally
