### PR TITLE
[Bugfix] Preserve nested environment configuration

### DIFF
--- a/internal/ome-agent/fine-tuned-adapter/fine_tuned_adapter_test.go
+++ b/internal/ome-agent/fine-tuned-adapter/fine_tuned_adapter_test.go
@@ -1,0 +1,35 @@
+package fine_tuned_adapter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithViperReadsModelFromEnvironment(t *testing.T) {
+	t.Setenv("OME_AGENT_MODEL", "")
+	t.Setenv("OME_AGENT_MODEL_NAMESPACE", "test-namespace")
+	t.Setenv("OME_AGENT_MODEL_BUCKET_NAME", "test-bucket")
+	t.Setenv("OME_AGENT_MODEL_OBJECT_NAME", "models/weights.zip-merged-weight")
+
+	// Match the agent's configuration file: model fields exist only in the environment.
+	const configYAML = `zipped_fine_tuned_weight_directory: /mnt/zipped-ft-models
+unzipped_fine_tuned_weight_directory: /mnt/unzipped-ft-models
+`
+	v := viper.New()
+	v.SetEnvPrefix("OME_AGENT")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.AutomaticEnv()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(configYAML)))
+
+	config, err := NewFineTunedAdapterConfig(WithViper(v))
+
+	require.NoError(t, err)
+	require.NotNil(t, config.FineTunedWeightURI)
+	require.Equal(t, "test-namespace", config.FineTunedWeightURI.Namespace)
+	require.Equal(t, "test-bucket", config.FineTunedWeightURI.BucketName)
+	require.Equal(t, "models/weights.zip-merged-weight", config.FineTunedWeightURI.ObjectName)
+}

