### PR TITLE
[Bugfix] scheduler: defer gang pin until hard spread filtering

### DIFF
--- a/charts/ome-scheduler/values.yaml
+++ b/charts/ome-scheduler/values.yaml
@@ -107,8 +107,10 @@ scheduler:
   # which hands Score a sample of the feasible nodes; OMEGangPack derives its
   # per-domain free-node counts from exactly that sample, so a partial view can
   # rank an empty domain above a partly-filled one. Set to 100 wherever
-  # standaloneDomainPacking is active. Gang pods never rely on this — PreFilter
-  # already narrows them to a single domain.
+  # standaloneDomainPacking is active. Gang correctness never relies on this:
+  # PreFilter either narrows to one domain or, for a hard spread constraint,
+  # exposes only domains that can each hold the complete gang. A partial sample
+  # can affect which surviving domain wins, but not whether the gang fits there.
   percentageOfNodesToScore:
 
   # The scheduler serves /metrics on a secure port (HTTPS + delegated authn/authz),

--- a/pkg/controller/v1beta1/workload/ops/render.go
+++ b/pkg/controller/v1beta1/workload/ops/render.go
@@ -224,8 +224,8 @@ const spreadPolicyRequired = "Required"
 // domain and a worker can never anchor the gang into one the leader could
 // not enter. Required renders as DoNotSchedule (maxSkew 1: balanced
 // spreading, enforced by any scheduler that runs PodTopologySpread's Filter
-// — including the OME gang scheduler's packing profile, whose retry loop
-// re-plans a vetoed domain choice); anything else renders as ScheduleAnyway
+// — including the OME gang scheduler's packing profile, which defers the initial
+// gang pin until that filter has narrowed the candidates); anything else renders as ScheduleAnyway
 // (advisory; inert under a profile that disables the spreading Score). The
 // constraint is deliberately not part of the revision hash: toggling the
 // policy shapes future placements (creates, repairs, migrations, rollouts)

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -56,11 +56,14 @@ go test ./test/integration/... -v
 
 ## Status
 
-The placement loop is live end to end: `PreFilter` best-fits and
-pins the gang's domain, `Filter` enforces it, `Permit` gates the gang until all
-members are present, and `Unreserve` unwinds a half-formed gang. `Reserve` claims
-the gang's whole-node capacity in its pinned domain so two gangs can't race into
-one and over-commit it. Gang membership + size come from the standard
+The placement loop is live end to end: `PreFilter` proves which domains can hold
+the complete gang and normally best-fit-pins one. When a gang has a hard topology
+spread constraint, it instead exposes every feasible domain so the framework's
+regular filters can narrow the candidates; `Reserve` then pins the selected
+node's domain. `Permit` gates the gang until all members are present, and
+`Unreserve` unwinds a half-formed gang. `Reserve` claims the gang's remaining
+whole-node capacity so two gangs can't race into one and over-commit it. Gang
+membership + size come from the standard
 scheduler-plugins `PodGroup`; the domain label is declared per-workload via a
 configured PodGroup annotation key; and node free-ness is inferred from the gang
 pod's own resource requests. The OME chart maps that generic setting to
@@ -74,8 +77,8 @@ reaching the gate) are turned into explicit activations. `NodeResourcesFit` supp
 node-level `MostAllocated` packing. Placement
 decisions, gate outcomes, unwinds, and the count of pinned groups are exported as
 `ome_scheduler_*` metrics on the
-scheduler's `/metrics` endpoint. Still ahead: replica spreading across domains
-for fault isolation, and topology-aware preemption.
+scheduler's `/metrics` endpoint. Required replica spreading composes with the
+built-in PodTopologySpread filter; topology-aware preemption is still ahead.
 
 ## Version policy
 

--- a/scheduler/pkg/placement/pins.go
+++ b/scheduler/pkg/placement/pins.go
@@ -168,6 +168,31 @@ func (p *Pins) ChooseForOwnerInTopologyOnNodes(group, owner, topologyKey string,
 		return c.domain.Name, c.id, true
 	}
 
+	eff := p.withoutReservedDomainsLocked(topologyKey, rawFree, nodesByDomain)
+
+	d, fit := topology.BestFit(eff, gangSize)
+	if !fit {
+		return "", 0, false
+	}
+	dom := Domain{TopologyKey: topologyKey, Name: d}
+	c := &commitment{domain: dom, owner: owner, id: p.nextCommitmentID(), nodes: nodeSet(nodesByDomain[d])}
+	p.byGroup[group] = c
+	p.setRemaining(c, gangSize)
+	return d, c.id, true
+}
+
+// WithoutReservedDomains returns a snapshot of rawFree with domains claimed by
+// another forming gang set to zero. GangPack uses it while deferring a hard
+// topology-spread gang's final domain choice until after the framework filters
+// run. ChooseForOwnerInTopologyOnNodes repeats the same check atomically when
+// Reserve commits the selected domain.
+func (p *Pins) WithoutReservedDomains(topologyKey string, rawFree topology.FreeByDomain, nodesByDomain map[string][]string) topology.FreeByDomain {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.withoutReservedDomainsLocked(topologyKey, rawFree, nodesByDomain)
+}
+
+func (p *Pins) withoutReservedDomainsLocked(topologyKey string, rawFree topology.FreeByDomain, nodesByDomain map[string][]string) topology.FreeByDomain {
 	// A forming gang exclusively owns its domain. Integer slot subtraction is not
 	// sound for heterogeneous pods: a reservation for a large or selector-bound
 	// member cannot be replaced by an arbitrary smaller slot. Hold the domain until
@@ -187,16 +212,7 @@ func (p *Pins) ChooseForOwnerInTopologyOnNodes(group, owner, topologyKey string,
 			eff[d] = f
 		}
 	}
