### PR TITLE
[Bugfix] Grant destinationrules RBAC to the manager

### DIFF
--- a/charts/ome-resources/templates/ome-controller/rbac/role.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/role.yaml
@@ -205,6 +205,7 @@ rules:
 - apiGroups:
   - networking.istio.io
   resources:
+  - destinationrules
   - sidecars
   verbs:
   - create

--- a/charts/ome-resources/tests/render_test.sh
+++ b/charts/ome-resources/tests/render_test.sh
@@ -467,15 +467,32 @@ grep -Eq '^  metricProviders:' <<<"${metric_providers_config}" ||
 grep -Fq '"cluster-prometheus":{"headers":{"X-Scope-OrgID":"tenant-a"},"serverAddress":"http://ome-prometheus.ome.svc:9090"}' <<<"${metric_providers_config}" ||
   fail "top-level metric provider binding was not rendered"
 
-# The traffic reconciler picks its translator by probing CRDs at startup
+# The traffic reconciler picks its translator at startup by probing CRDs
 # (reconcilers/traffic/factory) and then watches the chosen backend policy
-# kind. Every kind a translator can watch must be listable by the manager,
-# otherwise the informer never syncs and the manager exits on cache-sync
-# timeout on any cluster where that CRD happens to exist.
+# kind. Every kind a translator can watch must be listable and watchable by
+# the manager, otherwise the informer never syncs and the manager exits on
+# cache-sync timeout on any cluster where that CRD happens to exist.
 manager_role="$("${helm_bin}" template ome-resources "${chart_dir}" \
   --namespace ome \
   --show-only templates/ome-controller/rbac/role.yaml)"
-for translator_resource in destinationrules backendtrafficpolicies; do
-  grep -Eq "^  - ${translator_resource}\$" <<<"${manager_role}" ||
-    fail "manager ClusterRole does not grant ${translator_resource}, which a traffic translator watches"
+# role_grants <apiGroup> <resource>: true when some rule of the rendered
+# ClusterRole names both, and its verbs include list and watch.
+role_grants() {
+  awk -v group="$1" -v resource="$2" '
+    /^- apiGroups:/ { if (g && r && l && w) ok = 1; g = r = l = w = 0; section = "apiGroups"; next }
+    /^  resources:/ { section = "resources"; next }
+    /^  verbs:/ { section = "verbs"; next }
+    /^  - / {
+      item = substr($0, 5)
+      if (section == "apiGroups" && item == group) g = 1
+      if (section == "resources" && item == resource) r = 1
+      if (section == "verbs" && item == "list") l = 1
+      if (section == "verbs" && item == "watch") w = 1
+    }
+    END { if (g && r && l && w) ok = 1; exit !ok }
+  ' <<<"${manager_role}"
+}
+for translator_resource in networking.istio.io/destinationrules gateway.envoyproxy.io/backendtrafficpolicies; do
+  role_grants "${translator_resource%/*}" "${translator_resource#*/}" ||
+    fail "manager ClusterRole does not grant list+watch on ${translator_resource}, which a traffic translator watches"
 done

--- a/charts/ome-resources/tests/render_test.sh
+++ b/charts/ome-resources/tests/render_test.sh
@@ -466,3 +466,16 @@ grep -Eq '^  metricProviders:' <<<"${metric_providers_config}" ||
   fail "top-level metricProviders key was not rendered when bindings are set"
 grep -Fq '"cluster-prometheus":{"headers":{"X-Scope-OrgID":"tenant-a"},"serverAddress":"http://ome-prometheus.ome.svc:9090"}' <<<"${metric_providers_config}" ||
   fail "top-level metric provider binding was not rendered"
+
+# The traffic reconciler picks its translator by probing CRDs at startup
+# (reconcilers/traffic/factory) and then watches the chosen backend policy
+# kind. Every kind a translator can watch must be listable by the manager,
+# otherwise the informer never syncs and the manager exits on cache-sync
+# timeout on any cluster where that CRD happens to exist.
+manager_role="$("${helm_bin}" template ome-resources "${chart_dir}" \
+  --namespace ome \
+  --show-only templates/ome-controller/rbac/role.yaml)"
+for translator_resource in destinationrules backendtrafficpolicies; do
+  grep -Eq "^  - ${translator_resource}\$" <<<"${manager_role}" ||
+    fail "manager ClusterRole does not grant ${translator_resource}, which a traffic translator watches"
+done

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -205,6 +205,7 @@ rules:
 - apiGroups:
   - networking.istio.io
   resources:
+  - destinationrules
   - sidecars
   verbs:
   - create

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -82,6 +82,7 @@ import (
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ome.io,resources=inferenceservices/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=sidecars,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## What

The manager ClusterRole never granted `networking.istio.io/destinationrules`, but the traffic reconciler watches `DestinationRule` whenever the CRD exists and the Envoy Gateway `BackendTrafficPolicy` CRD does not (`reconcilers/traffic/factory` picks the Istio translator). On such a cluster the informer's list call is forbidden, the cache never syncs, and the manager exits on cache-sync timeout every two minutes:

```
Failed to watch ... networking.istio.io/v1, Kind=DestinationRule:
destinationrules.networking.istio.io is forbidden: User
"system:serviceaccount:ome:ome-controller-manager" cannot list resource
"destinationrules" in API group "networking.istio.io" at the cluster scope
...
Could not wait for Cache to sync {"controller": "inferenceservice", ...}
```

Webhooks keep answering during the loop, so the symptom is "InferenceService status stops updating" rather than an obvious crash.

This does not need a real Istio control plane: a partial Istio CRD set (e.g. the one Higress ships, which has `destinationrules` but not `virtualservices`) is enough to select the translator.

## Fix

- Add the `destinationrules` kubebuilder rbac marker next to the existing `sidecars` one.
- Regenerate `config/rbac/role.yaml` with controller-gen and sync it into the chart (one line each).
- Extend `charts/ome-resources/tests/render_test.sh` to assert the manager ClusterRole grants every backend-policy resource a traffic translator can watch (`destinationrules`, `backendtrafficpolicies`). The assertion fails on the previous `role.yaml` and passes with this change.

## Verified

- `bash charts/ome-resources/tests/render_test.sh` fails before, passes after.
- Running `controller-gen rbac:...` on the branch produces no further diff, so the marker and the generated file agree.
- Deployed on the affected cluster (k8s 1.33.4, partial Istio CRDs): manager stays up, no `Failed to watch`, InferenceServices reconcile again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Traffic reconciliation now supports managing Istio `DestinationRule` resources.
  - Updated access permissions support creating, viewing, modifying, monitoring, and deleting these resources.
- **Tests**
  - Added validation confirming the required permissions for Istio `DestinationRule` and Envoy `BackendTrafficPolicy` resources are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->