--- a/pkg/configutils/configutils.go
+++ b/pkg/configutils/configutils.go
@@ -186,6 +186,9 @@ func BindEnvsRecursive(v *viper.Viper, iface interface{}, path string) error {
 			if err := BindEnvsRecursive(v, field.Addr().Interface(), fullPath); err != nil {
 				return err
 			}
+			// Binding the parent lets Viper shadow nested environment keys
+			// during Unmarshal, so bind only the leaves of a struct.
+			continue
 		}
 
 		if err := v.BindEnv(fullPath); err != nil {

--- a/pkg/configutils/configutils_test.go
+++ b/pkg/configutils/configutils_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +43,83 @@ const expectedConfig = `a:
 imports:
     - intermediate.yaml
 `
+
+func TestBindEnvsRecursiveNestedConfig(t *testing.T) {
+	type checksum struct {
+		Algorithm string `mapstructure:"algorithm"`
+	}
+	type location struct {
+		Bucket   string   `mapstructure:"bucket"`
+		Object   string   `mapstructure:"object"`
+		Checksum checksum `mapstructure:"checksum"`
+	}
+	type config struct {
+		Source *location `mapstructure:"source"`
+		Target location  `mapstructure:"target"`
+	}
+
+	for _, initialized := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pointer_initialized_%t", initialized), func(t *testing.T) {
+			cfg := config{}
+			if initialized {
+				cfg.Source = &location{}
+			}
+			v := viper.New()
+			v.SetEnvPrefix("BIND_TEST")
+			v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+			v.AutomaticEnv()
+			t.Setenv("BIND_TEST_SOURCE_BUCKET", "source-bucket")
+			t.Setenv("BIND_TEST_SOURCE_OBJECT", "weights/model.bin")
+			t.Setenv("BIND_TEST_SOURCE_CHECKSUM_ALGORITHM", "sha256")
+			t.Setenv("BIND_TEST_TARGET_BUCKET", "target-bucket")
+			t.Setenv("BIND_TEST_TARGET_OBJECT", "copy/model.bin")
+			v.SetDefault("target.checksum.algorithm", "md5")
+
+			require.NoError(t, BindEnvsRecursive(v, &cfg, ""))
+			// Parent environment keys shadow nested keys in Viper's AllKeys,
+			// making environment-only fields disappear during Unmarshal.
+			require.ElementsMatch(t, []string{
+				"source.bucket", "source.object", "source.checksum.algorithm",
+				"target.bucket", "target.object", "target.checksum.algorithm",
+			}, v.AllKeys())
+			require.NoError(t, v.Unmarshal(&cfg))
+			assert.Equal(t, config{
+				Source: &location{Bucket: "source-bucket", Object: "weights/model.bin", Checksum: checksum{Algorithm: "sha256"}},
+				Target: location{Bucket: "target-bucket", Object: "copy/model.bin", Checksum: checksum{Algorithm: "md5"}},
+			}, cfg)
+		})
+	}
+}
+
+func TestBindEnvsRecursiveLeafTypes(t *testing.T) {
+	type config struct {
+		Name     *string           `mapstructure:"name"`
+		Enabled  bool              `mapstructure:"enabled"`
+		Workers  int               `mapstructure:"workers"`
+		Timeout  time.Duration     `mapstructure:"timeout"`
+		Labels   []string          `mapstructure:"labels"`
+		Metadata map[string]string `mapstructure:"metadata"`
+	}
+	cfg := config{}
+	v := viper.New()
+	v.SetEnvPrefix("BIND_TEST")
+	v.AutomaticEnv()
+	t.Setenv("BIND_TEST_NAME", "adapter")
+	t.Setenv("BIND_TEST_ENABLED", "true")
+	t.Setenv("BIND_TEST_WORKERS", "2")
+	t.Setenv("BIND_TEST_TIMEOUT", "30m")
+	t.Setenv("BIND_TEST_LABELS", "first,second")
+
+	require.NoError(t, BindEnvsRecursive(v, &cfg, ""))
+	assert.ElementsMatch(t, []string{"name", "enabled", "workers", "timeout", "labels", "metadata"}, v.AllKeys())
+	v.Set("metadata", map[string]string{"owner": "test"})
+	require.NoError(t, v.Unmarshal(&cfg))
+	name := "adapter"
+	assert.Equal(t, config{
+		Name: &name, Enabled: true, Workers: 2, Timeout: 30 * time.Minute,
+		Labels: []string{"first", "second"}, Metadata: map[string]string{"owner": "test"},
+	}, cfg)
+}
 
 func TestConfigFileImports(t *testing.T) {
 	// TODO: Would be ideal to use afero or similar in the future. Creating


### PR DESCRIPTION
## What this PR does

Updates `BindEnvsRecursive` to bind only leaf fields after traversing nested structs. Adds regression tests for nested configuration, supported field types, and environment-only configuration loading through the fine-tuned adapter.

## Why we need it

During fine-tuned model serving startup, the adapter intermittently loaded empty bucket or object names even though the corresponding environment variables were set. Downloads failed, the init container restarted repeatedly, and endpoint readiness was delayed. A later restart could succeed without any configuration changes.

The helper binds both a struct parent, such as `model`, and its children, such as `model.bucket_name`. Viper can let the parent binding hide child keys during unmarshalling. Because these keys are traversed in Go map order, the resulting configuration can differ between starts.

Binding only the leaf fields prevents this nondeterministic loss of nested configuration.

We audited all 10 existing `BindEnvsRecursive` call sites and found none that relies on decoding an entire struct from a parent environment variable. Their nested structs are configured through leaf fields. Removing struct-parent bindings therefore preserves the intended configuration behavior; scalar, slice, and map bindings remain unchanged. This was a repository code audit, not an audit of every deployment's environment variables.

## How to test

```sh
go test ./pkg/configutils ./internal/ome-agent/fine-tuned-adapter -count=1
```

Both packages pass with Go 1.26.0. The deterministic nested-key regression fails without the fix.

The full `make test` suite was not run. Broader testing found an unrelated existing Xet test failure: `TestConfig_Validate/valid_config` omits the required `CacheDir`.

## Checklist

- [x] Tests added/updated
- [ ] Docs updated — not applicable
- [ ] `make test` passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected environment-variable binding for nested configuration values.
  - Nested fields now resolve independently, preventing parent configuration paths from overriding or interfering with leaf settings.
  - Environment variables correctly support scalar values, collections, durations, and nested fields such as model URIs and checksums.
  - Existing YAML-configured settings, including weight directories and default checksum algorithms, are preserved when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->