-
-	d, fit := topology.BestFit(eff, gangSize)
-	if !fit {
-		return "", 0, false
-	}
-	dom := Domain{TopologyKey: topologyKey, Name: d}
-	c := &commitment{domain: dom, owner: owner, id: p.nextCommitmentID(), nodes: nodeSet(nodesByDomain[d])}
-	p.byGroup[group] = c
-	p.setRemaining(c, gangSize)
-	return d, c.id, true
+	return eff
 }
 
 // Place records that one of a group's members has landed on a real node in its

--- a/scheduler/pkg/plugins/gangpack/activation_test.go
+++ b/scheduler/pkg/plugins/gangpack/activation_test.go
@@ -62,6 +62,34 @@ func requiredAffinityTo(matchLabels map[string]string) *v1.Affinity {
 	}}
 }
 
+func TestUnconstrainedMemberWaitsForHardSpreadAnchor(t *testing.T) {
+	leader, worker := namedMember("leader"), namedMember("worker")
+	leader.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "topology.example/cube",
+		WhenUnsatisfiable: v1.DoNotSchedule,
+	}}
+	g, _, nodes := twoMemberGang(leader, worker)
+
+	workerState := newCycleState()
+	_, status := g.PreFilter(context.Background(), workerState, worker, nodes)
+	if status.Code() != framework.Unschedulable || !strings.Contains(status.Message(), "waiting for gang spread anchor") {
+		t.Fatalf("worker PreFilter = %v, want wait for constrained leader", status)
+	}
+	if pin := readPin(workerState); pin != nil {
+		t.Fatalf("worker wrote premature pin %+v", pin)
+	}
+
+	leaderState := newCycleState()
+	result, status := g.PreFilter(context.Background(), leaderState, leader, nodes)
+	if !status.IsSuccess() || result == nil || result.NodeNames.Len() != 2 {
+		t.Fatalf("leader PreFilter = %v, candidates=%v, want deferred two-node plan", status, result)
+	}
+	if readDeferredPin(leaderState) == nil {
+		t.Fatal("hard-spread leader must defer its pin until Reserve")
+	}
+}
+
 // TestTemplatesCompleteActivatesParkedMembersOnce: a member parked because the
 // live set was short of minMember is activated by the first PreFilter that sees
 // the set complete, and only by that one. The observing member is in flight and

--- a/scheduler/pkg/plugins/gangpack/plugin.go
+++ b/scheduler/pkg/plugins/gangpack/plugin.go
@@ -1,6 +1,7 @@
 // Package gangpack is the OME placement plugin: topology-aware gang placement and
-// bin-packing. PreFilter chooses and pins a gang's domain; Filter enforces it.
-// The core (domain accounting, best-fit, pins) lives in the pure
+// bin-packing. PreFilter identifies whole-gang-feasible domains and normally pins
+// one; hard-spread gangs defer the pin until Reserve sees the node that survived
+// the framework filters. The core (domain accounting, best-fit, pins) lives in the pure
 // topology/placement packages; this package wires the live scheduler state onto
 // them.
 package gangpack
@@ -120,12 +121,13 @@ func New(ctx context.Context, obj runtime.Object, h framework.Handle) (framework
 // Name returns the plugin's registered name.
 func (g *GangPack) Name() string { return Name }
 
-// PreFilter chooses and pins the gang's domain. For a resolvable gang it best-fits
-// a domain over the live node snapshot, records the pin (which Filter enforces),
-// and narrows downstream candidates to that domain's nodes. Standalone pods
-// continue so Filter can protect forming-gang reservations; labeled gang pods
-// fail closed when their PodGroup cannot be resolved. Unschedulable when a real
-// gang fits in no domain.
+// PreFilter plans the gang's domain. Most gangs best-fit and pin immediately.
+// For an unplaced gang whose current anchor carries a hard topology spread
+// constraint, it exposes the union of every whole-gang-feasible domain instead;
+// the framework's regular filters apply the constraint and Reserve pins the
+// domain of the selected node. Standalone pods continue so Filter can protect
+// forming-gang reservations; labeled gang pods fail closed when their PodGroup
+// cannot be resolved. Unschedulable when a real gang fits in no domain.
 func (g *GangPack) PreFilter(_ context.Context, state framework.CycleState, pod *v1.Pod, nodes []framework.NodeInfo) (*framework.PreFilterResult, *framework.Status) {
 	ns, name, isMember := podGroupNameOf(pod)
 	if !isMember {
@@ -243,6 +245,15 @@ func (g *GangPack) pinGang(state framework.CycleState, nodes []framework.NodeInf
 	if status != nil {
 		return nil, status
 	}
+	// OME puts hard spreading on one anchor (normally the leader). If an
+	// unconstrained sibling ran first it could commit the gang before that anchor's
+	// PodTopologySpread filter had a say. Let the anchor choose from all feasible
+	// domains; Permit activation will wake this member after the anchor is placed.
+	if sibling, blocked := hardSpreadAnchorBlocked(pod, templates[1:]); blocked {
+		klog.V(4).InfoS("gangpack.pinGang.spread_anchor_wait", "gang", gang.key, "sibling", klog.KObj(sibling))
+		return nil, framework.NewStatus(framework.Unschedulable,
+			"waiting for gang spread anchor "+sibling.Namespace+"/"+sibling.Name+" to be placed")
+	}
 	// A required affinity to a sibling that is neither bound nor assumed fails on
 	// every node, so planning now would only fail Filter and record the chosen
 	// domain as failed. Yield without a pin; the sibling's own Permit activation
@@ -294,6 +305,9 @@ func (g *GangPack) pinGang(state framework.CycleState, nodes []framework.NodeInf
 				"pinned domain "+domain+" cannot fit all remaining gang members "+gang.key)
 		}
 	}
+	if !pinned && placement.count == 0 && hasHardTopologySpread(pod) {
+		return g.deferDomainPin(state, nodes, gang, templates, free, need)
+	}
 
 	if !pinned {
 		d, id, status := g.planDomain(nodes, gang, placement, free, need)
@@ -312,6 +326,76 @@ func (g *GangPack) pinGang(state framework.CycleState, nodes []framework.NodeInf
 	}
 	writePin(state, domain, gang, commitment)
 	klog.V(4).InfoS("gangpack.pinGang.result", "gang", gang.key, "domain", domain, "narrowedNodes", candidates.Len())
+	return &framework.PreFilterResult{NodeNames: candidates}, nil
+}
+
+// hasHardTopologySpread identifies constraints that participate in Filter. Soft
+// ScheduleAnyway constraints affect only scoring and do not need domain-choice
+// deferral (OME's packing profile intentionally disables that built-in score).
+func hasHardTopologySpread(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, constraint := range pod.Spec.TopologySpreadConstraints {
+		if constraint.WhenUnsatisfiable == v1.DoNotSchedule {
+			return true
+		}
+	}
+	return false
+}
+
+func hardSpreadAnchorBlocked(current *v1.Pod, unplaced []*v1.Pod) (*v1.Pod, bool) {
+	if hasHardTopologySpread(current) {
+		return nil, false
+	}
+	for _, sibling := range unplaced {
+		if sibling != nil && !samePodIdentity(sibling, current) && hasHardTopologySpread(sibling) {
+			return sibling, true
+		}
+	}
+	return nil, false
+}
+
+// deferDomainPin returns candidate nodes from every domain that can fit the
+// entire gang. PodTopologySpread and the other framework filters can therefore
+// veto nodes or whole spread domains before GangPack makes a reservation. The
+// scheduler's selected node determines the final gang domain in Reserve.
+func (g *GangPack) deferDomainPin(state framework.CycleState, nodes []framework.NodeInfo, gang gangInfo, templates []*v1.Pod, free topology.FreeByDomain, need int) (*framework.PreFilterResult, *framework.Status) {
+	nodesByDomain := nodeNamesByDomain(nodes, gang.topologyKey)
+	available := g.pins.WithoutReservedDomains(gang.topologyKey, free, nodesByDomain)
+	choice, hadFailed := g.withoutFailedDomains(gang, available)
+	if _, fits := topology.BestFit(choice, need); !fits && hadFailed {
+		g.clearFailedDomains(gang)
+		choice = available
+	}
+	if _, fits := topology.BestFit(choice, need); !fits {
+		gangPinTotal.WithLabelValues("no_fit").Inc()
+		return nil, framework.NewStatus(framework.Unschedulable, "no domain has room for gang "+gang.key)
+	}
+
+	candidates := sets.New[string]()
+	plannedFree := make(topology.FreeByDomain)
+	plannedNodes := make(map[string][]string)
+	for domain, capacity := range choice {
+		if capacity < need {
+			continue
+		}
+		domainNodes := nodeInfosInDomain(nodes, gang.topologyKey, domain)
+		domainCandidates := matchingCandidateNodesForNeed(domainNodes, gang.topologyKey, domain, templates, need)
+		if domainCandidates.Len() == 0 {
+			continue
+		}
+		candidates.Insert(domainCandidates.UnsortedList()...)
+		plannedFree[domain] = capacity
+		plannedNodes[domain] = append([]string(nil), nodesByDomain[domain]...)
+	}
+	if candidates.Len() == 0 {
+		gangPinTotal.WithLabelValues("no_fit").Inc()
+		return nil, framework.NewStatus(framework.Unschedulable, "no domain has candidate nodes for gang "+gang.key)
+	}
+	writeDeferredPin(state, &deferredPinState{gang: gang, need: need, free: plannedFree, nodesByDomain: plannedNodes})
+	klog.V(4).InfoS("gangpack.pinGang.deferred", "gang", gang.key, "topologyKey", gang.topologyKey,
+		"domains", fmt.Sprintf("%v", plannedFree), "candidateNodes", candidates.Len())
 	return &framework.PreFilterResult{NodeNames: candidates}, nil
 }
 

--- a/scheduler/pkg/plugins/gangpack/prefilter_test.go
+++ b/scheduler/pkg/plugins/gangpack/prefilter_test.go
@@ -45,6 +45,84 @@ func TestPinGang(t *testing.T) {
 	}
 }
 
+// TestPinGangDefersHardSpreadDomainChoice proves that GangPack does not commit
+// an unplaced gang to one rack before PodTopologySpread has run. PreFilter
+// exposes every rack that can hold the complete gang; Reserve then commits to
+// the rack of the node selected from the framework-filtered candidates.
+func TestPinGangDefersHardSpreadDomainChoice(t *testing.T) {
+	g := &GangPack{pins: placement.New()}
+	nodes := []framework.NodeInfo{
+		nodeInfo(gpuNode("a1", "a", "4")), nodeInfo(gpuNode("a2", "a", "4")),
+		nodeInfo(gpuNode("b1", "b", "4")), nodeInfo(gpuNode("b2", "b", "4")), nodeInfo(gpuNode("b3", "b", "4")),
+	}
+	pod := gpuPod("4")
+	pod.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "kubernetes.io/hostname",
+		WhenUnsatisfiable: v1.DoNotSchedule,
+	}}
+	state := newCycleState()
+	gang := gangInfo{key: "team/spread", uid: "uid-1", minMember: 2, topologyKey: testKey}
+
+	result, status := g.pinGang(state, nodes, gang, pod)
+	if !status.IsSuccess() {
+		t.Fatalf("pinGang status = %v, want Success", status)
+	}
+	if result == nil || !result.NodeNames.Equal(sets.New("a1", "a2", "b1", "b2", "b3")) {
+		t.Fatalf("deferred candidates = %v, want every whole-gang-feasible domain", result.NodeNames)
+	}
+	if pin := readPin(state); pin != nil {
+		t.Fatalf("PreFilter pin = %+v, want nil until framework filters select a node", pin)
+	}
+	if plan := readDeferredPin(state); plan == nil || plan.need != 2 || len(plan.free) != 2 {
+		t.Fatalf("deferred plan = %+v, want two feasible domains for two members", plan)
+	}
+
+	// Model PodTopologySpread filtering rack a away by selecting b1. Reserve must
+	// commit the gang to b even though ordinary GangPack best-fit preferred a.
+	if status := g.Reserve(context.Background(), state, pod, "b1"); !status.IsSuccess() {
+		t.Fatalf("Reserve = %v, want Success", status)
+	}
+	if domain, ok := g.pins.Get("team/spread"); !ok || domain != "b" {
+		t.Fatalf("reserved domain = %q,%v, want b,true", domain, ok)
+	}
+	if pin := readPin(state); pin == nil || pin.domain != "b" || pin.commitment == 0 {
+		t.Fatalf("Reserve pin = %+v, want owned domain b pin", pin)
+	}
+	reservations := g.pins.Reservations()
+	if len(reservations) != 1 || reservations[0].Remaining != 1 {
+		t.Fatalf("post-Reserve reservation = %+v, want one remaining member", reservations)
+	}
+}
+
+func TestDeferredSpreadPlanExcludesReservedDomain(t *testing.T) {
+	g := &GangPack{pins: placement.New()}
+	nodes := []framework.NodeInfo{
+		nodeInfo(gpuNode("a1", "a", "4")), nodeInfo(gpuNode("a2", "a", "4")),
+		nodeInfo(gpuNode("b1", "b", "4")), nodeInfo(gpuNode("b2", "b", "4")),
+	}
+	if _, _, ok := g.pins.ChooseInTopologyOnNodes("team/forming", testKey,
+		topology.FreeByDomain{"a": 2}, map[string][]string{"a": {"a1", "a2"}}, 2); !ok {
+		t.Fatal("reserve domain a for forming gang")
+	}
+	pod := gpuPod("4")
+	pod.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       testKey,
+		WhenUnsatisfiable: v1.DoNotSchedule,
+	}}
+	state := newCycleState()
+
+	result, status := g.pinGang(state, nodes,
+		gangInfo{key: "team/spread", uid: "uid-1", minMember: 2, topologyKey: testKey}, pod)
+	if !status.IsSuccess() {
+		t.Fatalf("pinGang status = %v, want Success", status)
+	}
+	if result == nil || !result.NodeNames.Equal(sets.New("b1", "b2")) {
+		t.Fatalf("deferred candidates = %v, want only unreserved domain b", result.NodeNames)
+	}
+}
+
 // TestPinGangAdoptsBoundMembers: with the in-memory pin lost (restart) but a gang
 // member already placed in a domain, pinGang adopts that domain instead of
 // best-fitting fresh — even when a fresh best-fit would fail. Here domain "a" has

--- a/scheduler/pkg/plugins/gangpack/reserve.go
+++ b/scheduler/pkg/plugins/gangpack/reserve.go
@@ -10,23 +10,55 @@ import (
 	"k8s.io/kube-scheduler/framework"
 
 	"sigs.k8s.io/ome/scheduler/pkg/placement"
+	"sigs.k8s.io/ome/scheduler/pkg/topology"
 )
 
-// Reserve drains one whole node from the gang's domain reservation: this member
-// has now been assigned a real node (PreFilter pinned the domain and reserved the
-// gang's full capacity there; Filter kept it in-domain), so it becomes live
-// occupancy in the snapshot and its reserved slot is handed off via Place. That
-// hand-off is what stops two gangs racing into one domain — the reservation holds
-// the not-yet-placed capacity, and draining it as members land avoids
-// double-counting against the snapshot. A pod that is not a pinned gang member
-// reserves nothing.
-func (g *GangPack) Reserve(_ context.Context, state framework.CycleState, _ *v1.Pod, _ string) *framework.Status {
-	if pin := readPin(state); pin != nil {
-		_, drained := g.pins.PlaceIf(pin.gang.key, pin.commitment)
-		if drained {
-			g.clearFailedDomains(pin.gang)
-			g.activateReservationBlocked()
+// Reserve commits a deferred hard-spread plan to the selected node's domain, if
+// PreFilter did not pin it already, then drains one whole node from the gang's
+// reservation. The member becomes live occupancy in the snapshot and its
+// reserved slot is handed off via Place. That hand-off is what stops two gangs
+// racing into one domain — the reservation holds the not-yet-placed capacity,
+// and draining it as members land avoids double-counting against the snapshot. A
+// pod that is not a pinned or deferred gang member reserves nothing.
+func (g *GangPack) Reserve(_ context.Context, state framework.CycleState, _ *v1.Pod, nodeName string) *framework.Status {
+	pin := readPin(state)
+	if pin == nil {
+		plan := readDeferredPin(state)
+		if plan == nil {
+			return nil
 		}
+		domain := ""
+		for candidateDomain, names := range plan.nodesByDomain {
+			for _, name := range names {
+				if name == nodeName {
+					domain = candidateDomain
+					break
+				}
+			}
+			if domain != "" {
+				break
+			}
+		}
+		if domain == "" || plan.free[domain] < plan.need {
+			return framework.NewStatus(framework.Error, "selected node is outside the deferred gang plan")
+		}
+		selectedFree := topology.FreeByDomain{domain: plan.free[domain]}
+		selectedNodes := map[string][]string{domain: plan.nodesByDomain[domain]}
+		chosen, commitment, ok := g.pins.ChooseForOwnerInTopologyOnNodes(plan.gang.key, plan.gang.uid,
+			plan.gang.topologyKey, selectedFree, selectedNodes, plan.need)
+		if !ok || chosen != domain {
+			return framework.NewStatus(framework.Error, "selected gang domain became unavailable before Reserve")
+		}
+		writePin(state, domain, plan.gang, commitment)
+		pin = readPin(state)
+		gangPinTotal.WithLabelValues("pinned_after_filter").Inc()
+		pinnedGroups.Set(float64(g.pins.Len()))
+	}
+
+	_, drained := g.pins.PlaceIf(pin.gang.key, pin.commitment)
+	if drained {
+		g.clearFailedDomains(pin.gang)
+		g.activateReservationBlocked()
 	}
 	return nil
 }

--- a/scheduler/pkg/plugins/gangpack/score.go
+++ b/scheduler/pkg/plugins/gangpack/score.go
@@ -9,14 +9,17 @@ import (
 	"sigs.k8s.io/ome/scheduler/pkg/topology"
 )
 
-// Domain-level bin-packing score for standalone (non-gang) whole-node pods.
+// Domain-level bin-packing score for standalone whole-node pods and deferred
+// hard-spread gangs.
 //
 // Standalone pods — e.g. single-host TPU replicas that take one node of a slice
 // — are steered toward domains that are already partly used, so partly-filled
 // domains fill before empty ones are opened. That keeps whole domains free for
 // multi-host gangs instead of letting single-host replicas fragment every slice.
-// Gang members are left alone: their domain is already pinned in PreFilter, so
-// PreScore skips when a pin exists.
+// Gang members normally arrive already pinned from PreFilter. The exception is
+// an initial member with a hard topology spread constraint: its pin is deferred
+// until Reserve, so this score preserves best-fit ordering among the domains
+// that survived the framework's filters.
 //
 // The built-in node-level MostAllocated cannot do this: accelerator nodes are
 // whole-node, so every empty candidate looks identical; the packing signal only
@@ -63,10 +66,36 @@ func (g *GangPack) packingTopologyKey(state framework.CycleState) string {
 	return g.topologyKey
 }
 
-// PreScore computes, once per scheduling cycle, the free whole-node count per
-// domain over the filtered candidate nodes, so Score is a cheap per-node lookup.
-// Returns Skip (which also skips Score) when domain packing does not apply.
+// PreScore computes domain packing state once per scheduling cycle, so Score is
+// a cheap per-node lookup. Standalone pods count free filtered nodes directly;
+// deferred gangs keep the full-gang capacity calculated in PreFilter but drop
+// domains with no node left after the regular filters. Returns Skip (which also
+// skips Score) when domain packing does not apply.
 func (g *GangPack) PreScore(_ context.Context, state framework.CycleState, pod *v1.Pod, nodes []framework.NodeInfo) *framework.Status {
+	if plan := readDeferredPin(state); plan != nil {
+		filteredDomains := make(map[string]bool)
+		for _, node := range nodes {
+			if node != nil && node.Node() != nil {
+				filteredDomains[domainOf(node.Node(), plan.gang.topologyKey)] = true
+			}
+		}
+		free := make(topology.FreeByDomain)
+		maxFree := 0
+		for domain, capacity := range plan.free {
+			if !filteredDomains[domain] {
+				continue
+			}
+			free[domain] = capacity
+			if capacity > maxFree {
+				maxFree = capacity
+			}
+		}
+		if len(free) == 0 {
+			return framework.NewStatus(framework.Skip)
+		}
+		state.Write(preScoreStateKey, &domainPackState{topologyKey: plan.gang.topologyKey, free: free, maxFree: maxFree})
+		return nil
+	}
 	tk := g.packingTopologyKey(state)
 	if tk == "" {
 		return framework.NewStatus(framework.Skip)

--- a/scheduler/pkg/plugins/gangpack/score_test.go
+++ b/scheduler/pkg/plugins/gangpack/score_test.go
@@ -152,6 +152,43 @@ func TestScore_PinnedGangMemberSkipped(t *testing.T) {
 	}
 }
 
+// TestScore_DeferredGangPreservesBestFit verifies that deferring a hard-spread
+// gang's pin does not discard GangPack's packing preference. PreScore sees only
+// domains with nodes that survived the framework filters, then ranks the fuller
+// whole-gang-feasible domain above the emptier one.
+func TestScore_DeferredGangPreservesBestFit(t *testing.T) {
+	g := &GangPack{}
+	pod := gpuPod("4")
+	nodes := []framework.NodeInfo{
+		nodeInfo(gpuNode("a1", "a", "4")),
+		nodeInfo(gpuNode("b1", "b", "4")),
+	}
+	state := newCycleState()
+	writeDeferredPin(state, &deferredPinState{
+		gang: gangInfo{key: "ns/g", topologyKey: testKey},
+		need: 2,
+		free: map[string]int{"a": 2, "b": 3},
+	})
+
+	if status := g.PreScore(context.Background(), state, pod, nodes); !status.IsSuccess() {
+		t.Fatalf("PreScore = %v, want Success", status)
+	}
+	scores := make(framework.NodeScoreList, 0, len(nodes))
+	for _, node := range nodes {
+		score, status := g.Score(context.Background(), state, pod, node)
+		if !status.IsSuccess() {
+			t.Fatalf("Score(%s) = %v", node.Node().Name, status)
+		}
+		scores = append(scores, framework.NodeScore{Name: node.Node().Name, Score: score})
+	}
+	if status := g.NormalizeScore(context.Background(), state, pod, scores); !status.IsSuccess() {
+		t.Fatalf("NormalizeScore = %v", status)
+	}
+	if scores[0].Score != framework.MaxNodeScore || scores[1].Score != 0 {
+		t.Fatalf("deferred gang scores = %+v, want a=%d b=0", scores, framework.MaxNodeScore)
+	}
+}
+
 // TestScore_NodeWithoutDomainLabelNeutral: a node not in any domain scores 0 even
 // while other nodes pack. Uses two real domains so there is a packing gradient
 // (a: 1 free = fullest, b: 2 free) for the domainless node to lose to.

--- a/scheduler/pkg/plugins/gangpack/state.go
+++ b/scheduler/pkg/plugins/gangpack/state.go
@@ -1,10 +1,16 @@
 package gangpack
 
-import "k8s.io/kube-scheduler/framework"
+import (
+	"k8s.io/kube-scheduler/framework"
 
-// pinStateKey identifies the per-scheduling-cycle pin that PreFilter records and
-// Filter enforces. It is internal CycleState plumbing — it never leaves the
-// process — so the name is a neutral local identifier, not a label convention.
+	"sigs.k8s.io/ome/scheduler/pkg/topology"
+)
+
+// pinStateKey identifies the per-scheduling-cycle pin that PreFilter normally
+// records and Filter enforces. A hard-spread gang records it in Reserve instead,
+// after the regular filters select a node. It is internal CycleState plumbing —
+// it never leaves the process — so the name is a neutral local identifier, not a
+// label convention.
 const pinStateKey framework.StateKey = "gangpack.pin"
 
 // pinState is the domain a gang is committed to for this scheduling cycle, plus
@@ -23,7 +29,8 @@ func (s *pinState) Clone() framework.StateData {
 	return &c
 }
 
-// writePin records the pinned domain for this cycle (called by PreFilter).
+// writePin records the pinned domain for this cycle (called by PreFilter or,
+// for a deferred hard-spread plan, Reserve).
 func writePin(state framework.CycleState, domain string, gang gangInfo, commitment ...uint64) {
 	var id uint64
 	if len(commitment) > 0 {
@@ -47,4 +54,56 @@ func readPin(state framework.CycleState) *pinState {
 		return nil
 	}
 	return s
+}
+
+// deferredPinState is an unplaced gang whose current member has a hard topology
+// spread constraint. PreFilter cannot know which nodes the framework's later
+// filters will reject, so it exposes every domain that can hold the whole gang.
+// Reserve commits the gang to the domain of the node selected from that filtered
+// set. The maps are immutable after this state is written.
+type deferredPinState struct {
+	gang          gangInfo
+	need          int
+	free          topology.FreeByDomain
+	nodesByDomain map[string][]string
+}
+
+const deferredPinStateKey framework.StateKey = "gangpack.deferred-pin"
+
+func (s *deferredPinState) Clone() framework.StateData {
+	if s == nil {
+		return (*deferredPinState)(nil)
+	}
+	c := &deferredPinState{
+		gang:          s.gang,
+		need:          s.need,
+		free:          make(topology.FreeByDomain, len(s.free)),
+		nodesByDomain: make(map[string][]string, len(s.nodesByDomain)),
+	}
+	for domain, free := range s.free {
+		c.free[domain] = free
+	}
+	for domain, nodes := range s.nodesByDomain {
+		c.nodesByDomain[domain] = append([]string(nil), nodes...)
+	}
+	return c
+}
+
+func writeDeferredPin(state framework.CycleState, plan *deferredPinState) {
+	state.Write(deferredPinStateKey, plan)
+}
+
+func readDeferredPin(state framework.CycleState) *deferredPinState {
+	if state == nil {
+		return nil
+	}
+	v, err := state.Read(deferredPinStateKey)
+	if err != nil {
+		return nil
+	}
+	plan, ok := v.(*deferredPinState)
+	if !ok {
+		return nil
+	}
+	return plan
 }

--- a/scheduler/test/integration/spread_tsc_test.go
+++ b/scheduler/test/integration/spread_tsc_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -11,11 +12,9 @@ import (
 )
 
 // OME renders topologySpread as a standard DoNotSchedule constraint on each
-// gang's anchor (leader) pod — the scheduler carries NO spread logic of its
-// own. These tests prove the plugin's existing machinery absorbs that
-// constraint: gangpack best-fit-pins a packed domain, PodTopologySpread's
-// Filter (kept enabled for hard constraints) vetoes it, PostFilter remembers
-// the failed domain, and the retry re-plans into a compatible one.
+// gang's anchor (leader) pod. GangPack does not duplicate that logic: it offers
+// every whole-gang-feasible domain to the framework, PodTopologySpread filters
+// the candidates, and Reserve pins the gang to the selected node's domain.
 
 // cubeLabelKey is the coarser fault-domain label the split-key test spreads
 // across while co-locating by domainLabelKey (the TPU shape: gang-sized
@@ -55,11 +54,10 @@ func spreadLeaderPod(name, ns, pgName, spreadKey string, when v1.UnsatisfiableCo
 }
 
 // spreadWorkerPod mirrors the worker's spread-relevant surface: no
-// constraint of its own. Under this scheduler the gang PIN is what
-// co-locates workers with their leader (the rendered worker→leader
-// affinity is defense-in-depth for non-gang schedulers and is exercised
-// by the controller-side suites); the TSC-gated leader decides the fault
-// domain because only leaders match the constraint's selector.
+// constraint of its own. GangPack makes an unconstrained member wait for its
+// hard-spread anchor, then the gang PIN co-locates it with that leader (the
+// rendered worker→leader affinity is defense-in-depth for non-gang schedulers
+// and is exercised by the controller-side suites).
 func spreadWorkerPod(name, ns, pgName string) *v1.Pod {
 	p := makeGangPod(name, ns, pgName)
 	p.Labels["runner"] = "worker"
@@ -89,6 +87,15 @@ func placeTSCGang(t *testing.T, tc *testContext, ns, pgName, spreadKey, domainLa
 	}
 	n0 := waitForPodBound(t, tc, ns, pgName+"-0", 60*time.Second)
 	n1 := waitForPodBound(t, tc, ns, pgName+"-1", 60*time.Second)
+	events, err := tc.ClientSet.CoreV1().Events(ns).List(tc.Ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list events for %s: %v", pgName, err)
+	}
+	for _, event := range events.Items {
+		if event.InvolvedObject.Name == pgName+"-0" && strings.Contains(event.Message, "gang reservation released after all candidate nodes were filtered") {
+			t.Fatalf("leader %s committed before topology-spread filtering: %s", pgName+"-0", event.Message)
+		}
+	}
 	if labelOf(n0) != labelOf(n1) {
 		t.Fatalf("gang %s split across %s values %s/%s", pgName, domainLabel, labelOf(n0), labelOf(n1))
 	}
@@ -118,6 +125,49 @@ func TestTSCSpreadsGangsAcrossCubes(t *testing.T) {
 	c1 := placeTSCGang(t, tc, ns, "v1", cubeLabelKey, cubeLabelKey)
 	if c0 == c1 {
 		t.Fatalf("both gangs in cube %q — the leader constraint did not spread on the gang scheduler", c0)
+	}
+}
+
+// TestTSCNodeGranularityFiltersBeforeGangPin proves that the spread topology
+// need not match GangPack's co-location topology. Each hostname is a spread
+// domain, while each rack remains a two-node gang domain. Existing anchors on
+// both rack-a nodes make every rack-a candidate violate maxSkew; the first gang
+// commitment must therefore be made directly in rack b, without a PostFilter
+// unwind/retry through rack a.
+func TestTSCNodeGranularityFiltersBeforeGangPin(t *testing.T) {
+	tc := startScheduler(t, globalKubeConfig, gangPackOptions(t)...)
+	defer tc.teardown(t)
+
+	const ns = "tsc-hostnames"
+	createNamespace(t, tc, ns)
+	for _, n := range []struct{ name, rack string }{
+		{"th-a1", "a"}, {"th-a2", "a"}, {"th-b1", "b"}, {"th-b2", "b"},
+	} {
+		node := makeGPUNode(n.name, n.rack, 1)
+		node.Labels[v1.LabelHostname] = n.name
+		if _, err := tc.ClientSet.CoreV1().Nodes().Create(tc.Ctx, node, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create node %s: %v", n.name, err)
+		}
+	}
+	for _, node := range []string{"th-a1", "th-a2"} {
+		seed := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "seed-" + node,
+				Namespace: ns,
+				Labels:    map[string]string{"app": "tsc-svc", "runner": "leader"},
+			},
+			Spec: v1.PodSpec{
+				NodeName:   node,
+				Containers: []v1.Container{{Name: "app", Image: "registry.k8s.io/pause:3.10"}},
+			},
+		}
+		if _, err := tc.ClientSet.CoreV1().Pods(ns).Create(tc.Ctx, seed, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create seed on %s: %v", node, err)
+		}
+	}
+
+	if rack := placeTSCGang(t, tc, ns, "node-spread", v1.LabelHostname, domainLabelKey); rack != "b" {
+		t.Fatalf("node-level spread gang landed in rack %q, want b", rack)
 	}
 }
 


### PR DESCRIPTION
## What this PR does

- For an unplaced gang with an explicit hard (`DoNotSchedule`) topology-spread constraint, have `PreFilter` expose the union of all domains that can hold the complete gang instead of pinning one domain before the regular scheduler filters run.
- Make unconstrained gang members wait for the unplaced hard-spread anchor, so a worker cannot decide the domain before its leader's constraint is evaluated.
- Atomically validate and pin the selected node's domain in `Reserve`, then use the existing reservation handoff and Permit gate.
- Preserve GangPack's best-fit preference in `PreScore` across only the domains that survived normal filtering.
- Cover same-key rack spreading, split-key cube spreading, and node-level hostname spreading without a failed-domain unwind.

Soft `ScheduleAnyway` constraints retain the current packing behavior. The change deliberately does not parse or reimplement PodTopologySpread semantics; the built-in plugin remains authoritative.

## Why we need it

GangPack currently picks and reserves one co-location domain in `PreFilter`. A later framework filter can veto every node in that domain even when a different whole-gang-feasible domain would pass. The existing `PostFilter` records the first domain as failed, but the same pending gang may receive no prompt second scheduling cycle.

This is visible with OME's own required replica spreading. In a two-rack Kind test, replica 0 occupied rack8, replica 1 initially best-fit-pinned rack8, and PodTopologySpread correctly rejected it. Rack9 remained feasible, but the gang waited for `InstanceReadyTimeout` and Pod recreation before retrying there.

Deferring only the irreversible domain commitment lets the scheduler compose normally:

1. GangPack proves full-gang capacity in every candidate co-location domain.
2. PodTopologySpread and all other configured filters evaluate the candidate nodes.
3. The selected node determines the gang domain.
4. Reserve claims the remaining gang capacity there before another scheduling cycle begins.

This also works when the spread key differs from the gang key, including a coarser failure domain or node-level `kubernetes.io/hostname` spreading.

## How to test

```sh
cd scheduler
KUBEBUILDER_ASSETS="$(setup-envtest use 1.35.x! -p path)" go test ./...

cd ..
go test ./pkg/controller/v1beta1/workload/ops
```

The external OME + real-SMG Kind harness also passed with the scheduler requeue workaround disabled:

```sh
OME_MULTINODE_REF=codex/gangpack-topology-spread-aware \
OME_SCHEDULER_REQUEUE_WORKAROUND=false \
make -C tests/ome-smg multinode
```

Observed result: `leadersRequiringExplicitRequeue: 0`, zero backend-unavailable responses, successful compatible and incompatible zero-surge rollouts, successful whole-gang worker restart, and successful same-domain gang admission.

## Checklist

- [x] Tests added/updated
- [x] Docs updated
- [ ] `make test` passes locally (focused root tests plus the complete scheduler module and external Kind suite were run)
